### PR TITLE
Fix to Admin Dashboard

### DIFF
--- a/admin/includes/template/partials/tplDashboardMainSortables.php
+++ b/admin/includes/template/partials/tplDashboardMainSortables.php
@@ -24,7 +24,11 @@
             </div>
         </div>
         <div class="widget-body">
-        <?php require($tplVars[$widget['widget_key']]['templateFile']); ?>
+        <?php 
+          if (file_exists($tplVars[$widget['widget_key']]['templateFile'])) { 
+             require($tplVars[$widget['widget_key']]['templateFile']); 
+          }
+        ?>
         </div>
       </div>
 


### PR DESCRIPTION
Without this change, you can receive the log

[24-Sep-2013 00:04:54 UTC] PHP Fatal error: require(): Failed opening required '' (include_path='.:/usr/share/pear:/usr/share/php') in /var/www/html/demo_160/my_admin/includes/template/partials/tplDashboardMainSortables.php on line 27
