### PR TITLE
Extra double qoute in code removed

### DIFF
--- a/includes/functions/banner.php
+++ b/includes/functions/banner.php
@@ -147,7 +147,7 @@
         if ($banner->fields['banners_open_new_windows'] == '1') {
           $target = ' target="_blank"';
         }
-        $banner_string = '<a href="' . zen_href_link(FILENAME_REDIRECT, 'action=banner&goto=' . $banner->fields['banners_id']) . '"' . $target . '">' . zen_image(DIR_WS_IMAGES . $banner->fields['banners_image'], $banner->fields['banners_title']) . '</a>';
+        $banner_string = '<a href="' . zen_href_link(FILENAME_REDIRECT, 'action=banner&goto=' . $banner->fields['banners_id']) . '"' . $target . '>' . zen_image(DIR_WS_IMAGES . $banner->fields['banners_image'], $banner->fields['banners_title']) . '</a>';
       }
     }
 


### PR DESCRIPTION
This double quote was probably introduce when adding the $target variable, but it is one to many and is giving validation errors
