### PR TITLE
Updated admin zen_not_null to bring it in line with the non admin function

### DIFF
--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -438,7 +438,7 @@
         return false;
       }
     } else {
-      if ( (is_string($value) || is_int($value)) && ($value != '') && ($value != 'NULL') && (strlen(trim($value)) > 0)) {
+      if (($value != '') && (strtolower($value) != 'null') && (strlen(trim($value)) > 0)) {
         return true;
       } else {
         return false;


### PR DESCRIPTION
The primary concern with the admin one was zen_not_null(true) === false
The website one correctly does zen_not_null(true) === true
An explicit check for boolean could also be added but I guess it doesn't need it.
