### PR TITLE
See #57 - Add Developer Mode to installer.

### DIFF
--- a/zc_install/ajaxAdminSetup.php
+++ b/zc_install/ajaxAdminSetup.php
@@ -24,7 +24,7 @@ $word3[$pos] = strtoupper($word3[$pos]);
 $word2 = zen_create_random_value(3, 'chars');
 $adminNewDir = $adminDir;
 $result = FALSE;
-if ($adminDir == 'admin')
+if ($adminDir == 'admin' && (!defined('DEVELOPER_MODE') || DEVELOPER_MODE == false))
 {
   $adminNewDir =  $word1 . '-' . $word2 . '-' . $word3;
   $result = @rename(DIR_FS_ROOT . $adminDir, DIR_FS_ROOT . $adminNewDir);

--- a/zc_install/includes/application_top.php
+++ b/zc_install/includes/application_top.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package Installer
- * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @copyright Copyright 2003-2014 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: $
@@ -106,7 +106,20 @@ if (@ini_get('eaccelerator.enable') == 1) {
 
 // define the project version
 require (DIR_FS_INSTALL . 'includes/version.php');
-
+/**
+ * include the list of extra configure files
+ */
+if ($za_dir = @dir(DIR_FS_INSTALL . 'includes/extra_configures')) {
+  while ($zv_file = $za_dir->read()) {
+    if (preg_match('~^[^\._].*\.php$~i', $zv_file) > 0) {
+      /**
+       * load any user/contribution specific configuration files.
+       */
+      include(DIR_FS_INSTALL . 'includes/extra_configures/' . $zv_file);
+    }
+  }
+  $za_dir->close();
+}
 // set php_self in the local scope
 require (DIR_FS_ROOT . 'includes/classes/class.base.php');
 require (DIR_FS_ROOT . 'includes/classes/class.notifier.php');

--- a/zc_install/includes/extra_configures/index.html
+++ b/zc_install/includes/extra_configures/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <title></title>
+    <meta content="">
+    <style></style>
+  </head>
+  <body></body>
+</html>

--- a/zc_install/includes/modules/pages/admin_setup/header_php.php
+++ b/zc_install/includes/modules/pages/admin_setup/header_php.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package Installer
- * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @copyright Copyright 2003-2014 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id:
  */
@@ -16,8 +16,12 @@
     $adminDir = $adminNewDir;
   }
 // echo '<pre>'. print_r($_POST, TRUE) . '</pre>';
-
-  $admin_password = zen_create_PADSS_password();
+   if (defined('DEVELOPER_MODE') && DEVELOPER_MODE == true)
+   {
+     $admin_password = 'developer1';
+   } else {
+     $admin_password = zen_create_PADSS_password();
+   }
   if (isset($_POST['upgrade_mode']) && $_POST['upgrade_mode'] == 'yes')
   {
     $isUpgrade = TRUE;


### PR DESCRIPTION
```
Adds an extra_includes directory to installer and loads .php files from that directory
reponds to a php define DEVELOPER_MODE, which if set to true will
- by pass the renaming of admin directory
- set a default temporary password of developer1
```
