### PR TITLE
Vendor Autoloading update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ devtools.php
 dev-*.*
 includes/local
 composer.lock
-vendor
 bin
 build
 *.DS_Store

--- a/vendor/aura/autoload/CHANGES.md
+++ b/vendor/aura/autoload/CHANGES.md
@@ -1,0 +1,1 @@
+Initial 2.0.0-beta1 release.

--- a/vendor/aura/autoload/LICENSE
+++ b/vendor/aura/autoload/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2013, Aura for PHP
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/aura/autoload/README.md
+++ b/vendor/aura/autoload/README.md
@@ -1,0 +1,165 @@
+# Aura.Autoload
+
+Provides a PSR-4 (and limited PSR-0) autoloading facility. Although it is
+installable via Composer, its best use is probably outside a Composer-oriented
+project.
+
+## Foreword
+
+### Requirements
+
+This library requires PHP 5.3 or later, and has no userland dependencies.
+
+### Installation
+
+This library is installable and autoloadable via Composer with the following
+`require` element in your `composer.json` file:
+
+    "require": {
+        "aura/autoload": "dev-develop-2"
+    }
+    
+Alternatively, download or clone this repository, then require or include its
+_autoload.php_ file.
+
+### Tests
+
+[![Build Status](https://travis-ci.org/auraphp/Aura.Autoload.png?branch=develop-2)](https://travis-ci.org/auraphp/Aura.Autoload)
+
+This library has 100% code coverage with [PHPUnit][]. To run the tests at the
+command line, go to the _tests_ directory and issue `phpunit`.
+
+[PHPUnit]: http://phpunit.de/manual/
+
+### PSR Compliance
+
+This library attempts to comply with [PSR-1][], [PSR-2][], and [PSR-4][]. If
+you notice compliance oversights, please send a patch via pull request.
+
+[PSR-1]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-1-basic-coding-standard.md
+[PSR-2]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md
+[PSR-4]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md
+
+
+## Getting Started
+
+To use the autoloader, first instantiate it, then register it with SPL
+autoloader stack:
+
+```php
+<?php
+// instantiate
+$loader = new \Aura\Autoload\Loader;
+
+// append to the SPL autoloader stack; use register(true) to prepend instead
+$loader->register();
+?>
+```
+
+### PSR-4 Namespace Prefixes
+
+To add a namespace conforming to [PSR-4][] specifications, point to the base
+directory for that namespace. Multiple base directories are allowed, and will
+be searched in the order they are added.
+
+```php
+<?php
+$loader->addPrefix('Foo\Bar', '/path/to/foo-bar/src');
+$loader->addPrefix('Foo\Bar', '/path/to/foo-bar/tests');
+?>
+```
+
+To set several namespaces prefixes at once, overriding all previous prefix
+settings, use `setPrefixes()`.
+
+```php
+<?php
+$loader->setPrefixes(array(
+    'Foo\Bar' => array(
+        '/path/to/foo-bar/src',
+        '/path/to/foo-bar/tests',
+    ),
+    
+    'Baz\Dib' => array(
+        '/path/to/baz.dib/src',
+        '/path/to/baz.dib/tests',
+    ),
+));
+?>
+```
+
+### PSR-0 Namespaces
+
+To add a namespace conforming to [PSR-0][] specifications, one that uses only
+namespace separators in the class names (no underscores allowed!), point to
+the directory containing classes for that namespace. Multiple directories are
+allowed, and will be searched in the order they are added.
+
+```php
+<?php
+$loader->addPrefix('Baz\Dib', '/path/to/baz-dib/src/Baz/Dib');
+$loader->addPrefix('Baz\Dib', '/path/to/baz-dib/tests/Baz/Dib');
+?>
+```
+
+To set several namespaces prefixes at once, as with PSR-4, use `setPrefixes()`.
+
+### Explicit Class-to-File Mappings
+
+To map a class explictly to a file, use the `setClassFile()` method.
+
+```php
+<?php
+$loader->setClassFile('Foo\Bar\Baz', '/path/to/Foo/Bar/Baz.php');
+?>
+```
+
+To set several class-to-file mappings at once, overriding all previous
+mappings, use `setClassFiles()`. (Alternatively, use `addClassFiles()` to
+append to the existing mappings.)
+
+```php
+<?php
+$loader->setClassFiles(array(
+    'Foo\Bar\Baz'  => '/path/to/Foo/Bar/Baz.php',
+    'Foo\Bar\Qux'  => '/path/to/Foo/Bar/Qux.php',
+    'Foo\Bar\Quux' => '/path/to/Foo/Bar/Quux.php',
+));
+?>
+```
+
+### Inspection and Debugging
+
+These methods are available to inspect the `Loader`:
+
+- `getPrefixes()` returns all the added namespace prefixes and their base
+  directories
+  
+- `getClassFiles()` returns all the explicit class-to-file mappings
+
+- `getLoadedClasses()` returns all the class names loaded by the `Loader` and
+  the file names for the loaded classes
+
+If a class file cannot be loaded for some reason, review the debug information
+using `getDebug()`. This will show a log of information for the most-recent
+autoload attempt involving the `Loader`.
+
+```php
+<?php
+// set the wrong path for Foo\Bar classes
+$loader->addPrefix('Foo\Bar', '/wrong/path/to/foo-bar/src');
+
+// this will fail
+$baz = new \Foo\Bar\Baz;
+
+// examine the debug information
+var_dump($loader->getDebug());
+// array(
+//     'Loading Foo\\Bar\\Baz',
+//     'No explicit class file',
+//     'Foo\\Bar\\: /path/to/foo-bar/Baz.php not found',
+//     'Foo\\: no base dirs',
+//     'Foo\\Bar\\Baz not loaded',
+// )
+?>
+```

--- a/vendor/aura/autoload/autoload.php
+++ b/vendor/aura/autoload/autoload.php
@@ -1,0 +1,33 @@
+<?php
+spl_autoload_register(function ($class) {
+    
+    // what namespace prefix should be recognized?
+    $prefix = 'Aura\Autoload\\';
+    
+    // does the requested class match the namespace prefix?
+    $prefix_len = strlen($prefix);
+    if (substr($class, 0, $prefix_len) !== $prefix) {
+        return;
+    }
+    
+    // strip the prefix off the class
+    $class = substr($class, $prefix_len);
+    
+    // a partial filename
+    $part = str_replace('\\', DIRECTORY_SEPARATOR, $class) . '.php';
+    
+    // directories where we can find classes
+    $dirs = array(
+        __DIR__ . DIRECTORY_SEPARATOR . 'src',
+        __DIR__ . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'src',
+    );
+    
+    // go through the directories to find classes
+    foreach ($dirs as $dir) {
+        $file = $dir . DIRECTORY_SEPARATOR . $part;
+        if (is_readable($file)) {
+            require $file;
+            return;
+        }
+    }
+});

--- a/vendor/aura/autoload/composer.json
+++ b/vendor/aura/autoload/composer.json
@@ -1,0 +1,36 @@
+{
+    "name": "aura/autoload",
+    "type": "library",
+    "description": "Provides a PSR-4 compliant autoloader implementation.",
+    "keywords": [
+        "PSR-4",
+        "autoload",
+        "autoloader",
+        "SPL autoloader",
+        "class loader"
+    ],
+    "homepage": "https://github.com/auraphp/Aura.Autoload/releases",
+    "license": "BSD-2-Clause",
+    "authors": [
+        {
+            "name": "Aura.Autoload Contributors",
+            "homepage": "https://github.com/auraphp/Aura.Autoload/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=5.3.0"
+    },
+    "autoload": {
+        "files": [
+            "autoload.php"
+        ]
+    },
+    "extra": {
+        "aura": {
+            "type": "library"
+        },
+        "branch-alias": {
+            "dev-develop-2": "2.0.x-dev"
+        }
+    }
+}

--- a/vendor/aura/autoload/src/Loader.php
+++ b/vendor/aura/autoload/src/Loader.php
@@ -1,0 +1,368 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @package Aura.Autoload
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace Aura\Autoload;
+
+/**
+ *
+ * An SPL autoloader adhering to PSR-4.
+ *
+ * @package Aura.Autoload
+ *
+ */
+class Loader
+{
+    /**
+     *
+     * A map of explicit class names to their file paths.
+     *
+     * @var array
+     *
+     */
+    protected $class_files = array();
+
+    /**
+     *
+     * Debug information populated by loadClass().
+     *
+     * @var array
+     *
+     */
+    protected $debug = array();
+
+    /**
+     *
+     * Classes, interfaces, and traits loaded by the autoloader; the key is
+     * the class name and the value is the file name.
+     *
+     * @var array
+     *
+     */
+    protected $loaded_classes = array();
+
+    /**
+     *
+     * A map of namespace prefixes to base directories.
+     *
+     * @var array
+     *
+     */
+    protected $prefixes = array();
+
+    /**
+     *
+     * Registers this autoloader with SPL.
+     *
+     * @param bool $prepend True to prepend to the autoload stack.
+     *
+     * @return null
+     *
+     */
+    public function register($prepend = false)
+    {
+        spl_autoload_register(
+            array($this, 'loadClass'),
+            true,
+            (bool) $prepend
+        );
+    }
+
+    /**
+     *
+     * Unregisters this autoloader from SPL.
+     *
+     * @return null
+     *
+     */
+    public function unregister()
+    {
+        spl_autoload_unregister(array($this, 'loadClass'));
+    }
+
+    /**
+     *
+     * Returns the debugging information array from the last loadClass()
+     * attempt.
+     *
+     * @return array
+     *
+     */
+    public function getDebug()
+    {
+        return $this->debug;
+    }
+
+    /**
+     *
+     * Adds a base directory for a namespace prefix.
+     *
+     * @param string $prefix The namespace prefix.
+     *
+     * @param string|array $base_dirs One or more base directories for the
+     * namespace prefix.
+     *
+     * @param bool $prepend If true, prepend the base directories to the
+     * prefix instead of appending them; this causes them to be searched
+     * first rather than last.
+     *
+     * @return null
+     *
+     */
+    public function addPrefix($prefix, $base_dirs, $prepend = false)
+    {
+        // normalize the namespace prefix
+        $prefix = trim($prefix, '\\') . '\\';
+
+        // initialize the namespace prefix array if needed
+        if (! isset($this->prefixes[$prefix])) {
+            $this->prefixes[$prefix] = array();
+        }
+
+        // normalize each base dir with a trailing separator
+        $base_dirs = (array) $base_dirs;
+        foreach ($base_dirs as $key => $base_dir) {
+            $base_dirs[$key] = rtrim($base_dir, DIRECTORY_SEPARATOR)
+                             . DIRECTORY_SEPARATOR;
+        }
+
+        // prepend or append?
+        if ($prepend) {
+            $this->prefixes[$prefix] = array_merge($base_dirs, $this->prefixes[$prefix]);
+        } else {
+            $this->prefixes[$prefix] = array_merge($this->prefixes[$prefix], $base_dirs);
+        }
+    }
+
+    /**
+     *
+     * Sets all namespace prefixes and their base directories. This overwrites
+     * the existing prefixes.
+     *
+     * @param array $prefixes An associative array of namespace prefixes and
+     * their base directories.
+     *
+     * @return null
+     *
+     */
+    public function setPrefixes(array $prefixes)
+    {
+        $this->prefixes = array();
+        foreach ($prefixes as $key => $val) {
+            $this->addPrefix($key, $val);
+        }
+    }
+
+    /**
+     *
+     * Returns the list of all class name prefixes and their base directories.
+     *
+     * @return array
+     *
+     */
+    public function getPrefixes()
+    {
+        return $this->prefixes;
+    }
+
+    /**
+     *
+     * Sets the explicit file path for an explicit class name.
+     *
+     * @param string $class The explicit class name.
+     *
+     * @param string $file The file path to that class.
+     *
+     * @return null
+     *
+     */
+    public function setClassFile($class, $file)
+    {
+        $this->class_files[$class] = $file;
+    }
+
+    /**
+     *
+     * Sets all file paths for all class names; this overwrites all previous
+     * explicit mappings.
+     *
+     * @param array $class_files An array of class-to-file mappings where the
+     * key is the class name and the value is the file path.
+     *
+     * @return null
+     *
+     */
+    public function setClassFiles(array $class_files)
+    {
+        $this->class_files = $class_files;
+    }
+
+    /**
+     *
+     * Adds file paths for class names to the existing explicit mappings.
+     *
+     * @param array $class_files An array of class-to-file mappings where the
+     * key is the class name and the value is the file path.
+     *
+     * @return null
+     *
+     */
+    public function addClassFiles(array $class_files)
+    {
+        $this->class_files = array_merge($this->class_files, $class_files);
+    }
+
+    /**
+     *
+     * Returns the list of explicit class names and their file paths.
+     *
+     * @return array
+     *
+     */
+    public function getClassFiles()
+    {
+        return $this->class_files;
+    }
+
+    /**
+     *
+     * Returns the list of classes, interfaces, and traits loaded by the
+     * autoloader.
+     *
+     * @return array An array of key-value pairs where the key is the class
+     * or interface name and the value is the file name.
+     *
+     */
+    public function getLoadedClasses()
+    {
+        return $this->loaded_classes;
+    }
+
+    /**
+     *
+     * Loads the class file for a given class name.
+     *
+     * @param string $class The fully-qualified class name.
+     *
+     * @return mixed The mapped file name on success, or boolean false on
+     * failure.
+     *
+     */
+    public function loadClass($class)
+    {
+        // reset debug info
+        $this->debug = array("Loading $class");
+
+        // is an explicit class file noted?
+        if (isset($this->class_files[$class])) {
+            $file = $this->class_files[$class];
+            $found = $this->requireFile($file);
+            if ($found) {
+                $this->debug[] = "Loaded from explicit: $file";
+                $this->loaded_classes[$class] = $file;
+                return $file;
+            }
+        }
+
+        // no explicit class file
+        $this->debug[] = "No explicit class file";
+
+        // the current namespace prefix
+        $prefix = $class;
+
+        // work backwards through the namespace names of the fully-qualified
+        // class name to find a mapped file name
+        while (false !== $pos = strrpos($prefix, '\\')) {
+
+            // retain the trailing namespace separator in the prefix
+            $prefix = substr($class, 0, $pos + 1);
+
+            // the rest is the relative class name
+            $relative_class = substr($class, $pos + 1);
+
+            // try to load a mapped file for the prefix and relative class
+            $file = $this->loadFile($prefix, $relative_class);
+            if ($file) {
+                $this->debug[] = "Loaded from $prefix: $file";
+                $this->loaded_classes[$class] = $file;
+                return $file;
+            }
+
+            // remove the trailing namespace separator for the next iteration
+            // of strrpos()
+            $prefix = rtrim($prefix, '\\');
+        }
+
+        // did not find a file for the class
+        $this->debug[] = "$class not loaded";
+        return false;
+    }
+
+    /**
+     *
+     * Load the mapped file for a namespace prefix and relative class.
+     *
+     * @param string $prefix The namespace prefix.
+     *
+     * @param string $relative_class The relative class name.
+     *
+     * @return mixed Boolean false if no mapped file can be loaded, or the
+     * name of the mapped file that was loaded.
+     *
+     */
+    protected function loadFile($prefix, $relative_class)
+    {
+        // are there any base directories for this namespace prefix?
+        if (! isset($this->prefixes[$prefix])) {
+            $this->debug[] = "$prefix: no base dirs";
+            return false;
+        }
+
+        // look through base directories for this namespace prefix
+        foreach ($this->prefixes[$prefix] as $base_dir) {
+
+            // replace the namespace prefix with the base directory,
+            // replace namespace separators with directory separators
+            // in the relative class name, append with .php
+            $file = $base_dir
+                  . str_replace('\\', DIRECTORY_SEPARATOR, $relative_class)
+                  . '.php';
+
+            // if the mapped file exists, require it
+            if ($this->requireFile($file)) {
+                // yes, we're done
+                return $file;
+            }
+
+            // not in the base directory
+            $this->debug[] = "$prefix: $file not found";
+        }
+
+        // never found it
+        return false;
+    }
+
+    /**
+     *
+     * If a file exists, require it from the file system.
+     *
+     * @param string $file The file to require.
+     *
+     * @return bool True if the file exists, false if not.
+     *
+     */
+    protected function requireFile($file)
+    {
+        if (file_exists($file)) {
+            require $file;
+            return true;
+        }
+        return false;
+    }
+}

--- a/vendor/aura/autoload/tests/bootstrap.php
+++ b/vendor/aura/autoload/tests/bootstrap.php
@@ -1,0 +1,16 @@
+<?php
+// turn on all errors
+error_reporting(E_ALL);
+
+// autoloader
+require dirname(__DIR__) . '/autoload.php';
+
+// default globals
+if (is_readable(__DIR__ . '/globals.dist.php')) {
+    require __DIR__ . '/globals.dist.php';
+}
+
+// override globals
+if (is_readable(__DIR__ . '/globals.php')) {
+    require __DIR__ . '/globals.php';
+}

--- a/vendor/aura/autoload/tests/phpunit.xml
+++ b/vendor/aura/autoload/tests/phpunit.xml
@@ -1,0 +1,7 @@
+<phpunit bootstrap="./bootstrap.php">
+    <testsuites>
+        <testsuite>
+            <directory>./src</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/vendor/aura/autoload/tests/src/Bar.php
+++ b/vendor/aura/autoload/tests/src/Bar.php
@@ -1,0 +1,5 @@
+<?php
+namespace Aura\Autoload;
+class Bar
+{
+}

--- a/vendor/aura/autoload/tests/src/Baz/Qux/Quux.php
+++ b/vendor/aura/autoload/tests/src/Baz/Qux/Quux.php
@@ -1,0 +1,10 @@
+<?php
+namespace Baz\Qux;
+
+class Quux
+{
+    public function exec()
+    {
+        return 'Quux';
+    }
+}

--- a/vendor/aura/autoload/tests/src/Foo.php
+++ b/vendor/aura/autoload/tests/src/Foo.php
@@ -1,0 +1,5 @@
+<?php
+namespace Aura\Autoload;
+class Foo
+{
+}

--- a/vendor/aura/autoload/tests/src/LoaderTest.php
+++ b/vendor/aura/autoload/tests/src/LoaderTest.php
@@ -1,0 +1,203 @@
+<?php
+namespace Aura\Autoload;
+
+class LoaderTest extends \PHPUnit_Framework_TestCase
+{
+    protected $loader;
+    
+    protected $base_dir;
+    
+    protected function setup()
+    {
+        $this->loader = new Loader;
+    }
+    
+    public function testRegisterAndUnregister()
+    {
+        $this->loader->register();
+        
+        $functions = spl_autoload_functions();
+        list($actual_object, $actual_method) = array_pop($functions);
+        
+        $this->assertSame($this->loader, $actual_object);
+        $this->assertSame('loadClass', $actual_method);
+        
+        // now unregister it so we don't pollute later tests
+        $this->loader->unregister();
+    }
+    
+    public function testLoadClass()
+    {
+        $class = 'Aura\Autoload\Foo';
+
+        $this->loader->addPrefix('Aura\Autoload\\', __DIR__);
+        
+        $expect_file = $this->nds(__DIR__ . '/Foo.php');
+        $actual_file = $this->nds($this->loader->loadClass($class));
+        
+        $this->assertSame($expect_file, $actual_file);
+        
+        // is it actually loaded?
+        $this->assertTrue(in_array($class, get_declared_classes()));
+        
+        // is it recorded as loaded?
+        $expect = array($class => $expect_file);
+        $actual = $this->loader->getLoadedClasses();
+        $this->assertSame($expect, $actual);
+    }
+    
+    public function testLoadClassMissing()
+    {
+        $this->loader->addPrefix('Aura\Autoload\\', __DIR__);
+        $class = 'Aura\Autoload\MissingClass';
+        $this->loader->loadClass($class);
+        $loaded = $this->loader->getLoadedClasses();
+        $this->assertFalse(isset($loaded[$class]));
+    }
+    
+    public function testAddPrefix()
+    {
+        // append
+        $this->loader->addPrefix('Foo\Bar', '/path/to/foo-bar/tests');
+        
+        // prepend
+        $this->loader->addPrefix('Foo\Bar', '/path/to/foo-bar/src', true);
+        
+        $actual = $this->nds($this->loader->getPrefixes());
+        $expect = array(
+            'Foo\Bar\\' => array(
+                $this->nds('/path/to/foo-bar/src/'),
+                $this->nds('/path/to/foo-bar/tests/'),
+            ),
+        );
+        $this->assertSame($expect, $actual);
+    }
+    
+    public function testSetPrefixes()
+    {
+        $this->loader->setPrefixes(array(
+            'Foo\Bar' => $this->nds('/foo/bar'),
+            'Baz\Dib' => $this->nds('/baz/dib'),
+            'Zim\Gir' => $this->nds('/zim/gir'),
+        ));
+        
+        $actual = $this->loader->getPrefixes();
+        $expect = array(
+            'Foo\Bar\\' => array($this->nds('/foo/bar/')),
+            'Baz\Dib\\' => array($this->nds('/baz/dib/')),
+            'Zim\Gir\\' => array($this->nds('/zim/gir/')),
+        );
+        $this->assertSame($expect, $actual);
+    }
+    
+    public function testLoadExplicitClass()
+    {
+        $class = 'Aura\Autoload\Bar';
+        $file  = $this->nds(__DIR__ . '/Bar.php');
+        $this->loader->setClassFiles(array(
+            $class => $file,
+        ));
+
+        $actual_file = $this->nds($this->loader->loadClass($class));
+        $this->assertSame($file, $actual_file);
+        
+        // is it actually loaded?
+        $this->assertTrue(in_array($class, get_declared_classes()));
+        
+        // is it recorded as loaded?
+        $expect = array($class => $file);
+        $actual = $this->loader->getLoadedClasses();
+        $this->assertSame($expect, $actual);
+    }
+    
+    public function testLoadExplicitClassMissing()
+    {
+        $class = 'Aura\Autoload\MissingClass';
+        $file  = $this->nds(__DIR__ . '/MissingClass.php');
+        $this->loader->setClassFiles(array($class => $file));
+        
+        $this->assertFalse($this->loader->loadClass($class));
+        
+        $loaded = $this->loader->getLoadedClasses();
+        $this->assertFalse(isset($loaded[$class]));
+    }
+    
+    public function testAddClassFiles()
+    {
+        $series_1 = array(
+            'FooBar'  => $this->nds('/path/to/FooBar.php'),
+            'BazDib'  => $this->nds('/path/to/BazDib.php'),
+        );
+        
+        $series_2 = array(
+            'ZimGir'  => $this->nds('/path/to/ZimGir.php'),
+            'IrkDoom' => $this->nds('/path/to/IrkDoom.php'),
+        );
+        
+        $expect = array(
+            'FooBar'  => $this->nds('/path/to/FooBar.php'),
+            'BazDib'  => $this->nds('/path/to/BazDib.php'),
+            'ZimGir'  => $this->nds('/path/to/ZimGir.php'),
+            'IrkDoom' => $this->nds('/path/to/IrkDoom.php'),
+        );
+        
+        $this->loader->addClassFiles($series_1);
+        $this->loader->addClassFiles($series_2);
+        
+        $actual = $this->loader->getClassFiles();
+        $this->assertSame($expect, $actual);
+    }
+    
+    public function testSetClassFiles()
+    {
+        $this->loader->setClassFiles(array(
+            'FooBar' => $this->nds('/path/to/FooBar.php'),
+            'BazDib' => $this->nds('/path/to/BazDib.php'),
+            'ZimGir' => $this->nds('/path/to/ZimGir.php'),
+        ));
+
+        $this->loader->setClassFile('IrkDoom', $this->nds('/path/to/IrkDoom.php'));
+
+        $expect = array(
+            'FooBar'  => $this->nds('/path/to/FooBar.php'),
+            'BazDib'  => $this->nds('/path/to/BazDib.php'),
+            'ZimGir'  => $this->nds('/path/to/ZimGir.php'),
+            'IrkDoom' => $this->nds('/path/to/IrkDoom.php'),
+        );
+        
+        $actual = $this->loader->getClassFiles();
+        $this->assertSame($expect, $actual);
+    }
+    
+    public function testGetDebug()
+    {
+        $this->loader->addPrefix('Foo\Bar', '/path/to/foo-bar');
+        $this->loader->loadClass('Foo\Bar\Baz');
+        
+        $actual = $this->loader->getDebug();
+        
+        $expect = array(
+            'Loading Foo\\Bar\\Baz',
+            'No explicit class file',
+            'Foo\\Bar\\: /path/to/foo-bar/Baz.php not found',
+            'Foo\\: no base dirs',
+            'Foo\\Bar\\Baz not loaded',
+        );
+        
+        $this->assertSame($expect, $actual);
+    }
+    
+    public function testPsr0Loading()
+    {
+        $this->loader->addPrefix('Baz\Qux', __DIR__ . '/Baz/Qux');
+        $actual = $this->nds($this->loader->loadClass('Baz\Qux\Quux'));
+        $expect = $this->nds(__DIR__ . '/Baz/Qux/Quux.php');
+        $this->assertSame($expect, $actual);
+    }
+    
+    // normalize directory separators in file names for windows compatibilitys
+    protected function nds($file)
+    {
+        return str_replace('/', DIRECTORY_SEPARATOR, $file);
+    }
+}

--- a/vendor/zencart/dashboardWidgets/src/zcDashboardWidgetBase.php
+++ b/vendor/zencart/dashboardWidgets/src/zcDashboardWidgetBase.php
@@ -1,0 +1,85 @@
+<?php namespace Zencart\DashboardWidgets;
+/**
+ * zcDashboardWidgetBase Class.
+ *
+ * @package classes
+ * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version GIT: $Id: $
+ */
+if (!defined('IS_ADMIN_FLAG')) {
+  die('Illegal Access');
+}
+/**
+ * zcDashboardWidgetBase Class
+ *
+ * @package classes
+ */
+class zcDashboardWidgetBase extends \base
+{
+  public function __construct($widgetKey, $widgetInfo = NULL)
+  {
+    $this->widgetInfo = $widgetInfo;
+    $this->widgetKey = $widgetKey;
+    $this->tplVars = array();
+    $this->tplVars['content'] = array();
+  }
+  public function prepareContent()
+  {
+    return array();
+  }
+  public function getTemplateFile()
+  {
+    $tplFile = DIR_FS_ADMIN . DIR_WS_INCLUDES . 'template/dashboardWidgets/tpl' . self::camelize(strtolower($this->widgetKey), TRUE) . '.php';
+    if (!file_exists($tplFile))
+    {
+      $tplFile = DIR_FS_ADMIN . DIR_WS_INCLUDES . 'template/dashboardWidgets/tplDefault.php';
+    }
+    return $tplFile;
+  }
+  public function getWidgetTitle()
+  {
+    $name = $this->widgetInfo['widget_name'];
+    if (defined($name)) $name = constant($name);
+    return $name;
+  }
+  public function getWidgetBaseId()
+  {
+    return strtolower(str_replace('_', '-', $this->widgetKey));
+  }
+  /**
+   * Default form validation
+   *
+   * default form only contains settings for refresh, however does need to validate the securityToken
+   * @return boolean
+   */
+  public function validateEditForm()
+  {
+    return TRUE;
+  }
+  public function getFormValidationErrors()
+  {
+    return $this->formValidationErrors;
+  }
+  public function executeEditForm()
+  {
+    if (isset($_POST['widget-refresh']))
+    {
+      $item = $_POST['id'];
+      zcWidgetManager::setWidgetRefresh($_POST['widget-refresh'], $item, $_SESSION['admin_id']);
+    }
+  }
+  public function setFormValidationErrors($errors)
+  {
+    $this->formValidationErrors = $errors;
+  }
+  public function getWidgetInfo()
+  {
+    return $this->widgetInfo;
+  }
+  public function getFormDefaults($item, $handler)
+  {
+      $result = zcWidgetManager::getWidgetRefresh($item, $_SESSION['admin_id']);
+      $handler->templateVariables['widget-refresh'] = $result;
+  }
+}


### PR DESCRIPTION
previous merge failed to pull all files due to an .gitignore entry for the vendor directory
:blush:
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/zencart/zc-v1-series/pull/98%23issuecomment-48860288%22%2C%20%22https%3A//github.com/zencart/zc-v1-series/pull/98%23issuecomment-48860349%22%2C%20%22https%3A//github.com/zencart/zc-v1-series/pull/98%23issuecomment-48860469%22%2C%20%22https%3A//github.com/zencart/zc-v1-series/pull/98%23issuecomment-48860743%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/zencart/zc-v1-series/pull/98%23issuecomment-48860288%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3A%2B1%3A%20continuation%20of%20%2395%20%22%2C%20%22created_at%22%3A%20%222014-07-14T02%3A24%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/404472%3F%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drbyte%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A-1%3A%20The%20%60vendor%60%20directory%20is%20managed%20by%20composer.%20It%20should%20never%20be%20added%20to%20source%20control%20or%20modified%20in%20any%20way.%20%20This%20is%20clearly%20a%20lack%20of%20experience%20or%20understanding%20of%20what%20composer%20does%20or%20how%20to%20use%20it.%20%20See%20%2397.%22%2C%20%22created_at%22%3A%20%222014-07-14T02%3A25%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1590605%3F%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/texdc%22%7D%7D%2C%20%7B%22body%22%3A%20%22https%3A//getcomposer.org/doc/faqs/should-i-commit-the-dependencies-in-my-vendor-directory.md%22%2C%20%22created_at%22%3A%20%222014-07-14T02%3A29%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1590605%3F%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/texdc%22%7D%7D%2C%20%7B%22body%22%3A%20%22Agreed%3A%20if%20composer%20is%20being%20relied%20upon%2C%20it%20should%20be%20left%20alone.%20%5Cr%5CnBut%2C%20it%20isn%27t.%20And%20may%20even%20be%20removed%20altogether%20as%20it%27s%20irrelevant%20to%20v1.6%5Cr%5Cn%5Cr%5CnThis%20PR%20is%20a%20hotfix%20to%20the%20prior%20commit%20which%20broke%20things.%20%20Thus%20this%20quick%20fix%20has%20been%20merged.%5Cr%5CnThe%20implementation%20is%20not%20complete.%5Cr%5Cn%5Cr%5CnYour%20PR%20%2397%20combines%20way%20too%20many%20things%20into%20one%20commit.%20Will%20deal%20with%20that%20over%20on%20%2397.%22%2C%20%22created_at%22%3A%20%222014-07-14T02%3A37%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/404472%3F%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drbyte%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/zencart/zc-v1-series/pull/98#issuecomment-48860288'>General Comment</a></b>
- <a href='https://github.com/drbyte'><img border=0 src='https://avatars.githubusercontent.com/u/404472?size=16' height=16 width=16'></a> :+1: continuation of #95
- <a href='https://github.com/texdc'><img border=0 src='https://avatars.githubusercontent.com/u/1590605?size=16' height=16 width=16'></a> :-1: The `vendor` directory is managed by composer. It should never be added to source control or modified in any way.  This is clearly a lack of experience or understanding of what composer does or how to use it.  See #97.
- <a href='https://github.com/texdc'><img border=0 src='https://avatars.githubusercontent.com/u/1590605?size=16' height=16 width=16'></a> https://getcomposer.org/doc/faqs/should-i-commit-the-dependencies-in-my-vendor-directory.md
- <a href='https://github.com/drbyte'><img border=0 src='https://avatars.githubusercontent.com/u/404472?size=16' height=16 width=16'></a> Agreed: if composer is being relied upon, it should be left alone.
  But, it isn't. And may even be removed altogether as it's irrelevant to v1.6
  This PR is a hotfix to the prior commit which broke things.  Thus this quick fix has been merged.
  The implementation is not complete.
  Your PR #97 combines way too many things into one commit. Will deal with that over on #97.

<a href='https://www.codereviewhub.com/zencart/zc-v1-series/pull/98?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/zencart/zc-v1-series/pull/98?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/zencart/zc-v1-series/pull/98'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
