### PR TITLE
Enhance some classes when loaded from administrative interface

### DIFF
--- a/includes/classes/order_total.php
+++ b/includes/classes/order_total.php
@@ -31,11 +31,10 @@ class order_total extends base {
       while (list(, $value) = each($module_list)) {
         $lang_file = null;
         $module_file = DIR_WS_MODULES . 'order_total/' . $value;
-        if(IS_ADMIN_FLAG === true) {
+        if (IS_ADMIN_FLAG === true) {
           $lang_file = zen_get_file_directory(DIR_FS_CATALOG . DIR_WS_LANGUAGES . $_SESSION['language'] . '/modules/order_total/', $value, 'false');
           $module_file = DIR_FS_CATALOG . $module_file;
-        }
-        else {
+        } else {
           $lang_file = zen_get_file_directory(DIR_WS_LANGUAGES . $_SESSION['language'] . '/modules/order_total/', $value, 'false');
         }
 

--- a/includes/classes/shipping.php
+++ b/includes/classes/shipping.php
@@ -40,14 +40,12 @@ class shipping extends base {
       }
 
       for ($i=0, $n=sizeof($include_modules); $i<$n; $i++) {
-        //          include(DIR_WS_LANGUAGES . $_SESSION['language'] . '/modules/shipping/' . $include_modules[$i]['file']);
         $lang_file = null;
         $module_file = DIR_WS_MODULES . 'shipping/' . $include_modules[$i]['file'];
-        if(IS_ADMIN_FLAG === true) {
+        if (IS_ADMIN_FLAG === true) {
           $lang_file = zen_get_file_directory(DIR_FS_CATALOG . DIR_WS_LANGUAGES . $_SESSION['language'] . '/modules/shipping/', $include_modules[$i]['file'], 'false');
           $module_file = DIR_FS_CATALOG . $module_file;
-        }
-        else {
+        } else {
           $lang_file = zen_get_file_directory(DIR_WS_LANGUAGES . $_SESSION['language'] . '/modules/shipping/', $include_modules[$i]['file'], 'false');
         }
         if (@file_exists($lang_file)) {


### PR DESCRIPTION
The changes facilitate the following:
- Allow order total modules and language files to be loaded
- Allow shipping modules and language files to be loaded

NOTES: The current Zen Cart administrative pages do not make full use of shipping modules or order total modules. In testing the existing Zen Cart administrative pages were not negatively impacted (shipping modules configuration and order total configuration). Some 3rd party modules may need to be updated to work with any Zen Cart page fully utilizing shipping modules or order total modules.