### PR TITLE
Display first comment in right info box

### DIFF
--- a/admin/orders.php
+++ b/admin/orders.php
@@ -1006,8 +1006,8 @@ if (($_GET['page'] == '' or $_GET['page'] <= 1) and $_GET['oID'] != '') {
       }
 
 // display customers comment if any exist (comment from first available order status)
-      if (zen_get_orders_comments($oInfo->orders_id) != NULL) {
-        $contents[] = array('align' => 'left', 'text' => '<br />' . TABLE_HEADING_COMMENTS . ': ' . zen_get_orders_comments($oInfo->orders_id));
+      if ($orders_comment = zen_get_orders_comments($oInfo->orders_id)) {
+        $contents[] = array('align' => 'left', 'text' => '<br />' . TABLE_HEADING_COMMENTS . ': ' . $orders_comment);
       }
 
       $contents[] = array('text' => '<br />' . zen_image(DIR_WS_IMAGES . 'pixel_black.gif','','100%','3'));


### PR DESCRIPTION
At the moment Zen Cart is just displaying 'Comments' in the right info box when selecting orders in order list view, even if it's just some comments added by status change from a payment module - or a admin. This doesn't make any sense...

I believe it's better to just display this when there is a comment from the customer (from the first available order status), and at the same time display the comment so the admin can see if it's anything important without having to open every order first. This change in code will fix that.

At the same time I added a missing translation for ordered products bellow.
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/zcwilt%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/227354%3Fv%3D1%22%7D%2C%20%22https%3A//github.com/texdc%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1590605%3Fv%3D1%22%7D%2C%20%22https%3A//github.com/syntaxerror%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/858132%3Fv%3D1%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/zencart/zc-v1-series/pull/115%23issuecomment-50601915%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222014-07-30T11%3A16%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/858132%3Fv%3D1%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/syntaxerror%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222014-07-30T22%3A33%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1590605%3Fv%3D1%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/texdc%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40syntaxerror%20thanks%21%22%2C%20%22created_at%22%3A%20%222014-07-30T22%3A33%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1590605%3Fv%3D1%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/texdc%22%7D%7D%2C%20%7B%22body%22%3A%20%22Good%20suggestion%20%40syntaxerror%20%5Cr%5CnThanks%20for%20contributing%20the%20code%21%5Cr%5CnAnd%20good%20suggestion%20from%20%40texdc%20on%20optimizing%20to%20minimize%20db%20queries%2C%20and%20make%20the%20code%20more%20performant.%5Cr%5Cn%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222014-07-31T17%3A28%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/404472%3Fv%3D1%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drbyte%22%7D%7D%2C%20%7B%22body%22%3A%20%22Just%20a%20note.%20Please%20don%27t%20suggest%20%3Ashipit%3A%20until%20at%20least%20on%20other%20person%20has%20upvoted.%20Also%20don%27t%20%3Ashipit%3A%20%20your%20own%20pr.%20%5Cr%5Cn%5Cr%5CnThat%20said%5Cr%5Cn%5Cr%5Cn%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222014-07-31T17%3A31%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/227354%3Fv%3D1%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/zcwilt%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40zcwilt%20OK%2C%20didn%27t%20know%20what%20it%20was%20about%20at%20first.%20Thought%20I%20had%20to%20approve%20something%2C%20as%20that%20button%20was%20kind%20of%20unclear%20-%20and%20I%27ve%20never%20seen%20this%20CodeReviewHub%20system%20in%20use%20before.%20But%20I%20have%20found%20some%20more%20info%20about%20it%20now%2C%20and%20I%20see%20you%27re%20working%20on%20some%20great%20docs%20for%20contributing%20also.%20%5Cr%5Cn%5Cr%5CnThanks%20for%20feedback%20and%20understanding.%20Still%20learning%20to%20fly%20here.%20%3B%29%22%2C%20%22created_at%22%3A%20%222014-07-31T18%3A33%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/858132%3Fv%3D1%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/syntaxerror%22%7D%7D%2C%20%7B%22body%22%3A%20%22No%20worries.%20You%20don%27t%20need%20to%20do%20anything%20with%20the%20CodeReviewHub%20box%20at%20all.%20That%27s%20for%20the%20core%20dev%20team%20to%20work%20with%20when%20auditing%20for%20Peer%20Review%20compliance.%22%2C%20%22created_at%22%3A%20%222014-07-31T18%3A42%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/404472%3Fv%3D1%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drbyte%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK%2C%20good%20to%20know.%20Thanks.%22%2C%20%22created_at%22%3A%20%222014-07-31T18%3A48%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/858132%3Fv%3D1%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/syntaxerror%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2074418563883faefc8dd8ab1610c29f82f0559286%20admin/orders.php%2010%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/zencart/zc-v1-series/pull/115%23discussion_r15594482%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Duplicate%20function%20call%20to%20%60zen_get_orders_comments%28%29%60.%20%20Store%20the%20result%20locally%20to%20avoid%20repetition.%5Cr%5Cn%60%60%60php%5Cr%5Cnif%20%28%24order_comments%20%3D%20zen_get_orders_comments%28%24oInfo-%3Eorders_id%29%29%20%7B%5Cr%5Cn%20%20%20%20//%20...%5Cr%5Cn%7D%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222014-07-30T16%3A19%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1590605%3Fv%3D1%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/texdc%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222014-07-30T21%3A51%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/858132%3Fv%3D1%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/syntaxerror%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20admin/orders.php%3AL1005-1019%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/zencart/zc-v1-series/pull/115%23issuecomment-50601915%22%2C%20%22https%3A//github.com/zencart/zc-v1-series/pull/115%23issuecomment-50689716%22%2C%20%22https%3A//github.com/zencart/zc-v1-series/pull/115%23issuecomment-50689759%22%2C%20%22https%3A//github.com/zencart/zc-v1-series/pull/115%23issuecomment-50791079%22%2C%20%22https%3A//github.com/zencart/zc-v1-series/pull/115%23issuecomment-50791495%22%2C%20%22https%3A//github.com/zencart/zc-v1-series/pull/115%23discussion_r15594482%22%2C%20%22https%3A//github.com/zencart/zc-v1-series/pull/115%23discussion_r15614861%22%2C%20%22https%3A//github.com/zencart/zc-v1-series/pull/115%23issuecomment-50799845%22%2C%20%22https%3A//github.com/zencart/zc-v1-series/pull/115%23issuecomment-50800984%22%2C%20%22https%3A//github.com/zencart/zc-v1-series/pull/115%23issuecomment-50801940%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/zcwilt'><img src='https://avatars.githubusercontent.com/u/227354?v=1' width=34 height=34></a><a href='https://github.com/texdc'><img src='https://avatars.githubusercontent.com/u/1590605?v=1' width=34 height=34></a><a href='https://github.com/syntaxerror'><img src='https://avatars.githubusercontent.com/u/858132?v=1' width=34 height=34></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/zencart/zc-v1-series/pull/115#issuecomment-50601915'>General Comment</a></b>
- <a href='https://github.com/syntaxerror'><img border=0 src='https://avatars.githubusercontent.com/u/858132?v=1' height=16 width=16'></a> :shipit:
- <a href='https://github.com/texdc'><img border=0 src='https://avatars.githubusercontent.com/u/1590605?v=1' height=16 width=16'></a> :shipit:
- <a href='https://github.com/texdc'><img border=0 src='https://avatars.githubusercontent.com/u/1590605?v=1' height=16 width=16'></a> @syntaxerror thanks!
- <a href='https://github.com/drbyte'><img border=0 src='https://avatars.githubusercontent.com/u/404472?v=1' height=16 width=16'></a> Good suggestion @syntaxerror
  Thanks for contributing the code!
  And good suggestion from @texdc on optimizing to minimize db queries, and make the code more performant.
  :+1:
- <a href='https://github.com/zcwilt'><img border=0 src='https://avatars.githubusercontent.com/u/227354?v=1' height=16 width=16'></a> Just a note. Please don't suggest :shipit: until at least on other person has upvoted. Also don't :shipit:  your own pr.
  That said
  :+1:
- <a href='https://github.com/syntaxerror'><img border=0 src='https://avatars.githubusercontent.com/u/858132?v=1' height=16 width=16'></a> @zcwilt OK, didn't know what it was about at first. Thought I had to approve something, as that button was kind of unclear - and I've never seen this CodeReviewHub system in use before. But I have found some more info about it now, and I see you're working on some great docs for contributing also.
  Thanks for feedback and understanding. Still learning to fly here. ;)
- <a href='https://github.com/drbyte'><img border=0 src='https://avatars.githubusercontent.com/u/404472?v=1' height=16 width=16'></a> No worries. You don't need to do anything with the CodeReviewHub box at all. That's for the core dev team to work with when auditing for Peer Review compliance.
- <a href='https://github.com/syntaxerror'><img border=0 src='https://avatars.githubusercontent.com/u/858132?v=1' height=16 width=16'></a> OK, good to know. Thanks.
- [x] <a href='#crh-comment-Pull 74418563883faefc8dd8ab1610c29f82f0559286 admin/orders.php 10'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/zencart/zc-v1-series/pull/115#discussion_r15594482'>File: admin/orders.php:L1005-1019</a></b>
- <a href='https://github.com/texdc'><img border=0 src='https://avatars.githubusercontent.com/u/1590605?v=1' height=16 width=16'></a> Duplicate function call to `zen_get_orders_comments()`.  Store the result locally to avoid repetition.

``` php
if ($order_comments = zen_get_orders_comments($oInfo->orders_id)) {
// ...
}
```

<a href='https://www.codereviewhub.com/zencart/zc-v1-series/pull/115?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/zencart/zc-v1-series/pull/115?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/zencart/zc-v1-series/pull/115?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/zencart/zc-v1-series/pull/115'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
