### PR TITLE
Failed Installation on Windows

### DIFF
--- a/zc_install/includes/classes/class.zcConfigureFileWriter.php
+++ b/zc_install/includes/classes/class.zcConfigureFileWriter.php
@@ -24,7 +24,7 @@ class zcConfigureFileWriter
     $replaceVars['ENABLE_SSL_CATALOG'] = isset($inputs['enable_ssl_catalog']) ? 'true' : 'false' ;
     $replaceVars['DIR_WS_CATALOG'] = '/' . trim($inputs['dir_ws_http_catalog'], ' /\\') . '/';
     $replaceVars['DIR_WS_HTTPS_CATALOG'] = '/' . trim($inputs['dir_ws_https_catalog'], ' /\\') . '/';
-    $replaceVars['DIR_FS_CATALOG'] = rtrim($inputs['physical_path'], '/\\') . DIRECTORY_SEPARATOR;
+    $replaceVars['DIR_FS_CATALOG'] = rtrim($inputs['physical_path'], '/\\') . '/';
     $replaceVars['DB_TYPE'] = trim($inputs['db_type']);
     $replaceVars['DB_PREFIX'] = trim($inputs['db_prefix']);
     $replaceVars['DB_CHARSET'] = trim($inputs['db_charset']);


### PR DESCRIPTION
Looks like the DIRECTORY_SEPARATOR constant made both admin and catalog
configure.php file messed up.

Just a reminder, if that constant return '\' on Windows. I think it's better to
just use '/'
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/zencart/zc-v1-series/pull/116%23issuecomment-51128706%22%2C%20%22https%3A//github.com/zencart/zc-v1-series/pull/116%23issuecomment-51147485%22%2C%20%22https%3A//github.com/zencart/zc-v1-series/pull/116%23issuecomment-51256836%22%2C%20%22https%3A//github.com/zencart/zc-v1-series/pull/116%23issuecomment-51379103%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/zencart/zc-v1-series/pull/116%23issuecomment-51128706%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27ve%20checked%20the%20%5Bphp%20bugs%20site%5D%28https%3A//bugs.php.net/search.php%3Fcmd%3Ddisplay%26search_for%3DDIRECTORY_SEPARATOR%26x%3D0%26y%3D0%29%20and%20didn%27t%20find%20anything.%20%20Could%20someone%20else%20verify%20this%20under%20Windows%3F%20%20Also%2C%20we%27ll%20probably%20need%20more%20information%2C%20such%20as%20an%20example%20of%20how%20it%27s%20%5C%22messed%20up%5C%22.%5Cr%5Cn%5Cr%5CnRegardless%2C%20I%20don%27t%20have%20a%20problem%20with%20this%20change%20as%20it%20makes%20it%20consistent%20with%20the%20rest%20of%20the%20directory%20strings.%22%2C%20%22created_at%22%3A%20%222014-08-04T22%3A49%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1590605%3Fv%3D2%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/texdc%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20%5C%22messed%20up%5C%22%20configure.php%20file%20I%20meant%20is%20related%20to%20quote%20escape.%5Cr%5CnPlease%20take%20a%20look%20at%20code%20below.%20%5Cr%5Cn%5Cr%5Cn%60%60%60php%5Cr%5Cndefine%28%27DIR_FS_CATALOG%27%2C%20%27C%3A/xampp/htdocs/160%5C%5C%27%29%3B%5Cr%5Cn%5Cr%5Cn/%2A%2A%5Cr%5Cn%20%2A%20The%20following%20settings%20define%20your%20database%20connection.%5Cr%5Cn%20%2A%20These%20must%20be%20the%20SAME%20as%20you%27re%20using%20in%20your%20non-admin%20copy%20of%20configure.php%5Cr%5Cn%20%2A/%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnIt%20should%20be%20like%20this%5Cr%5Cn%5Cr%5Cn%60%60%60php%5Cr%5Cndefine%28%27DIR_FS_CATALOG%27%2C%20%27C%3A/xampp/htdocs/160/%27%29%3B%5Cr%5Cn%5Cr%5Cn/%2A%2A%5Cr%5Cn%20%2A%20The%20following%20settings%20define%20your%20database%20connection.%5Cr%5Cn%20%2A%20These%20must%20be%20the%20SAME%20as%20you%27re%20using%20in%20your%20non-admin%20copy%20of%20configure.php%5Cr%5Cn%20%2A/%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222014-08-05T04%3A01%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1428276%3Fv%3D2%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/IronLady%22%7D%7D%2C%20%7B%22body%22%3A%20%22Agreed%20on%20the%20consistency%20remark.%20I%20we%20were%20using%20DIRECTORY_SEPARATOR%20ubiquitously%2C%20then%20it%20would%20be%20something%20to%20look%20into.%5Cr%5CnOtherwise%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222014-08-05T20%3A43%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/227354%3Fv%3D2%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/zcwilt%22%7D%7D%2C%20%7B%22body%22%3A%20%22Agreed%20there%20needs%20to%20be%20some%20escaping%20or%20translating%2C%20based%20on%20the%20OS%2C%20if%20using%20DIRECTORY_SEPARATOR.%5Cr%5CnGenerally%20the%20use%20of%20%27/%27%20is%20perfectly%20sufficient.%5Cr%5Cn%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222014-08-06T18%3A48%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/404472%3Fv%3D2%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drbyte%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/zencart/zc-v1-series/pull/116#issuecomment-51128706'>General Comment</a></b>
- <a href='https://github.com/texdc'><img border=0 src='https://avatars.githubusercontent.com/u/1590605?v=2' height=16 width=16'></a> I've checked the [php bugs site](https://bugs.php.net/search.php?cmd=display&search_for=DIRECTORY_SEPARATOR&x=0&y=0) and didn't find anything.  Could someone else verify this under Windows?  Also, we'll probably need more information, such as an example of how it's "messed up".
  Regardless, I don't have a problem with this change as it makes it consistent with the rest of the directory strings.
- <a href='https://github.com/IronLady'><img border=0 src='https://avatars.githubusercontent.com/u/1428276?v=2' height=16 width=16'></a> The "messed up" configure.php file I meant is related to quote escape.
  Please take a look at code below.

``` php
define('DIR_FS_CATALOG', 'C:/xampp/htdocs/160\');
/**
* The following settings define your database connection.
* These must be the SAME as you're using in your non-admin copy of configure.php
*/
```

It should be like this

``` php
define('DIR_FS_CATALOG', 'C:/xampp/htdocs/160/');
/**
* The following settings define your database connection.
* These must be the SAME as you're using in your non-admin copy of configure.php
*/
```
- <a href='https://github.com/zcwilt'><img border=0 src='https://avatars.githubusercontent.com/u/227354?v=2' height=16 width=16'></a> Agreed on the consistency remark. I we were using DIRECTORY_SEPARATOR ubiquitously, then it would be something to look into.
  Otherwise :+1:
- <a href='https://github.com/drbyte'><img border=0 src='https://avatars.githubusercontent.com/u/404472?v=2' height=16 width=16'></a> Agreed there needs to be some escaping or translating, based on the OS, if using DIRECTORY_SEPARATOR.
  Generally the use of '/' is perfectly sufficient.
  :+1:

<a href='https://www.codereviewhub.com/zencart/zc-v1-series/pull/116?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/zencart/zc-v1-series/pull/116?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/zencart/zc-v1-series/pull/116'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
