### PR TITLE
Habitat support -- for VM dev env, pre-enter db pwd and bypass admin rename

### DIFF
--- a/admin/includes/init_includes/init_admin_auth.php
+++ b/admin/includes/init_includes/init_admin_auth.php
@@ -12,8 +12,14 @@ define('SUPERUSER_PROFILE', 1);
 $page = zcRequest::readGet('cmd', basename($PHP_SELF, ".php"));
 $hasDoneStartWizard = TRUE;
 
+$val = getenv('HABITAT');
+$habitat = false;
+if ($val == 'zencart' || $_SERVER['USER'] == 'vagrant') {
+  $habitat = true;
+}
+
 // admin folder rename required
-if (! defined('ADMIN_BLOCK_WARNING_OVERRIDE') || ADMIN_BLOCK_WARNING_OVERRIDE == '')
+if ((!defined('ADMIN_BLOCK_WARNING_OVERRIDE') || ADMIN_BLOCK_WARNING_OVERRIDE == '') && ($habitat == false))
 {
   if ($page != FILENAME_ALERT_PAGE)
   {

--- a/zc_install/includes/application_top.php
+++ b/zc_install/includes/application_top.php
@@ -14,6 +14,11 @@ if (file_exists(DIR_FS_INSTALL . 'includes/localConfig.php')) {
   require (DIR_FS_INSTALL . 'includes/localConfig.php');
 }
 
+$envHabitat = getenv('HABITAT') ;
+if ($envHabitat == 'zencart' || $_SERVER['USER'] == 'vagrant') {
+  define('DEVELOPER_MODE', true);
+}
+
 $controller = 'main';
 /* detect CLI params */
 if (isset($argc) && $argc > 0) {

--- a/zc_install/includes/modules/pages/admin_setup/header_php.php
+++ b/zc_install/includes/modules/pages/admin_setup/header_php.php
@@ -16,7 +16,7 @@
     $adminDir = $adminNewDir;
   }
 // echo '<pre>'. print_r($_POST, TRUE) . '</pre>';
-   if (defined('DEVELOPER_MODE') && DEVELOPER_MODE == true)
+   if (defined('DEVELOPER_MODE') && DEVELOPER_MODE === true)
    {
      $admin_password = 'developer1';
    } else {

--- a/zc_install/includes/modules/pages/database/header_php.php
+++ b/zc_install/includes/modules/pages/database/header_php.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package Installer
- * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @copyright Copyright 2003-2014 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id:
  */
@@ -15,6 +15,10 @@ $sqlCacheType = array(array('id' => 'none', 'text' => TEXT_DATABASE_SETUP_CACHE_
 $sqlCacheTypeOptions = zen_get_select_options($sqlCacheType, isset($sql_cache_method) ? $sql_cache_method : '');
 $db_host = isset($db_host) ? $db_host : 'localhost';
 $db_name = isset($db_name) ? $db_name : 'zencart';
+if (defined('DEVELOPER_MODE') && DEVELOPER_MODE === true) {
+  $db_user = (isset($db_user)) ? $db_user : 'zencart';
+  $db_password = (isset($db_password)) ? $db_password : 'zencart';
+}
 
 // attempt to intelligently manage user-adjusted subdirectory values if they are different from detected defaults
 if ($_POST['http_server_catalog'] != $_POST['detected_http_server_catalog']) $_POST['dir_ws_http_catalog'] = rtrim(str_replace($_POST['http_server_catalog'], '', $_POST['http_url_catalog']), '/') .'/';

--- a/zc_install/includes/template/templates/completion_default.php
+++ b/zc_install/includes/template/templates/completion_default.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package Installer
- * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @copyright Copyright 2003-2014 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id:
  */
@@ -16,14 +16,14 @@
  <?php if ($catalogLink != '#') echo TEXT_COMPLETION_INSTALL_LINKS_BELOW; ?>
 </div>
 <?php } ?>
-<?php if ($_POST['admin_directory'] == 'admin') { ?>
+<?php if ($_POST['admin_directory'] == 'admin' && !defined('DEVELOPER_MODE')) { ?>
 <br>
 <div class="alert-box alert">
 <?php echo TEXT_COMPLETION_ADMIN_DIRECTORY_WARNING; ?>
 </div>
 <br>
 <?php } ?>
-<?php if (file_exists(DIR_FS_INSTALL)) { ?>
+<?php if (file_exists(DIR_FS_INSTALL) && !defined('DEVELOPER_MODE')) { ?>
 <br>
 <div class="alert-box alert">
 <?php echo TEXT_COMPLETION_INSTALLATION_DIRECTORY_WARNING; ?>


### PR DESCRIPTION
Habitat support -- for VM dev environments, pre-enter db pwd during zc_install, and bypass admin rename
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/zencart/zc-v1-series/pull/127%23issuecomment-52389206%22%2C%20%22https%3A//github.com/zencart/zc-v1-series/pull/127%23issuecomment-52403801%22%2C%20%22https%3A//github.com/zencart/zc-v1-series/pull/127%23issuecomment-52485428%22%2C%20%22https%3A//github.com/zencart/zc-v1-series/pull/127%23issuecomment-52485455%22%2C%20%22https%3A//github.com/zencart/zc-v1-series/pull/127%23issuecomment-52498764%22%2C%20%22https%3A//github.com/zencart/zc-v1-series/pull/127%23issuecomment-52789136%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/zencart/zc-v1-series/pull/127%23issuecomment-52389206%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Question%3A%20Could%20some%20%28or%20all%29%20of%20this%20be%20added%20to%20the%20testing%20environment%20setup%20instead%3F%22%2C%20%22created_at%22%3A%20%222014-08-16T10%3A07%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2963958%3Fv%3D2%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lhungil%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40lhungil%20No%2C%20unfortunately%20these%20components%20are%20edited%20in%20core%20specifically%20so%20that%20the%20testing%20environment%20can%20properly%20integrate%20with%20core%20code.%22%2C%20%22created_at%22%3A%20%222014-08-16T19%3A42%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/404472%3Fv%3D2%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drbyte%22%7D%7D%2C%20%7B%22body%22%3A%20%22Just%20to%20expand%20on%20what%20Chris%20has%20said.%20The%20habitat%20vm%20itself%20uses%20certain%20defaults.%20e.g.%20the%20default%20user/pwd%20for%20mysql.%20To%20support%20this%2C%20the%20installer%20itself%20needs%20to%20set%20these.%20%20We%20could%20of%20course%20allow%20for%20configuration%20in%20the%20vm%20provisioner%2C%20to%20allow%20for%20setting%20such%20things%20as%20a%20different%20user/pwd%20for%20mysql%2C%20but%20this%20would%20complicate%20the%20configuration%20system%20and%20the%20provisioner.%20%5Cr%5Cn%5Cr%5CnThe%20idea%20here%20is%20to%20make%20the%20workflow%20of%20doing%20an%20install%20in%20the%20vm%20as%20simple%20as%20possible.%20%22%2C%20%22created_at%22%3A%20%222014-08-18T12%3A30%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/227354%3Fv%3D2%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/zcwilt%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222014-08-18T12%3A30%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/227354%3Fv%3D2%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/zcwilt%22%7D%7D%2C%20%7B%22body%22%3A%20%22Adding%20code%20to%20files%20required%20for%20normal%20operation%20in%20a%20production%20environment%20for%20the%20sole%20purpose%20of%20testing%20is%20not%20an%20ideal%20solution.%20I%27m%20looking%20specifically%20at%20you%20%5C%22/admin/includes/init_includes/init_admin_auth.php%5C%22.%20I%27d%20prefer%20to%20see%20the%20changes%20in%20this%20file%20reverted%20and%20the%20installer%20in%20%5C%22DEVELOPER_MODE%5C%22%20rename%20the%20admin%20folder%20to%20something%20easy%20to%20remember%20for%20testing%20such%20as%20%5C%22manage%5C%22%2C%20%5C%22backend%5C%22%2C%20etc.%5Cr%5Cn%5Cr%5CnAs%20for%20the%20changes%20under%20%5C%22/zc_install%5C%22%20%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222014-08-18T14%3A23%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2963958%3Fv%3D2%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lhungil%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20Reviewed%20and%20looks%20good%22%2C%20%22created_at%22%3A%20%222014-08-20T14%3A51%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1992427%3Fv%3D2%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ajeh%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/zencart/zc-v1-series/pull/127#issuecomment-52389206'>General Comment</a></b>
- <a href='https://github.com/lhungil'><img border=0 src='https://avatars.githubusercontent.com/u/2963958?v=2' height=16 width=16'></a> Question: Could some (or all) of this be added to the testing environment setup instead?
- <a href='https://github.com/drbyte'><img border=0 src='https://avatars.githubusercontent.com/u/404472?v=2' height=16 width=16'></a> @lhungil No, unfortunately these components are edited in core specifically so that the testing environment can properly integrate with core code.
- <a href='https://github.com/zcwilt'><img border=0 src='https://avatars.githubusercontent.com/u/227354?v=2' height=16 width=16'></a> Just to expand on what Chris has said. The habitat vm itself uses certain defaults. e.g. the default user/pwd for mysql. To support this, the installer itself needs to set these.  We could of course allow for configuration in the vm provisioner, to allow for setting such things as a different user/pwd for mysql, but this would complicate the configuration system and the provisioner.
  The idea here is to make the workflow of doing an install in the vm as simple as possible.
- <a href='https://github.com/zcwilt'><img border=0 src='https://avatars.githubusercontent.com/u/227354?v=2' height=16 width=16'></a> :+1:
- <a href='https://github.com/lhungil'><img border=0 src='https://avatars.githubusercontent.com/u/2963958?v=2' height=16 width=16'></a> Adding code to files required for normal operation in a production environment for the sole purpose of testing is not an ideal solution. I'm looking specifically at you "/admin/includes/init_includes/init_admin_auth.php". I'd prefer to see the changes in this file reverted and the installer in "DEVELOPER_MODE" rename the admin folder to something easy to remember for testing such as "manage", "backend", etc.
  As for the changes under "/zc_install" :+1:
- <a href='https://github.com/ajeh'><img border=0 src='https://avatars.githubusercontent.com/u/1992427?v=2' height=16 width=16'></a> :+1: Reviewed and looks good

<a href='https://www.codereviewhub.com/zencart/zc-v1-series/pull/127?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/zencart/zc-v1-series/pull/127?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/zencart/zc-v1-series/pull/127'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
