### PR TITLE
Page not found when incorrect EZPage link remove status

### DIFF
--- a/includes/modules/pages/page/header_php.php
+++ b/includes/modules/pages/page/header_php.php
@@ -36,7 +36,6 @@ if ($var_pageDetails->EOF) {
   require(DIR_WS_MODULES . zen_get_module_directory('require_languages.php'));
   $messageStack->add_session('header', ERROR_PAGE_NOT_FOUND, 'caution');
   header('HTTP/1.1 404 Not Found');
-  header('Status: 404 Not Found');
   zen_redirect(zen_href_link(FILENAME_DEFAULT));
 }
 


### PR DESCRIPTION
Page not found when incorrect EZPage link
This appears most often on FastCGI
Removing it corrects the issue
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/zencart/zc-v1-series/pull/152%23issuecomment-54875064%22%2C%20%22https%3A//github.com/zencart/zc-v1-series/pull/152%23issuecomment-55200508%22%2C%20%22https%3A//github.com/zencart/zc-v1-series/pull/152%23issuecomment-55298366%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/zencart/zc-v1-series/pull/152%23issuecomment-54875064%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3A%2B1%3A%20%5Cr%5Cn%5Cr%5CnThis%20has%20been%20discussed%20with%20many%20users%20via%20the%20forum.%20I%20agree%20with%20the%20fix%2C%20although%20I%27ve%20not%20regression-tested%20it%20in%20the%20environments%20those%20users%20say%20they%27re%20using.%20The%20change%20makes%20the%20code%20consistent%20with%20the%20way%20we%27ve%20implemented%20those%20calls%20elsewhere%20in%20the%20code.%22%2C%20%22created_at%22%3A%20%222014-09-08T19%3A38%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/404472%3Fv%3D2%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drbyte%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222014-09-10T23%3A38%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1590605%3Fv%3D2%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/texdc%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222014-09-11T17%3A27%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/227354%3Fv%3D2%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/zcwilt%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/zcwilt%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/227354%3Fv%3D2%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/zcwilt'><img src='https://avatars.githubusercontent.com/u/227354?v=2' width=34 height=34></a>
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/zencart/zc-v1-series/pull/152#issuecomment-54875064'>General Comment</a></b>
- <a href='https://github.com/drbyte'><img border=0 src='https://avatars.githubusercontent.com/u/404472?v=2' height=16 width=16'></a> :+1:
  This has been discussed with many users via the forum. I agree with the fix, although I've not regression-tested it in the environments those users say they're using. The change makes the code consistent with the way we've implemented those calls elsewhere in the code.

<a href='https://www.codereviewhub.com/zencart/zc-v1-series/pull/152?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/zencart/zc-v1-series/pull/152?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/zencart/zc-v1-series/pull/152?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/zencart/zc-v1-series/pull/152'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
