### PR TITLE
Fixes #128 - Change display of Admin login password expiry and session logout notices

### DIFF
--- a/admin/includes/languages/english/login.php
+++ b/admin/includes/languages/english/login.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @copyright Copyright 2003-2014 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version GIT: $Id: Author: DrByte  Mon Jul 16 14:10:24 2012 -0400 Modified in v1.5.1 $
@@ -21,7 +21,7 @@ define('ERROR_SECURITY_ERROR', 'There was a security error when trying to login.
 
 define('TEXT_PASSWORD_FORGOTTEN', 'Forgot Password');
 
-define('LOGIN_EXPIRY_NOTICE', 'Please be aware that after ' . round(SESSION_TIMEOUT_ADMIN/60) . ' minutes of inactivity, you will be required to login again.<br /><br />Note: All passwords expire after 90 days, at which time you will be prompted for a new password.');
+define('LOGIN_EXPIRY_NOTICE', '');
 define('ERROR_PASSWORD_EXPIRED', 'NOTE: Your password has expired. Please select a new password. Your password <strong>must contain both NUMBERS and LETTERS and minimum 7 characters.</strong>');
 define('TEXT_TEMPORARY_PASSWORD_MUST_BE_CHANGED', 'For security reasons, your temporary password needs to be changed. Please select a new password.<br />Your password <strong>must contain both NUMBERS and LETTERS and minimum 7 characters.</strong>');
 


### PR DESCRIPTION
Fixes #128 - Change display of Admin login password expiry and session logout notices

For some reason, modern-day computer users don't understand the concept of "password expiration" as well as people accustomed to using client-server or mainframe systems, and thus tend to become paranoid at the concept of a password "expiring". They think they'll be locked out, rather than merely required to provide a new password on a scheduled cycle.

This commit simply removes the language causing the confusion. Less is more.
