### PR TITLE
Fixes #172 - Pagination issue with single-item-on-next-page

### DIFF
--- a/includes/modules/pages/index/header_php.php
+++ b/includes/modules/pages/index/header_php.php
@@ -65,11 +65,11 @@ if (true)
   $box = new zcListingBoxProductsDefault ();
   $box->init ();
   $tplVars['listingBox'] = $box->getTemplateVariables ();
-  if ($category_depth == 'products' && !$box->getHasContent ())
-    $robotsNoIndex = true;
+  if ($category_depth == 'products' && !$box->getHasContent ()) $robotsNoIndex = true;
   if (SKIP_SINGLE_PRODUCT_CATEGORIES == 'True' and (! isset ( $_GET['filter_id'] ) and ! isset ( $_GET['alpha_filter'] )))
   {
-    if ($box->getFormattedItemsCount () == 1)
+    // If there is only one item in the list, and the total items available including pagination is still only 1, redirect directly to the product page
+    if ($box->getFormattedItemsCount () == 1 && $box->paginator->getAdapter()->getTotalItems() < 2)
     {
       zen_redirect ( zen_href_link ( zen_get_info_page ( $tplVars['listingBox']['items'][0]['products_id'] ), ($cPath ? 'cPath=' . $tplVars['listingBox']['items'][0]['productCpath'] . '&' : '') . 'products_id=' . $tplVars['listingBox']['items'][0]['products_id'] ) );
     }


### PR DESCRIPTION
Stops the one-product-in-list redirect from happening if more than 1 item is available in the selected category.
