### PR TITLE
Closes #184 - Stop making configure.php read-only

### DIFF
--- a/includes/functions/functions_general.php
+++ b/includes/functions/functions_general.php
@@ -1534,7 +1534,7 @@ if (!defined('IS_ADMIN_FLAG')) {
     $fp = @fopen($filepath, 'a');
     if ($fp) {
       @fclose($fp);
-      if ($make_unwritable) set_unwritable($filepath);
+//       if ($make_unwritable) set_unwritable($filepath);
       $fp = @fopen($filepath, 'a');
       if ($fp) {
         @fclose($fp);


### PR DESCRIPTION
Stop making configure.php read-only (after a period of open discussion)

(And, yes, this is intentionally merely commented-out, and may remain so for a period of deprecation, and then refactored out in a subsequent version.)
