### PR TITLE
Add phpDocumentor configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ includes/configure.php
 local/configure.php
 includes/local/configure.php
 admin/includes/local/configure.php
+docs/phpdocs*
+phpdoc.xml
 dbencdata*.ini
 testFramework/webtests/config/*
 !testFramework/webtests/config/localconfig_EXAMPLE.php

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "require-dev": {
         "phpunit/phpunit": "~4.0",
         "phpmd/phpmd": "~2.0",
+        "phpdocumentor/phpdocumentor": "2.*",
         "squizlabs/php_codesniffer": "~1.4",
         "satooshi/php-coveralls": "~0.6"
     },

--- a/docs/phpdoc.dist.xml
+++ b/docs/phpdoc.dist.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<phpdocumentor>
+    <title>Zen Cart v1.6.0 phpDocs</title>
+    <parser>
+        <default-package-name>general</default-package-name>
+        <target>./phpdocs</target>
+    </parser>
+    <transformer>
+      <target>./phpdocs</target>
+    </transformer>
+    <files>
+        <file>../index.php</file>
+        <directory>../includes</directory>
+        <directory>../admin</directory>
+        <ignore>includes/classes/support/*</ignore>
+        <ignore>includes/classes/vendors/*</ignore>
+        <ignore>includes/library/*</ignore>
+        <ignore>admin/includes/library/*</ignore>
+        <directory>../admin/includes/library/zencart</directory>
+        <directory>../includes/library/zencart</directory>
+        <file>../ipn_main_handler.php</file>
+        <file>../page_not_found.php</file>
+    </files>
+    <plugins>
+        <plugin path="Core" />
+    </plugins>
+    <transformations>
+        <template name="responsive" />
+    </transformations>
+</phpdocumentor>


### PR DESCRIPTION
Add phpDocumentor configuration
This is the bare essentials for phpDocumentor.

Simply run `phpdoc` from the `/docs/` folder.

To customize, copy the `/docs/phpdoc.dist.xml` to `/docs/phpdoc.xml` and make your desired changes, then run `phpdoc` to regenerate. The `phpdoc.xml` file is your custom file and will be ignored by git.
