### PR TITLE
Discount Coupons accepted with or without spaces

### DIFF
--- a/includes/modules/order_total/ot_coupon.php
+++ b/includes/modules/order_total/ot_coupon.php
@@ -147,6 +147,7 @@ class ot_coupon {
   function collect_posts() {
     global $db, $currencies, $messageStack, $order;
     global $discount_coupon;
+    $_POST['dc_redeem_code'] = trim($_POST['dc_redeem_code']);
     // remove discount coupon by request
     if (isset($_POST['dc_redeem_code']) && strtoupper($_POST['dc_redeem_code']) == 'REMOVE') {
       unset($_POST['dc_redeem_code']);


### PR DESCRIPTION
Correct accept Discount Coupon when spaces are on Discount Code. This is typical of a copy & paste.
