### PR TITLE
Remove define HEADING_COUPON_HELP it has never been used

### DIFF
--- a/includes/languages/english/discount_coupon.php
+++ b/includes/languages/english/discount_coupon.php
@@ -14,7 +14,6 @@ define('TEXT_INFORMATION', '');
 define('TEXT_COUPON_FAILED', '<span class="alert important">%s</span> does not appear to be a valid Coupon Redemption Code. Please try typing it in again.');
 define('TEXT_COUPON_INACTIVE', '<span class="alert important">%s</span> is expired or no longer valid.');
 
-define('HEADING_COUPON_HELP', 'Discount Coupon Help');
 define('TEXT_COUPON_HELP_HEADER', '<p class="bold">The Discount Coupon Redemption Code you have entered is for ');
 define('TEXT_COUPON_HELP_NAME', '\'%s\'. </p>');
 define('TEXT_COUPON_HELP_FIXED', '<p>The coupon is worth %s discount against your order</p>');

--- a/includes/languages/english/popup_coupon_help.php
+++ b/includes/languages/english/popup_coupon_help.php
@@ -7,7 +7,6 @@
  * @version $Id: popup_coupon_help.php 14141 2009-08-10 19:34:47Z wilt $
  */
 
-define('HEADING_COUPON_HELP', 'Discount Coupon Help');
 define('TEXT_COUPON_HELP_HEADER', '<strong>The Discount Coupon Redemption Code you have entered is for</strong> ');
 define('TEXT_COUPON_HELP_NAME', '<br /><br />Coupon Name : %s');
 define('TEXT_COUPON_HELP_FIXED', '<p>The coupon is worth %s discount against your order</p>');


### PR DESCRIPTION
No version of Zen Cart has ever used these constants
