### PR TITLE
Poor scoping in action class, affecting admin templates

### DIFF
--- a/admin/includes/classes/actions/class.zcActionAdminBase.php
+++ b/admin/includes/classes/actions/class.zcActionAdminBase.php
@@ -43,6 +43,7 @@ abstract class zcActionAdminBase extends base
     {
         global $extraCss, $PHP_SELF, $messageStack, $new_gv_queue_cnt, $goto_gv, $new_version;
         global $hide_languages, $languages, $languages_array, $languages_selected;
+        $this->templateVariables['cmd'] = $this->request->readGet('cmd');
         if ($this->useView) {
             if (isset($extraCss))
                 $this->templateVariables ['extraCss'] = $extraCss;

--- a/admin/includes/template/common/tplHeader.php
+++ b/admin/includes/template/common/tplHeader.php
@@ -56,7 +56,7 @@ if ($tplVars['messageStack']->size > 0) {
     <td class="headerBarContent" align="left">
       <?php
       if (!$tplVars['hide_languages']) {
-        echo zen_draw_form('languages', $zcRequest->readGet('cmd'), '', 'get');
+        echo zen_draw_form('languages', $tplVars['cmd'], '', 'get');
         echo DEFINE_LANGUAGE . '&nbsp;&nbsp;' . (sizeof($tplVars['languages']) > 1 ? zen_draw_pull_down_menu('language', $tplVars['languages_array'], $tplVars['languages_selected'], 'onChange="this.form.submit();"') : '');
         echo zen_hide_session_id();
         echo zen_post_all_get_params(array('language'));


### PR DESCRIPTION
Poor scoping in action class means $zcRequest is not available in templates

Fixes #200

tplHeader directly addresses the $zcRequest variable when multiple languages are installed.
However on the home page which is served via an Action Class, $zcRequest is not in the global scope, as templates are rendered using a method of the ActionAdminBase class.

Need to add a template variable to pass in the current cmd param so this can be rendered correctly in the tplHeader template.

It should be noted also that the action class stuff is due for a refactor, and this will be done shortly
