### PR TITLE
Deprecate zen_random_select()

### DIFF
--- a/includes/functions/functions_general.php
+++ b/includes/functions/functions_general.php
@@ -1057,21 +1057,6 @@ if (!defined('IS_ADMIN_FLAG')) {
 
 
 ////
-// Return a random row from a database query
-  function zen_random_select($query) {
-    global $db;
-    $random_product = '';
-    $random_query = $db->Execute($query);
-    $num_rows = $random_query->RecordCount();
-    if ($num_rows > 1) {
-      $random_row = zen_rand(0, ($num_rows - 1));
-      $random_query->Move($random_row);
-    }
-    return $random_query;
-  }
-
-
-////
 // Truncate a string
   function zen_trunc_string($str = "", $len = 150, $more = 'true') {
     if ($str == "") return $str;

--- a/includes/modules/sideboxes/featured.php
+++ b/includes/modules/sideboxes/featured.php
@@ -3,7 +3,7 @@
  * featured sidebox - displays a random Featured Product
  *
  * @package templateSystem
- * @copyright Copyright 2003-2007 Zen Cart Development Team
+ * @copyright Copyright 2003-2014 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: featured.php 6475 2007-06-08 21:10:33Z ajeh $
@@ -25,7 +25,6 @@
                            and pd.language_id = '" . (int)$_SESSION['languages_id'] . "'";
 
     // randomly select ONE featured product from the list retrieved:
-    //$random_featured_product = zen_random_select($random_featured_products_query);
     $random_featured_product = $db->ExecuteRandomMulti($random_featured_products_query, MAX_RANDOM_SELECT_FEATURED_PRODUCTS);
 
     if ($random_featured_product->RecordCount() > 0)  {
@@ -35,4 +34,3 @@
       require($template->get_template_dir($column_box_default, DIR_WS_TEMPLATE, $current_page_base,'common') . '/' . $column_box_default);
     }
   }
-?>

--- a/includes/modules/sideboxes/specials.php
+++ b/includes/modules/sideboxes/specials.php
@@ -32,7 +32,6 @@
                              and pd.language_id = '" . (int)$_SESSION['languages_id'] . "'
                              and s.status = 1";
 
-//    $random_specials_sidebox_product = zen_random_select($random_specials_sidebox_product_query);
     $random_specials_sidebox_product = $db->ExecuteRandomMulti($random_specials_sidebox_product_query, MAX_RANDOM_SELECT_SPECIALS);
 
     if ($random_specials_sidebox_product->RecordCount() > 0)  {

--- a/includes/modules/sideboxes/whats_new.php
+++ b/includes/modules/sideboxes/whats_new.php
@@ -20,7 +20,6 @@
                            and pd.language_id = '" . (int)$_SESSION['languages_id'] . "'
                            and p.products_status = 1 " . $display_limit;
 
-//  $random_whats_new_sidebox_product = zen_random_select($random_whats_new_sidebox_product_query);
   $random_whats_new_sidebox_product = $db->ExecuteRandomMulti($random_whats_new_sidebox_product_query, MAX_RANDOM_SELECT_NEW);
 
   if ($random_whats_new_sidebox_product->RecordCount() > 0 ) {


### PR DESCRIPTION
Deprecating unused function zen_random_select() in favor of ExecuteRandomMulti or perhaps "order by rand".
It's not only unused in core code, it also randomly causes a bug in the queryFactory iterator, so requires fixing or removal. Currently choosing to remove.
