### PR TITLE
Simplify result randomization

### DIFF
--- a/includes/classes/db/mysql/query_factory.php
+++ b/includes/classes/db/mysql/query_factory.php
@@ -320,13 +320,8 @@ class queryFactory extends base {
         unset($zp_ii, $zp_result_array, $key, $value);
         $obj->EOF = false;
 
-        $obj->result_random = array_rand($obj->result, count($obj->result));
-        if(is_array($obj->result_random)) {
-          shuffle($obj->result_random);
-        }
-        else {
-          $obj->result_random = array(0 => $obj->result_random);
-        }
+        $obj->result_random = $obj->result;
+        shuffle($obj->result_random);
         $obj->cursor = -1;
         $obj->MoveNextRandom();
       }


### PR DESCRIPTION
The second argument for [array_rand](http://php.net/manual/en/function.array-rand.php) must be between 1 and the size of the array, not 0.  But, [shuffle](http://php.net/manual/en/function.shuffle.php) is sufficient.

Fixes #206
