### PR TITLE
Fixes #206 - bug with random result selection

### DIFF
--- a/includes/classes/db/mysql/query_factory.php
+++ b/includes/classes/db/mysql/query_factory.php
@@ -298,11 +298,11 @@ class queryFactory extends base {
 
       $zp_rows = $obj->RecordCount();
       if ($zp_rows > 0 && $zf_limit > 0) {
-        $zp_Start_row = 0;
+        $zp_start_row = 0;
         if ($zf_limit) {
           $zp_start_row = zen_rand(0, $zp_rows - $zf_limit);
         }
-        $obj->Move($zp_start_row);
+        mysqli_data_seek($zp_db_resource, $zp_start_row);
         $zp_ii = 0;
         while ($zp_ii < $zf_limit) {
           $zp_result_array = @mysqli_fetch_array($zp_db_resource);


### PR DESCRIPTION
The problem here was that originally the queryFactoryResult->Move method did a mysql_data_seek to reset the pointer after reading in the result->fields. This was shown to break the Iterator rewind, so was removed. However ExecuteRandomMulti was relying on that pointer reset.
However executeRandomMulti doesn't even need to call Move, as it builds it own result->fields, we can therefore just replace the call to move with a mysqli_data_seek

credit to @zcwilt for the fix.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/zencart/zc-v1-series/211)

<!-- Reviewable:end -->
