### PR TITLE
Add product id+model data to order_summary metadata

### DIFF
--- a/includes/modules/checkout_process.php
+++ b/includes/modules/checkout_process.php
@@ -69,7 +69,7 @@ if (strpos($GLOBALS[$_SESSION['payment']]->code, 'paypal') !== 0) {
 }
 if ($credit_covers === TRUE)
 {
-	$order->info['payment_method'] = $order->info['payment_module_code'] = '';
+  $order->info['payment_method'] = $order->info['payment_module_code'] = '';
 }
 $zco_notifier->notify('NOTIFY_CHECKOUT_PROCESS_BEFORE_ORDER_TOTALS_PROCESS');
 $order_totals = $order_total_modules->process();
@@ -118,7 +118,7 @@ if (isset($_SESSION['payment_attempt'])) unset($_SESSION['payment_attempt']);
   $_SESSION['order_summary']['order_total'] = $ototal;
   $_SESSION['order_summary']['commissionable_order'] = $commissionable_order;
   $_SESSION['order_summary']['commissionable_order_formatted'] = $commissionable_order_formatted;
-  $_SESSION['order_summary']['coupon_code'] = $order->info['coupon_code'];
+  $_SESSION['order_summary']['coupon_code'] = urlencode($order->info['coupon_code']);
   $_SESSION['order_summary']['currency_code'] = $order->info['currency'];
   $_SESSION['order_summary']['currency_value'] = $order->info['currency_value'];
   $_SESSION['order_summary']['payment_module_code'] = $order->info['payment_module_code'];
@@ -126,5 +126,11 @@ if (isset($_SESSION['payment_attempt'])) unset($_SESSION['payment_attempt']);
   $_SESSION['order_summary']['orders_status'] = $order->info['orders_status'];
   $_SESSION['order_summary']['tax'] = $otax;
   $_SESSION['order_summary']['shipping'] = $oshipping;
+  $products_array = array();
+  foreach ($order->products as $key=>$val) {
+    $products_array[urlencode($val['id'])] = urlencode($val['model']);
+  }
+  $_SESSION['order_summary']['products_ordered_ids'] = implode('|', array_keys($products_array));
+  $_SESSION['order_summary']['products_ordered_models'] = implode('|', array_values($products_array));
   $zco_notifier->notify('NOTIFY_CHECKOUT_PROCESS_HANDLE_AFFILIATES');
 

--- a/ipn_main_handler.php
+++ b/ipn_main_handler.php
@@ -357,12 +357,15 @@ Processing...
         $order->send_order_email($insert_id, 2);
         ipn_debug_email('Breakpoint: 5m - emailing customer');
         $zco_notifier->notify('NOTIFY_CHECKOUT_PROCESS_AFTER_SEND_ORDER_EMAIL');
+
         /** Prepare sales-tracking data for use by notifier class **/
         $ototal = $order_subtotal = $credits_applied = 0;
         for ($i=0, $n=sizeof($order_totals); $i<$n; $i++) {
           if ($order_totals[$i]['code'] == 'ot_subtotal') $order_subtotal = $order_totals[$i]['value'];
           if ($$order_totals[$i]['code']->credit_class == true) $credits_applied += $order_totals[$i]['value'];
           if ($order_totals[$i]['code'] == 'ot_total') $ototal = $order_totals[$i]['value'];
+          if ($order_totals[$i]['code'] == 'ot_tax') $otax = $order_totals[$i]['value'];
+          if ($order_totals[$i]['code'] == 'ot_shipping') $oshipping = $order_totals[$i]['value'];
         }
         $commissionable_order = ($order_subtotal - $credits_applied);
         $commissionable_order_formatted = $currencies->format($commissionable_order);
@@ -372,7 +375,21 @@ Processing...
         $_SESSION['order_summary']['order_total'] = $ototal;
         $_SESSION['order_summary']['commissionable_order'] = $commissionable_order;
         $_SESSION['order_summary']['commissionable_order_formatted'] = $commissionable_order_formatted;
-        $_SESSION['order_summary']['coupon_code'] = $order->info['coupon_code'];
+        $_SESSION['order_summary']['coupon_code'] = urlencode($order->info['coupon_code']);
+        $_SESSION['order_summary']['currency_code'] = $order->info['currency'];
+        $_SESSION['order_summary']['currency_value'] = $order->info['currency_value'];
+        $_SESSION['order_summary']['payment_module_code'] = $order->info['payment_module_code'];
+        $_SESSION['order_summary']['shipping_method'] = $order->info['shipping_method'];
+        $_SESSION['order_summary']['orders_status'] = $order->info['orders_status'];
+        $_SESSION['order_summary']['tax'] = $otax;
+        $_SESSION['order_summary']['shipping'] = $oshipping;
+        $products_array = array();
+        foreach ($order->products as $key=>$val) {
+          $products_array[urlencode($val['id'])] = urlencode($val['model']);
+        }
+        $_SESSION['order_summary']['products_ordered_ids'] = implode('|', array_keys($products_array));
+        $_SESSION['order_summary']['products_ordered_models'] = implode('|', array_values($products_array));
+
         $zco_notifier->notify('NOTIFY_CHECKOUT_PROCESS_HANDLE_AFFILIATES', 'paypalipn');
         $_SESSION['cart']->reset(true);
         ipn_debug_email('Breakpoint: 5n - emptying cart');


### PR DESCRIPTION
On the checkout-success page we support outputting data for affiliate tracking. 
This PR adds the product IDs and model numbers to that data.
This also brings the ipn code in sync with it.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/zencart/zc-v1-series/239)

<!-- Reviewable:end -->
