### PR TITLE
use correct timestamp function name

### DIFF
--- a/includes/classes/cache.php
+++ b/includes/classes/cache.php
@@ -125,7 +125,7 @@ class cache extends base {
         return true;
       }
       $result_serialize = $db->prepare_input(base64_encode(serialize($zf_result_array)));
-      $sql = "insert ignore into " . TABLE_DB_CACHE . " (cache_entry_name, cache_data, cache_entry_created) VALUES (:cachename, :cachedata, time() )";
+      $sql = "insert ignore into " . TABLE_DB_CACHE . " (cache_entry_name, cache_data, cache_entry_created) VALUES (:cachename, :cachedata, unix_timestamp() )";
       $sql = $db->bindVars($sql, ':cachename', $zp_cache_name, 'string');
       $sql = $db->bindVars($sql, ':cachedata', $result_serialize, 'string');
       $db->Execute($sql);


### PR DESCRIPTION
unix_timestamp() gives the correct replacement for PHP time() function
Amends #244 

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/zencart/zc-v1-series/245)

<!-- Reviewable:end -->
