### PR TITLE
Fix path to include used from multiple locations

### DIFF
--- a/includes/classes/class.zcPassword.php
+++ b/includes/classes/class.zcPassword.php
@@ -46,7 +46,7 @@ class zcPassword extends base
   public function __construct($phpVersion = PHP_VERSION)
   {
     if (version_compare($phpVersion, '5.5.0', '<')) {
-      require_once (DIR_FS_CATALOG . DIR_WS_CLASSES . 'vendors/password_compat-master/lib/password.php');
+      require_once realpath(dirname(__FILE__)) . '/vendors/password_compat-master/lib/password.php';
     }
   }
   /**


### PR DESCRIPTION
When this code is instantiated from zc_install it sometimes triggers a path error. Using autodetection avoids that.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/zencart/zc-v1-series/246)

<!-- Reviewable:end -->
