### PR TITLE
Upgrades from prior to 150 weren't setting a profile

### DIFF
--- a/zc_install/sql/updates/mysql_upgrade_zencart_150.sql
+++ b/zc_install/sql/updates/mysql_upgrade_zencart_150.sql
@@ -139,6 +139,9 @@ CREATE TABLE admin_pages_to_profiles (
 # Insert default data into admin profiles table
 INSERT INTO admin_profiles (profile_id, profile_name) VALUES (1, 'Superuser');
 
+#set all users as superuser for now; can be changed manually as needed
+UPDATE admin SET admin_profile = 1;
+
 # Insert default data into admin_menus table
 INSERT INTO admin_menus (menu_key, language_key, sort_order)
 VALUES ('configuration', 'BOX_HEADING_CONFIGURATION', 1),


### PR DESCRIPTION
For upgrades from much older versions, set all users as profile1 and let administrator assign permissions later.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/zencart/zc-v1-series/248)

<!-- Reviewable:end -->
