### PR TITLE
Populates order table with store address for store_pickups #594

### DIFF
--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -438,6 +438,7 @@ class order extends base {
                             'country' => array('id' => $shipping_address->fields['countries_id'], 'title' => $shipping_address->fields['countries_name'], 'iso_code_2' => $shipping_address->fields['countries_iso_code_2'], 'iso_code_3' => $shipping_address->fields['countries_iso_code_3']),
                             'country_id' => $shipping_address->fields['entry_country_id'],
                             'format_id' => (int)$shipping_address->fields['address_format_id']);
+    $this->check_pickup();
 
     $this->billing = array('firstname' => $billing_address->fields['entry_firstname'],
                            'lastname' => $billing_address->fields['entry_lastname'],
@@ -620,6 +621,19 @@ class order extends base {
     }
     $this->notify('NOTIFY_ORDER_CART_FINISHED');
   }
+  function check_pickup() {
+    if (strstr($this->info['shipping_module_code'], 'storepickup') or strstr($_SESSION['shipping']['id'], 'storepickup')) {
+      $this->delivery['firstname'] = zen_get_config_remove_attention('STORE_NAME');
+      $this->delivery['lastname'] = '';
+      $this->delivery['street_address'] = zen_get_config_remove_attention('MODULE_SHIPPING_STOREPICKUP_ADDR1');
+      $this->delivery['suburb'] = zen_get_config_remove_attention('MODULE_SHIPPING_STOREPICKUP_SUBURB');
+      $this->delivery['city'] = zen_get_config_remove_attention('MODULE_SHIPPING_STOREPICKUP_CITY');
+      $this->delivery['postcode'] = zen_get_config_remove_attention('MODULE_SHIPPING_STOREPICKUP_ZIP');
+      $this->delivery['state'] = zen_get_config_remove_attention('MODULE_SHIPPING_STOREPICKUP_STATE');
+      $this->delivery['company'] = '';
+      $this->delivery['country']['title'] = zen_get_country_name(zen_get_configuration_key_value('STORE_COUNTRY'));
+    }
+  }
 
   function create($zf_ot_modules, $zf_mode = FALSE) {
     global $db;
@@ -650,6 +664,8 @@ class order extends base {
       $cStart = substr($this->info['cc_number'], 0, ($cOffset > 4 ? 4 : (int)$cOffset));
       $this->info['cc_number'] = str_pad($cStart, 6, 'X') . $cEnd;
     };
+
+    $this->check_pickup();
 
     $sql_data_array = array('customers_id' => $_SESSION['customer_id'],
                             'customers_name' => $this->customer['firstname'] . ' ' . $this->customer['lastname'],

--- a/includes/functions/functions_lookups.php
+++ b/includes/functions/functions_lookups.php
@@ -965,4 +965,8 @@
 
     return $new_range;
   }
+function zen_get_config_remove_attention($config_value)
+{
+  return (strpos(zen_get_configuration_key_value($config_value), 'lookupAttention') ? '' : zen_get_configuration_key_value($config_value));
+}
 

--- a/includes/modules/shipping/storepickup.php
+++ b/includes/modules/shipping/storepickup.php
@@ -211,6 +211,11 @@ class storepickup extends base {
     $db->Execute("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Tax Basis', 'MODULE_SHIPPING_STOREPICKUP_TAX_BASIS', 'Shipping', 'On what basis is Shipping Tax calculated. Options are<br />Shipping - Based on customers Shipping Address<br />Billing Based on customers Billing address<br />Store - Based on Store address if Billing/Shipping Zone equals Store zone', '6', '0', 'zen_cfg_select_option(array(\'Shipping\', \'Billing\'), ', now())");
     $db->Execute("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, use_function, set_function, date_added) values ('Shipping Zone', 'MODULE_SHIPPING_STOREPICKUP_ZONE', '0', 'If a zone is selected, only enable this shipping method for that zone.', '6', '0', 'zen_get_zone_class_title', 'zen_cfg_pull_down_zone_classes(', now())");
     $db->Execute("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Sort Order', 'MODULE_SHIPPING_STOREPICKUP_SORT_ORDER', '0', 'Sort order of display.', '6', '0', now())");
+    $db->Execute("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Address 1', 'MODULE_SHIPPING_STOREPICKUP_ADDR1', '', 'Address Line for Store Pickup', '6', '500', now())");
+    $db->Execute("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Address Line 2', 'MODULE_SHIPPING_STOREPICKUP_SUBURB', '', '2nd Address Line for Store Pickup', '6', '510', now())");
+    $db->Execute("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('City', 'MODULE_SHIPPING_STOREPICKUP_CITY', '', 'City for Store Pickup', '6', '520', now())");
+    $db->Execute("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('State', 'MODULE_SHIPPING_STOREPICKUP_STATE', '', 'State', '6', '530', now())");
+    $db->Execute("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Zip', 'MODULE_SHIPPING_STOREPICKUP_ZIP', '', 'Zip', '6', '540', now())");
   }
   /**
    * Remove the module and all its settings
@@ -225,7 +230,7 @@ class storepickup extends base {
    * @return array
    */
   function keys() {
-    return array('MODULE_SHIPPING_STOREPICKUP_STATUS', 'MODULE_SHIPPING_STOREPICKUP_LOCATIONS_LIST', 'MODULE_SHIPPING_STOREPICKUP_COST', 'MODULE_SHIPPING_STOREPICKUP_TAX_CLASS', 'MODULE_SHIPPING_STOREPICKUP_TAX_BASIS', 'MODULE_SHIPPING_STOREPICKUP_ZONE', 'MODULE_SHIPPING_STOREPICKUP_SORT_ORDER');
+    return array('MODULE_SHIPPING_STOREPICKUP_STATUS', 'MODULE_SHIPPING_STOREPICKUP_LOCATIONS_LIST', 'MODULE_SHIPPING_STOREPICKUP_COST', 'MODULE_SHIPPING_STOREPICKUP_TAX_CLASS', 'MODULE_SHIPPING_STOREPICKUP_TAX_BASIS', 'MODULE_SHIPPING_STOREPICKUP_ZONE', 'MODULE_SHIPPING_STOREPICKUP_SORT_ORDER', 'MODULE_SHIPPING_STOREPICKUP_ADDR1', 'MODULE_SHIPPING_STOREPICKUP_SUBURB', 'MODULE_SHIPPING_STOREPICKUP_CITY', 'MODULE_SHIPPING_STOREPICKUP_STATE', 'MODULE_SHIPPING_STOREPICKUP_ZIP');
   }
 }
 


### PR DESCRIPTION
i would prefer a change to the zen_get_configuration_key_value function to add another variable to remove the get_attention.  plus i'm sure there are other config values that may make the new ones superfluous.  however, i do not like the idea of parsing the MODULE_SHIPPING_STOREPICKUP_LOCATIONS_LIST to address this issue.