### PR TITLE
Fixes Add Widget when logged out

### DIFF
--- a/admin/includes/template/templates/tplIndex.php
+++ b/admin/includes/template/templates/tplIndex.php
@@ -54,6 +54,8 @@ $(function() {
       }).done(function( response ) {
         $('.add-widget-container').html(response.html);
         $('#add-widget').foundation('reveal', 'open');
+      }).fail(function( response ) {
+        window.location.replace("<?php echo zen_admin_href_link(FILENAME_LOGIN);?>"); 
       });
 
 


### PR DESCRIPTION
Failure on call to getInstallableWidgets because of login timeout
occurs silently, so the user has no idea what's happening.  This
redirects them to re-authenticate.

Testing: 
- login to admin
- open a new tab on an admin page, and logout on that tab.
- on first tab, press Add Widget button.  With this fix, you'll be redirected to login.
