### PR TITLE
order_status_name field is not shown

### DIFF
--- a/includes/library/zencart/listingBox/src/boxes/LeadOrdersStatus.php
+++ b/includes/library/zencart/listingBox/src/boxes/LeadOrdersStatus.php
@@ -79,7 +79,6 @@ class LeadOrdersStatus extends AbstractLeadListingBox
                 ),
                 'orders_status_name' => array(
                     'bindVarsType' => 'string',
-                    'language' => true,
                     'layout' => array(
                         'common' => array(
                             'title' => TEXT_ENTRY_ORDERS_STATUS_NAME,


### PR DESCRIPTION
the line "'language' => true," needs to be removed, otherwise the when inserting, or editing a order status name the appropriate field is not shown

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zencart/zencart/968)
<!-- Reviewable:end -->
