### PR TITLE
Changes to make test runnable in insolation

### DIFF
--- a/testFramework/unittests/testsSundry/AdminLoggingTest.php
+++ b/testFramework/unittests/testsSundry/AdminLoggingTest.php
@@ -26,13 +26,16 @@ if (!function_exists('zen_get_admin_name')) {
  */
 class testAdminLoggingCase extends zcTestCase
 {
+    protected $preserveGlobalState = FALSE;
+    protected $runTestInSeparateProcess = TRUE;
+
     public function setUp()
     {
         parent::setUp();
-        require DIR_FS_ADMIN . 'includes/functions/general.php';
-        require DIR_FS_ADMIN . 'includes/classes/class.admin.zcObserverLogEventListener.php';
-        require DIR_FS_ADMIN . 'includes/classes/class.admin.zcObserverLogWriterTextfile.php';
-        require DIR_FS_ADMIN . 'includes/classes/class.admin.zcObserverLogWriterDatabase.php';
+        require_once DIR_FS_ADMIN . 'includes/functions/general.php';
+        require_once DIR_FS_ADMIN . 'includes/classes/class.admin.zcObserverLogEventListener.php';
+        require_once DIR_FS_ADMIN . 'includes/classes/class.admin.zcObserverLogWriterTextfile.php';
+        require_once DIR_FS_ADMIN . 'includes/classes/class.admin.zcObserverLogWriterDatabase.php';
         vfsStreamWrapper::register();
         vfsStream::useDotFiles(false);
         $_SESSION['securityToken'] = 'abc';


### PR DESCRIPTION
These changes were required so that this test could be
run stand alone without running the entire suite, i.e.
```
phpunit --filter testAdminLoggingCase testFramework/unittests/testsSundry/AdminFunctionsGeneralTest.php
```
I am writing documentation on how to create and modify tests, and
I want to use this as an example.