### PR TITLE
Change references to $_SERVER['PHP_SELF'] to $_SERVER['SCRIPT_NAME']

### DIFF
--- a/admin/includes/application_bootstrap.php
+++ b/admin/includes/application_bootstrap.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2015 Zen Cart Development Team
+ * @copyright Copyright 2003-2016 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version GIT: $Id:
@@ -44,7 +44,7 @@ if (defined('STRICT_ERROR_REPORTING') && STRICT_ERROR_REPORTING == true) {
   error_reporting(0);
 }
 // set php_self in the local scope
-if (!isset($PHP_SELF)) $PHP_SELF = $_SERVER['PHP_SELF'];
+if (!isset($PHP_SELF)) $PHP_SELF = $_SERVER['SCRIPT_NAME'];
 $PHP_SELF = htmlspecialchars($PHP_SELF);
 // Suppress html from error messages
 @ini_set("html_errors","0");

--- a/includes/functions/whos_online.php
+++ b/includes/functions/whos_online.php
@@ -3,7 +3,7 @@
  * whos_online functions
  *
  * @package functions
- * @copyright Copyright 2003-2007 Zen Cart Development Team
+ * @copyright Copyright 2003-2016 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: whos_online.php 6113 2007-04-04 06:11:02Z drbyte $
@@ -38,9 +38,9 @@ function zen_update_whos_online() {
     $uri = $_SERVER['REQUEST_URI'];
    } else {
     if (isset($_SERVER['QUERY_STRING'])) {
-     $uri = $_SERVER['PHP_SELF'] .'?'. $_SERVER['QUERY_STRING'];
+     $uri = $_SERVER['SCRIPT_NAME'] .'?'. $_SERVER['QUERY_STRING'];
     } else {
-     $uri = $_SERVER['PHP_SELF'] .'?'. $_SERVER['argv'][0];
+     $uri = $_SERVER['SCRIPT_NAME'] .'?'. $_SERVER['argv'][0];
     }
   }
   if (substr($uri, -1)=='?') $uri = substr($uri,0,strlen($uri)-1);
@@ -104,4 +104,3 @@ function whos_online_session_recreate($old_session, $new_session) {
   $sql = $db->bindVars($sql, ':oldSessionID', $old_session, 'string'); 
   $db->Execute($sql);
 }
-?>

--- a/includes/init_includes/init_file_db_names.php
+++ b/includes/init_includes/init_file_db_names.php
@@ -32,7 +32,7 @@ $request_type = (((isset($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) ==
 /**
  * set php_self in the local scope
  */
-if (!isset($PHP_SELF)) $PHP_SELF = $_SERVER['PHP_SELF'];
+if (!isset($PHP_SELF)) $PHP_SELF = $_SERVER['SCRIPT_NAME'];
 /**
  * require global definitons for Filenames
  */


### PR DESCRIPTION
Some server engines don't set `PHP_SELF` reliably, so using `SCRIPT_NAME` appears to be more reliable and compatible.


As for compatibility, here's a simple reference: http://php.about.com/od/learnphp/qt/_SERVER_PHP.htm