### PR TITLE
Suggest adding target

### DIFF
--- a/admin/includes/template/partials/specialMenu/tplStandardLinks.php
+++ b/admin/includes/template/partials/specialMenu/tplStandardLinks.php
@@ -8,6 +8,6 @@
 ?>
 <li><a href="<?php echo zen_href_link(FILENAME_DEFAULT, '', 'NONSSL'); ?>"><?php echo HEADER_TITLE_TOP; ?></a></li>
 <li><a href="<?php echo zen_catalog_href_link(FILENAME_DEFAULT); ?>" target="_blank"><?php echo HEADER_TITLE_ONLINE_CATALOG; ?></a></li>
-<li><a href="http://www.zen-cart.com/"><?php echo HEADER_TITLE_SUPPORT_SITE; ?></a></li>
+<li><a href="http://www.zen-cart.com/" target="_blank"><?php echo HEADER_TITLE_SUPPORT_SITE; ?></a></li>
 <li><a href="<?php echo zen_href_link(FILENAME_SERVER_INFO); ?>"><?php echo HEADER_TITLE_VERSION; ?></a></li>
 

--- a/admin/includes/template/partials/specialMenu/tplStandardLinks.php
+++ b/admin/includes/template/partials/specialMenu/tplStandardLinks.php
@@ -7,7 +7,7 @@
  */
 ?>
 <li><a href="<?php echo zen_href_link(FILENAME_DEFAULT, '', 'NONSSL'); ?>"><?php echo HEADER_TITLE_TOP; ?></a></li>
-<li><a href="<?php echo zen_catalog_href_link(FILENAME_DEFAULT); ?>"><?php echo HEADER_TITLE_ONLINE_CATALOG; ?></a></li>
+<li><a href="<?php echo zen_catalog_href_link(FILENAME_DEFAULT); ?>" target="_blank"><?php echo HEADER_TITLE_ONLINE_CATALOG; ?></a></li>
 <li><a href="http://www.zen-cart.com/"><?php echo HEADER_TITLE_SUPPORT_SITE; ?></a></li>
 <li><a href="<?php echo zen_href_link(FILENAME_SERVER_INFO); ?>"><?php echo HEADER_TITLE_VERSION; ?></a></li>
 


### PR DESCRIPTION
When clicking the link Storefront, the user is directed to the Storefront as expected, but in the same screen, which is not the way it used to work in the old link. I suggest putting the targent="_blank" back in the link

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zencart/zencart/984)
<!-- Reviewable:end -->
