### PR TITLE
Adding missing buid in values

### DIFF
--- a/admin/includes/extra_configures/system_inspection.php
+++ b/admin/includes/extra_configures/system_inspection.php
@@ -33,6 +33,7 @@ $built_in_boxes = array(
 'BOX_CONFIGURATION_INDEX_LISTING',
 'BOX_CONFIGURATION_DEFINE_PAGE_STATUS',
 'BOX_CONFIGURATION_EZPAGES_SETTINGS',
+'BOX_CONFIGURATION_CHECKOUT_SETTINGS',
 
 // modules box text
 'BOX_HEADING_MODULES',
@@ -170,6 +171,7 @@ $built_in_tables = array(
 'counter',
 'counter_history',
 'countries',
+'countries_name',
 'coupon_email_track',
 'coupon_gv_customer',
 'coupon_gv_queue',


### PR DESCRIPTION
Using the system inspection page, I came across these values that were missing from the build in arrays

Very handy tool :smile:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zencart/zencart/985)
<!-- Reviewable:end -->
