### PR TITLE
Authorize.net has changed their rollout plan for Akamai

### DIFF
--- a/includes/modules/payment/authorizenet.php
+++ b/includes/modules/payment/authorizenet.php
@@ -88,7 +88,7 @@ class authorizenet extends base {
 
     if (is_object($order)) $this->update_status();
 
-    $this->form_action_url = 'https://secure.authorize.net/gateway/transact.dll';
+    $this->form_action_url = 'https://secure2.authorize.net/gateway/transact.dll';
     if (MODULE_PAYMENT_AUTHORIZENET_TESTMODE == 'Sandbox') $this->form_action_url = 'https://test.authorize.net/gateway/transact.dll';
 
 //     $this->form_action_url = 'https://www.eprocessingnetwork.com/cgi-bin/an/order.pl';

--- a/includes/modules/payment/authorizenet_aim.php
+++ b/includes/modules/payment/authorizenet_aim.php
@@ -638,7 +638,7 @@ class authorizenet_aim extends base {
       default:
       case 'AIM':
         $submit_data['x_solution_id'] = 'A1000003'; // used by authorize.net
-        $url = 'https://secure.authorize.net/gateway/transact.dll';
+        $url = 'https://secure2.authorize.net/gateway/transact.dll';
         $devurl = 'https://test.authorize.net/gateway/transact.dll';
         $certurl = 'https://certification.authorize.net/gateway/transact.dll';
         if (MODULE_PAYMENT_AUTHORIZENET_AIM_TESTMODE == 'Sandbox') $url = $devurl;

--- a/includes/modules/payment/authorizenet_echeck.php
+++ b/includes/modules/payment/authorizenet_echeck.php
@@ -561,7 +561,7 @@ class authorizenet_echeck extends base {
     }
 
     // set URL
-    $url = 'https://secure.authorize.net/gateway/transact.dll';
+    $url = 'https://secure2.authorize.net/gateway/transact.dll';
     $devurl = 'https://test.authorize.net/gateway/transact.dll';
     $dumpurl = 'https://developer.authorize.net/param_dump.asp';
     $certurl = 'https://certification.authorize.net/gateway/transact.dll';


### PR DESCRIPTION
According to previous communication, Authorize.net was going to switch to Akamai on June 30 "automatically". But they've delayed that due to many vendors not being prepared.

To benefit from the improved reliability sooner than later, this simple URL change is all that's required in ZC.