### PR TITLE
Optimizing some category-lookup-related functions

### DIFF
--- a/admin/includes/modules/category_product_listing.php
+++ b/admin/includes/modules/category_product_listing.php
@@ -171,7 +171,7 @@ if (!isset($_SESSION['display_categories_dropdown'])) {
       }
       if (SHOW_CATEGORY_PRODUCTS_LINKED_STATUS == '1' || (SHOW_CATEGORY_PRODUCTS_LINKED_STATUS == '2' && $categories->fields['parent_id'] != (int)TOPMOST_CATEGORY_PARENT_ID))
       {
-        if (zen_get_products_to_categories($categories->fields['categories_id'], true, 'products_active') == 'true') {
+        if (zen_get_products_to_categories($categories->fields['categories_id'], true, 'products_active') === true) {
           echo '&nbsp;&nbsp;' . zen_image(DIR_WS_IMAGES . 'icon_yellow_on.gif', IMAGE_ICON_LINKED);
         }
       } else

--- a/includes/functions/compatibility.php
+++ b/includes/functions/compatibility.php
@@ -33,3 +33,13 @@
     return $data['directory'];
   }
 
+
+/**
+ * Count how many subcategories exist in a category
+ * TABLES: categories
+ */
+  function zen_get_products_master_categories_name($categories_id) {
+    return zen_get_categories_parent_name($categories_id);
+  }
+
+

--- a/includes/functions/functions_categories.php
+++ b/includes/functions/functions_categories.php
@@ -22,13 +22,13 @@
         $cPath_new = '';
         $last_category_query = "select parent_id
                                 from " . TABLE_CATEGORIES . "
-                                where categories_id = '" . (int)$cPath_array[($cp_size-1)] . "'";
+                                where categories_id = " . (int)$cPath_array[($cp_size-1)];
 
         $last_category = $db->Execute($last_category_query);
 
         $current_category_query = "select parent_id
                                    from " . TABLE_CATEGORIES . "
-                                   where categories_id = '" . (int)$current_category_id . "'";
+                                   where categories_id = " . (int)$current_category_id;
 
         $current_category = $db->Execute($current_category_query);
 
@@ -68,26 +68,17 @@
       $limit_count = '';
     }
 
-    if ($include_deactivated) {
-
-      $products = $db->Execute("select count(*) as total
-                                from " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_TO_CATEGORIES . " p2c
-                                where p.products_id = p2c.products_id
-                                and p2c.categories_id = '" . (int)$categories_id . "'" . $limit_count);
-    } else {
-      $products = $db->Execute("select count(*) as total
-                                from " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_TO_CATEGORIES . " p2c
-                                where p.products_id = p2c.products_id
-                                and p.products_status = 1
-                                and p2c.categories_id = '" . (int)$categories_id . "'" . $limit_count);
-
-    }
+    $products = $db->Execute("select count(*) as total
+                              from " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_TO_CATEGORIES . " p2c
+                              where p.products_id = p2c.products_id " . 
+                              ($include_deactivated ? ' and p.products_status = 1 ' : '') . "
+                              and p2c.categories_id = " . (int)$categories_id . $limit_count);
 
     $products_count += $products->fields['total'];
 
     if ($include_child) {
       $childs = $db->Execute("select categories_id from " . TABLE_CATEGORIES . "
-                              where parent_id = '" . (int)$categories_id . "'");
+                              where parent_id = " . (int)$categories_id);
       if ($childs->RecordCount() > 0 ) {
         while (!$childs->EOF) {
           $products_count += zen_count_products_in_category($childs->fields['categories_id'], $include_deactivated);
@@ -106,15 +97,11 @@
     global $db;
     $child_category_query = "select count(*) as count
                              from " . TABLE_CATEGORIES . "
-                             where parent_id = '" . (int)$category_id . "'";
+                             where parent_id = " . (int)$category_id;
 
     $child_category = $db->Execute($child_category_query);
 
-    if ($child_category->fields['count'] > 0) {
-      return true;
-    } else {
-      return false;
-    }
+    return ($child_category->fields['count'] > 0);
   }
 
 ////
@@ -133,9 +120,9 @@
     $categories_query = "select c.categories_id, cd.categories_name, c.categories_status
                          from " . TABLE_CATEGORIES . " c, " . TABLE_CATEGORIES_DESCRIPTION . " cd
                          where " . $zc_status . "
-                         parent_id = '" . (int)$parent_id . "'
+                         parent_id = " . (int)$parent_id . "
                          and c.categories_id = cd.categories_id
-                         and cd.language_id = '" . (int)$_SESSION['languages_id'] . "'
+                         and cd.language_id = " . (int)$_SESSION['languages_id'] . "
                          order by sort_order, cd.categories_name";
 
     $categories = $db->Execute($categories_query);
@@ -160,7 +147,7 @@
     global $db;
     $subcategories_query = "select categories_id
                             from " . TABLE_CATEGORIES . "
-                            where parent_id = '" . (int)$parent_id . "'";
+                            where parent_id = " . (int)$parent_id;
 
     $subcategories = $db->Execute($subcategories_query);
 
@@ -182,7 +169,7 @@
     global $db;
     $parent_categories_query = "select parent_id
                                 from " . TABLE_CATEGORIES . "
-                                where categories_id = '" . (int)$categories_id . "'";
+                                where categories_id = " . (int)$categories_id;
 
     $parent_categories = $db->Execute($parent_categories_query);
 
@@ -214,7 +201,7 @@
 
     $category_query = "select p.products_id, p.master_categories_id
                        from " . TABLE_PRODUCTS . " p
-                       where p.products_id = '" . (int)$products_id . "' limit 1";
+                       where p.products_id = " . (int)$products_id . " limit 1";
 
 
     $category = $db->Execute($category_query);
@@ -257,7 +244,7 @@
     global $db;
     $in_cat=false;
     $category_query_raw = "select categories_id from " . TABLE_PRODUCTS_TO_CATEGORIES . "
-                           where products_id = '" . (int)$product_id . "'";
+                           where products_id = " . (int)$product_id;
 
     $category = $db->Execute($category_query_raw);
 
@@ -265,7 +252,7 @@
       if ($category->fields['categories_id'] == $cat_id) $in_cat = true;
       if (!$in_cat) {
         $parent_categories_query = "select parent_id from " . TABLE_CATEGORIES . "
-                                    where categories_id = '" . $category->fields['categories_id'] . "'";
+                                    where categories_id = " . $category->fields['categories_id'];
 
         $parent_categories = $db->Execute($parent_categories_query);
 //echo 'cat='.$category->fields['categories_id'].'#'. $cat_id;
@@ -289,7 +276,7 @@
       $in_cat = true;
     } else {
       $parent_categories_query = "select parent_id from " . TABLE_CATEGORIES . "
-                                  where categories_id = '" . (int)$parent_cat_id . "'";
+                                  where categories_id = " . (int)$parent_cat_id;
 
       $parent_categories = $db->Execute($parent_categories_query);
 
@@ -328,14 +315,14 @@
                                 left join " . TABLE_PRODUCTS_TO_CATEGORIES . " ptc on ptc.products_id = p.products_id, " .
                                 TABLE_PRODUCTS_DESCRIPTION . " pd
                                 where p.products_id = pd.products_id
-                                and pd.language_id = '" . (int)$_SESSION['languages_id'] . "'
-                                and ptc.categories_id = '" . (int)$current_category_id . "'
+                                and pd.language_id = " . (int)$_SESSION['languages_id'] . "
+                                and ptc.categories_id = " . (int)$current_category_id . "
                                 order by products_name");
     } else {
       $products = $db->Execute("select p.products_id, pd.products_name, p.products_price, p.products_model
                               from " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_DESCRIPTION . " pd
                               where p.products_id = pd.products_id
-                              and pd.language_id = '" . (int)$_SESSION['languages_id'] . "'
+                              and pd.language_id = " . (int)$_SESSION['languages_id'] . "
                               order by products_name");
     }
 
@@ -353,7 +340,6 @@
 
     return $select_string;
   }
-
 
 /**
  * product pulldown with attributes
@@ -380,7 +366,7 @@
                                        TABLE_PRODUCTS_DESCRIPTION . " pd, " .
                                        TABLE_PRODUCTS_ATTRIBUTES . " pa " ."
                               where p.products_id= pa.products_id and p.products_id = pd.products_id
-                              and pd.language_id = '" . (int)$_SESSION['languages_id'] . "'
+                              and pd.language_id = " . (int)$_SESSION['languages_id'] . "
                               order by products_name");
 
     while (!$products->EOF) {
@@ -427,7 +413,7 @@
     while (!$categories->EOF) {
       if (!in_array($categories->fields['categories_id'], $exclude)) {
         if ($show_parent == true) {
-          $parent = zen_get_products_master_categories_name($categories->fields['categories_id']);
+          $parent = zen_get_categories_parent_name($categories->fields['categories_id']);
           if ($parent != '') {
             $parent = ' : in ' . $parent;
           }
@@ -470,7 +456,7 @@
                                 where pa.products_id= ptoc.products_id
                                 and ptoc.categories_id= c.categories_id
                                 and c.categories_id = cd.categories_id
-                                and cd.language_id = '" . (int)$_SESSION['languages_id'] . "'
+                                and cd.language_id = " . (int)$_SESSION['languages_id'] . "
                                 order by categories_name");
 
     while (!$categories->EOF) {
@@ -492,7 +478,7 @@
 
     $lookup = str_replace('cPath=','',$lookup);
 
-    $sql = "select product_type_id from " . TABLE_PRODUCT_TYPES_TO_CATEGORY . " where category_id='" . (int)$lookup . "'";
+    $sql = "select product_type_id from " . TABLE_PRODUCT_TYPES_TO_CATEGORY . " where category_id=" . (int)$lookup;
     $look_up = $db->Execute($sql);
 
     if ($look_up->RecordCount() > 0) {
@@ -502,17 +488,16 @@
     }
   }
 
-//// look up parent categories name
+/**
+ * look up parent category name
+ */
   function zen_get_categories_parent_name($categories_id) {
     global $db;
 
-    $lookup_query = "select parent_id from " . TABLE_CATEGORIES . " where categories_id='" . (int)$categories_id . "'";
+    $lookup_query = "select parent_id from " . TABLE_CATEGORIES . " where categories_id=" . (int)$categories_id;
     $lookup = $db->Execute($lookup_query);
 
-    $lookup_query = "select categories_name from " . TABLE_CATEGORIES_DESCRIPTION . " where categories_id='" . (int)$lookup->fields['parent_id'] . "' and language_id= " . $_SESSION['languages_id'];
-    $lookup = $db->Execute($lookup_query);
-
-    return $lookup->fields['categories_name'];
+    return zen_get_category_name($lookup->fields['parent_id'], (int)$_SESSION['languages_id']);
   }
 
 /**
@@ -531,7 +516,7 @@
     $sql = "select p.products_id
             from " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_TO_CATEGORIES . " p2c
             where p.products_id = p2c.products_id
-            and p2c.categories_id = '" . (int)$childCatID . "'" .
+            and p2c.categories_id = " . (int)$childCatID .
             ($include_deactivated ? " and p.products_status = 1" : "") .
             $display_limit;
 
@@ -543,7 +528,7 @@
 
     if ($include_child) {
       $sql = "select categories_id from " . TABLE_CATEGORIES . "
-              where parent_id = '" . (int)$childCatID . "'";
+              where parent_id = " . (int)$childCatID;
 
       $childs = $db->Execute($sql);
       if ($childs->RecordCount() > 0 ) {
@@ -565,7 +550,7 @@
     if ($from == 'product') {
       $categories = $db->Execute("select categories_id
                                   from " . TABLE_PRODUCTS_TO_CATEGORIES . "
-                                  where products_id = '" . (int)$id . "'");
+                                  where products_id = " . (int)$id);
 
       while (!$categories->EOF) {
         if ($categories->fields['categories_id'] == (int)TOPMOST_CATEGORY_PARENT_ID) {
@@ -573,9 +558,9 @@
         } else {
           $category = $db->Execute("select cd.categories_name, c.parent_id
                                     from " . TABLE_CATEGORIES . " c, " . TABLE_CATEGORIES_DESCRIPTION . " cd
-                                    where c.categories_id = '" . (int)$categories->fields['categories_id'] . "'
+                                    where c.categories_id = " . (int)$categories->fields['categories_id'] . "
                                     and c.categories_id = cd.categories_id
-                                    and cd.language_id = '" . (int)$_SESSION['languages_id'] . "'");
+                                    and cd.language_id = " . (int)$_SESSION['languages_id']);
 
           $categories_array[$index][] = array('id' => $categories->fields['categories_id'], 'text' => $category->fields['categories_name']);
           if (zen_not_null($category->fields['parent_id']) && $category->fields['parent_id'] != (int)TOPMOST_CATEGORY_PARENT_ID) {
@@ -589,9 +574,9 @@
     } elseif ($from == 'category') {
       $category = $db->Execute("select cd.categories_name, c.parent_id
                                 from " . TABLE_CATEGORIES . " c, " . TABLE_CATEGORIES_DESCRIPTION . " cd
-                                where c.categories_id = '" . (int)$id . "'
+                                where c.categories_id = " . (int)$id . "
                                 and c.categories_id = cd.categories_id
-                                and cd.language_id = '" . (int)$_SESSION['languages_id'] . "'");
+                                and cd.language_id = " . (int)$_SESSION['languages_id']);
       if (!$category->EOF) {
         $categories_array[$index][] = array('id' => $id, 'text' => $category->fields['categories_name']);
         if (zen_not_null($category->fields['parent_id']) && $category->fields['parent_id'] != (int)TOPMOST_CATEGORY_PARENT_ID) {
@@ -659,7 +644,8 @@
 
     return $categories_imploded;
   }
-//// bof: manage master_categories_id vs cPath
+
+// manage master_categories_id vs cPath
   function zenGetLeafCategory($cpath)
   {
     return (str_replace('_', '', substr($cpath, strrpos($cpath, '_'))));
@@ -672,21 +658,21 @@
 
     $sql = "SELECT categories_id
             FROM " . TABLE_CATEGORIES . "
-            WHERE parent_id = '" . ( int ) $categoryId . "'";
-    $result = $db->execute ( $sql );
-    if ($result->recordCount () > 0)
+            WHERE parent_id = " . (int) $categoryId;
+    $result = $db->Execute($sql);
+    if ($result->RecordCount() > 0)
     {
-      while ( ! $result->EOF )
+      while (!$result->EOF)
       {
         $categories = zenGetCategoryArrayWithChildren($result->fields['categories_id'], $categories);
-        $result->moveNext();
+        $result->MoveNext();
       }
     }
     return $categories;
   }
 
 
-  function zen_get_category_tree($parent_id = '0', $spacing = '', $exclude = '', $category_tree_array = '', $include_itself = false, $category_has_products = false, $limit = false) {
+  function zen_get_category_tree($parent_id = TOPMOST_CATEGORY_PARENT_ID, $spacing = '', $exclude = '', $category_tree_array = '', $include_itself = false, $category_has_products = false, $limit = false) {
     global $db;
 
     if ($limit) {
@@ -696,13 +682,15 @@
     }
 
     if (!is_array($category_tree_array)) $category_tree_array = array();
-    if ( (sizeof($category_tree_array) < 1) && ($exclude != '0') ) $category_tree_array[] = array('id' => '0', 'text' => TEXT_TOP);
+    if ( (sizeof($category_tree_array) < 1) && ($exclude != TOPMOST_CATEGORY_PARENT_ID) ) {
+      $category_tree_array[] = array('id' => TOPMOST_CATEGORY_PARENT_ID, 'text' => TEXT_TOP);
+    }
 
     if ($include_itself) {
       $category = $db->Execute("select cd.categories_name
                                 from " . TABLE_CATEGORIES_DESCRIPTION . " cd
-                                where cd.language_id = '" . (int)$_SESSION['languages_id'] . "'
-                                and cd.categories_id = '" . (int)$parent_id . "'" . $limit_count);
+                                where cd.language_id = " . (int)$_SESSION['languages_id'] . "
+                                and cd.categories_id = " . (int)$parent_id . $limit_count);
 
       $category_tree_array[] = array('id' => $parent_id, 'text' => $category->fields['categories_name']);
     }
@@ -710,8 +698,8 @@
     $categories = $db->Execute("select c.categories_id, cd.categories_name, c.parent_id
                                 from " . TABLE_CATEGORIES . " c, " . TABLE_CATEGORIES_DESCRIPTION . " cd
                                 where c.categories_id = cd.categories_id
-                                and cd.language_id = '" . (int)$_SESSION['languages_id'] . "'
-                                and c.parent_id = '" . (int)$parent_id . "'
+                                and cd.language_id = " . (int)$_SESSION['languages_id'] . "
+                                and c.parent_id = " . (int)$parent_id . "
                                 order by c.sort_order, cd.categories_name" . $limit_count);
 
     while (!$categories->EOF) {
@@ -728,15 +716,13 @@
     return $category_tree_array;
   }
 
-
-
   function zen_count_products_in_cats($category_id) {
     global $db;
     $c_array = array();
     $cat_products_query = "select count(if (p.products_status=1,1,NULL)) as pr_on, count(*) as total
                            from " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_TO_CATEGORIES . " p2c
                            where p.products_id = p2c.products_id
-                           and p2c.categories_id = '" . (int)$category_id . "'";
+                           and p2c.categories_id = " . (int)$category_id;
 
     $pr_count = $db->Execute($cat_products_query);
 //    echo $pr_count->RecordCount();
@@ -745,7 +731,7 @@
 
     $cat_child_categories_query = "select categories_id
                                from " . TABLE_CATEGORIES . "
-                               where parent_id = '" . (int)$category_id . "'";
+                               where parent_id = " . (int)$category_id;
 
     $cat_child_categories = $db->Execute($cat_child_categories_query);
 
@@ -773,39 +759,21 @@
 
     $cat_products_count = 0;
     $products_linked = '';
-    if ($include_inactive == true) {
-      switch ($counts_what) {
-        case ('products'):
-        $cat_products_query = "select count(*) as total
-                           from " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_TO_CATEGORIES . " p2c
-                           where p.products_id = p2c.products_id
-                           and p2c.categories_id = '" . (int)$category_id . "'";
-        break;
-        case ('products_active'):
-        $cat_products_query = "select p.products_id
-                           from " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_TO_CATEGORIES . " p2c
-                           where p.products_id = p2c.products_id
-                           and p2c.categories_id = '" . (int)$category_id . "'";
-        break;
-      }
-
-    } else {
-      switch ($counts_what) {
-        case ('products'):
-          $cat_products_query = "select count(*) as total
-                             from " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_TO_CATEGORIES . " p2c
-                             where p.products_id = p2c.products_id
-                             and p.products_status = 1
-                             and p2c.categories_id = '" . (int)$category_id . "'";
-        break;
-        case ('products_active'):
-          $cat_products_query = "select p.products_id
-                             from " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_TO_CATEGORIES . " p2c
-                             where p.products_id = p2c.products_id
-                             and p.products_status = 1
-                             and p2c.categories_id = '" . (int)$category_id . "'";
-        break;
-      }
+    switch ($counts_what) {
+      case ('products'):
+      $cat_products_query = "select count(*) as total
+                         from " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_TO_CATEGORIES . " p2c
+                         where p.products_id = p2c.products_id " .
+                         ($include_inactive ? '' :  ' and p.products_status = 1 ') . "
+                         and p2c.categories_id = " . (int)$category_id;
+      break;
+      case ('products_active'):
+      $cat_products_query = "select p.products_id
+                         from " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_TO_CATEGORIES . " p2c
+                         where p.products_id = p2c.products_id" .
+                         ($include_inactive ? '' :  ' and p.products_status = 1 ') . "
+                         and p2c.categories_id = " . (int)$category_id;
+      break;
     }
     $cat_products = $db->Execute($cat_products_query);
     switch ($counts_what) {
@@ -815,7 +783,7 @@
       case ('products_active'):
         while (!$cat_products->EOF) {
           if (zen_get_product_is_linked($cat_products->fields['products_id']) == 'true') {
-            return $products_linked = 'true';
+            return true;
           }
           $cat_products->MoveNext();
         }
@@ -835,8 +803,8 @@
           $cat_products_count += zen_get_products_to_categories($cat_child_categories->fields['categories_id'], $include_inactive);
           break;
         case ('products_active'):
-          if (zen_get_products_to_categories($cat_child_categories->fields['categories_id'], true, 'products_active') == 'true') {
-            return $products_linked = 'true';
+          if (zen_get_products_to_categories($cat_child_categories->fields['categories_id'], true, 'products_active') === true) {
+            return true;
           }
           break;
         }
@@ -856,14 +824,15 @@
 
 /**
  * check if linked
+ * NOTE: returns stringified boolean, until legacy code using these string responses is rewritten
  */
-  function zen_get_product_is_linked($product_id, $show_count = 'false') {
+  function zen_get_product_is_linked($product_id, $show_count = false) {
     global $db;
 
     $sql = "select * from " . TABLE_PRODUCTS_TO_CATEGORIES . (zen_not_null($product_id) ? " where products_id=" . (int)$product_id : "");
     $check_linked = $db->Execute($sql);
     if ($check_linked->RecordCount() > 1) {
-      if ($show_count == 'true') {
+      if ($show_count == true) {
         return $check_linked->RecordCount();
       } else {
         return 'true';
@@ -872,7 +841,6 @@
       return 'false';
     }
   }
-
 
 /**
  * Lookup and return product's master_categories_id
@@ -883,27 +851,9 @@
 
     $categories_lookup = $db->Execute("select master_categories_id
                                 from " . TABLE_PRODUCTS . "
-                                where products_id = '" . (int)$product_id . "'");
+                                where products_id = " . (int)$product_id);
     if ($categories_lookup->EOF) return '';
     return $categories_lookup->fields['master_categories_id'];
-  }
-
-
-/**
- * Count how many subcategories exist in a category
- * TABLES: categories
- * old v1.2 name zen_get_parent_category_name
- */
-  function zen_get_products_master_categories_name($categories_id) {
-    global $db;
-
-    $categories_lookup = $db->Execute("select parent_id
-                                from " . TABLE_CATEGORIES . "
-                                where categories_id = '" . (int)$categories_id . "'");
-
-    $parent_name = zen_get_category_name($categories_lookup->fields['parent_id'], (int)$_SESSION['languages_id']);
-
-    return $parent_name;
   }
 
 ////
@@ -915,7 +865,7 @@
 
     $categories = $db->Execute("select categories_id
                                 from " . TABLE_CATEGORIES . "
-                                where parent_id = '" . (int)$categories_id . "'");
+                                where parent_id = " . (int)$categories_id);
 
     while (!$categories->EOF) {
       $categories_count++;

--- a/includes/functions/functions_lookups.php
+++ b/includes/functions/functions_lookups.php
@@ -461,36 +461,36 @@
   function zen_get_products_category_id($products_id) {
     global $db;
 
-    $the_products_category_query = "select products_id, master_categories_id from " . TABLE_PRODUCTS . " where products_id = '" . (int)$products_id . "'";
-    $the_products_category = $db->Execute($the_products_category_query);
-    if ($the_products_category->EOF) return '';
-    return $the_products_category->fields['master_categories_id'];
+    $sql = "select master_categories_id from " . TABLE_PRODUCTS . " where products_id = " . (int)$products_id;
+    $result = $db->Execute($sql);
+    if ($result->EOF) return '';
+    return $result->fields['master_categories_id'];
   }
 
 /*
  * Return category's image
  * TABLES: categories
  */
-  function zen_get_categories_image($what_am_i) {
+  function zen_get_categories_image($category_id) {
     global $db;
 
-    $the_categories_image_query= "select categories_image from " . TABLE_CATEGORIES . " where categories_id= '" . $what_am_i . "'";
-    $the_products_category = $db->Execute($the_categories_image_query);
+    $sql = "select categories_image from " . TABLE_CATEGORIES . " where categories_id= " . (int)$category_id;
+    $result = $db->Execute($sql);
 
-    return $the_products_category->fields['categories_image'];
+    return $result->fields['categories_image'];
   }
 
 /*
  *  Return category's name from ID, assuming current language
  *  TABLES: categories_description
  */
-  function zen_get_categories_name($who_am_i) {
+  function zen_get_categories_name($category_id) {
     global $db;
-    $the_categories_name_query= "select categories_name from " . TABLE_CATEGORIES_DESCRIPTION . " where categories_id= '" . $who_am_i . "' and language_id= '" . $_SESSION['languages_id'] . "'";
+    $sql = "select categories_name from " . TABLE_CATEGORIES_DESCRIPTION . " where categories_id= " . (int)$category_id . " and language_id= " . (int)$_SESSION['languages_id'];
 
-    $the_categories_name = $db->Execute($the_categories_name_query);
+    $result = $db->Execute($sql);
 
-    return $the_categories_name->fields['categories_name'];
+    return $result->fields['categories_name'];
   }
 
 


### PR DESCRIPTION
Reduce some cyclomatic complexity of some functions by removing (some) duplication.
Change treatment of integer values to be integers instead of strings.
Deprecate some duplicates.

(Addendum to #967 which consolidated functions files)