### PR TITLE
Split the nginx config into input-template and output-conf files

### DIFF
--- a/zc_install/includes/languages/lngEnglish.php
+++ b/zc_install/includes/languages/lngEnglish.php
@@ -276,10 +276,10 @@ define('REASON_PRIMARY_KEY_ALREADY_EXISTS','Cannot add primary key to table %s b
 
 
 define('TEXT_COMPLETION_NGINX_TEXT', "<u>Important security information for Nginx</u>");
-define('TEXT_HELP_TITLE_NGINXCONF', "Securing ZEN CART on Nginx Webservers");
+define('TEXT_HELP_TITLE_NGINXCONF', "Securing Zen Cart on Nginx Webservers");
 define('TEXT_HELP_CONTENT_NGINXCONF', "<div>
 	<p>
-		Your ZEN CART installation comes with security measures in a format native to the Apache Webserver.
+		Your Zen Cart installation comes with security measures in a format native to the Apache Webserver.
 		<br>
 		See below to implement a similar set of measures for the Nginx Webserver. 
 	</p>
@@ -305,7 +305,7 @@ define('TEXT_HELP_CONTENT_NGINXCONF', "<div>
 			</ul>
 		</li>
 		<li>
-			Add the contents of <strong>'zencart_ngx_server.conf'</strong> to the relevant <strong>'server'</strong> block for ZEN CART in your Nginx configuration file.
+			Add the contents of <strong>'zencart_ngx_server.conf'</strong> to the relevant <strong>'server'</strong> block for Zen Cart in your Nginx configuration file.
 			<ul style='list-style-type:circle'>
 				<li>
 					The directives may be used for SSL and/or Non SSL server blocks.
@@ -368,7 +368,7 @@ define('TEXT_HELP_CONTENT_NGINXCONF', "<div>
 	<ol>
 </div>
 <div class='alert-box alert'>
-	<strong>IMPORTANT:</strong> These location blocks should be <strong>BEFORE</strong> any other location blocks in your Nginx configuration server block for ZEN CART.
+	<strong>IMPORTANT:</strong> These location blocks should be <strong>BEFORE</strong> any other location blocks in your Nginx configuration server block for Zen Cart.
 </div>
 <hr>");
 

--- a/zc_install/includes/modules/pages/completion/header_php.php
+++ b/zc_install/includes/modules/pages/completion/header_php.php
@@ -51,13 +51,14 @@
     "%%slash_folder%%" => $ngx_slash,
   );
   
-  $ngx_file = "includes/nginx_conf/zencart_ngx_server.conf";
-  $ngx_handle = fopen($ngx_file, "r");
-  $ngx_content = fread($ngx_handle, filesize($ngx_file));
+  $ngx_input_file = "includes/nginx_conf/ngx_server_template.txt";
+  $ngx_output_file = "includes/nginx_conf/zencart_ngx_server.conf";
+  $fh = fopen($ngx_input_file, "r");
+  $ngx_content = fread($fh, filesize($ngx_input_file));
+  fclose($fh);
   foreach($ngx_array as $ngx_placeholder => $ngx_string) {
   	$ngx_content = str_replace($ngx_placeholder, $ngx_string, $ngx_content);
   }
-  $ngx_handle = fopen($ngx_file, "w");
-  fwrite($ngx_handle, $ngx_content);
-  fclose($ngx_handle);
-  
+  $fh = fopen($ngx_output_file, "w");
+  fwrite($fh, $ngx_content);
+  fclose($fh);

--- a/zc_install/includes/nginx_conf/.gitignore
+++ b/zc_install/includes/nginx_conf/.gitignore
@@ -1,0 +1,1 @@
+zencart_ngx_server.conf

--- a/zc_install/includes/nginx_conf/ngx_server_template.txt
+++ b/zc_install/includes/nginx_conf/ngx_server_template.txt
@@ -4,7 +4,7 @@
 ### 		                  NGINX CONFIGURATION FOR ZEN CART
 ###
 ### NOTES: 
-###    - Copy and paste into ZEN CART handling ‘server’ section of nginx conf file
+###    - Copy and paste into Zen Cart handling ‘server’ section of nginx conf file
 ###    - Location Block order is important
 ###    - Include before any other location blocks if any
 ###
@@ -15,7 +15,7 @@
 	
 	
 	#############################################################################################
-	# ZEN CART PHP Handler
+	# Zen Cart PHP Handler
 	#############################################################################################	
 	## The following block serves all PHP requests internally directed to it within this conf file
 	## Edit to reflect your actual setup for serving PHP
@@ -49,7 +49,7 @@
 	
 	
 	#############################################################################################
-	# ZEN CART Pretty URLs Handler
+	# Zen Cart Pretty URLs Handler
 	#############################################################################################	
 	## The following block handles Pretty URLs
 	## Insert directives below as required
@@ -59,9 +59,9 @@
 	
 	
 	#############################################################################################
-	# ZEN CART Root Folder
+	# Zen Cart Root Folder
 	#############################################################################################	
-	## Allow all requests to specific PHP files directly under the ZEN CART ROOT folder
+	## Allow all requests to specific PHP files directly under the Zen Cart ROOT folder
 	location ~ %%store_folder%%/(ajax|index|page_not_found|ipn_main_handler)\.php$ {
 		error_page 418 = @zencart_php_handler;
 		return 418;
@@ -72,7 +72,7 @@
 	}
 	
 	#############################################################################################
-	# ZEN CART 'includes' Folder
+	# Zen Cart 'includes' Folder
 	#############################################################################################	
 	## Allow all 'GET' and 'HEAD' requests to specific static file types in 'includes' and/or subfolders
 	location ~ %%store_folder%%/includes {
@@ -96,7 +96,7 @@
 	
 	
 	#############################################################################################
-	# ZEN CART 'images' Folder
+	# Zen Cart 'images' Folder
 	#############################################################################################	
 	## Allow internal requests to 'images/uploads'
 	location ~ %%store_folder%%/images/uploads {
@@ -114,7 +114,7 @@
 	
 	
 	#############################################################################################
-	# ZEN CART 'pub' Folder
+	# Zen Cart 'pub' Folder
 	#############################################################################################	
 	## Allow and force downloads of all requests to specific static file types in 'pub' and/or subfolders
 	location ~ %%store_folder%%/pub/.+\.(g?zip|pdf|mp3?4?|swf|wma|wmv|wav|epub|ogg|webm|m4v?a?)$ {
@@ -128,7 +128,7 @@
 	
 	
 	#############################################################################################
-	# ZEN CART 'download' Folder
+	# Zen Cart 'download' Folder
 	#############################################################################################	
 	## Allow and force downloads of internal requests to specific static file types in 'download' and/or subfolders
 	location ~ %%store_folder%%/download/.+\.(mpe?g?3?4?|swf|avi|wma?v?|wav|epub|flv|ogg|webm|m4v?a?|mov|g?zip|rar|t?gz|tar|pdf)$ {
@@ -145,7 +145,7 @@
 	
 	
 	#############################################################################################
-	# ZEN CART 'media' Folder
+	# Zen Cart 'media' Folder
 	#############################################################################################	
 	## Allow all requests to specific static file types in 'media' and/or subfolders
 	location ~ %%store_folder%%/media/.+\.(mpe?g?3?4?|swf|avi|wma?v?|wav|epub|flv|ogg|webm|m4v?a?|mov|ra?m?)$ {
@@ -159,7 +159,7 @@
 	
 	
 	#############################################################################################
-	# ZEN CART 'extras' Folder
+	# Zen Cart 'extras' Folder
 	#############################################################################################	
 	## Allow all requests to html files in 'extras' and/or subfolders
 	location ~ %%store_folder%%/extras/.+\.html$ {
@@ -177,7 +177,7 @@
 	
 	
 	#############################################################################################
-	# ZEN CART 'email' Folder
+	# Zen Cart 'email' Folder
 	#############################################################################################	
 	## Allow all requests to specific static file types in 'email' and/or subfolders
 	location ~ %%store_folder%%/email/.+\.(jpe?g|gif|png)$ {
@@ -190,7 +190,7 @@
 	
 	
 	#############################################################################################
-	# ZEN CART 'editors' and 'docs' Folders
+	# Zen Cart 'editors' and 'docs' Folders
 	#############################################################################################	
 	## Allow all requests to specific static file types in 'editors' or 'docs' and/or subfolders
 	location ~ %%store_folder%%/(editors|docs)/.+\.(js|css|jpe?g|gif|png|html?|xml|pdf)$ {
@@ -203,7 +203,7 @@
 	
 	
 	#############################################################################################
-	# ZEN CART ADMIN Folder
+	# Zen Cart ADMIN Folder
 	#############################################################################################	
 	## Allow all 'GET' and 'HEAD' requests to specific file types
 	location ~ %%admin_folder%% {
@@ -238,7 +238,7 @@
 	
 	
 	#############################################################################################
-	# ZEN CART 'cache' Folder
+	# Zen Cart 'cache' Folder
 	#############################################################################################	
 	## Allow internal requests to 'cache' and/or subfolders
 	location ~ %%store_folder%%/cache {
@@ -247,7 +247,7 @@
 	
 	
 	#############################################################################################
-	# ZEN CART 'logs' Folder
+	# Zen Cart 'logs' Folder
 	#############################################################################################	
 	## Allow internal requests to 'logs' and/or subfolders
 	location ~ %%store_folder%%/logs {
@@ -256,7 +256,7 @@
 	
 	
 	#############################################################################################
-	# ZEN CART 'zc_install' Folder
+	# Zen Cart 'zc_install' Folder
 	#############################################################################################	
 	## Allow all requests to specific static file types in 'zc_install' and/or subfolders
 	location ~ %%store_folder%%/zc_install/.+\.(ico|js|css|jpg|gif|png|html)$ {
@@ -293,9 +293,9 @@
 	
 	
 	#############################################################################################
-	# ZEN CART Catchall
+	# Zen Cart Catchall
 	#############################################################################################	
-	## Redirect any request not previously explicitly handled to main ZEN CART index.php file
+	## Redirect any request not previously explicitly handled to main Zen Cart index.php file
 	location ~ %%slash_folder%% {
 		rewrite ^ %%store_folder%%/index.php? redirect;
 	}

--- a/zc_install/includes/nginx_conf/ngx_server_template.txt
+++ b/zc_install/includes/nginx_conf/ngx_server_template.txt
@@ -1,0 +1,303 @@
+####################################################################################################
+####################################################################################################
+####################################################################################################
+### 		                  NGINX CONFIGURATION FOR ZEN CART
+###
+### NOTES: 
+###    - Copy and paste into ZEN CART handling ‘server’ section of nginx conf file
+###    - Location Block order is important
+###    - Include before any other location blocks if any
+###
+###
+####################################################################################################
+####################################################################################################
+####################################################################################################
+	
+	
+	#############################################################################################
+	# ZEN CART PHP Handler
+	#############################################################################################	
+	## The following block serves all PHP requests internally directed to it within this conf file
+	## Edit to reflect your actual setup for serving PHP
+	location @zencart_php_handler {
+		if (!-f $document_root$fastcgi_script_name) { return 404; }
+
+		fastcgi_index   index.php;
+		fastcgi_pass    12.0.0.1:9000;
+		
+		fastcgi_param	SCRIPT_FILENAME     $document_root$fastcgi_script_name;
+		fastcgi_param	QUERY_STRING        $query_string;
+		fastcgi_param	REQUEST_METHOD      $request_method;
+		fastcgi_param	CONTENT_TYPE        $content_type;
+		fastcgi_param	CONTENT_LENGTH      $content_length;
+		fastcgi_param	SCRIPT_NAME         $fastcgi_script_name;
+		fastcgi_param	REQUEST_URI         $request_uri;
+		fastcgi_param	DOCUMENT_URI        $document_uri;
+		fastcgi_param	DOCUMENT_ROOT       $document_root;
+		fastcgi_param	SERVER_PROTOCOL     $server_protocol;
+		fastcgi_param	GATEWAY_INTERFACE   CGI/1.1;
+		fastcgi_param	SERVER_SOFTWARE     nginx/$nginx_version;
+		fastcgi_param	REMOTE_ADDR         $remote_addr;
+		fastcgi_param	REMOTE_PORT         $remote_port;
+		fastcgi_param	SERVER_ADDR         $server_addr;
+		fastcgi_param	SERVER_PORT         $server_port;
+		fastcgi_param	SERVER_NAME         $server_name;
+		fastcgi_param	REDIRECT_STATUS     200;
+		
+		fastcgi_hide_header X-Powered-By;
+	}
+	
+	
+	#############################################################################################
+	# ZEN CART Pretty URLs Handler
+	#############################################################################################	
+	## The following block handles Pretty URLs
+	## Insert directives below as required
+	#
+	#
+	#
+	
+	
+	#############################################################################################
+	# ZEN CART Root Folder
+	#############################################################################################	
+	## Allow all requests to specific PHP files directly under the ZEN CART ROOT folder
+	location ~ %%store_folder%%/(ajax|index|page_not_found|ipn_main_handler)\.php$ {
+		error_page 418 = @zencart_php_handler;
+		return 418;
+	}
+	## Allow all requests to specific static file types
+	location ~ %%store_folder%%/.+\.(md|ico|txt|html)$ {
+		expires $zencart_expires;
+	}
+	
+	#############################################################################################
+	# ZEN CART 'includes' Folder
+	#############################################################################################	
+	## Allow all 'GET' and 'HEAD' requests to specific static file types in 'includes' and/or subfolders
+	location ~ %%store_folder%%/includes {
+		location ~ %%store_folder%%/includes.+\.(ico|jpe?g|gif|otf|webp|png|swf|flv|pdf|svg?z)$ {
+			if ( $request_method !~ ^(GET|HEAD)$ ) { return 403; }
+			add_header Cache-Control 'max-age=864000, public, must-revalidate';
+			expires $zencart_expires;		
+		}
+		location ~ %%store_folder%%/includes/.+\.(html|htm|xml|txt|xsl)$ {
+			if ( $request_method !~ ^(GET|HEAD)$ ) { return 403; }
+			add_header Cache-Control 'max-age=7200, must-revalidate';
+			expires $zencart_expires;		
+		}
+		location ~ %%store_folder%%/includes/.+\.(js|css)$ {
+			if ( $request_method !~ ^(GET|HEAD)$ ) { return 403; }
+			expires $zencart_expires;		
+		}
+		# Deny any other request to 'includes' and/or subfolders
+		return 403;
+	}
+	
+	
+	#############################################################################################
+	# ZEN CART 'images' Folder
+	#############################################################################################	
+	## Allow internal requests to 'images/uploads'
+	location ~ %%store_folder%%/images/uploads {
+		internal;
+	}
+	## Allow all requests to specific static file types in 'images' and/or subfolders
+	location ~ %%store_folder%%/images/.+\.(jpe?g|gif|webp|png|swf)$ {
+		add_header Cache-Control 'max-age=864000, public, must-revalidate';
+		expires $zencart_expires;		
+	}
+	## Deny any other request to 'images' and/or subfolders
+	location ~ %%store_folder%%/images {
+		return 403;
+	}
+	
+	
+	#############################################################################################
+	# ZEN CART 'pub' Folder
+	#############################################################################################	
+	## Allow and force downloads of all requests to specific static file types in 'pub' and/or subfolders
+	location ~ %%store_folder%%/pub/.+\.(g?zip|pdf|mp3?4?|swf|wma|wmv|wav|epub|ogg|webm|m4v?a?)$ {
+		types { }
+		default_type application/octet-stream;
+	}
+	## Deny any other request to 'pub' and/or subfolders
+	location ~ %%store_folder%%/pub {
+		return 403;
+	}
+	
+	
+	#############################################################################################
+	# ZEN CART 'download' Folder
+	#############################################################################################	
+	## Allow and force downloads of internal requests to specific static file types in 'download' and/or subfolders
+	location ~ %%store_folder%%/download/.+\.(mpe?g?3?4?|swf|avi|wma?v?|wav|epub|flv|ogg|webm|m4v?a?|mov|g?zip|rar|t?gz|tar|pdf)$ {
+		types { }
+		default_type application/octet-stream;
+		
+		# Comment out the 'internal' line below if you wish to allow direct access to 'download' folder
+		internal;
+	}
+	## Deny any other request to 'download' and/or subfolders
+	location ~ %%store_folder%%/download {
+		return 403;
+	}
+	
+	
+	#############################################################################################
+	# ZEN CART 'media' Folder
+	#############################################################################################	
+	## Allow all requests to specific static file types in 'media' and/or subfolders
+	location ~ %%store_folder%%/media/.+\.(mpe?g?3?4?|swf|avi|wma?v?|wav|epub|flv|ogg|webm|m4v?a?|mov|ra?m?)$ {
+		add_header Cache-Control 'max-age=864000, public, must-revalidate';
+		expires $zencart_expires;		
+	}
+	## Deny any other request to 'media' and/or subfolders
+	location ~ %%store_folder%%/media {
+		return 403;
+	}
+	
+	
+	#############################################################################################
+	# ZEN CART 'extras' Folder
+	#############################################################################################	
+	## Allow all requests to html files in 'extras' and/or subfolders
+	location ~ %%store_folder%%/extras/.+\.html$ {
+		expires $zencart_expires;		
+	}
+	## Allow all requests to all PHP files
+	location ~ %%store_folder%%/extras/.+\.php$ {
+		error_page 418 = @zencart_php_handler;
+		return 418;
+	}
+	## Deny any other request to 'extras' and/or subfolders
+	location ~ %%store_folder%%/extras {
+		return 403;
+	}
+	
+	
+	#############################################################################################
+	# ZEN CART 'email' Folder
+	#############################################################################################	
+	## Allow all requests to specific static file types in 'email' and/or subfolders
+	location ~ %%store_folder%%/email/.+\.(jpe?g|gif|png)$ {
+		expires $zencart_expires;		
+	}
+	## Deny any other request to 'email' and/or subfolders
+	location ~ %%store_folder%%/email {
+		return 403;
+	}
+	
+	
+	#############################################################################################
+	# ZEN CART 'editors' and 'docs' Folders
+	#############################################################################################	
+	## Allow all requests to specific static file types in 'editors' or 'docs' and/or subfolders
+	location ~ %%store_folder%%/(editors|docs)/.+\.(js|css|jpe?g|gif|png|html?|xml|pdf)$ {
+		expires $zencart_expires;		
+	}
+	## Deny any other request to 'editors' or 'docs' and/or subfolders
+	location ~ %%store_folder%%/(editors|docs) {
+		return 403;
+	}
+	
+	
+	#############################################################################################
+	# ZEN CART ADMIN Folder
+	#############################################################################################	
+	## Allow all 'GET' and 'HEAD' requests to specific file types
+	location ~ %%admin_folder%% {
+		## Additionally allow all 'POST' requests to all PHP files in ADMIN folder and/or subfolders
+		location ~ %%admin_folder%%/.+\.php$ {
+			if ( $request_method !~ ^(GET|HEAD|POST)$ ) { return 403; }
+			error_page 418 = @zencart_php_handler;
+			return 418;
+		}
+		location ~ %%admin_folder%%/.+\.(ico|jpe?g|gif|eot|otf|woff2?|ttf|webp|png|swf|flv|pdf|svgz?)$ {
+			if ( $request_method !~ ^(GET|HEAD)$ ) { return 403; }
+			add_header Cache-Control 'max-age=864000, public, must-revalidate';
+			expires $zencart_expires;		
+		}
+		location ~ %%admin_folder%%/.+\.(html|htm|xml|txt|xsl)$ {
+			if ( $request_method !~ ^(GET|HEAD)$ ) { return 403; }
+			add_header Cache-Control 'max-age=7200, must-revalidate';		
+			expires $zencart_expires;		
+		}
+		location ~ %%admin_folder%%/.+\.(js|css)$ {
+			if ( $request_method !~ ^(GET|HEAD)$ ) { return 403; }
+			expires $zencart_expires;		
+		}
+		# Redirect all requests to ADMIN root to ADMIN/index.php 
+		location ~ %%admin_folder%%(/?)$ {
+			if ( $request_method !~ ^(GET|HEAD)$ ) { return 403; }
+			rewrite ^ %%admin_folder%%/index.php? redirect;
+		}
+		# Deny any other request to ADMIN folder and/or subfolders
+		return 403;
+	}
+	
+	
+	#############################################################################################
+	# ZEN CART 'cache' Folder
+	#############################################################################################	
+	## Allow internal requests to 'cache' and/or subfolders
+	location ~ %%store_folder%%/cache {
+		internal;
+	}
+	
+	
+	#############################################################################################
+	# ZEN CART 'logs' Folder
+	#############################################################################################	
+	## Allow internal requests to 'logs' and/or subfolders
+	location ~ %%store_folder%%/logs {
+		internal;
+	}
+	
+	
+	#############################################################################################
+	# ZEN CART 'zc_install' Folder
+	#############################################################################################	
+	## Allow all requests to specific static file types in 'zc_install' and/or subfolders
+	location ~ %%store_folder%%/zc_install/.+\.(ico|js|css|jpg|gif|png|html)$ {
+		expires 5m;	
+	}
+	## Allow internal requests to PHP files in subdirectories under 'zc_install'
+	location ~ %%store_folder%%/zc_install/.+/.+\.php$ {
+		internal;
+		error_page 418 = @zencart_php_handler;
+		return 418;
+	}
+	## Allow all requests to index.php file directly under 'zc_install'
+	location ~ %%store_folder%%/zc_install/index\.php$ {
+		error_page 418 = @zencart_php_handler;
+		return 418;
+	}
+	## Allow all requests to PHP files that start with 'ajax' directly under 'zc_install' 
+	location ~ %%store_folder%%/zc_install/ajax.+\.php$ {
+		error_page 418 = @zencart_php_handler;
+		return 418;
+	}
+	## Allow internal requests to 'zc_install/sql' and/or subfolders
+	location ~ %%store_folder%%/zc_install/sql(.*)$ {
+		internal;
+	}
+	## Redirect all requests to 'zc_install' root to 'zc_install/index.php'
+	location ~ %%store_folder%%/zc_install(/?)$ {
+		rewrite ^ %%store_folder%%/zc_install/index.php? redirect;
+	}
+	## Deny any other request to 'zc_install' and/or subfolders
+	location ~ %%store_folder%%/zc_install {
+		return 403;
+	}
+	
+	
+	#############################################################################################
+	# ZEN CART Catchall
+	#############################################################################################	
+	## Redirect any request not previously explicitly handled to main ZEN CART index.php file
+	location ~ %%slash_folder%% {
+		rewrite ^ %%store_folder%%/index.php? redirect;
+	}
+	
+	

--- a/zc_install/includes/nginx_conf/zencart_ngx_http.conf
+++ b/zc_install/includes/nginx_conf/zencart_ngx_http.conf
@@ -1,5 +1,5 @@
 #######################################################################
-# ZEN CART ‘Expires’ map
+# Zen Cart ‘Expires’ map
 # Maps "expires" values to mime types and stores in a variable
 #
 # Add to the ‘http’ section of your Nginx conf file

--- a/zc_install/includes/nginx_conf/zencart_ngx_server.conf
+++ b/zc_install/includes/nginx_conf/zencart_ngx_server.conf
@@ -4,7 +4,7 @@
 ### 		                  NGINX CONFIGURATION FOR ZEN CART
 ###
 ### NOTES: 
-###    - Copy and paste into ZEN CART handling ‘server’ section of nginx conf file
+###    - Copy and paste into Zen Cart handling ‘server’ section of nginx conf file
 ###    - Location Block order is important
 ###    - Include before any other location blocks if any
 ###
@@ -15,7 +15,7 @@
 	
 	
 	#############################################################################################
-	# ZEN CART PHP Handler
+	# Zen Cart PHP Handler
 	#############################################################################################	
 	## The following block serves all PHP requests internally directed to it within this conf file
 	## Edit to reflect your actual setup for serving PHP
@@ -49,7 +49,7 @@
 	
 	
 	#############################################################################################
-	# ZEN CART Pretty URLs Handler
+	# Zen Cart Pretty URLs Handler
 	#############################################################################################	
 	## The following block handles Pretty URLs
 	## Insert directives below as required
@@ -59,9 +59,9 @@
 	
 	
 	#############################################################################################
-	# ZEN CART Root Folder
+	# Zen Cart Root Folder
 	#############################################################################################	
-	## Allow all requests to specific PHP files directly under the ZEN CART ROOT folder
+	## Allow all requests to specific PHP files directly under the Zen Cart ROOT folder
 	location ~ %%store_folder%%/(ajax|index|page_not_found|ipn_main_handler)\.php$ {
 		error_page 418 = @zencart_php_handler;
 		return 418;
@@ -72,7 +72,7 @@
 	}
 	
 	#############################################################################################
-	# ZEN CART 'includes' Folder
+	# Zen Cart 'includes' Folder
 	#############################################################################################	
 	## Allow all 'GET' and 'HEAD' requests to specific static file types in 'includes' and/or subfolders
 	location ~ %%store_folder%%/includes {
@@ -96,7 +96,7 @@
 	
 	
 	#############################################################################################
-	# ZEN CART 'images' Folder
+	# Zen Cart 'images' Folder
 	#############################################################################################	
 	## Allow internal requests to 'images/uploads'
 	location ~ %%store_folder%%/images/uploads {
@@ -114,7 +114,7 @@
 	
 	
 	#############################################################################################
-	# ZEN CART 'pub' Folder
+	# Zen Cart 'pub' Folder
 	#############################################################################################	
 	## Allow and force downloads of all requests to specific static file types in 'pub' and/or subfolders
 	location ~ %%store_folder%%/pub/.+\.(g?zip|pdf|mp3?4?|swf|wma|wmv|wav|epub|ogg|webm|m4v?a?)$ {
@@ -128,7 +128,7 @@
 	
 	
 	#############################################################################################
-	# ZEN CART 'download' Folder
+	# Zen Cart 'download' Folder
 	#############################################################################################	
 	## Allow and force downloads of internal requests to specific static file types in 'download' and/or subfolders
 	location ~ %%store_folder%%/download/.+\.(mpe?g?3?4?|swf|avi|wma?v?|wav|epub|flv|ogg|webm|m4v?a?|mov|g?zip|rar|t?gz|tar|pdf)$ {
@@ -145,7 +145,7 @@
 	
 	
 	#############################################################################################
-	# ZEN CART 'media' Folder
+	# Zen Cart 'media' Folder
 	#############################################################################################	
 	## Allow all requests to specific static file types in 'media' and/or subfolders
 	location ~ %%store_folder%%/media/.+\.(mpe?g?3?4?|swf|avi|wma?v?|wav|epub|flv|ogg|webm|m4v?a?|mov|ra?m?)$ {
@@ -159,7 +159,7 @@
 	
 	
 	#############################################################################################
-	# ZEN CART 'extras' Folder
+	# Zen Cart 'extras' Folder
 	#############################################################################################	
 	## Allow all requests to html files in 'extras' and/or subfolders
 	location ~ %%store_folder%%/extras/.+\.html$ {
@@ -177,7 +177,7 @@
 	
 	
 	#############################################################################################
-	# ZEN CART 'email' Folder
+	# Zen Cart 'email' Folder
 	#############################################################################################	
 	## Allow all requests to specific static file types in 'email' and/or subfolders
 	location ~ %%store_folder%%/email/.+\.(jpe?g|gif|png)$ {
@@ -190,7 +190,7 @@
 	
 	
 	#############################################################################################
-	# ZEN CART 'editors' and 'docs' Folders
+	# Zen Cart 'editors' and 'docs' Folders
 	#############################################################################################	
 	## Allow all requests to specific static file types in 'editors' or 'docs' and/or subfolders
 	location ~ %%store_folder%%/(editors|docs)/.+\.(js|css|jpe?g|gif|png|html?|xml|pdf)$ {
@@ -203,7 +203,7 @@
 	
 	
 	#############################################################################################
-	# ZEN CART ADMIN Folder
+	# Zen Cart ADMIN Folder
 	#############################################################################################	
 	## Allow all 'GET' and 'HEAD' requests to specific file types
 	location ~ %%admin_folder%% {
@@ -238,7 +238,7 @@
 	
 	
 	#############################################################################################
-	# ZEN CART 'cache' Folder
+	# Zen Cart 'cache' Folder
 	#############################################################################################	
 	## Allow internal requests to 'cache' and/or subfolders
 	location ~ %%store_folder%%/cache {
@@ -247,7 +247,7 @@
 	
 	
 	#############################################################################################
-	# ZEN CART 'logs' Folder
+	# Zen Cart 'logs' Folder
 	#############################################################################################	
 	## Allow internal requests to 'logs' and/or subfolders
 	location ~ %%store_folder%%/logs {
@@ -256,7 +256,7 @@
 	
 	
 	#############################################################################################
-	# ZEN CART 'zc_install' Folder
+	# Zen Cart 'zc_install' Folder
 	#############################################################################################	
 	## Allow all requests to specific static file types in 'zc_install' and/or subfolders
 	location ~ %%store_folder%%/zc_install/.+\.(ico|js|css|jpg|gif|png|html)$ {
@@ -293,9 +293,9 @@
 	
 	
 	#############################################################################################
-	# ZEN CART Catchall
+	# Zen Cart Catchall
 	#############################################################################################	
-	## Redirect any request not previously explicitly handled to main ZEN CART index.php file
+	## Redirect any request not previously explicitly handled to main Zen Cart index.php file
 	location ~ %%slash_folder%% {
 		rewrite ^ %%store_folder%%/index.php? redirect;
 	}


### PR DESCRIPTION
When zc_install replaces the original file every time it is run, it makes code maintenance complicated. This splits it out into separate files: a template, and an output file.