### PR TITLE
Reorder load-order of components in checkout_process

### DIFF
--- a/includes/modules/checkout_process.php
+++ b/includes/modules/checkout_process.php
@@ -48,12 +48,13 @@ if (!isset($credit_covers)) $credit_covers = FALSE;
 // load selected payment module
 require(DIR_WS_CLASSES . 'payment.php');
 $payment_modules = new payment($_SESSION['payment']);
-// load the selected shipping module
-require(DIR_WS_CLASSES . 'shipping.php');
-$shipping_modules = new shipping($_SESSION['shipping']);
 
 require(DIR_WS_CLASSES . 'order.php');
 $order = new order;
+
+// load the selected shipping module
+require(DIR_WS_CLASSES . 'shipping.php');
+$shipping_modules = new shipping($_SESSION['shipping']);
 
 // prevent 0-entry orders from being generated/spoofed
 if (sizeof($order->products) < 1) {


### PR DESCRIPTION
In rare and unexplained circumstances tax calculations may not fire properly on shipping.
Changing the load-order to match the order used in other stages of checkout appears to help prevent this.

Long discussion at https://www.zen-cart.com/showthread.php?220280-Shipping-tax-not-added-in-order-confirmation-possible-bug&p=1312461#post1312461