### PR TITLE
Prevent fatal error if widget class is missing

### DIFF
--- a/includes/library/zencart/DashboardWidget/src/WidgetManager.php
+++ b/includes/library/zencart/DashboardWidget/src/WidgetManager.php
@@ -117,6 +117,7 @@ final class WidgetManager
         if (!class_exists($className, true) && is_readable($classFile)) {
           require_once($classFile);
         }
+        if (!class_exists($className)) continue;
 
         $widgetClass = new $className($widget['widget_key'], $widget);
         $widgetList[$widget['widget_key']] = $widgetClass;


### PR DESCRIPTION
If user's widget is defined in db table but class is missing, a fatal error was occurring.
Now it just displays an empty widget without crashing.