### PR TITLE
Warn the user on the system_setup page to get a certificate

### DIFF
--- a/zc_install/includes/languages/lngEnglish.php
+++ b/zc_install/includes/languages/lngEnglish.php
@@ -183,6 +183,7 @@ define('TEXT_ERROR_EXTENSION_NOT_LOADED', '%s extension does not seem to be load
 define('TEXT_ERROR_FUNCTION_DOES_NOT_EXIST', 'PHP function %s does not exist');
 define('TEXT_ERROR_CURL_LIVE_TEST', 'Could not use CURL to contact a live server');
 define('TEXT_ERROR_HTTPS', 'PRO TIP: If possible you should already have installed an SSL certificate, and run the installer using https://');
+define('TEXT_ERROR_HTTPS_CONFIGURE', 'As soon as possible, you should install an SSL certificate, and update your configure.php files.');
 define('TEXT_ERROR_SUCCESS_EXISTING_CONFIGURE', 'An existing configure.php file was found. The installer will attempt to upgrade your database structure if you choose "Upgrade..." below.');
 define('TEXT_ERROR_SUCCESS_EXISTING_CONFIGURE_NO_UPDATE', 'An existing configure.php file was found. However your database seems to be current. This suggests you are on a live site. Proceeding with Install will wipe out the current database contents! Are you sure you want to install?');
 define('TEXT_ERROR_MULTIPLE_ADMINS_NONE_SELECTED', 'Multiple Admin directories seem to exist. Either remove old admin directories and click Refresh or select the correct admin directory below and click Refresh.');

--- a/zc_install/includes/template/templates/system_setup_default.php
+++ b/zc_install/includes/template/templates/system_setup_default.php
@@ -16,6 +16,10 @@ require(DIR_FS_INSTALL . DIR_WS_INSTALL_TEMPLATE . 'partials/partial_modal_help.
   <input type="hidden" name="detected_detected_https_server_catalog" value="<?php echo $catalogHttpsServer; ?>">
   <input type="hidden" name="adminDir" value="<?php echo $adminDir; ?>">
   <input type="hidden" name="db_type" value="<?php echo $db_type; ?>">
+
+  <?php if ($request_type != 'SSL') { ?>
+  <div class="alert-box warning"><?php echo TEXT_ERROR_HTTPS_CONFIGURE; ?></div>
+  <?php } ?>
   <fieldset>
     <legend>License</legend>
     <div class="row">


### PR DESCRIPTION
Uses a more intense color and tells them follow up will be needed:

```
'As soon as possible, you should install an SSL certificate, and update your configure.php files.'
```