### PR TITLE
Automatically disable session.use_trans_sid

### DIFF
--- a/admin/includes/application_bootstrap.php
+++ b/admin/includes/application_bootstrap.php
@@ -48,6 +48,7 @@ if (!isset($PHP_SELF)) $PHP_SELF = $_SERVER['SCRIPT_NAME'];
 $PHP_SELF = htmlspecialchars($PHP_SELF);
 // Suppress html from error messages
 @ini_set("html_errors","0");
+@ini_set("session.use_trans_sid","0");
 /*
  * Get time zone info from PHP config
 */

--- a/includes/application_top.php
+++ b/includes/application_top.php
@@ -62,6 +62,7 @@ define('PAGE_PARSE_START_TIME', microtime());
 //  define('DISPLAY_PAGE_PARSE_TIME', 'true');
 @ini_set("arg_separator.output","&");
 @ini_set("html_errors","0");
+@ini_set("session.use_trans_sid","0");
 /**
  * Set the local configuration parameters - mainly for developers
  */

--- a/zc_install/includes/application_top.php
+++ b/zc_install/includes/application_top.php
@@ -8,6 +8,7 @@
  */
 
 @ini_set("arg_separator.output", "&");
+@ini_set("session.use_trans_sid","0");
 @set_time_limit(250);
 
 if (file_exists(DIR_FS_INSTALL . 'includes/localConfig.php')) {

--- a/zc_install/includes/systemChecks.yml
+++ b/zc_install/includes/systemChecks.yml
@@ -1,6 +1,6 @@
 #
 # @package Installer
-# @copyright Copyright 2003-2015 Zen Cart Development Team
+# @copyright Copyright 2003-2016 Zen Cart Development Team
 # @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
 # @version $Id:  New in v1.6.0 $
 #
@@ -144,12 +144,6 @@ systemChecks:
         parameters:
           sessionName: zenInstallerId
       checkIniGet1:
-        method: checkIniGet
-        parameters:
-          inigetName: session.use_trans_sid
-          expectedValue: FALSE
-        localErrorText: <?php echo TEXT_ERROR_SESSION_SUPPORT_USE_TRANS_SID . PHP_EOL; ?>
-      checkIniGet2:
         method: checkIniGet
         parameters:
           inigetName: session.auto_start


### PR DESCRIPTION
Given that `session.use_trans_sid` can be disabled at the application level, let's do that automatically, instead of leaving it up to the end-user to have to figure out how to change `php.ini`