### PR TITLE
Stop use of deprecated "zen_href_link" in Admin Folder - Updates #937

### DIFF
--- a/admin/includes/functions/html_output.php
+++ b/admin/includes/functions/html_output.php
@@ -8,8 +8,7 @@
  */
 
   /**
-   * Deprecated and will be removed in later versions. 
-   * Use zen_admin_href_link instead
+   * @deprecated in version 1.6.0. Use zen_admin_href_link instead
    */
   function zen_href_link($page = '', $parameters = '', $connection = 'NONSSL', $add_session_id = true) {
    return zen_admin_href_link($page, $parameters, $add_session_id);

--- a/admin/includes/functions/html_output.php
+++ b/admin/includes/functions/html_output.php
@@ -11,10 +11,9 @@
    * Deprecated and will be removed in later versions. 
    * Use zen_admin_href_link instead
    */
-  //Disabled until Prerelease Stage to stop delopers from using in core code
-  //function zen_href_link($page = '', $parameters = '', $connection = 'NONSSL', $add_session_id = true) {
-  // return zen_admin_href_link($page, $parameters, $add_session_id);
-  //}
+  function zen_href_link($page = '', $parameters = '', $connection = 'NONSSL', $add_session_id = true) {
+   return zen_admin_href_link($page, $parameters, $add_session_id);
+  }
 
   /**
    * Returns a admin link formatted for use in a href attribute. This should

--- a/admin/includes/functions/html_output.php
+++ b/admin/includes/functions/html_output.php
@@ -11,9 +11,10 @@
    * Deprecated and will be removed in later versions. 
    * Use zen_admin_href_link instead
    */
-  function zen_href_link($page = '', $parameters = '', $connection = 'NONSSL', $add_session_id = true) {
-    return zen_admin_href_link($page, $parameters, $add_session_id);
-  }
+  //Disabled until Prerelease Stage to stop delopers from using in core code
+  //function zen_href_link($page = '', $parameters = '', $connection = 'NONSSL', $add_session_id = true) {
+  // return zen_admin_href_link($page, $parameters, $add_session_id);
+  //}
 
   /**
    * Returns a admin link formatted for use in a href attribute. This should

--- a/admin/includes/init_includes/init_header.php
+++ b/admin/includes/init_includes/init_header.php
@@ -178,11 +178,11 @@ if (SHOW_GV_QUEUE==true && (zen_is_superuser() || check_page(FILENAME_ORDERS, ar
   $new_gv_queue_cnt = 0;
   if ($new_gv_queue->RecordCount() > 0) {
     $new_gv_queue_cnt= $new_gv_queue->RecordCount();
-    $goto_gv = '<a href="' . zen_href_link(FILENAME_GV_QUEUE) . '">' . '<input type="button" class="btn btn-info" value="' . IMAGE_GIFT_QUEUE . '"/></a>';
+    $goto_gv = '<a href="' . zen_admin_href_link(FILENAME_GV_QUEUE) . '">' . '<input type="button" class="btn btn-info" value="' . IMAGE_GIFT_QUEUE . '"/></a>';
 
 
     $adminNotifications = $di->get('zencart_notifications');
-    $notification = array('type' => 'bell', 'text' => sprintf(TEXT_HEADER_GV_QUEUE, $new_gv_queue_cnt), 'link' => zen_href_link(FILENAME_GV_QUEUE), 'pageKey' => 'gvQueue');
+    $notification = array('type' => 'bell', 'text' => sprintf(TEXT_HEADER_GV_QUEUE, $new_gv_queue_cnt), 'link' => zen_admin_href_link(FILENAME_GV_QUEUE), 'pageKey' => 'gvQueue');
     $adminNotifications->addNotification($notification);
 
   }

--- a/admin/includes/template/common/tplHeader.php
+++ b/admin/includes/template/common/tplHeader.php
@@ -4,7 +4,7 @@
 <!-- Main Header -->
 <header class="main-header">
     <section>
-        <a href="<?php echo zen_href_link(FILENAME_DEFAULT); ?>">
+        <a href="<?php echo zen_admin_href_link(FILENAME_DEFAULT); ?>">
             <?php echo zen_image(DIR_WS_IMAGES . HEADER_LOGO_IMAGE, HEADER_ALT_TEXT, HEADER_LOGO_WIDTH, HEADER_LOGO_HEIGHT); ?>
         </a>
     </section>
@@ -30,7 +30,7 @@
                 <?php require('includes/template/partials/specialMenu/tplStandardLinks.php'); ?>
                 <?php require('includes/template/partials/specialMenu/tplNotificationsBell.php'); ?>
                 <?php require('includes/template/partials/specialMenu/tplUserDropdown.php'); ?>
-                <li><a title="<?php echo HEADER_TITLE_LOGOFF ?>" href="<?php echo zen_href_link(FILENAME_LOGOFF, '', 'SSL'); ?>"><i class="fa fa-sign-out text-white"></i></a></li>
+                <li><a title="<?php echo HEADER_TITLE_LOGOFF ?>" href="<?php echo zen_admin_href_link(FILENAME_LOGOFF); ?>"><i class="fa fa-sign-out text-white"></i></a></li>
                 <li>
                     <a href="#" data-toggle="control-sidebar"><i class="fa fa-gears"></i></a>
                 </li>

--- a/admin/includes/template/common/tplMainMenu.php
+++ b/admin/includes/template/common/tplMainMenu.php
@@ -26,7 +26,7 @@
                                 class="caret"></span></a>
                         <ul class="dropdown-menu">
                             <?php foreach ($pages as $page) { ?>
-                                <li><a href="<?php echo zen_href_link($page['file'],
+                                <li><a href="<?php echo zen_admin_href_link($page['file'],
                                         $page['params']) ?>"><?php echo $page['name'] ?></a></li>
                             <?php } ?>
                         </ul>

--- a/admin/includes/template/dashboardWidgets/tplSalesGraphReport.php
+++ b/admin/includes/template/dashboardWidgets/tplSalesGraphReport.php
@@ -9,7 +9,7 @@
  */
 ?>
 <div class="row">
-  <div class="col-xs-12"><?php echo SALES_GRAPH_TEXT_MONTHLY; ?>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<?php echo '<a href="' . zen_href_link(FILENAME_STATS_SALES_REPORT_GRAPHS) . '">' . SALES_GRAPH_TEXT_CLICK . '</a>'; ?></div>
+  <div class="col-xs-12"><?php echo SALES_GRAPH_TEXT_MONTHLY; ?>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<?php echo '<a href="' . zen_admin_href_link(FILENAME_STATS_SALES_REPORT_GRAPHS) . '">' . SALES_GRAPH_TEXT_CLICK . '</a>'; ?></div>
 </div>
 
 <div class="row">

--- a/admin/includes/template/dashboardWidgets/tplWhosOnline.php
+++ b/admin/includes/template/dashboardWidgets/tplWhosOnline.php
@@ -41,5 +41,5 @@
 </div>
 <div class="row">
   <div class="col-xs-6"><?php echo WO_TOTAL; ?> <?php echo $widget['total']; ?></div>
-  <div class="col-xs-6 right"><?php echo '<a href="' . zen_href_link(FILENAME_WHOS_ONLINE) . '">' . WO_FULL_DETAILS . '</a>'; ?></div>
+  <div class="col-xs-6 right"><?php echo '<a href="' . zen_admin_href_link(FILENAME_WHOS_ONLINE) . '">' . WO_FULL_DETAILS . '</a>'; ?></div>
 </div>

--- a/admin/includes/template/partials/specialMenu/tplStandardLinks.php
+++ b/admin/includes/template/partials/specialMenu/tplStandardLinks.php
@@ -6,8 +6,8 @@
  * Time: 17:09
  */
 ?>
-<li><a href="<?php echo zen_href_link(FILENAME_DEFAULT, '', 'NONSSL'); ?>"><?php echo HEADER_TITLE_TOP; ?></a></li>
+<li><a href="<?php echo zen_admin_href_link(FILENAME_DEFAULT); ?>"><?php echo HEADER_TITLE_TOP; ?></a></li>
 <li><a href="<?php echo zen_catalog_href_link(FILENAME_DEFAULT); ?>" target="_blank"><?php echo HEADER_TITLE_ONLINE_CATALOG; ?></a></li>
 <li><a href="http://www.zen-cart.com/" target="_blank"><?php echo HEADER_TITLE_SUPPORT_SITE; ?></a></li>
-<li><a href="<?php echo zen_href_link(FILENAME_SERVER_INFO); ?>"><?php echo HEADER_TITLE_VERSION; ?></a></li>
+<li><a href="<?php echo zen_admin_href_link(FILENAME_SERVER_INFO); ?>"><?php echo HEADER_TITLE_VERSION; ?></a></li>
 

--- a/admin/includes/template/partials/specialMenu/tplUserDropdown.php
+++ b/admin/includes/template/partials/specialMenu/tplUserDropdown.php
@@ -22,10 +22,10 @@
         <li class="user-body bg-blue-active">
             <div class="row">
                 <div class="col-sm-6 pull-left">
-                    <a href="<?php echo zen_href_link(FILENAME_ADMIN_ACCOUNT); ?>" class="btn btn-default"><?php echo HEADER_TITLE_ACCOUNT; ?></a>
+                    <a href="<?php echo zen_admin_href_link(FILENAME_ADMIN_ACCOUNT); ?>" class="btn btn-default"><?php echo HEADER_TITLE_ACCOUNT; ?></a>
                 </div>
                 <div class="col-sm-6 pull-right">
-                    <a href="<?php echo zen_href_link(FILENAME_LOGOFF); ?>" class="btn btn-default"><?php echo HEADER_TITLE_LOGOFF; ?></a>
+                    <a href="<?php echo zen_admin_href_link(FILENAME_LOGOFF); ?>" class="btn btn-default"><?php echo HEADER_TITLE_LOGOFF; ?></a>
                 </div>
             </div>
         </li>

--- a/admin/includes/template/partials/tplAdminLeadListOutput.php
+++ b/admin/includes/template/partials/tplAdminLeadListOutput.php
@@ -7,7 +7,7 @@
  */
 ?>
 <div class="box-body no-padding">
-<form class="form" name="lead_filter" id="lead_filter_form" action="<?php echo zen_href_link($_GET['cmd'], 'action=multiEdit'); ?>"
+<form class="form" name="lead_filter" id="lead_filter_form" action="<?php echo zen_admin_href_link($_GET['cmd'], 'action=multiEdit'); ?>"
       method="post">
     <input type="hidden" name="securityToken"
            value="<?php echo $_SESSION['securityToken']; ?>">
@@ -35,7 +35,7 @@
                 <?php } ?>
                 <?php if ($tplVars['leadDefinition']['hasRowActions']) { ?>
                 <th>
-                    <a href="<?php echo zen_href_link($_GET['cmd'], zen_get_all_get_params(array('action'))); ?>" id="clearFiltersLink">Clear Filters</a>
+                    <a href="<?php echo zen_admin_href_link($_GET['cmd'], zen_get_all_get_params(array('action'))); ?>" id="clearFiltersLink">Clear Filters</a>
                 </th>
                 <?php } ?>
             </tr>

--- a/admin/includes/template/templates/tplSystemInspection.php
+++ b/admin/includes/template/templates/tplSystemInspection.php
@@ -120,7 +120,7 @@
                 <tbody>
                 <?php foreach($tplVars['missingPages'] as $missingPage) { ?>
                     <tr>
-                        <td><?php echo'<a href="' . zen_href_link(FILENAME_CONFIGURATION, "gID=" . (int)$missingPage['gid']) .'">' . $missingPage['name'] . '</a>'; ?></td>
+                        <td><?php echo'<a href="' . zen_admin_href_link(FILENAME_CONFIGURATION, "gID=" . (int)$missingPage['gid']) .'">' . $missingPage['name'] . '</a>'; ?></td>
                     </tr>
                 <?php } ?>
                 </tbody>

--- a/admin/stats_sales_report_graphs.php
+++ b/admin/stats_sales_report_graphs.php
@@ -179,11 +179,11 @@ require('includes/admin_html_head.php');
                             <tr>
                                 <td align="right" class="menuBoxHeading">
                                     <?php
-                                    echo '<a href="' . zen_href_link('stats_sales_report_graphs.php', 'report=1' . $sales_report_filter_link) . '">' . 'Hourly' . '</a> | ';
-                                    echo '<a href="' . zen_href_link('stats_sales_report_graphs.php', 'report=2' . $sales_report_filter_link) . '">' . 'Daily' . '</a> | ';
-                                    echo '<a href="' . zen_href_link('stats_sales_report_graphs.php', 'report=3' . $sales_report_filter_link) . '">' . 'Weekly' . '</a> | ';
-                                    echo '<a href="' . zen_href_link('stats_sales_report_graphs.php', 'report=4' . $sales_report_filter_link) . '">' . 'Monthly' . '</a> | ';
-                                    echo '<a href="' . zen_href_link('stats_sales_report_graphs.php', 'report=5' . $sales_report_filter_link) . '">' . 'Yearly' . '</a>';
+                                    echo '<a href="' . zen_admin_href_link('stats_sales_report_graphs.php', 'report=1' . $sales_report_filter_link) . '">' . 'Hourly' . '</a> | ';
+                                    echo '<a href="' . zen_admin_href_link('stats_sales_report_graphs.php', 'report=2' . $sales_report_filter_link) . '">' . 'Daily' . '</a> | ';
+                                    echo '<a href="' . zen_admin_href_link('stats_sales_report_graphs.php', 'report=3' . $sales_report_filter_link) . '">' . 'Weekly' . '</a> | ';
+                                    echo '<a href="' . zen_admin_href_link('stats_sales_report_graphs.php', 'report=4' . $sales_report_filter_link) . '">' . 'Monthly' . '</a> | ';
+                                    echo '<a href="' . zen_admin_href_link('stats_sales_report_graphs.php', 'report=5' . $sales_report_filter_link) . '">' . 'Yearly' . '</a>';
                                     ?>
                                 </td>
                             </tr>
@@ -225,7 +225,7 @@ require('includes/admin_html_head.php');
                                                 <td class="dataTableContent">
                                                     <?php
                                                     if (strlen($report->info[$i]['link']) > 0) {
-                                                        echo '<a href="' . zen_href_link('stats_sales_report_graphs.php', $report->info[$i]['link']) . '">';
+                                                        echo '<a href="' . zen_admin_href_link('stats_sales_report_graphs.php', $report->info[$i]['link']) . '">';
                                                     }
                                                     echo $report->info[$i]['text'];
                                                     if (strlen($report->info[$i]['link']) > 0) {
@@ -258,14 +258,14 @@ require('includes/admin_html_head.php');
                                                             <td align="left">
                                                                 <?php
                                                                 if (strlen($report->previous) > 0) {
-                                                                    echo '<a href="' . zen_href_link('stats_sales_report_graphs.php', $report->previous, 'NONSSL') . '">&lt;&lt;&nbsp;Previous</a>';
+                                                                    echo '<a href="' . zen_admin_href_link('stats_sales_report_graphs.php', $report->previous) . '">&lt;&lt;&nbsp;Previous</a>';
                                                                 }
                                                                 ?>
                                                             </td>
                                                             <td align="right">
                                                                 <?php
                                                                 if (strlen($report->next) > 0) {
-                                                                    echo '<a href="' . zen_href_link('stats_sales_report_graphs.php', $report->next, 'NONSSL') . '">Next&nbsp;&gt;&gt;</a>';
+                                                                    echo '<a href="' . zen_admin_href_link('stats_sales_report_graphs.php', $report->next) . '">Next&nbsp;&gt;&gt;</a>';
                                                                     echo "";
                                                                 }
                                                                 ?>
@@ -318,7 +318,7 @@ require('includes/admin_html_head.php');
                                                 <?php
                                                 if (substr($sales_report_filter, $i, 1) == "0") {
                                                     $tmp = substr($sales_report_filter, 0, $i) . "1" . substr($sales_report_filter, $i + 1, $report->status_available_size - ($i + 1));
-                                                    $tmp = zen_href_link('stats_sales_report_graphs.php', $report->filter_link . "&filter=" . $tmp, 'NONSSL');
+                                                    $tmp = zen_admin_href_link('stats_sales_report_graphs.php', $report->filter_link . "&filter=" . $tmp);
                                                     ?>
                                                     <td class="dataTableContent" width="100%" align="right">
                                                         <?php echo zen_image(DIR_WS_IMAGES . 'icon_status_green.gif', IMAGE_ICON_STATUS_GREEN, 10, 10) ?>&nbsp;
@@ -326,7 +326,7 @@ require('includes/admin_html_head.php');
                                                     <?php
                                                 } else {
                                                     $tmp = substr($sales_report_filter, 0, $i) . "0" . substr($sales_report_filter, $i + 1);
-                                                    $tmp = zen_href_link('stats_sales_report_graphs.php', $report->filter_link . "&filter=" . $tmp, 'NONSSL');
+                                                    $tmp = zen_admin_href_link('stats_sales_report_graphs.php', $report->filter_link . "&filter=" . $tmp);
                                                     ?>
                                                     <td class="dataTableContent" width="100%" align="right">
                                                         <a href="<?php echo $tmp; ?>"><?php echo zen_image(DIR_WS_IMAGES . 'icon_status_green_light.gif', IMAGE_ICON_STATUS_GREEN, 10, 10) ?></a>


### PR DESCRIPTION
A few instances of the deprecated function have crept back in since the original PR.

This cleans these up and additionally, comments out the function with a view to ensure devs do not use it in the core code. This can be uncommented before releasing back into the wild and will make sure it is indeed deprecated in the core.