### PR TITLE
Consolidate admin order-update/search logic into shared order class

### DIFF
--- a/admin/includes/functions/functions_crud.php
+++ b/admin/includes/functions/functions_crud.php
@@ -229,11 +229,9 @@ while (!$chk_sale_categories_all->EOF) {
     $db->Execute("delete from " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . "
                   where products_id = '" . (int)$product_id . "'");
 
-
     $product_reviews = $db->Execute("select reviews_id
                                      from " . TABLE_REVIEWS . "
                                      where products_id = '" . (int)$product_id . "'");
-
     while (!$product_reviews->EOF) {
       $db->Execute("delete from " . TABLE_REVIEWS_DESCRIPTION . "
                     where reviews_id = '" . (int)$product_reviews->fields['reviews_id'] . "'");
@@ -268,44 +266,6 @@ while (!$chk_sale_categories_all->EOF) {
       $remove_downloads->MoveNext();
     }
   }
-
-  function zen_remove_order($order_id, $restock = false) {
-    global $db, $zco_notifier;
-    $zco_notifier->notify('NOTIFIER_ADMIN_ZEN_REMOVE_ORDER', array(), $order_id, $restock);
-    if ($restock == 'on') {
-      $order = $db->Execute("select products_id, products_quantity
-                             from " . TABLE_ORDERS_PRODUCTS . "
-                             where orders_id = '" . (int)$order_id . "'");
-
-      while (!$order->EOF) {
-        $db->Execute("update " . TABLE_PRODUCTS . "
-                      set products_quantity = products_quantity + " . $order->fields['products_quantity'] . ", products_ordered = products_ordered - " . $order->fields['products_quantity'] . " where products_id = '" . (int)$order->fields['products_id'] . "'");
-        $order->MoveNext();
-      }
-    }
-
-    $db->Execute("delete from " . TABLE_ORDERS . " where orders_id = '" . (int)$order_id . "'");
-    $db->Execute("delete from " . TABLE_ORDERS_PRODUCTS . "
-                  where orders_id = '" . (int)$order_id . "'");
-
-    $db->Execute("delete from " . TABLE_ORDERS_PRODUCTS_ATTRIBUTES . "
-                  where orders_id = '" . (int)$order_id . "'");
-
-    $db->Execute("delete from " . TABLE_ORDERS_PRODUCTS_DOWNLOAD . "
-                  where orders_id = '" . (int)$order_id . "'");
-
-    $db->Execute("delete from " . TABLE_ORDERS_STATUS_HISTORY . "
-                  where orders_id = '" . (int)$order_id . "'");
-
-    $db->Execute("delete from " . TABLE_ORDERS_TOTAL . "
-                  where orders_id = '" . (int)$order_id . "'");
-
-    $db->Execute("delete from " . TABLE_COUPON_GV_QUEUE . "
-                  where order_id = '" . (int)$order_id . "' and release_flag = 'N'");
-
-    zen_record_admin_activity('Deleted order ' . (int)$order_id . ' from database via admin console.', 'warning');
-  }
-
 
 ////
 // Sets the status of a product

--- a/admin/includes/languages/english/orders_email.php
+++ b/admin/includes/languages/english/orders_email.php
@@ -1,5 +1,11 @@
 <?php
-
+/**
+ * @package admin
+ * @copyright Copyright 2003-2016 Zen Cart Development Team
+ * @copyright Portions Copyright 2003 osCommerce
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id:  Modified in v1.6.0 $
+ */
 define('EMAIL_SEPARATOR', '------------------------------------------------------');
 define('EMAIL_TEXT_SUBJECT', 'Order Update');
 define('EMAIL_TEXT_ORDER_NUMBER', 'Order Number:');
@@ -9,3 +15,4 @@ define('EMAIL_TEXT_COMMENTS_UPDATE', '<em>The comments for your order are: </em>
 define('EMAIL_TEXT_STATUS_UPDATED', 'Your order has been updated to the following status:' . "\n");
 define('EMAIL_TEXT_STATUS_LABEL', '<strong>New status:</strong> %s' . "\n\n");
 define('EMAIL_TEXT_STATUS_PLEASE_REPLY', 'Please reply to this email if you have any questions.' . "\n");
+define('EMAIL_TEXT_GUEST_ORDER_STATUS_URL', 'Click here to check the status of your order:');

--- a/admin/includes/modules/orders_download.php
+++ b/admin/includes/modules/orders_download.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2015 Zen Cart Development Team
+ * @copyright Copyright 2003-2016 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: orders_download.php drbyte  Modified in v1.6.0 $
@@ -9,12 +9,10 @@
 if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
 }
-  // select downloads for current order
-  $orders_download_query = "select * from " . TABLE_ORDERS_PRODUCTS_DOWNLOAD . " where orders_id='" . (int)$_GET['oID'] . "'";
-  $orders_download = $db->Execute($orders_download_query);
+  $orders_download = $order->downloads;
 
 // only display if there are downloads to display
-  if ($orders_download->RecordCount() > 0) {
+  if (sizeof($orders_download) > 0) {
 ?>
       <tr>
         <td class="main"><table border="1" cellspacing="0" cellpadding="5">
@@ -34,48 +32,47 @@ if (!defined('IS_ADMIN_FLAG')) {
           </tr>
 <?php
 // add legend
-    while (!$orders_download->EOF) {
-      // $order->info['date_purchased'] . ' vs ' . (zen_date_diff($order->info['date_purchased'], date('Y-m-d')) > $orders_download->fields['download_maxdays'] ? 'NO' : 'YES') . ' vs ' .
+    foreach($orders_download as $download) {
+      // $order->info['date_purchased'] . ' vs ' . (zen_date_diff($order->info['date_purchased'], date('Y-m-d')) > $download['download_maxdays'] ? 'NO' : 'YES') . ' vs ' .
       switch (true) {
-        case ($orders_download->fields['download_maxdays'] <= 0 && $orders_download->fields['download_count'] <= 0):
-          $zc_file_status = TEXT_INFO_EXPIRED_DATE . '<a href="' . zen_admin_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('oID', 'action')) . 'oID=' . $_GET['oID'] . '&action=edit&download_reset_on=' . $orders_download->fields['orders_products_download_id']) . '">' . zen_image(DIR_WS_IMAGES . 'icon_yellow_on.gif', IMAGE_ICON_STATUS_EXPIRED) . '</a>';
+        case ($download['download_maxdays'] <= 0 && $download['download_count'] <= 0):
+          $zc_file_status = TEXT_INFO_EXPIRED_DATE . '<a href="' . zen_admin_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('oID', 'action')) . 'oID=' . $_GET['oID'] . '&action=edit&download_reset_on=' . $download['orders_products_download_id']) . '">' . zen_image(DIR_WS_IMAGES . 'icon_yellow_on.gif', IMAGE_ICON_STATUS_EXPIRED) . '</a>';
           break;
-        case ($orders_download->fields['download_maxdays'] != 0 && (zen_date_diff($order->info['date_purchased'], date('Y-m-d')) > $orders_download->fields['download_maxdays'])):
-          $zc_file_status = TEXT_INFO_EXPIRED_DATE . '<a href="' . zen_admin_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('oID', 'action')) . 'oID=' . $_GET['oID'] . '&action=edit&download_reset_on=' . $orders_download->fields['orders_products_download_id']) . '">' . zen_image(DIR_WS_IMAGES . 'icon_yellow_on.gif', IMAGE_ICON_STATUS_EXPIRED) . '</a>';
+        case ($download['download_maxdays'] != 0 && (zen_date_diff($order->info['date_purchased'], date('Y-m-d')) > $download['download_maxdays'])):
+          $zc_file_status = TEXT_INFO_EXPIRED_DATE . '<a href="' . zen_admin_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('oID', 'action')) . 'oID=' . $_GET['oID'] . '&action=edit&download_reset_on=' . $download['orders_products_download_id']) . '">' . zen_image(DIR_WS_IMAGES . 'icon_yellow_on.gif', IMAGE_ICON_STATUS_EXPIRED) . '</a>';
           break;
-        case ($orders_download->fields['download_maxdays'] == 0):
-          $zc_file_status = '<a href="' . zen_admin_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('oID', 'action')) . 'oID=' . $_GET['oID'] . '&action=edit&download_reset_off=' . $orders_download->fields['orders_products_download_id']) . '">' . zen_image(DIR_WS_IMAGES . 'icon_green_on.gif', IMAGE_ICON_STATUS_CURRENT) . '</a>';
+        case ($download['download_maxdays'] == 0):
+          $zc_file_status = '<a href="' . zen_admin_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('oID', 'action')) . 'oID=' . $_GET['oID'] . '&action=edit&download_reset_off=' . $download['orders_products_download_id']) . '">' . zen_image(DIR_WS_IMAGES . 'icon_green_on.gif', IMAGE_ICON_STATUS_CURRENT) . '</a>';
           break;
-        case ($orders_download->fields['download_maxdays'] > 0 and $orders_download->fields['download_count'] > 0):
-          $zc_file_status = '<a href="' . zen_admin_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('oID', 'action')) . 'oID=' . $_GET['oID'] . '&action=edit&download_reset_off=' . $orders_download->fields['orders_products_download_id']) . '">' . zen_image(DIR_WS_IMAGES . 'icon_green_on.gif', IMAGE_ICON_STATUS_CURRENT) . '</a>';
+        case ($download['download_maxdays'] > 0 and $download['download_count'] > 0):
+          $zc_file_status = '<a href="' . zen_admin_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('oID', 'action')) . 'oID=' . $_GET['oID'] . '&action=edit&download_reset_off=' . $download['orders_products_download_id']) . '">' . zen_image(DIR_WS_IMAGES . 'icon_green_on.gif', IMAGE_ICON_STATUS_CURRENT) . '</a>';
           break;
 /*
-        case ($orders_download->fields['download_maxdays'] <= 1 or $orders_download->fields['download_count'] <= 1):
-          $zc_file_status = TEXT_INFO_EXPIRED_COUNT . '<a href="' . zen_admin_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('oID', 'action')) . 'oID=' . $_GET['oID'] . '&action=edit&download_reset_on=' . $orders_download->fields['orders_products_download_id']) . '">' . zen_image(DIR_WS_IMAGES . 'icon_yellow_on.gif', IMAGE_ICON_STATUS_EXPIRED) . '</a>';
+        case ($download['download_maxdays'] <= 1 or $download['download_count'] <= 1):
+          $zc_file_status = TEXT_INFO_EXPIRED_COUNT . '<a href="' . zen_admin_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('oID', 'action')) . 'oID=' . $_GET['oID'] . '&action=edit&download_reset_on=' . $download['orders_products_download_id']) . '">' . zen_image(DIR_WS_IMAGES . 'icon_yellow_on.gif', IMAGE_ICON_STATUS_EXPIRED) . '</a>';
           break;
 */
-        case ($orders_download->fields['download_maxdays'] !=0 && $orders_download->fields['download_count'] <= 1):
-          $zc_file_status = TEXT_INFO_EXPIRED_COUNT . '<a href="' . zen_admin_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('oID', 'action')) . 'oID=' . $_GET['oID'] . '&action=edit&download_reset_on=' . $orders_download->fields['orders_products_download_id']) . '">' . zen_image(DIR_WS_IMAGES . 'icon_yellow_on.gif', IMAGE_ICON_STATUS_EXPIRED) . '</a>';
+        case ($download['download_maxdays'] !=0 && $download['download_count'] <= 1):
+          $zc_file_status = TEXT_INFO_EXPIRED_COUNT . '<a href="' . zen_admin_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('oID', 'action')) . 'oID=' . $_GET['oID'] . '&action=edit&download_reset_on=' . $download['orders_products_download_id']) . '">' . zen_image(DIR_WS_IMAGES . 'icon_yellow_on.gif', IMAGE_ICON_STATUS_EXPIRED) . '</a>';
           break;
         default:
-          $zc_file_status = '<a href="' . zen_admin_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('oID', 'action')) . 'oID=' . $_GET['oID'] . '&action=edit&download_reset_on=' . $orders_download->fields['orders_products_download_id']) . '">' . zen_image(DIR_WS_IMAGES . 'icon_yellow_on.gif', IMAGE_ICON_STATUS_EXPIRED) . '</a>';
+          $zc_file_status = '<a href="' . zen_admin_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('oID', 'action')) . 'oID=' . $_GET['oID'] . '&action=edit&download_reset_on=' . $download['orders_products_download_id']) . '">' . zen_image(DIR_WS_IMAGES . 'icon_yellow_on.gif', IMAGE_ICON_STATUS_EXPIRED) . '</a>';
           break;
           break;
       }
 
 // if not on server show red
-      if (!zen_verify_download_file_is_valid($orders_download->fields['orders_products_filename'])) {
+      if (!zen_verify_download_file_is_valid($download['orders_products_filename'])) {
         $zc_file_status = zen_image(DIR_WS_IMAGES . 'icon_red_on.gif', IMAGE_ICON_STATUS_OFF);
       }
 ?>
           <tr>
             <td class="smallText" align="center"><?php echo $zc_file_status; ?></td>
-            <td class="smallText" align="left"><?php echo $orders_download->fields['orders_products_filename']; ?></td>
-            <td class="smallText" align="center"><?php echo $orders_download->fields['download_maxdays']; ?></td>
-            <td class="smallText" align="center"><?php echo $orders_download->fields['download_count']; ?></td>
+            <td class="smallText" align="left"><?php echo $download['orders_products_filename']; ?></td>
+            <td class="smallText" align="center"><?php echo $download['download_maxdays']; ?></td>
+            <td class="smallText" align="center"><?php echo $download['download_count']; ?></td>
           </tr>
 <?php
-        $orders_download->MoveNext();
     }
 ?>
       </table></td>

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -15,378 +15,104 @@
 
   $currencies = new currencies();
 
-  if (isset($_GET['oID'])) $_GET['oID'] = (int)$_GET['oID'];
-  if (isset($_GET['download_reset_on'])) $_GET['download_reset_on'] = (int)$_GET['download_reset_on'];
-  if (isset($_GET['download_reset_off'])) $_GET['download_reset_off'] = (int)$_GET['download_reset_off'];
-
   include(DIR_FS_CATALOG . DIR_WS_CLASSES . 'order.php');
 
   // prepare order-status pulldown list
-  $orders_statuses = array();
-  $orders_status_array = array();
-  $orders_status = $db->Execute("select orders_status_id, orders_status_name
-                                 from " . TABLE_ORDERS_STATUS . "
-                                 where language_id = '" . (int)$_SESSION['languages_id'] . "' order by orders_status_id");
-  while (!$orders_status->EOF) {
-    $orders_statuses[] = array('id' => $orders_status->fields['orders_status_id'],
-                               'text' => $orders_status->fields['orders_status_name'] . ' [' . $orders_status->fields['orders_status_id'] . ']');
-    $orders_status_array[$orders_status->fields['orders_status_id']] = $orders_status->fields['orders_status_name'];
-    $orders_status->MoveNext();
+  $orders_statuses_pulldown_list = array();
+  $orders_status_array = \order::get_order_statuses();
+  foreach($orders_status_array as $key=>$val)
+  {
+    $orders_statuses_pulldown_list[] = array('id' => $key, 'text' => $val . ' [' . $key . ']');
   }
 
   $action = (isset($_GET['action']) ? $_GET['action'] : '');
   $order_exists = false;
+
   if (isset($_GET['oID']) && trim($_GET['oID']) == '') unset($_GET['oID']);
   if ($action == 'edit' && !isset($_GET['oID'])) $action = '';
+  if (isset($_GET['oID'])) $_GET['oID'] = (int)$_GET['oID'];
 
-  $oID = FALSE;
+// initialize the order from get/post
+  $oID = 0;
   if (isset($_POST['oID'])) {
-    $oID = zen_db_prepare_input(trim($_POST['oID']));
+    $oID = (int)$_POST['oID'];
   } elseif (isset($_GET['oID'])) {
-    $oID = zen_db_prepare_input(trim($_GET['oID']));
+    $oID = (int)$_GET['oID'];
   }
   if ($oID) {
-    $orders = $db->Execute("select orders_id from " . TABLE_ORDERS . "
-                              where orders_id = '" . (int)$oID . "'");
-    $order_exists = true;
-    if ($orders->RecordCount() <= 0) {
-      $order_exists = false;
+    $order = new \order((int)$oID);
+    $order_exists = ($order->id > 0);
+    if (!$order_exists) {
       if ($action != '') $messageStack->add_session(ERROR_ORDER_DOES_NOT_EXIST . ' ' . $oID, 'error');
       zen_redirect(zen_admin_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('oID', 'action'))));
     }
   }
 
+  // disallow any action other than "edit" (view) if demo active
+  if (zen_admin_demo() && $action != 'edit') {
+    $_GET['action']= '';
+    $messageStack->add_session(ERROR_ADMIN_DEMO, 'caution');
+    zen_redirect(zen_admin_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('action')) . 'action=edit'));
+  }
+
+  // process $action events
   if (zen_not_null($action) && $order_exists == true) {
     switch ($action) {
       case 'edit':
       // reset single download to on
         if ($_GET['download_reset_on'] > 0) {
-          // adjust download_maxdays based on current date
-          $check_status = $db->Execute("select customers_name, customers_email_address, orders_status,
-                                      date_purchased, is_guest_order from " . TABLE_ORDERS . "
-                                      where orders_id = '" . $_GET['oID'] . "'");
-
-          // check for existing product attribute download days and max
-          $chk_products_download_query = "SELECT orders_products_id, orders_products_filename, products_prid from " . TABLE_ORDERS_PRODUCTS_DOWNLOAD . " WHERE orders_products_download_id='" . $_GET['download_reset_on'] . "'";
-          $chk_products_download = $db->Execute($chk_products_download_query);
-
-          $chk_products_download_time_query = "SELECT pa.products_attributes_id, pa.products_id, pad.products_attributes_filename, pad.products_attributes_maxdays, pad.products_attributes_maxcount
-          from " . TABLE_PRODUCTS_ATTRIBUTES . " pa, " . TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD . " pad
-          WHERE pa.products_attributes_id = pad.products_attributes_id
-          and pad.products_attributes_filename = '" . $db->prepare_input($chk_products_download->fields['orders_products_filename']) . "'
-          and pa.products_id = '" . (int)$chk_products_download->fields['products_prid'] . "'";
-
-          $chk_products_download_time = $db->Execute($chk_products_download_time_query);
-
-          if ($chk_products_download_time->EOF) {
-            $zc_max_days = (DOWNLOAD_MAX_DAYS == 0 ? 0 : zen_date_diff($check_status->fields['date_purchased'], date('Y-m-d H:i:s', time())) + DOWNLOAD_MAX_DAYS);
-            $update_downloads_query = "update " . TABLE_ORDERS_PRODUCTS_DOWNLOAD . " set download_maxdays='" . $zc_max_days . "', download_count='" . DOWNLOAD_MAX_COUNT . "' where orders_id='" . $_GET['oID'] . "' and orders_products_download_id='" . $_GET['download_reset_on'] . "'";
-          } else {
-            $zc_max_days = ($chk_products_download_time->fields['products_attributes_maxdays'] == 0 ? 0 : zen_date_diff($check_status->fields['date_purchased'], date('Y-m-d H:i:s', time())) + $chk_products_download_time->fields['products_attributes_maxdays']);
-            $update_downloads_query = "update " . TABLE_ORDERS_PRODUCTS_DOWNLOAD . " set download_maxdays='" . $zc_max_days . "', download_count='" . $chk_products_download_time->fields['products_attributes_maxcount'] . "' where orders_id='" . $_GET['oID'] . "' and orders_products_download_id='" . $_GET['download_reset_on'] . "'";
-          }
-
-          $db->Execute($update_downloads_query);
+          $order->resetSingleDownloadToOn((int)$_GET['download_reset_on']);
           unset($_GET['download_reset_on']);
-
           $messageStack->add_session(SUCCESS_ORDER_UPDATED_DOWNLOAD_ON, 'success');
           zen_redirect(zen_admin_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('action')) . 'action=edit'));
         }
       // reset single download to off
         if ($_GET['download_reset_off'] > 0) {
-          // adjust download_maxdays based on current date
-          // *** fix: adjust count not maxdays to cancel download
-//          $update_downloads_query = "update " . TABLE_ORDERS_PRODUCTS_DOWNLOAD . " set download_maxdays='0', download_count='0' where orders_id='" . $_GET['oID'] . "' and orders_products_download_id='" . $_GET['download_reset_off'] . "'";
-          $update_downloads_query = "update " . TABLE_ORDERS_PRODUCTS_DOWNLOAD . " set download_count='0' where orders_id='" . $_GET['oID'] . "' and orders_products_download_id='" . $_GET['download_reset_off'] . "'";
-          $db->Execute($update_downloads_query);
+          $order->resetSingleDownloadToOff((int)$_GET['download_reset_off']);
           unset($_GET['download_reset_off']);
-
           $messageStack->add_session(SUCCESS_ORDER_UPDATED_DOWNLOAD_OFF, 'success');
           zen_redirect(zen_admin_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('action')) . 'action=edit'));
         }
       break;
       case 'update_order':
-        // demo active test
-        if (zen_admin_demo()) {
-          $_GET['action']= '';
-          $messageStack->add_session(ERROR_ADMIN_DEMO, 'caution');
-          zen_redirect(zen_admin_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('action')) . 'action=edit'));
-        }
-        $oID = zen_db_prepare_input($_GET['oID']);
-        $comments = zen_db_prepare_input($_POST['comments']);
-        $status = (int)zen_db_prepare_input($_POST['status']);
-        $order = new order((int)$oID);
-        $orderLanguage = $lng->get_language_data_by_code($order->info['language_code']);
-        $orderLanguageId = (int)$orderLanguage['id'];
-        zen_load_language_file('orders_email.php', $orderLanguage['directory']);
+        if ((int)$_POST['status'] < 1) break;
 
-        if ($status < 1) break;
+        $order_updated = $order->update_status_and_comments($zcRequest->readPost('status'), $zcRequest->readPost('comments'), $zcRequest->readPost('notify', 0), $zcRequest->readPost('notify_comments', '') );
 
-        $order_updated = false;
-        $check_status = $db->Execute("select customers_name, customers_email_address, orders_status,
-                                      date_purchased, is_guest_order from " . TABLE_ORDERS . "
-                                      where orders_id = '" . (int)$oID . "'");
-
-        if ( ($check_status->fields['orders_status'] != $status) || zen_not_null($comments)) {
-          $db->Execute("update " . TABLE_ORDERS . "
-                        set orders_status = '" . zen_db_input($status) . "', last_modified = now()
-                        where orders_id = '" . (int)$oID . "'");
-
-          $ordersStatusLocalizedQuery = $db->Execute("SELECT orders_status_name
-                                                      FROM " . TABLE_ORDERS_STATUS . "
-                                                      WHERE language_id = '" . $orderLanguageId . "'
-                                                      AND orders_status_id = " . $status);
-          $ordersStatusLocalized = $ordersStatusLocalizedQuery->fields['orders_status_name'];
-
-          $customer_notified = '0';
-          if (isset($_POST['notify']) && ($_POST['notify'] == '1')) {
-
-            $notify_comments = '';
-            if (isset($_POST['notify_comments']) && ($_POST['notify_comments'] == 'on') && zen_not_null($comments)) {
-              $notify_comments = EMAIL_TEXT_COMMENTS_UPDATE . $comments . "\n\n";
-            }
-
-            //send emails
-
-            if (GUEST_ORDER_STATUS == 'true') {
-              if ($check_status->fields['is_guest_order'] == 1)  {
-
-                $message =
-                    EMAIL_TEXT_ORDER_NUMBER . ' ' . $oID . "\n\n" .
-                    EMAIL_TEXT_INVOICE_URL . ' ' . zen_catalog_href_link(FILENAME_ORDER_STATUS, 'order_id=' . $oID, 'SSL') . "\n\n" .
-                    EMAIL_TEXT_DATE_ORDERED . ' ' . zen_date_long($check_status->fields['date_purchased']) . "\n\n" .
-                    $notify_comments .
-                    EMAIL_TEXT_STATUS_UPDATED . sprintf(EMAIL_TEXT_STATUS_LABEL, $ordersStatusLocalized ) .
-                    EMAIL_TEXT_STATUS_PLEASE_REPLY;
-
-                $html_msg['EMAIL_CUSTOMERS_NAME']    = $check_status->fields['customers_name'];
-                $html_msg['EMAIL_TEXT_ORDER_NUMBER'] = EMAIL_TEXT_ORDER_NUMBER . ' ' . $oID;
-                $html_msg['EMAIL_TEXT_INVOICE_URL']  = '<a href="' . zen_catalog_href_link(FILENAME_ORDER_STATUS, 'order_id=' . $oID, 'SSL') .'">'.str_replace(':','','Click here to check the status of your order:').'</a>';
-                $html_msg['EMAIL_TEXT_DATE_ORDERED'] = EMAIL_TEXT_DATE_ORDERED . ' ' . zen_date_long($check_status->fields['date_purchased']);
-                $html_msg['EMAIL_TEXT_STATUS_COMMENTS'] = nl2br($notify_comments);
-                $html_msg['EMAIL_TEXT_STATUS_UPDATED'] = str_replace('\n','', EMAIL_TEXT_STATUS_UPDATED);
-                $html_msg['EMAIL_TEXT_STATUS_LABEL'] = str_replace('\n','', sprintf(EMAIL_TEXT_STATUS_LABEL, $orders_status_array[$status] ));
-                $html_msg['EMAIL_TEXT_NEW_STATUS'] = $orders_status_array[$status];
-                $html_msg['EMAIL_TEXT_STATUS_PLEASE_REPLY'] = str_replace('\n','', EMAIL_TEXT_STATUS_PLEASE_REPLY);
-
-                zen_mail($check_status->fields['customers_name'], $check_status->fields['customers_email_address'], EMAIL_TEXT_SUBJECT . ' #' . $oID, $message, STORE_NAME, EMAIL_FROM, $html_msg, 'order_status');
-                $customer_notified = '1';
-              }
-            }
-            if (GUEST_ORDER_STATUS == 'false') {
-              if ($check_status->fields['is_guest_order'] == 1)  {
-
-                $htmlInvoiceURL='';
-                $htmlInvoiceValue='';
-                $message =
-                  EMAIL_TEXT_ORDER_NUMBER . ' ' . $oID . "\n\n" .
-                  EMAIL_TEXT_DATE_ORDERED . ' ' . zen_date_long($check_status->fields['date_purchased']) . "\n\n" .
-                  $notify_comments .
-                  EMAIL_TEXT_STATUS_UPDATED . sprintf(EMAIL_TEXT_STATUS_LABEL, $orders_status_array[$status] ) .
-                  EMAIL_TEXT_STATUS_PLEASE_REPLY;
-                $html_msg['EMAIL_CUSTOMERS_NAME']    = $check_status->fields['customers_name'];
-                $html_msg['EMAIL_TEXT_ORDER_NUMBER'] = EMAIL_TEXT_ORDER_NUMBER . ' ' . $oID;
-                $html_msg['INTRO_URL_TEXT']        = '';
-                $html_msg['INTRO_URL_VALUE']       = '';
-                $html_msg['EMAIL_TEXT_DATE_ORDERED'] = EMAIL_TEXT_DATE_ORDERED . ' ' . zen_date_long($check_status->fields['date_purchased']);
-                $html_msg['EMAIL_TEXT_STATUS_COMMENTS'] = nl2br($notify_comments);
-                $html_msg['EMAIL_TEXT_STATUS_UPDATED'] = str_replace('\n','', EMAIL_TEXT_STATUS_UPDATED);
-                $html_msg['EMAIL_TEXT_STATUS_LABEL'] = str_replace('\n','', sprintf(EMAIL_TEXT_STATUS_LABEL, $orders_status_array[$status] ));
-                $html_msg['EMAIL_TEXT_NEW_STATUS'] = $orders_status_array[$status];
-                $html_msg['EMAIL_TEXT_STATUS_PLEASE_REPLY'] = str_replace('\n','', EMAIL_TEXT_STATUS_PLEASE_REPLY);
-
-                zen_mail($check_status->fields['customers_name'], $check_status->fields['customers_email_address'], EMAIL_TEXT_SUBJECT . ' #' . $oID, $message, STORE_NAME, EMAIL_FROM, $html_msg, 'order_status');
-                $customer_notified = '1';
-              }
-            }
-            if ($check_status->fields['is_guest_order'] != 1)  {
-              $message =
-                EMAIL_TEXT_ORDER_NUMBER . ' ' . $oID . "\n\n" .
-                EMAIL_TEXT_INVOICE_URL . ' ' . zen_catalog_href_link(FILENAME_CATALOG_ACCOUNT_HISTORY_INFO, 'order_id=' . $oID, 'SSL') . "\n\n" .
-                EMAIL_TEXT_DATE_ORDERED . ' ' . zen_date_long($check_status->fields['date_purchased']) . "\n\n" .
-                $notify_comments .
-                EMAIL_TEXT_STATUS_UPDATED . sprintf(EMAIL_TEXT_STATUS_LABEL, $orders_status_array[$status] ) .
-                EMAIL_TEXT_STATUS_PLEASE_REPLY;
-
-              $html_msg['EMAIL_CUSTOMERS_NAME']    = $check_status->fields['customers_name'];
-              $html_msg['EMAIL_TEXT_ORDER_NUMBER'] = EMAIL_TEXT_ORDER_NUMBER . ' ' . $oID;
-              $html_msg['EMAIL_TEXT_INVOICE_URL']  = '<a href="' . zen_catalog_href_link(FILENAME_CATALOG_ACCOUNT_HISTORY_INFO, 'order_id=' . $oID, 'SSL') .'">'.str_replace(':','',EMAIL_TEXT_INVOICE_URL).'</a>';
-              $html_msg['EMAIL_TEXT_DATE_ORDERED'] = EMAIL_TEXT_DATE_ORDERED . ' ' . zen_date_long($check_status->fields['date_purchased']);
-              $html_msg['EMAIL_TEXT_STATUS_COMMENTS'] = nl2br($notify_comments);
-              $html_msg['EMAIL_TEXT_STATUS_UPDATED'] = str_replace('\n','', EMAIL_TEXT_STATUS_UPDATED);
-              $html_msg['EMAIL_TEXT_STATUS_LABEL'] = str_replace('\n','', sprintf(EMAIL_TEXT_STATUS_LABEL, $orders_status_array[$status] ));
-              $html_msg['EMAIL_TEXT_NEW_STATUS'] = $orders_status_array[$status];
-              $html_msg['EMAIL_TEXT_STATUS_PLEASE_REPLY'] = str_replace('\n','', EMAIL_TEXT_STATUS_PLEASE_REPLY);
-              $html_msg['EMAIL_PAYPAL_TRANSID'] = '';
-
-              zen_mail($check_status->fields['customers_name'], $check_status->fields['customers_email_address'], EMAIL_TEXT_SUBJECT . ' #' . $oID, $message, STORE_NAME, EMAIL_FROM, $html_msg, 'order_status');
-              $customer_notified = '1';
-            }
-
-            // PayPal Trans ID, if any
-            $sql = "select txn_id, parent_txn_id from " . TABLE_PAYPAL . " where order_id = :orderID order by last_modified DESC, date_added DESC, parent_txn_id DESC, paypal_ipn_id DESC ";
-            $sql = $db->bindVars($sql, ':orderID', $oID, 'integer');
-            $result = $db->Execute($sql);
-            if ($result->RecordCount() > 0) {
-              $message .= "\n\n" . ' PayPal Trans ID: ' . $result->fields['txn_id'];
-              $html_msg['EMAIL_PAYPAL_TRANSID'] = $result->fields['txn_id'];
-            }
-
-            //send extra emails
-            if (SEND_EXTRA_ORDERS_STATUS_ADMIN_EMAILS_TO_STATUS == '1' and SEND_EXTRA_ORDERS_STATUS_ADMIN_EMAILS_TO != '') {
-              zen_mail('', SEND_EXTRA_ORDERS_STATUS_ADMIN_EMAILS_TO, SEND_EXTRA_ORDERS_STATUS_ADMIN_EMAILS_TO_SUBJECT . ' ' . EMAIL_TEXT_SUBJECT . ' #' . $oID, $message, STORE_NAME, EMAIL_FROM, $html_msg, 'order_status_extra');
-            }
-          } elseif (isset($_POST['notify']) && ($_POST['notify'] == '-1')) {
-            // hide comment
-            $customer_notified = '-1';
-          }
-
-          $db->Execute("insert into " . TABLE_ORDERS_STATUS_HISTORY . "
-                      (orders_id, orders_status_id, date_added, customer_notified, comments)
-                      values ('" . (int)$oID . "',
-                      '" . zen_db_input($status) . "',
-                      now(),
-                      '" . zen_db_input($customer_notified) . "',
-                      '" . zen_db_input($comments)  . "')");
-          $order_updated = true;
-        }
-
-        // trigger any appropriate updates which should be sent back to the payment gateway:
-        if ($order->info['payment_module_code']) {
-          if (file_exists(DIR_FS_CATALOG_MODULES . 'payment/' . $order->info['payment_module_code'] . '.php')) {
-            require_once(DIR_FS_CATALOG_MODULES . 'payment/' . $order->info['payment_module_code'] . '.php');
-            require_once(DIR_FS_CATALOG_LANGUAGES . $_SESSION['language'] . '/modules/payment/' . $order->info['payment_module_code'] . '.php');
-            $module = new $order->info['payment_module_code'];
-            if (method_exists($module, '_doStatusUpdate')) {
-              $response = $module->_doStatusUpdate($oID, $status, $comments, $customer_notified, $check_status->fields['orders_status']);
-            }
-          }
-        }
-
-        if ($order_updated == true) {
-          if ($status == DOWNLOADS_ORDERS_STATUS_UPDATED_VALUE) {
-
-            // adjust download_maxdays based on current date
-            $chk_downloads_query = "SELECT opd.*, op.products_id from " . TABLE_ORDERS_PRODUCTS_DOWNLOAD . " opd, " . TABLE_ORDERS_PRODUCTS . " op
-                                    WHERE op.orders_id='" . (int)$oID . "'
-                                    and opd.orders_products_id = op.orders_products_id";
-            $chk_downloads = $db->Execute($chk_downloads_query);
-
-            while (!$chk_downloads->EOF) {
-              $chk_products_download_time_query = "SELECT pa.products_attributes_id, pa.products_id, pad.products_attributes_filename, pad.products_attributes_maxdays, pad.products_attributes_maxcount
-                                                    from " . TABLE_PRODUCTS_ATTRIBUTES . " pa, " . TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD . " pad
-                                                    WHERE pa.products_attributes_id = pad.products_attributes_id
-                                                    and pad.products_attributes_filename = '" . $db->prepare_input($chk_downloads->fields['orders_products_filename']) . "'
-                                                    and pa.products_id = '" . $chk_downloads->fields['products_id'] . "'";
-
-              $chk_products_download_time = $db->Execute($chk_products_download_time_query);
-
-              if ($chk_products_download_time->EOF) {
-                $zc_max_days = (DOWNLOAD_MAX_DAYS == 0 ? 0 : zen_date_diff($check_status->fields['date_purchased'], date('Y-m-d H:i:s', time())) + DOWNLOAD_MAX_DAYS);
-                $update_downloads_query = "update " . TABLE_ORDERS_PRODUCTS_DOWNLOAD . " set download_maxdays='" . $zc_max_days . "', download_count='" . DOWNLOAD_MAX_COUNT . "' where orders_id='" . (int)$oID . "' and orders_products_download_id='" . $_GET['download_reset_on'] . "'";
-              } else {
-                $zc_max_days = ($chk_products_download_time->fields['products_attributes_maxdays'] == 0 ? 0 : zen_date_diff($check_status->fields['date_purchased'], date('Y-m-d H:i:s', time())) + $chk_products_download_time->fields['products_attributes_maxdays']);
-                $update_downloads_query = "update " . TABLE_ORDERS_PRODUCTS_DOWNLOAD . " set download_maxdays='" . $zc_max_days . "', download_count='" . $chk_products_download_time->fields['products_attributes_maxcount'] . "' where orders_id='" . (int)$oID . "' and orders_products_download_id='" . $chk_downloads->fields['orders_products_download_id'] . "'";
-              }
-
-              $db->Execute($update_downloads_query);
-
-              $chk_downloads->MoveNext();
-            }
-          }
+        if ($order_updated) {
           $messageStack->add_session(SUCCESS_ORDER_UPDATED, 'success');
-          zen_record_admin_activity('Order ' . $oID . ' updated.', 'info');
-          $zco_notifier->notify('ADMIN_ORDER_UPDATED', $oID);
         } else {
           $messageStack->add_session(WARNING_ORDER_NOT_UPDATED, 'warning');
         }
         zen_redirect(zen_admin_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('action')) . 'action=edit'));
         break;
       case 'deleteconfirm':
-        // demo active test
-        if (zen_admin_demo()) {
-          $_GET['action']= '';
-          $messageStack->add_session(ERROR_ADMIN_DEMO, 'caution');
-          zen_redirect(zen_admin_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('oID', 'action'))));
-        }
-        $oID = zen_db_prepare_input($_POST['oID']);
-
-        zen_remove_order($oID, $_POST['restock']);
-
+        $order->delete_order($oID, $_POST['restock'] == 'on');
         zen_redirect(zen_admin_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('oID', 'action'))));
         break;
       case 'delete_cvv':
-        $delete_cvv = $db->Execute("update " . TABLE_ORDERS . " set cc_cvv = '" . TEXT_DELETE_CVV_REPLACEMENT . "' where orders_id = '" . (int)$_GET['oID'] . "'");
+        $order->delete_cvv($zcRequest->readGet('oID'));
         zen_redirect(zen_admin_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('action')) . 'action=edit'));
         break;
       case 'mask_cc':
-        $result  = $db->Execute("select cc_number from " . TABLE_ORDERS . " where orders_id = '" . (int)$_GET['oID'] . "'");
-        $old_num = $result->fields['cc_number'];
-        $new_num = substr($old_num, 0, 4) . str_repeat('*', (strlen($old_num) - 8)) . substr($old_num, -4);
-        $mask_cc = $db->Execute("update " . TABLE_ORDERS . " set cc_number = '" . $new_num . "' where orders_id = '" . (int)$_GET['oID'] . "'");
+        $order->mask_cc($zcRequest->readGet('oID'));
         zen_redirect(zen_admin_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('action')) . 'action=edit'));
         break;
 
       case 'doRefund':
-        $order = new order($oID);
-        if ($order->info['payment_module_code']) {
-          if (file_exists(DIR_FS_CATALOG_MODULES . 'payment/' . $order->info['payment_module_code'] . '.php')) {
-            require_once(DIR_FS_CATALOG_MODULES . 'payment/' . $order->info['payment_module_code'] . '.php');
-            require_once(DIR_FS_CATALOG_LANGUAGES . $_SESSION['language'] . '/modules/payment/' . $order->info['payment_module_code'] . '.php');
-            $module = new $order->info['payment_module_code'];
-            if (method_exists($module, '_doRefund')) {
-              $module->_doRefund($oID);
-              $zco_notifier->notify('ADMIN_ORDER_REFUNDED', $oID);
-            }
-          }
-        }
-        zen_record_admin_activity('Order ' . $oID . ' refund processed. See order comments for details.', 'info');
+        $order->doRefund();
         zen_redirect(zen_admin_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('action')) . 'action=edit'));
         break;
       case 'doAuth':
-        $order = new order($oID);
-        if ($order->info['payment_module_code']) {
-          if (file_exists(DIR_FS_CATALOG_MODULES . 'payment/' . $order->info['payment_module_code'] . '.php')) {
-            require_once(DIR_FS_CATALOG_MODULES . 'payment/' . $order->info['payment_module_code'] . '.php');
-            require_once(DIR_FS_CATALOG_LANGUAGES . $_SESSION['language'] . '/modules/payment/' . $order->info['payment_module_code'] . '.php');
-            $module = new $order->info['payment_module_code'];
-            if (method_exists($module, '_doAuth')) {
-              $module->_doAuth($oID, $order->info['total'], $order->info['currency']);
-              $zco_notifier->notify('ADMIN_ORDER_PAYMENT_AUTH', $oID, $order->info['total'], $order->info['currency']);
-            }
-          }
-        }
+        $order->doAuth();
         zen_redirect(zen_admin_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('action')) . 'action=edit'));
         break;
       case 'doCapture':
-        $order = new order($oID);
-        if ($order->info['payment_module_code']) {
-          if (file_exists(DIR_FS_CATALOG_MODULES . 'payment/' . $order->info['payment_module_code'] . '.php')) {
-            require_once(DIR_FS_CATALOG_MODULES . 'payment/' . $order->info['payment_module_code'] . '.php');
-            require_once(DIR_FS_CATALOG_LANGUAGES . $_SESSION['language'] . '/modules/payment/' . $order->info['payment_module_code'] . '.php');
-            $module = new $order->info['payment_module_code'];
-            if (method_exists($module, '_doCapt')) {
-              $module->_doCapt($oID, 'Complete', $order->info['total'], $order->info['currency']);
-              $zco_notifier->notify('ADMIN_ORDER_PAYMENT_CAPTURE', $oID, $order->info['total'], $order->info['currency']);
-            }
-          }
-        }
+        $order->doCapture();
         zen_redirect(zen_admin_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('action')) . 'action=edit'));
         break;
       case 'doVoid':
-        $order = new order($oID);
-        if ($order->info['payment_module_code']) {
-          if (file_exists(DIR_FS_CATALOG_MODULES . 'payment/' . $order->info['payment_module_code'] . '.php')) {
-            require_once(DIR_FS_CATALOG_MODULES . 'payment/' . $order->info['payment_module_code'] . '.php');
-            require_once(DIR_FS_CATALOG_LANGUAGES . $_SESSION['language'] . '/modules/payment/' . $order->info['payment_module_code'] . '.php');
-            $module = new $order->info['payment_module_code'];
-            if (method_exists($module, '_doVoid')) {
-              $module->_doVoid($oID);
-              $zco_notifier->notify('ADMIN_ORDER_PAYMENT_VOID', $oID);
-            }
-          }
-        }
-        zen_record_admin_activity('Order ' . $oID . ' void processed. See order comments for details.', 'info');
+        $order->doVoid();
         zen_redirect(zen_admin_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('action')) . 'action=edit'));
         break;
     }
@@ -468,7 +194,7 @@ function couponpopupWindow(url) {
             </div>
             <div class="form-group col-xs-4 col-sm-3 col-md-3 col-lg-3">
               <?php echo zen_draw_form('status', FILENAME_ORDERS, '', 'get', '', true);
-                echo '<label for="selectstatus" class="sr-only">' . HEADING_TITLE_STATUS . '</label> ' . zen_draw_pull_down_menu('status', array_merge(array(array('id' => '', 'text' => TEXT_ALL_ORDERS)), $orders_statuses), (int)$_GET['status'], 'class="form-control" onChange="this.form.submit();" id="selectstatus"');
+                echo '<label for="selectstatus" class="sr-only">' . HEADING_TITLE_STATUS . '</label> ' . zen_draw_pull_down_menu('status', array_merge(array(array('id' => '', 'text' => TEXT_ALL_ORDERS)), $orders_statuses_pulldown_list), (int)$_GET['status'], 'class="form-control" onChange="this.form.submit();" id="selectstatus"');
                 echo '</form>';
               ?>
             </div>
@@ -481,8 +207,7 @@ function couponpopupWindow(url) {
 
 
 <?php
-  if ($action == 'edit'&& $order_exists) {
-    $order = new order($oID);
+  if ($action == 'edit' && $order_exists) {
     $zco_notifier->notify('NOTIFY_ADMIN_ORDERS_EDIT_BEGIN', $oID, $order);
     if ($order->info['payment_module_code']) {
       if (file_exists(DIR_FS_CATALOG_MODULES . 'payment/' . $order->info['payment_module_code'] . '.php')) {
@@ -495,7 +220,7 @@ function couponpopupWindow(url) {
 
 
     $prev_button = '';
-    $result = $db->Execute("SELECT orders_id FROM " . TABLE_ORDERS . " WHERE orders_id < '" . $oID . "' ORDER BY orders_id DESC LIMIT 1");
+    $result = $db->Execute("SELECT orders_id FROM " . TABLE_ORDERS . " WHERE orders_id < " . (int)$oID . " ORDER BY orders_id DESC LIMIT 1");
     if ($result->RecordCount()) {
       $prev_button = '<button type="button" class="btn btn-default" onclick="window.location.href=\'' . zen_admin_href_link(FILENAME_ORDERS, 'oID=' . $result->fields['orders_id'] . '&action=edit') . '\'">&laquo; ' . $result->fields['orders_id'] . '</button>';
     }
@@ -739,27 +464,22 @@ function couponpopupWindow(url) {
             <td class="smallText" align="center"><strong><?php echo TABLE_HEADING_COMMENTS; ?></strong></td>
           </tr>
 <?php
-    $orders_history = $db->Execute("select orders_status_id, date_added, customer_notified, comments
-                                    from " . TABLE_ORDERS_STATUS_HISTORY . "
-                                    where orders_id = '" . zen_db_input($oID) . "'
-                                    order by date_added");
-
-    if ($orders_history->RecordCount() > 0) {
-      while (!$orders_history->EOF) {
+    $orders_history = $order->status_history;
+    if (count($orders_history)) {
+      foreach($orders_history as $history) {
         echo '          <tr>' . "\n" .
-             '            <td class="smallText" align="center">' . zen_datetime_short($orders_history->fields['date_added']) . '</td>' . "\n" .
+             '            <td class="smallText" align="center">' . zen_datetime_short($history['date_added']) . '</td>' . "\n" .
              '            <td class="smallText" align="center">';
-        if ($orders_history->fields['customer_notified'] == '1') {
+        if ($history['customer_notified'] == '1') {
           echo zen_image(DIR_WS_ICONS . 'tick.gif', TEXT_YES) . "</td>\n";
-        } else if ($orders_history->fields['customer_notified'] == '-1') {
+        } else if ($history['customer_notified'] == '-1') {
           echo zen_image(DIR_WS_ICONS . 'locked.gif', TEXT_HIDDEN) . "</td>\n";
         } else {
           echo zen_image(DIR_WS_ICONS . 'unlocked.gif', TEXT_VISIBLE) . "</td>\n";
         }
-        echo '            <td class="smallText">' . $orders_status_array[$orders_history->fields['orders_status_id']] . '</td>' . "\n";
-        echo '            <td class="smallText">' . nl2br(zen_db_output($orders_history->fields['comments'])) . '&nbsp;</td>' . "\n" .
+        echo '            <td class="smallText">' . $orders_status_array[$history['orders_status_id']] . '</td>' . "\n";
+        echo '            <td class="smallText">' . nl2br(zen_db_output($history['comments'])) . '&nbsp;</td>' . "\n" .
              '          </tr>' . "\n";
-        $orders_history->MoveNext();
       }
     } else {
         echo '          <tr>' . "\n" .
@@ -783,8 +503,7 @@ function couponpopupWindow(url) {
       </tr>
       <tr>
         <td class="main noprint">
-          <?php $orderLanguage = $lng->get_language_data_by_code($order->info['language_code']); ?>
-          <strong><?php echo TEXT_INFO_ORDER_LANGUAGE; ?></strong> <?php echo $orderLanguage['name']; ?>
+          <strong><?php echo TEXT_INFO_ORDER_LANGUAGE; ?></strong> <?php echo $order->language['name']; ?>
         </td>
       </tr>
       <tr>
@@ -792,7 +511,7 @@ function couponpopupWindow(url) {
           <tr>
             <td><table border="0" cellspacing="0" cellpadding="2">
               <tr>
-                <td class="main"><strong><?php echo ENTRY_STATUS; ?></strong> <?php echo zen_draw_pull_down_menu('status', $orders_statuses, $order->info['orders_status']); ?></td>
+                <td class="main"><strong><?php echo ENTRY_STATUS; ?></strong> <?php echo zen_draw_pull_down_menu('status', $orders_statuses_pulldown_list, $order->info['orders_status']); ?></td>
               </tr>
               <tr>
                 <td class="main"><strong><?php echo ENTRY_NOTIFY_CUSTOMER; ?></strong> [<?php echo zen_draw_radio_field('notify', '1', true) . '-' . TEXT_EMAIL . ' ' . zen_draw_radio_field('notify', '0', FALSE) . '-' . TEXT_NOEMAIL . ' ' . zen_draw_radio_field('notify', '-1', FALSE) . '-' . TEXT_HIDE; ?>]&nbsp;&nbsp;&nbsp;</td>
@@ -805,15 +524,12 @@ function couponpopupWindow(url) {
         </table></td>
       </form></tr>
       <tr>
-        <td colspan="2" align="right" class="noprint"><?php echo '<a href="' . zen_admin_href_link(FILENAME_ORDERS_INVOICE, 'oID=' . $_GET['oID']) . '" target="_blank">' . zen_image_button('button_invoice.gif', IMAGE_ORDERS_INVOICE) . '</a> <a href="' . zen_admin_href_link(FILENAME_ORDERS_PACKINGSLIP, 'oID=' . $_GET['oID']) . '" target="_blank">' . zen_image_button('button_packingslip.gif', IMAGE_ORDERS_PACKINGSLIP) . '</a> <a href="' . zen_admin_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('action'))) . '">' . zen_image_button('button_orders.gif', IMAGE_ORDERS) . '</a>'; ?></td>
+        <td colspan="2" align="right" class="noprint"><?php echo '<a href="' . zen_admin_href_link(FILENAME_ORDERS_INVOICE, 'oID=' . $order->id) . '" target="_blank">' . zen_image_button('button_invoice.gif', IMAGE_ORDERS_INVOICE) . '</a> <a href="' . zen_admin_href_link(FILENAME_ORDERS_PACKINGSLIP, 'oID=' . $order->id) . '" target="_blank">' . zen_image_button('button_packingslip.gif', IMAGE_ORDERS_PACKINGSLIP) . '</a> <a href="' . zen_admin_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('action'))) . '">' . zen_image_button('button_orders.gif', IMAGE_ORDERS) . '</a>'; ?></td>
       </tr>
 <?php
 // check if order has open gv
-        $gv_check = $db->Execute("select order_id, unique_id
-                                  from " . TABLE_COUPON_GV_QUEUE ."
-                                  where order_id = '" . $_GET['oID'] . "' and release_flag='N' limit 1");
-        if ($gv_check->RecordCount() > 0) {
-          $goto_gv = '<a href="' . zen_admin_href_link(FILENAME_GV_QUEUE, 'order=' . $_GET['oID']) . '">' . zen_image_button('button_gift_queue.gif',IMAGE_GIFT_QUEUE) . '</a>';
+        if ($order->info['gv_count_in_queue'] > 0) {
+          $goto_gv = '<a href="' . zen_admin_href_link(FILENAME_GV_QUEUE, 'order=' . $order->id) . '">' . zen_image_button('button_gift_queue.gif',IMAGE_GIFT_QUEUE) . '</a>';
           echo '      <tr><td align="right"><table width="225"><tr>';
           echo '        <td align="center">';
           echo $goto_gv . '&nbsp;&nbsp;';
@@ -832,34 +548,6 @@ function couponpopupWindow(url) {
           <tr>
             <td valign="top"><table border="0" width="100%" cellspacing="0" cellpadding="2">
               <tr class="dataTableHeadingRow">
-<?php
-// Sort Listing
-          switch ($_GET['list_order']) {
-              case "id-asc":
-              $disp_order = "c.customers_id";
-              break;
-              case "firstname":
-              $disp_order = "c.customers_firstname";
-              break;
-              case "firstname-desc":
-              $disp_order = "c.customers_firstname DESC";
-              break;
-              case "lastname":
-              $disp_order = "c.customers_lastname, c.customers_firstname";
-              break;
-              case "lastname-desc":
-              $disp_order = "c.customers_lastname DESC, c.customers_firstname";
-              break;
-              case "company":
-              $disp_order = "a.entry_company";
-              break;
-              case "company-desc":
-              $disp_order = "a.entry_company DESC";
-              break;
-              default:
-              $disp_order = "c.customers_id DESC";
-          }
-?>
                 <td class="dataTableHeadingContent" align="center"><?php echo TABLE_HEADING_ORDERS_ID; ?></td>
                 <td class="dataTableHeadingContent" align="left" width="50"><?php echo TABLE_HEADING_PAYMENT_METHOD; ?></td>
                 <td class="dataTableHeadingContent"><?php echo TABLE_HEADING_CUSTOMERS; ?></td>
@@ -871,71 +559,16 @@ function couponpopupWindow(url) {
               </tr>
 
 <?php
-// Only one or the other search
-// create search_orders_products filter
-  $search = '';
-  $new_table = '';
-  $new_fields = '';
-  if (isset($_GET['search_orders_products']) && zen_not_null($_GET['search_orders_products'])) {
-    $new_fields = '';
-    $search_distinct = ' distinct ';
-    $new_table = " left join " . TABLE_ORDERS_PRODUCTS . " op on (op.orders_id = o.orders_id) ";
-    $keywords = zen_db_input(zen_db_prepare_input($_GET['search_orders_products']));
-    $search = " and (op.products_model like '%" . $keywords . "%' or op.products_name like '" . $keywords . "%')";
-    if (substr(strtoupper($_GET['search_orders_products']), 0, 3) == 'ID:') {
-      $keywords = TRIM(substr($_GET['search_orders_products'], 3));
-      $search = " and op.products_id ='" . (int)$keywords . "'";
-    }
-  } else {
-?>
-<?php
-// create search filter
-  $search = '';
-  if (isset($_GET['search']) && zen_not_null($_GET['search'])) {
-    $search_distinct = ' ';
-    $keywords = zen_db_input(zen_db_prepare_input($_GET['search']));
-    $search = " and (o.customers_city like '%" . $keywords . "%' or o.customers_postcode like '%" . $keywords . "%' or o.date_purchased like '%" . $keywords . "%' or o.billing_name like '%" . $keywords . "%' or o.billing_company like '%" . $keywords . "%' or o.billing_street_address like '%" . $keywords . "%' or o.delivery_city like '%" . $keywords . "%' or o.delivery_postcode like '%" . $keywords . "%' or o.delivery_name like '%" . $keywords . "%' or o.delivery_company like '%" . $keywords . "%' or o.delivery_street_address like '%" . $keywords . "%' or o.billing_city like '%" . $keywords . "%' or o.billing_postcode like '%" . $keywords . "%' or o.customers_email_address like '%" . $keywords . "%' or o.customers_name like '%" . $keywords . "%' or o.customers_company like '%" . $keywords . "%' or o.customers_street_address  like '%" . $keywords . "%' or o.customers_telephone like '%" . $keywords . "%' or o.ip_address  like '%" . $keywords . "%')";
-    $new_table = '';
-//    $new_fields = ", o.customers_company, o.customers_email_address, o.customers_street_address, o.delivery_company, o.delivery_name, o.delivery_street_address, o.billing_company, o.billing_name, o.billing_street_address, o.payment_module_code, o.shipping_module_code, o.ip_address ";
-  }
-} // eof: search orders or orders_products
-    $new_fields = ", o.customers_company, o.customers_email_address, o.customers_street_address, o.delivery_company, o.delivery_name, o.delivery_street_address, o.billing_company, o.billing_name, o.billing_street_address, o.payment_module_code, o.shipping_module_code, o.ip_address, o.language_code ";
-?>
-<?php
-
-    $orders_query_raw = "select " . $search_distinct . " o.orders_id, o.customers_id, o.customers_name, o.payment_method, o.shipping_method, o.date_purchased, o.last_modified, o.currency, o.currency_value, s.orders_status_name, ot.text as order_total" .
-$new_fields . "
-                          from (" . TABLE_ORDERS . " o " .
-                          $new_table . ")
-                          left join " . TABLE_ORDERS_STATUS . " s on (o.orders_status = s.orders_status_id and s.language_id = " . (int)$_SESSION['languages_id'] . ")
-                          left join " . TABLE_ORDERS_TOTAL . " ot on (o.orders_id = ot.orders_id and ot.class = 'ot_total') ";
-
-
-    if (isset($_GET['cID'])) {
-      $cID = (int)zen_db_prepare_input($_GET['cID']);
-      $orders_query_raw .= " WHERE o.customers_id = " . (int)$cID;
-//echo '<BR><BR>I SEE A: ' . $orders_query_raw . '<BR><BR>';
-
-    } elseif ($_GET['status'] != '') {
-      $status = (int)zen_db_prepare_input($_GET['status']);
-      $orders_query_raw .= " WHERE s.orders_status_id = " . (int)$status . $search;
-//echo '<BR><BR>I SEE B: ' . $orders_query_raw . '<BR><BR>';
-
-    } else {
-      $orders_query_raw .= (trim($search) != '') ? preg_replace('/ *AND /i', ' WHERE ', $search) : '';
-//echo '<BR><BR>I SEE C: ' . $orders_query_raw . '<BR><BR>';
-    }
-
-    $orders_query_raw .= " order by o.orders_id DESC";
+$orders_query_raw = \order::build_search_query($_GET['search'], $_GET['search_orders_products'], $_GET['cID'], $_GET['status']);
 
 // Split Page
 // reset page when page is unknown
-if (($_GET['page'] == '' or $_GET['page'] <= 1) and $_GET['oID'] != '') {
+if (($_GET['page'] == '' or $_GET['page'] <= 1) and (int)$oID > 0) {
   $check_page = $db->Execute($orders_query_raw);
   $check_count=1;
   if ($check_page->RecordCount() > MAX_DISPLAY_SEARCH_RESULTS_ORDERS) {
     while (!$check_page->EOF) {
-      if ($check_page->fields['orders_id'] == $_GET['oID']) {
+      if ($check_page->fields['orders_id'] == (int)$oID) {
         break;
       }
       $check_count++;
@@ -951,7 +584,7 @@ if (($_GET['page'] == '' or $_GET['page'] <= 1) and $_GET['oID'] != '') {
     $orders_split = new splitPageResults($_GET['page'], MAX_DISPLAY_SEARCH_RESULTS_ORDERS, $orders_query_raw, $orders_query_numrows);
     $orders = $db->Execute($orders_query_raw);
     while (!$orders->EOF) {
-    if ((!isset($_GET['oID']) || (isset($_GET['oID']) && ($_GET['oID'] == $orders->fields['orders_id']))) && !isset($oInfo)) {
+    if ((!isset($oID) || (isset($oID) && ($oID == $orders->fields['orders_id']))) && !isset($oInfo)) {
         $oInfo = new objectInfo($orders->fields);
       }
 
@@ -998,8 +631,7 @@ if (($_GET['page'] == '' or $_GET['page'] <= 1) and $_GET['oID'] != '') {
                       <?php
                         echo '<a href="' . zen_admin_href_link(FILENAME_ORDERS) . '">' . zen_image_button('button_reset.gif', IMAGE_RESET) . '</a>';
                         if (isset($_GET['search']) && zen_not_null($_GET['search'])) {
-                          $keywords = zen_db_input(zen_db_prepare_input($_GET['search']));
-                          echo '<br/ >' . TEXT_INFO_SEARCH_DETAIL_FILTER . $keywords;
+                          echo '<br/ >' . TEXT_INFO_SEARCH_DETAIL_FILTER . zen_output_string_protected($_GET['search']);
                         }
                       ?>
                     </td>
@@ -1026,10 +658,11 @@ if (($_GET['page'] == '' or $_GET['page'] <= 1) and $_GET['oID'] != '') {
       break;
     default:
       if (isset($oInfo) && is_object($oInfo)) {
+        $order = new \order($oInfo->orders_id);
         $heading[] = array('text' => '<strong>[' . $oInfo->orders_id . ']&nbsp;&nbsp;' . zen_datetime_short($oInfo->date_purchased) . '</strong>');
 
         $contents[] = array('align' => 'center', 'text' => '<a href="' . zen_admin_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('oID', 'action')) . 'oID=' . $oInfo->orders_id . '&action=edit') . '">' . zen_image_button('button_edit.gif', IMAGE_EDIT) . '</a> <a href="' . zen_admin_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('oID', 'action')) . 'oID=' . $oInfo->orders_id . '&action=delete') . '">' . zen_image_button('button_delete.gif', IMAGE_DELETE) . '</a>');
-        $contents[] = array('align' => 'center', 'text' => '<a href="' . zen_admin_href_link(FILENAME_ORDERS_INVOICE, 'oID=' . $oInfo->orders_id) . '" TARGET="_blank">' . zen_image_button('button_invoice.gif', IMAGE_ORDERS_INVOICE) . '</a> <a href="' . zen_admin_href_link(FILENAME_ORDERS_PACKINGSLIP, 'oID=' . $oInfo->orders_id) . '" TARGET="_blank">' . zen_image_button('button_packingslip.gif', IMAGE_ORDERS_PACKINGSLIP) . '</a>');
+        $contents[] = array('align' => 'center', 'text' => '<a href="' . zen_admin_href_link(FILENAME_ORDERS_INVOICE, 'oID=' . $oInfo->orders_id) . '" target="_blank">' . zen_image_button('button_invoice.gif', IMAGE_ORDERS_INVOICE) . '</a> <a href="' . zen_admin_href_link(FILENAME_ORDERS_PACKINGSLIP, 'oID=' . $oInfo->orders_id) . '" target="_blank">' . zen_image_button('button_packingslip.gif', IMAGE_ORDERS_PACKINGSLIP) . '</a>');
         $zco_notifier->notify('NOTIFY_ADMIN_ORDERS_MENU_BUTTONS', $oInfo, $contents);
 
         $contents[] = array('text' => '<br />' . TEXT_DATE_ORDER_CREATED . ' ' . zen_date_short($oInfo->date_purchased));
@@ -1038,26 +671,22 @@ if (($_GET['page'] == '' or $_GET['page'] <= 1) and $_GET['oID'] != '') {
         if (zen_not_null($oInfo->last_modified)) $contents[] = array('text' => TEXT_DATE_ORDER_LAST_MODIFIED . ' ' . zen_date_short($oInfo->last_modified));
         $contents[] = array('text' => '<br />' . TEXT_INFO_PAYMENT_METHOD . ' '  . $oInfo->payment_method);
         $contents[] = array('text' => '<br />' . ENTRY_SHIPPING . ' '  . $oInfo->shipping_method);
-        $orderLanguage = $lng->get_language_data_by_code($oInfo->language_code);
-        $contents[] = array('text' => '<br />' . TEXT_INFO_ORDER_LANGUAGE . ' ' . $orderLanguage['name']);
+        $contents[] = array('text' => '<br />' . TEXT_INFO_ORDER_LANGUAGE . ' ' . $order->language['name']);
 
 // check if order has open gv
-        $gv_check = $db->Execute("select order_id, unique_id
-                                  from " . TABLE_COUPON_GV_QUEUE ."
-                                  where order_id = '" . $oInfo->orders_id . "' and release_flag='N' limit 1");
-        if ($gv_check->RecordCount() > 0) {
+        if ($order->info['gv_count_in_queue'] > 0) {
           $goto_gv = '<a href="' . zen_admin_href_link(FILENAME_GV_QUEUE, 'order=' . $oInfo->orders_id) . '">' . zen_image_button('button_gift_queue.gif',IMAGE_GIFT_QUEUE) . '</a>';
           $contents[] = array('text' => '<br />' . zen_image(DIR_WS_IMAGES . 'pixel_black.gif','','100%','3'));
           $contents[] = array('align' => 'center', 'text' => $goto_gv);
         }
 
 // display customers comment if any exist (comment from first available order status)
-      if ($orders_comment = zen_get_orders_comments($oInfo->orders_id)) {
-        $contents[] = array('align' => 'left', 'text' => '<br />' . TABLE_HEADING_COMMENTS . ': ' . $orders_comment);
+        if (sizeof($order->status_history) && trim($order->status_history[0]['comments']) != '') {
+          $contents[] = array('align' => 'left', 'text' => '<br />' . TABLE_HEADING_COMMENTS . ': ' . $order->status_history[0]['comments']);
         }
 
         $contents[] = array('text' => '<br />' . zen_image(DIR_WS_IMAGES . 'pixel_black.gif','','100%','3'));
-        $order = new order($oInfo->orders_id);
+
         $contents[] = array('text' => TABLE_HEADING_PRODUCTS . ': ' . sizeof($order->products) );
         for ($i=0; $i<sizeof($order->products); $i++) {
           $contents[] = array('text' => $order->products[$i]['qty'] . '&nbsp;x&nbsp;' . $order->products[$i]['name']);

--- a/includes/classes/language.php
+++ b/includes/classes/language.php
@@ -21,7 +21,7 @@ class language extends base {
   /**
    * @var Array of all available languages in the store
    */
-  protected $available_languages = array();
+  protected $available_languages = array('en'=> array('id' => 1, 'name' => 'english', 'image' => 'icon.gif', 'code' => 'en', 'directory' => 'english'));
   /**
    * @var string comma-delimited list of languages supported by the user's browser
    */
@@ -32,6 +32,7 @@ class language extends base {
   protected $language = '';
 
   /**
+   * @deprecated since v1.6.0
    * @var array DEPRECATED - This is old, and only present for compatibility reasons. Use get_available_languages() instead.
    */
   public $catalog_languages = array();
@@ -55,11 +56,6 @@ class language extends base {
               'code' => $val['code'],
               'directory' => $val['directory'],
               );
-    }
-
-    if (!sizeof($this->available_languages)) {
-      // if none were found, there's gonna be trouble, but here we set a default, so we can avoid having to test for it later
-      $this->available_languages['en'] = array('id' => 1, 'name' => 'english', 'image' => 'icon.gif', 'code' => 'en', 'directory' => 'english');
     }
 
     // for legacy compatibility only:
@@ -107,8 +103,7 @@ class language extends base {
   }
 
   /**
-   * Lookup language details by language Code
-   * (mainly used in admin for displaying language-icons on attribute option-name pages
+   * Lookup language details by 2-letter language Code
    * @param string $lang_code
    * @return array|boolean
    */

--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -18,8 +18,19 @@ if (!defined('IS_ADMIN_FLAG')) {
 }
 
 class order extends base {
-  public $info, $totals, $products, $customer, $billing, $delivery, $content_type, $email_low_stock, $products_ordered_attributes,
-  $products_ordered, $products_ordered_email, $attachArray, $currency, $queryReturnFlag;
+  public $id = 0;
+  public $info, $totals, $customer, $billing, $delivery = array();
+  public $products = array();
+  public $attachArray = array();
+  public $queryReturnFlag = null; 
+  public $currency = array();
+  public $language = array();
+  public $content_type = '';
+  public $email_low_stock = '';
+  public $products_ordered_email, $products_ordered, $products_ordered_html, $products_ordered_attributes = '';
+  public $order_statuses_array = array();
+  public $status_history = array();
+  public $downloads = array();
 
   /**
    * Constructor
@@ -29,21 +40,20 @@ class order extends base {
    * @param bool $override_currency
    */
   public function __construct($order_id = 0, $override_currency = false) {
+    global $lng;
 
     $this->currency = ($override_currency === false) ? $_SESSION['currency'] : $override_currency;
-
-    $this->info = array();
-    $this->totals = array();
-    $this->products = array();
-    $this->customer = array();
-    $this->delivery = array();
 
     $this->notify('NOTIFY_ORDER_INSTANTIATE', array(), $order_id);
     if ((int)$order_id > 0) {
       $this->query((int)$order_id);
+      $this->language = $lng->get_language_data_by_code($this->info['language_code']);
     } else {
       $this->cart($_SESSION['cart']);
+      $this->language = $lng->get_language_data_by_id($_SESSION['languages_id']);
     }
+
+    if (!defined('ORDER_EMAIL_DATE_FORMAT')) define('ORDER_EMAIL_DATE_FORMAT', 'M-d-Y h:iA');
   }
 
   /**
@@ -60,16 +70,15 @@ class order extends base {
     if ($this->queryReturnFlag === TRUE) return;
 
     // cast again in case the notifier changed it
-    $order_id = (int)$order_id;
+    $this->id = (int)$order_id;
 
-    $order_query = "select *
-                        from " . TABLE_ORDERS . "
-                        where orders_id = '" . (int)$order_id . "'";
+    $language_id = (int)$_SESSION['languages_id'];
+    $order_query = "select o.*, os.orders_status_name from " . TABLE_ORDERS . " o, " . TABLE_ORDERS_STATUS . " os WHERE orders_id = " . (int)$this->id . " AND os.language_id = " . (int)$language_id;
     $order = $db->Execute($order_query);
 
     $totals_query = "select title, text, class, value
                          from " . TABLE_ORDERS_TOTAL . "
-                         where orders_id = " . (int)$order_id . "
+                         where orders_id = " . (int)$this->id . "
                          order by sort_order";
     $totals = $db->Execute($totals_query);
     while (!$totals->EOF) {
@@ -88,11 +97,11 @@ class order extends base {
       $totals->MoveNext();
     }
 
-    $order_status_query = "select orders_status_name
-                             from " . TABLE_ORDERS_STATUS . "
-                             where orders_status_id = '" . $order->fields['orders_status'] . "'
-                             and language_id = '" . (int)$_SESSION['languages_id'] . "'";
-    $order_status = $db->Execute($order_status_query);
+    // count unreleased GVs associated with this order
+    $result = $db->Execute("select order_id, unique_id
+                              from " . TABLE_COUPON_GV_QUEUE ."
+                              where order_id = " . $this->id . " and release_flag='N'");
+    $gv_count_in_queue = count($result);
 
     $this->info = array('currency' => $order->fields['currency'],
                         'currency_value' => $order->fields['currency_value'],
@@ -108,13 +117,15 @@ class order extends base {
                         'cc_expires' => $order->fields['cc_expires'],
                         'date_purchased' => $order->fields['date_purchased'],
                         'orders_status' => $order->fields['orders_status'],
-                        'orders_status_name' => $order_status->fields['orders_status_name'],
+                        'orders_status_name' => $order->fields['orders_status_name'],
                         'total' => $order->fields['order_total'],
                         'tax' => $order->fields['order_tax'],
                         'last_modified' => $order->fields['last_modified'],
                         'ip_address' => $order->fields['ip_address'],
                         'order_weight' => $order->fields['order_weight'],
-                        'language_code' => $order->fields['language_code']
+                        'is_guest_order' => $order->fields['is_guest_order'],
+                        'language_code' => $order->fields['language_code'],
+                        'gv_count_in_queue' => $gv_count_in_queue,
                         );
 
     $this->customer = array('id' => $order->fields['customers_id'],
@@ -154,29 +165,28 @@ class order extends base {
                            'country' => $order->fields['billing_country'],
                            'format_id' => $order->fields['billing_address_format_id']);
 
-    $index = 0;
     $orders_products_query = "select *
-                                  from " . TABLE_ORDERS_PRODUCTS . "
-                                  where orders_id = " . (int)$order_id . "
-                                  order by orders_products_id";
-
+                              from " . TABLE_ORDERS_PRODUCTS . "
+                              where orders_id = " . (int)$this->id . "
+                              order by orders_products_id";
     $orders_products = $db->Execute($orders_products_query);
 
-    while (!$orders_products->EOF) {
+    $index = 0;
+    foreach($orders_products as $product) {
       // convert quantity to proper decimals (particularly for account history)
       if (QUANTITY_DECIMALS != 0) {
-        $fix_qty = $orders_products->fields['products_quantity'];
+        $fix_qty = $product['products_quantity'];
         switch (true) {
           case (!strstr($fix_qty, '.')):
           $new_qty = $fix_qty;
           break;
           default:
           // remove trailing 0's
-          $new_qty = preg_replace('/[0]+$/', '', $orders_products->fields['products_quantity']);
+          $new_qty = preg_replace('/[0]+$/', '', $product['products_quantity']);
           break;
         }
       } else {
-        $new_qty = $orders_products->fields['products_quantity'];
+        $new_qty = $product['products_quantity'];
       }
 
       $new_qty = round($new_qty, QUANTITY_DECIMALS);
@@ -186,51 +196,85 @@ class order extends base {
       }
 
       $this->products[$index] = array('qty' => $new_qty,
-                                      'id' => $orders_products->fields['products_id'],
-                                      'name' => $orders_products->fields['products_name'],
-                                      'model' => $orders_products->fields['products_model'],
-                                      'tax' => $orders_products->fields['products_tax'],
-                                      'price' => $orders_products->fields['products_price'],
-                                      'final_price' => $orders_products->fields['final_price'],
-                                      'onetime_charges' => $orders_products->fields['onetime_charges'],
-                                      'products_priced_by_attribute' => $orders_products->fields['products_priced_by_attribute'],
-                                      'product_is_free' => $orders_products->fields['product_is_free'],
-                                      'products_discount_type' => $orders_products->fields['products_discount_type'],
-                                      'products_discount_type_from' => $orders_products->fields['products_discount_type_from'],
-                                      'products_weight' => $orders_products->fields['products_weight'],
-                                      'products_virtual' => $orders_products->fields['products_virtual'],
-                                      'product_is_always_free_shipping' => $orders_products->fields['product_is_always_free_shipping'],
-                                      'products_quantity_order_min' => $orders_products->fields['products_quantity_order_min'],
-                                      'products_quantity_order_units' => $orders_products->fields['products_quantity_order_units'],
-                                      'products_quantity_order_max' => $orders_products->fields['products_quantity_order_max'],
-                                      'products_quantity_mixed' => $orders_products->fields['products_quantity_mixed'],
-                                      'products_mixed_discount_quantity' => $orders_products->fields['products_mixed_discount_quantity']
+                                      'id' => $product['products_id'],
+                                      'name' => $product['products_name'],
+                                      'model' => $product['products_model'],
+                                      'tax' => $product['products_tax'],
+                                      'price' => $product['products_price'],
+                                      'final_price' => $product['final_price'],
+                                      'onetime_charges' => $product['onetime_charges'],
+                                      'products_priced_by_attribute' => $product['products_priced_by_attribute'],
+                                      'product_is_free' => $product['product_is_free'],
+                                      'products_discount_type' => $product['products_discount_type'],
+                                      'products_discount_type_from' => $product['products_discount_type_from'],
+                                      'products_weight' => $product['products_weight'],
+                                      'products_virtual' => $product['products_virtual'],
+                                      'product_is_always_free_shipping' => $product['product_is_always_free_shipping'],
+                                      'products_quantity_order_min' => $product['products_quantity_order_min'],
+                                      'products_quantity_order_units' => $product['products_quantity_order_units'],
+                                      'products_quantity_order_max' => $product['products_quantity_order_max'],
+                                      'products_quantity_mixed' => $product['products_quantity_mixed'],
+                                      'products_mixed_discount_quantity' => $product['products_mixed_discount_quantity']
                                       );
 
       $attributes_query = "select * from " . TABLE_ORDERS_PRODUCTS_ATTRIBUTES . "
-                               where orders_id = " . (int)$order_id . "
-                               and orders_products_id = " . (int)$orders_products->fields['orders_products_id'];
+                           where orders_id = " . (int)$this->id . "
+                           and orders_products_id = " . (int)$product['orders_products_id'];
       $attributes = $db->Execute($attributes_query);
-      if ($attributes->RecordCount()) {
-        while (!$attributes->EOF) {
-          $this->products[$index]['attributes'][] = array('option' => $attributes->fields['products_options'],
-                                                                   'value' => $attributes->fields['products_options_values'],
-                                                                   'option_id' => $attributes->fields['products_options_id'],
-                                                                   'value_id' => $attributes->fields['products_options_values_id'],
-                                                                   'prefix' => $attributes->fields['price_prefix'],
-                                                                   'price' => $attributes->fields['options_values_price'],
-                                                                   'product_attribute_is_free' =>$attributes->fields['product_attribute_is_free'],
-                                                                   );
-          $attributes->MoveNext();
+      if (sizeof($attributes)) {
+        foreach($attributes as $attribute) {
+          $this->products[$index]['attributes'][]  = array('option' => $attribute['products_options'],
+                                                           'value' => $attribute['products_options_values'],
+                                                           'option_id' => $attribute['products_options_id'],
+                                                           'value_id' => $attribute['products_options_values_id'],
+                                                           'prefix' => $attribute['price_prefix'],
+                                                           'price' => $attribute['options_values_price'],
+                                                           'product_attribute_is_free' =>$attribute['product_attribute_is_free'],
+                                                           );
         }
-      }
+      }// endif sizeof attributes
 
-      $this->info['tax_groups']["{$this->products[$index]['tax']}"] = '1';
+      $this->info['tax_groups']["{$this->products[$index]['tax']}"] = 1;
 
       $index++;
-      $orders_products->MoveNext();
+    } // end loop $orders_products as $product
+
+    // retrieve downloads for current order
+    $orders_download_query = "select * from " . TABLE_ORDERS_PRODUCTS_DOWNLOAD . " where orders_id=" . (int)$this->id;
+    $orders_download = $db->Execute($orders_download_query);
+    foreach($orders_download as $key=>$row) 
+    {
+      $this->downloads[] = $row;
     }
-    $this->notify('NOTIFY_ORDER_AFTER_QUERY', array(), $order_id);
+
+    // get order-status-history including comments
+    $orders_history = $db->Execute("select orders_status_id, date_added, customer_notified, comments
+                                    from " . TABLE_ORDERS_STATUS_HISTORY . "
+                                    where orders_id = " . (int)$this->id . "
+                                    order by date_added asc");
+    foreach($orders_history as $key=>$row) 
+    {
+      $this->status_history[] = $row;
+    }
+
+    $this->notify('NOTIFY_ORDER_AFTER_QUERY', array(), $this->id);
+  }
+  /**
+   * Get list of all order status names and ids for the specified language
+   */
+  public static function get_order_statuses($language_id = null)
+  {
+    global $db;
+    if (!$language_id) $language_id = $_SESSION['languages_id'];
+    $order_statuses_array = array();
+    $result = $db->Execute("select orders_status_id, orders_status_name
+                            from " . TABLE_ORDERS_STATUS . "
+                            where language_id = " . (int)$language_id . "
+                            order by orders_status_id");
+    foreach($result as $row) {
+      $order_statuses_array[$row['orders_status_id']] = $row['orders_status_name'];
+    }
+    return $order_statuses_array;
   }
 
   /**
@@ -255,10 +299,10 @@ class order extends base {
                                    left join " . TABLE_ZONES . " z on (ab.entry_zone_id = z.zone_id)
                                    left join " . TABLE_COUNTRIES . " co on (ab.entry_country_id = co.countries_id)
                                    left join " . TABLE_COUNTRIES_NAME . " cn on (ab.entry_country_id = cn.countries_id)
-                                   where c.customers_id = '" . (int)$_SESSION['customer_id'] . "'
-                                   and ab.customers_id = '" . (int)$_SESSION['customer_id'] . "'
+                                   where c.customers_id = " . (int)$_SESSION['customer_id'] . "
+                                   and ab.customers_id = " . (int)$_SESSION['customer_id'] . "
                                    and c.customers_default_address_id = ab.address_book_id
-                                   and cn.language_id = '" . (int)$_SESSION['languages_id'] . "'";
+                                   and cn.language_id = " . (int)$_SESSION['languages_id'];
 
     $customer_address = $db->Execute($customer_address_query);
 
@@ -271,9 +315,9 @@ class order extends base {
                                    left join " . TABLE_ZONES . " z on (ab.entry_zone_id = z.zone_id)
                                    left join " . TABLE_COUNTRIES . " c on (ab.entry_country_id = c.countries_id)
                                    left join " . TABLE_COUNTRIES_NAME . " cn on (ab.entry_country_id = cn.countries_id)
-                                   where ab.customers_id = '" . (int)$_SESSION['customer_id'] . "'
-                                   and ab.address_book_id = '" . (int)$_SESSION['sendto'] . "'
-                                   and cn.language_id = '" . (int)$_SESSION['languages_id'] . "'";
+                                   where ab.customers_id = " . (int)$_SESSION['customer_id'] . "
+                                   and ab.address_book_id = " . (int)$_SESSION['sendto'] . "
+                                   and cn.language_id = " . (int)$_SESSION['languages_id'];
 
     $shipping_address = $db->Execute($shipping_address_query);
 
@@ -286,9 +330,9 @@ class order extends base {
                                   left join " . TABLE_ZONES . " z on (ab.entry_zone_id = z.zone_id)
                                   left join " . TABLE_COUNTRIES . " c on (ab.entry_country_id = c.countries_id)
                                   left join " . TABLE_COUNTRIES_NAME . " cn on (ab.entry_country_id = cn.countries_id)
-                                  where ab.customers_id = '" . (int)$_SESSION['customer_id'] . "'
-                                  and ab.address_book_id = '" . (int)$_SESSION['billto'] . "'
-                                  and cn.language_id = '" . (int)$_SESSION['languages_id'] . "'";
+                                  where ab.customers_id = " . (int)$_SESSION['customer_id'] . "
+                                  and ab.address_book_id = " . (int)$_SESSION['billto'] . "
+                                  and cn.language_id = " . (int)$_SESSION['languages_id'];
 
     $billing_address = $db->Execute($billing_address_query);
 
@@ -304,15 +348,15 @@ class order extends base {
         $tax_address_query = "select ab.entry_country_id, ab.entry_zone_id
                                 from " . TABLE_ADDRESS_BOOK . " ab
                                 left join " . TABLE_ZONES . " z on (ab.entry_zone_id = z.zone_id)
-                                where ab.customers_id = '" . (int)$_SESSION['customer_id'] . "'
-                                and ab.address_book_id = '" . (int)($this->content_type == 'virtual' ? $_SESSION['billto'] : $_SESSION['sendto']) . "'";
+                                where ab.customers_id = " . (int)$_SESSION['customer_id'] . "
+                                and ab.address_book_id = " . (int)($this->content_type == 'virtual' ? $_SESSION['billto'] : $_SESSION['sendto']);
         break;
         case 'Billing':
         $tax_address_query = "select ab.entry_country_id, ab.entry_zone_id
                                 from " . TABLE_ADDRESS_BOOK . " ab
                                 left join " . TABLE_ZONES . " z on (ab.entry_zone_id = z.zone_id)
-                                where ab.customers_id = '" . (int)$_SESSION['customer_id'] . "'
-                                and ab.address_book_id = '" . (int)$_SESSION['billto'] . "'";
+                                where ab.customers_id = " . (int)$_SESSION['customer_id'] . "
+                                and ab.address_book_id = " . (int)$_SESSION['billto'];
         break;
         case 'Store':
         if ($billing_address->fields['entry_zone_id'] == STORE_ZONE) {
@@ -320,14 +364,14 @@ class order extends base {
           $tax_address_query = "select ab.entry_country_id, ab.entry_zone_id
                                   from " . TABLE_ADDRESS_BOOK . " ab
                                   left join " . TABLE_ZONES . " z on (ab.entry_zone_id = z.zone_id)
-                                  where ab.customers_id = '" . (int)$_SESSION['customer_id'] . "'
-                                  and ab.address_book_id = '" . (int)$_SESSION['billto'] . "'";
+                                  where ab.customers_id = " . (int)$_SESSION['customer_id'] . "
+                                  and ab.address_book_id = " . (int)$_SESSION['billto'];
         } else {
           $tax_address_query = "select ab.entry_country_id, ab.entry_zone_id
                                   from " . TABLE_ADDRESS_BOOK . " ab
                                   left join " . TABLE_ZONES . " z on (ab.entry_zone_id = z.zone_id)
-                                  where ab.customers_id = '" . (int)$_SESSION['customer_id'] . "'
-                                  and ab.address_book_id = '" . (int)($this->content_type == 'virtual' ? $_SESSION['billto'] : $_SESSION['sendto']) . "'";
+                                  where ab.customers_id = " . (int)$_SESSION['customer_id'] . "
+                                  and ab.address_book_id = " . (int)($this->content_type == 'virtual' ? $_SESSION['billto'] : $_SESSION['sendto']);
         }
       }
       if ($tax_address_query != '') {
@@ -339,13 +383,15 @@ class order extends base {
       }
     }
 
+    $this->notify('NOTIFY_ORDER_CART_ADD_PRODUCT_TAX_ZONES', [], $taxCountryId, $taxZoneId, $decimals);
+
     $class =& $_SESSION['payment'];
 
     $coupon_code = '';
     if (isset($_SESSION['cc_id'])) {
       $coupon_code_query = "select coupon_code
                               from " . TABLE_COUPONS . "
-                              where coupon_id = '" . (int)$_SESSION['cc_id'] . "'";
+                              where coupon_id = " . (int)$_SESSION['cc_id'];
       $result = $db->Execute($coupon_code_query);
       if ($result->RecordCount()) $coupon_code = $result->fields['coupon_code'];
     }
@@ -367,7 +413,7 @@ class order extends base {
                         'comments' => (isset($_SESSION['comments']) ? $_SESSION['comments'] : ''),
                         'ip_address' => $_SESSION['customers_ip_address'] . ' - ' . zen_get_ip_address(),
                         'order_weight' => ($shipping_weight * $shipping_num_boxes),
-                        'language_code' => $_SESSION['languages_code']
+                        'language_code' => $_SESSION['languages_code'],
                         );
 
     $this->customer = array('firstname' => $customer_address->fields['customers_firstname'],
@@ -441,7 +487,7 @@ class order extends base {
                                       'products_quantity_order_units' => $products[$i]['products_quantity_order_units'],
                                       'products_quantity_order_max' => $products[$i]['products_quantity_order_max'],
                                       'products_quantity_mixed' => $products[$i]['products_quantity_mixed'],
-                                      'products_mixed_discount_quantity' => $products[$i]['products_mixed_discount_quantity']
+                                      'products_mixed_discount_quantity' => $products[$i]['products_mixed_discount_quantity'],
                                       );
 
       if (STORE_PRODUCT_TAX_BASIS == 'Shipping' && isset($_SESSION['shipping']['id']) && stristr($_SESSION['shipping']['id'], 'storepickup') == TRUE)
@@ -465,13 +511,13 @@ class order extends base {
                                    from " . TABLE_PRODUCTS_OPTIONS . " popt,
                                         " . TABLE_PRODUCTS_OPTIONS_VALUES . " poval,
                                         " . TABLE_PRODUCTS_ATTRIBUTES . " pa
-                                   where pa.products_id = '" . (int)$products[$i]['id'] . "'
-                                   and pa.options_id = '" . (int)$option . "'
+                                   where pa.products_id = " . (int)$products[$i]['id'] . "
+                                   and pa.options_id = " . (int)$option . "
                                    and pa.options_id = popt.products_options_id
-                                   and pa.options_values_id = '" . (int)$value . "'
+                                   and pa.options_values_id = " . (int)$value . "
                                    and pa.options_values_id = poval.products_options_values_id
-                                   and popt.language_id = '" . (int)$_SESSION['languages_id'] . "'
-                                   and poval.language_id = '" . (int)$_SESSION['languages_id'] . "'";
+                                   and popt.language_id = " . (int)$_SESSION['languages_id'] . "
+                                   and poval.language_id = " . (int)$_SESSION['languages_id'];
 
           $attributes = $db->Execute($attributes_query);
 
@@ -482,6 +528,7 @@ class order extends base {
             $attr_value = $attributes->fields['products_options_values_name'];
           }
 
+          $this->notify('NOTIFY_ORDER_CART_ADD_ATTRIBUTE_LIST', array('index'=>$index, 'subindex'=>$subindex, 'products'=>$products[$i], 'attributes'=>$attributes), $attr_value, $option, $value, $attributes);
           $this->products[$index]['attributes'][$subindex] = array('option' => $attributes->fields['products_options_name'],
                                                                    'value' => $attr_value,
                                                                    'option_id' => $option,
@@ -489,7 +536,6 @@ class order extends base {
                                                                    'prefix' => $attributes->fields['price_prefix'],
                                                                    'price' => $attributes->fields['options_values_price']);
 
-          $this->notify('NOTIFY_ORDER_CART_ADD_ATTRIBUTE_LIST', array('index'=>$index, 'subindex'=>$subindex, 'products'=>$products[$i], 'attributes'=>$attributes));
           $subindex++;
         }
       }
@@ -562,15 +608,15 @@ class order extends base {
 
   /**
    * Creates a new order from the object's arrays built from the cart() method triggered by the constructor
-   * $zf_ot_modules is an array of order-totals calculated by checkout_process during checkout
+   * $order_totals is an array of order-totals calculated by checkout_process during checkout
    *
-   * @param array $zf_ot_modules
+   * @param array $order_totals
    * @return int order number
    */
-  public function create($zf_ot_modules) {
+  public function create($order_totals) {
     global $db;
 
-    $this->notify('NOTIFY_ORDER_CART_EXTERNAL_TAX_DURING_ORDER_CREATE', array(), $zf_ot_modules);
+    $this->notify('NOTIFY_ORDER_CART_EXTERNAL_TAX_DURING_ORDER_CREATE', array(), $order_totals);
 
     if ($this->info['total'] == 0) {
       if (DEFAULT_ZERO_BALANCE_ORDERS_STATUS_ID == 0) {
@@ -650,34 +696,34 @@ class order extends base {
     $this->notify('NOTIFY_ORDER_CREATE_SET_SQL_DATA_ARRAY', array(), $sql_data_array);
     zen_db_perform(TABLE_ORDERS, $sql_data_array);
 
-    $insert_id = $db->Insert_ID();
-    $this->notify('NOTIFY_ORDER_DURING_CREATE_ADDED_ORDER_HEADER', array_merge(array('orders_id' => $insert_id, 'shipping_weight' => $this->info['order_weight']), $sql_data_array), $insert_id);
+    $this->id = $this->info['id'] = $db->Insert_ID();
+    $this->notify('NOTIFY_ORDER_DURING_CREATE_ADDED_ORDER_HEADER', array_merge(array('orders_id' => $this->id, 'shipping_weight' => $this->info['order_weight']), $sql_data_array));
 
-    for ($i=0, $n=sizeof($zf_ot_modules); $i<$n; $i++) {
-      $sql_data_array = array('orders_id' => $insert_id,
-                              'title' => $zf_ot_modules[$i]['title'],
-                              'text' => $zf_ot_modules[$i]['text'],
-                              'value' => (is_numeric($zf_ot_modules[$i]['value'])) ? $zf_ot_modules[$i]['value'] : '0',
-                              'class' => $zf_ot_modules[$i]['code'],
-                              'sort_order' => $zf_ot_modules[$i]['sort_order']);
+    for ($i=0, $n=sizeof($order_totals); $i<$n; $i++) {
+      $sql_data_array = array('orders_id' => $this->id,
+                              'title' => $order_totals[$i]['title'],
+                              'text' => $order_totals[$i]['text'],
+                              'value' => (is_numeric($order_totals[$i]['value'])) ? $order_totals[$i]['value'] : '0',
+                              'class' => $order_totals[$i]['code'],
+                              'sort_order' => $order_totals[$i]['sort_order']);
 
       zen_db_perform(TABLE_ORDERS_TOTAL, $sql_data_array);
-      $ot_insert_id = $db->insert_ID();
+      $ot_insert_id = $db->Insert_ID();
       $this->notify('NOTIFY_ORDER_DURING_CREATE_ADDED_ORDERTOTAL_LINE_ITEM', $sql_data_array, $ot_insert_id);
     }
 
     $customer_notification = (SEND_EMAILS == 'true') ? '1' : '0';
-    $sql_data_array = array('orders_id' => $insert_id,
+    $sql_data_array = array('orders_id' => $this->id,
                             'orders_status_id' => $this->info['order_status'],
                             'date_added' => 'now()',
                             'customer_notified' => $customer_notification,
                             'comments' => $this->info['comments']);
 
     zen_db_perform(TABLE_ORDERS_STATUS_HISTORY, $sql_data_array);
-    $osh_insert_id = $db->insert_ID();
+    $osh_insert_id = $db->Insert_ID();
     $this->notify('NOTIFY_ORDER_DURING_CREATE_ADDED_ORDER_COMMENT', $sql_data_array, $osh_insert_id);
 
-    return $insert_id;
+    return $this->id;
   }
 
   /**
@@ -705,23 +751,21 @@ class order extends base {
       // Stock Update - Joao Correia
       if ($this->doStockDecrement) {
         if (DOWNLOAD_ENABLED == 'true') {
-          $stock_query_raw = "select p.products_quantity, pad.products_attributes_filename, p.product_is_always_free_shipping
-                              from " . TABLE_PRODUCTS . " p
-                              left join " . TABLE_PRODUCTS_ATTRIBUTES . " pa
-                               on p.products_id=pa.products_id
-                              left join " . TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD . " pad
-                               on pa.products_attributes_id=pad.products_attributes_id
-                              WHERE p.products_id = '" . zen_get_prid($this->products[$i]['id']) . "'";
+          $stock_query_raw = "SELECT p.products_quantity, pad.products_attributes_filename, p.product_is_always_free_shipping
+                              FROM " . TABLE_PRODUCTS . " p
+                              LEFT JOIN " . TABLE_PRODUCTS_ATTRIBUTES . " pa ON p.products_id=pa.products_id
+                              LEFT JOIN " . TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD . " pad ON pa.products_attributes_id=pad.products_attributes_id
+                              WHERE p.products_id = " . zen_get_prid($this->products[$i]['id']);
 
           // Will work with only one option for downloadable products
           // otherwise, we have to build the query dynamically with a loop
           $products_attributes = $this->products[$i]['attributes'];
           if (is_array($products_attributes)) {
-            $stock_query_raw .= " AND pa.options_id = '" . $products_attributes[0]['option_id'] . "' AND pa.options_values_id = '" . $products_attributes[0]['value_id'] . "'";
+            $stock_query_raw .= " AND pa.options_id = " . $products_attributes[0]['option_id'] . " AND pa.options_values_id = " . $products_attributes[0]['value_id'];
           }
           $stock_values = $db->Execute($stock_query_raw, false, false, 0, true);
         } else {
-          $stock_values = $db->Execute("select products_quantity, '' as products_attributes_filename, product_is_always_free_shipping from " . TABLE_PRODUCTS . " where products_id = '" . zen_get_prid($this->products[$i]['id']) . "'", false, false, 0, true);
+          $stock_values = $db->Execute("select products_quantity, '' as products_attributes_filename, product_is_always_free_shipping from " . TABLE_PRODUCTS . " where products_id = " . zen_get_prid($this->products[$i]['id']), false, false, 0, true);
         }
 
         $this->notify('NOTIFY_ORDER_PROCESSING_STOCK_DECREMENT_BEGIN', $i, $stock_values);
@@ -735,11 +779,11 @@ class order extends base {
             $stock_left = $stock_values->fields['products_quantity'];
           }
 
-          $db->Execute("update " . TABLE_PRODUCTS . " set products_quantity = '" . $stock_left . "' where products_id = '" . zen_get_prid($this->products[$i]['id']) . "'");
+          $db->Execute("update " . TABLE_PRODUCTS . " set products_quantity = '" . $stock_left . "' where products_id = " . zen_get_prid($this->products[$i]['id']));
           if ($stock_left <= 0) {
             // only set status to off when not displaying sold out
             if (SHOW_PRODUCTS_SOLD_OUT == '0') {
-              $db->Execute("update " . TABLE_PRODUCTS . " set products_status = 0 where products_id = '" . zen_get_prid($this->products[$i]['id']) . "'");
+              $db->Execute("update " . TABLE_PRODUCTS . " set products_status = 0 where products_id = " . zen_get_prid($this->products[$i]['id']));
             }
           }
 
@@ -755,7 +799,7 @@ class order extends base {
       $this->bestSellersUpdate = TRUE;
       $this->notify('NOTIFY_ORDER_PROCESSING_BESTSELLERS_UPDATE', array(), $this->products[$i], $i);
       if ($this->bestSellersUpdate) {
-        $db->Execute("update " . TABLE_PRODUCTS . " set products_ordered = products_ordered + " . sprintf('%f', $this->products[$i]['qty']) . " where products_id = '" . zen_get_prid($this->products[$i]['id']) . "'");
+        $db->Execute("update " . TABLE_PRODUCTS . " set products_ordered = products_ordered + " . sprintf('%f', $this->products[$i]['qty']) . " where products_id = " . zen_get_prid($this->products[$i]['id']));
       }
 
       $this->notify('NOTIFY_ORDER_PROCESSING_STOCK_DECREMENT_END', $i);
@@ -812,16 +856,14 @@ class order extends base {
                                  pa.attributes_price_letters, pa.attributes_price_letters_free,
                                  pad.products_attributes_maxdays, pad.products_attributes_maxcount, pad.products_attributes_filename
                                  from " . TABLE_PRODUCTS_OPTIONS . " popt, " . TABLE_PRODUCTS_OPTIONS_VALUES . " poval, " .
-            TABLE_PRODUCTS_ATTRIBUTES . " pa
-                                  left join " . TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD . " pad
-                                  on pa.products_attributes_id=pad.products_attributes_id
-                                 where pa.products_id = '" . zen_db_input($this->products[$i]['id']) . "'
-                                  and pa.options_id = '" . $this->products[$i]['attributes'][$j]['option_id'] . "'
+                                  TABLE_PRODUCTS_ATTRIBUTES . " pa LEFT JOIN  " . TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD . " pad on pa.products_attributes_id=pad.products_attributes_id
+                                 where pa.products_id = " . (int)$this->products[$i]['id'] . "
+                                  and pa.options_id = " . (int)$this->products[$i]['attributes'][$j]['option_id'] . "
                                   and pa.options_id = popt.products_options_id
-                                  and pa.options_values_id = '" . $this->products[$i]['attributes'][$j]['value_id'] . "'
+                                  and pa.options_values_id = " . (int)$this->products[$i]['attributes'][$j]['value_id'] . "
                                   and pa.options_values_id = poval.products_options_values_id
-                                  and popt.language_id = '" . $_SESSION['languages_id'] . "'
-                                  and poval.language_id = '" . $_SESSION['languages_id'] . "'";
+                                  and popt.language_id = " . (int)$_SESSION['languages_id'] . "
+                                  and poval.language_id = popt.language_id";
 
             $attributes_values = $db->Execute($attributes_query);
           } else {
@@ -835,13 +877,13 @@ class order extends base {
                                  pa.attributes_price_words, pa.attributes_price_words_free,
                                  pa.attributes_price_letters, pa.attributes_price_letters_free
                                  from " . TABLE_PRODUCTS_OPTIONS . " popt, " . TABLE_PRODUCTS_OPTIONS_VALUES . " poval, " . TABLE_PRODUCTS_ATTRIBUTES . " pa
-                                 where pa.products_id = '" . $this->products[$i]['id'] . "' 
-                                 and pa.options_id = '" . (int)$this->products[$i]['attributes'][$j]['option_id'] . "' 
+                                 where pa.products_id = " . (int)$this->products[$i]['id'] . "
+                                 and pa.options_id = " . (int)$this->products[$i]['attributes'][$j]['option_id'] . "
                                  and pa.options_id = popt.products_options_id 
-                                 and pa.options_values_id = '" . (int)$this->products[$i]['attributes'][$j]['value_id'] . "' 
+                                 and pa.options_values_id = " . (int)$this->products[$i]['attributes'][$j]['value_id'] . "
                                  and pa.options_values_id = poval.products_options_values_id 
-                                 and popt.language_id = '" . $_SESSION['languages_id'] . "' 
-                                 and poval.language_id = '" . $_SESSION['languages_id'] . "'");
+                                 and popt.language_id = " . (int)$_SESSION['languages_id'] . "
+                                 and poval.language_id = popt.language_id");
           }
 
           $sql_data_array = array('orders_id' => $order_id,
@@ -877,7 +919,7 @@ class order extends base {
 
           $this->notify('NOTIFY_ORDER_DURING_CREATE_ADDED_ATTRIBUTE_LINE_ITEM', array_merge(array('orders_products_attributes_id' => $products_attributes_id), $sql_data_array), $products_attributes_id);
 
-          if ((DOWNLOAD_ENABLED == 'true') && isset($attributes_values->fields['products_attributes_filename']) && zen_not_null($attributes_values->fields['products_attributes_filename'])) {
+          if (DOWNLOAD_ENABLED == 'true' && isset($attributes_values->fields['products_attributes_filename']) && zen_not_null($attributes_values->fields['products_attributes_filename'])) {
             $sql_data_array = array('orders_id' => $order_id,
                                     'orders_products_id' => $order_products_id,
                                     'orders_products_filename' => $attributes_values->fields['products_attributes_filename'],
@@ -964,22 +1006,30 @@ class order extends base {
   }
 
   /**
+   * Alias to send_order_confirmation_email()
+   */
+  public function send_order_email($order_id) {
+    return $this->send_order_confirmation_email($order_id);
+  }
+
+  /**
    * Sends order-confirmation email to customer and storeowner
    * Depends on the product-related content being prepared in advance by the create_add_products() method
    *
    * @param $order_id
    */
-  public function send_order_email($order_id) {
+  public function send_order_confirmation_email($order_id) {
     global $currencies, $order_totals;
 
     $this->notify('NOTIFY_ORDER_SEND_EMAIL_INITIALIZE', array(), $order_id, $order_totals);
-    if (!defined('ORDER_EMAIL_DATE_FORMAT')) define('ORDER_EMAIL_DATE_FORMAT', 'M-d-Y h:iA');
+
+    if (!$order_id) $order_id = $this->id;
 
     $this->sendLowStockEmails();
 
     // prepare the email confirmation message details
     // make an array to store the html version of the email
-    $html_msg=array();
+    $html_msg = array();
     $email_order = '';
 
     $emailTextInvoiceText = EMAIL_TEXT_INVOICE_URL_CLICK;
@@ -1113,5 +1163,430 @@ class order extends base {
     }
     $this->notify('NOTIFY_ORDER_AFTER_SEND_ORDER_EMAIL', $order_id, $email_order, $extra_info, $html_msg);
   }
+
+  /**
+   * Reset download count and max_days for the specified orders_products_download_id on the current order
+   * Used by toggle on admin order screen, and on update_status_and_comments()
+   */
+  public function resetSingleDownloadToOn($orders_products_download_id = 0, $order_id = null)
+  {
+    global $db;
+    if ((int)$orders_products_download_id == 0) return false;
+    if (!$order_id) $order_id = $this->id;
+
+    // get existing download days and max, if present
+    $sql = "SELECT pad.products_attributes_maxdays, pad.products_attributes_maxcount
+            from " . TABLE_PRODUCTS_ATTRIBUTES . " pa, " . TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD . " pad, " . TABLE_ORDERS_PRODUCTS_DOWNLOAD . " opd
+            WHERE pa.products_attributes_id = pad.products_attributes_id
+            and pad.products_attributes_filename = opd.orders_products_filename
+            and pa.products_id = opd.products_prid
+            and opd.orders_products_download_id=" . (int)$orders_products_download_id;
+    $result = $db->Execute($sql);
+
+    // defaults
+    $days = DOWNLOAD_MAX_DAYS;
+    $count = DOWNLOAD_MAX_COUNT;
+
+    // override defaults with db values, if exist
+    if (count($result)) {
+      $days = $result->fields['products_attributes_maxdays'];
+      $count = $result->fields['products_attributes_maxcount'];
+    }
+    // prepare and execute SQL
+    $zc_max_days = ($days == 0 ? 0 : zen_date_diff($this->info['date_purchased'], date('Y-m-d H:i:s', time())) + $days);
+    $sql = "update " . TABLE_ORDERS_PRODUCTS_DOWNLOAD . " set download_maxdays=" . $zc_max_days . ", download_count=" . $count . " where orders_id=" . $order_id . " and orders_products_download_id=" . (int)$orders_products_download_id;
+    $db->Execute($sql);
+  }
+
+  /**
+   * disable specified download item by resetting count to 0
+   */
+  public function resetSingleDownloadToOff($orders_products_download_id = 0)
+  {
+    global $db;
+    if ((int)$orders_products_download_id == 0) return false;
+    $sql = "update " . TABLE_ORDERS_PRODUCTS_DOWNLOAD . " set download_count=0 where orders_id=" . (int)$this->id . " and orders_products_download_id=" . (int)$orders_products_download_id;
+    $db->Execute($sql);
+  }
+
+  /**
+   * Re-enable all downloads for the specified or current order
+   */
+  public function reEnableAllDownloads($order_id = null)
+  {
+    global $db;
+    if (!$order_id) $order_id = $this->id;
+
+    // retrieve all downloadable attribute IDs for this order
+    $sql = "SELECT opd.orders_products_download_id from " . TABLE_ORDERS_PRODUCTS_DOWNLOAD . " opd, " . TABLE_ORDERS_PRODUCTS . " op
+            WHERE op.orders_id=" . (int)$order_id . "
+            AND opd.orders_products_id = op.orders_products_id";
+    $result = $db->Execute($sql);
+    if ($result->EOF) return false;
+
+    foreach($result as $row) {
+      $this->resetSingleDownloadToOn($row['orders_products_download_id'], $order_id);
+    }
+    return count($result);
+  }
+
+
+  public function update_status_and_comments($status = 0, $comments = '', $send_notify_email = true, $notify_include_comments = 'on', $fields = null)
+  {
+    global $db;
+    $order_updated = $customer_notified = false;
+    $status = (int)$status;
+    $comments = $db->prepare_input($comments);
+    $notify_comments = '';
+    $order_number_string = $this->id; // for email text
+    $html_msg = array();
+    $message = '';
+
+    $this->notify('NOTIFY_ORDER_SEND_STATUS_EMAIL_INITIALIZE', $this->id, $status, $comments, $send_notify_email, $notify_include_comments, $fields);
+
+    // note: this refers to the *admin* language file named orders_email.php
+    zen_load_language_file('orders_email.php', $this->language['directory']);
+
+    // get PayPal Trans ID, if any
+    $paypal_txn = $html_msg['EMAIL_PAYPAL_TRANSID'] = '';
+    $sql = "select txn_id, parent_txn_id from " . TABLE_PAYPAL . " where order_id = :orderID order by last_modified DESC, date_added DESC, parent_txn_id DESC, paypal_ipn_id DESC ";
+    $sql = $db->bindVars($sql, ':orderID', $this->id, 'integer');
+    $result = $db->Execute($sql);
+    if ($result->RecordCount() > 0) {
+      $paypal_txn = $result->fields['txn_id'];
+    }
+
+    if ($this->info['orders_status'] != $status || zen_not_null($comments)) {
+      $db->Execute("update " . TABLE_ORDERS . "
+                    set orders_status = " . (int)$status . ", last_modified = now()
+                    where orders_id = " . $this->id);
+
+      // obtain localized status name
+      $ordersStatusLocalizedQuery = $db->Execute("SELECT orders_status_name
+                                                  FROM " . TABLE_ORDERS_STATUS . "
+                                                  WHERE language_id = " . (int)$this->language['id'] . "
+                                                  AND orders_status_id = " . $status);
+      $ordersStatusLocalized = $ordersStatusLocalizedQuery->fields['orders_status_name'];
+
+      $customer_notified = 0;
+      if ($send_notify_email == 1) {
+        if ($notify_include_comments == 'on' && zen_not_null($comments)) {
+          $notify_comments = EMAIL_TEXT_COMMENTS_UPDATE . $comments . "\n\n";
+        }
+
+        //send emails
+        if (GUEST_ORDER_STATUS == 'true') {
+          if ($this->info['is_guest_order'] == 1)  {
+
+            $message =
+                EMAIL_TEXT_ORDER_NUMBER . ' ' . $order_number_string . "\n\n" .
+                EMAIL_TEXT_GUEST_ORDER_STATUS_URL . ' ' . zen_catalog_href_link(FILENAME_ORDER_STATUS, 'order_id=' . $this->id, 'SSL') . "\n\n" .
+                EMAIL_TEXT_DATE_ORDERED . ' ' . zen_date_long($this->info['date_purchased']) . "\n\n" .
+                $notify_comments .
+                EMAIL_TEXT_STATUS_UPDATED . sprintf(EMAIL_TEXT_STATUS_LABEL, $ordersStatusLocalized ) .
+                EMAIL_TEXT_STATUS_PLEASE_REPLY;
+
+            $html_msg['EMAIL_CUSTOMERS_NAME']    = $this->customer['name'];
+            $html_msg['EMAIL_TEXT_ORDER_NUMBER'] = EMAIL_TEXT_ORDER_NUMBER . ' ' . $order_number_string;
+            $html_msg['EMAIL_TEXT_INVOICE_URL']  = '<a href="' . zen_catalog_href_link(FILENAME_ORDER_STATUS, 'order_id=' . $this->id, 'SSL') .'">'.str_replace(':','',EMAIL_TEXT_GUEST_ORDER_STATUS_URL).'</a>';
+            $html_msg['EMAIL_TEXT_DATE_ORDERED'] = EMAIL_TEXT_DATE_ORDERED . ' ' . zen_date_long($this->info['date_purchased']);
+            $html_msg['EMAIL_TEXT_STATUS_COMMENTS'] = nl2br($notify_comments);
+            $html_msg['EMAIL_TEXT_STATUS_UPDATED'] = str_replace('\n','', EMAIL_TEXT_STATUS_UPDATED);
+            $html_msg['EMAIL_TEXT_STATUS_LABEL'] = str_replace('\n','', sprintf(EMAIL_TEXT_STATUS_LABEL, $ordersStatusLocalized));
+            $html_msg['EMAIL_TEXT_NEW_STATUS'] = $ordersStatusLocalized;
+            $html_msg['EMAIL_TEXT_STATUS_PLEASE_REPLY'] = str_replace('\n','', EMAIL_TEXT_STATUS_PLEASE_REPLY);
+
+            if ($paypal_txn != '') {
+              $message .= "\n\n" . ' PayPal Trans ID: ' . $result->fields['txn_id'];
+              $html_msg['EMAIL_PAYPAL_TRANSID'] = $result->fields['txn_id'];
+            }
+
+            zen_mail($this->customer['name'], $this->customer['email_address'], EMAIL_TEXT_SUBJECT . ' #' . $order_number_string, $message, STORE_NAME, EMAIL_FROM, $html_msg, 'order_status');
+            $customer_notified = 1;
+          }
+        }
+        if (GUEST_ORDER_STATUS == 'false') {
+          if ($this->info['is_guest_order'] == 1)  {
+            $message =
+              EMAIL_TEXT_ORDER_NUMBER . ' ' . $order_number_string . "\n\n" .
+              EMAIL_TEXT_DATE_ORDERED . ' ' . zen_date_long($this->info['date_purchased']) . "\n\n" .
+              $notify_comments .
+              EMAIL_TEXT_STATUS_UPDATED . sprintf(EMAIL_TEXT_STATUS_LABEL, $ordersStatusLocalized) .
+              EMAIL_TEXT_STATUS_PLEASE_REPLY;
+            $html_msg['EMAIL_CUSTOMERS_NAME']    = $this->customer['name'];
+            $html_msg['EMAIL_TEXT_ORDER_NUMBER'] = EMAIL_TEXT_ORDER_NUMBER . ' ' . $order_number_string;
+            $html_msg['INTRO_URL_TEXT']        = '';
+            $html_msg['INTRO_URL_VALUE']       = '';
+            $html_msg['EMAIL_TEXT_DATE_ORDERED'] = EMAIL_TEXT_DATE_ORDERED . ' ' . zen_date_long($this->info['date_purchased']);
+            $html_msg['EMAIL_TEXT_STATUS_COMMENTS'] = nl2br($notify_comments);
+            $html_msg['EMAIL_TEXT_STATUS_UPDATED'] = str_replace('\n','', EMAIL_TEXT_STATUS_UPDATED);
+            $html_msg['EMAIL_TEXT_STATUS_LABEL'] = str_replace('\n','', sprintf(EMAIL_TEXT_STATUS_LABEL, $ordersStatusLocalized));
+            $html_msg['EMAIL_TEXT_NEW_STATUS'] = $ordersStatusLocalized;
+            $html_msg['EMAIL_TEXT_STATUS_PLEASE_REPLY'] = str_replace('\n','', EMAIL_TEXT_STATUS_PLEASE_REPLY);
+
+            if ($paypal_txn != '') {
+              $message .= "\n\n" . ' PayPal Trans ID: ' . $result->fields['txn_id'];
+              $html_msg['EMAIL_PAYPAL_TRANSID'] = $result->fields['txn_id'];
+            }
+
+            zen_mail($this->customer['name'], $this->customer['email_address'], EMAIL_TEXT_SUBJECT . ' #' . $order_number_string, $message, STORE_NAME, EMAIL_FROM, $html_msg, 'order_status');
+            $customer_notified = 1;
+          }
+        }
+        if ($this->info['is_guest_order'] != 1)  {
+          $message =
+            EMAIL_TEXT_ORDER_NUMBER . ' ' . $order_number_string . "\n\n" .
+            EMAIL_TEXT_INVOICE_URL . ' ' . zen_catalog_href_link(FILENAME_CATALOG_ACCOUNT_HISTORY_INFO, 'order_id=' . $order_number_string, 'SSL') . "\n\n" .
+            EMAIL_TEXT_DATE_ORDERED . ' ' . zen_date_long($this->info['date_purchased']) . "\n\n" .
+            $notify_comments .
+            EMAIL_TEXT_STATUS_UPDATED . sprintf(EMAIL_TEXT_STATUS_LABEL, $ordersStatusLocalized) .
+            EMAIL_TEXT_STATUS_PLEASE_REPLY;
+
+          $html_msg['EMAIL_CUSTOMERS_NAME']    = $this->customer['name'];
+          $html_msg['EMAIL_TEXT_ORDER_NUMBER'] = EMAIL_TEXT_ORDER_NUMBER . ' ' . $order_number_string;
+          $html_msg['EMAIL_TEXT_INVOICE_URL']  = '<a href="' . zen_catalog_href_link(FILENAME_CATALOG_ACCOUNT_HISTORY_INFO, 'order_id=' . $this->id, 'SSL') .'">'.str_replace(':','',EMAIL_TEXT_INVOICE_URL).'</a>';
+          $html_msg['EMAIL_TEXT_DATE_ORDERED'] = EMAIL_TEXT_DATE_ORDERED . ' ' . zen_date_long($this->info['date_purchased']);
+          $html_msg['EMAIL_TEXT_STATUS_COMMENTS'] = nl2br($notify_comments);
+          $html_msg['EMAIL_TEXT_STATUS_UPDATED'] = str_replace('\n','', EMAIL_TEXT_STATUS_UPDATED);
+          $html_msg['EMAIL_TEXT_STATUS_LABEL'] = str_replace('\n','', sprintf(EMAIL_TEXT_STATUS_LABEL, $ordersStatusLocalized));
+          $html_msg['EMAIL_TEXT_NEW_STATUS'] = $ordersStatusLocalized;
+          $html_msg['EMAIL_TEXT_STATUS_PLEASE_REPLY'] = str_replace('\n','', EMAIL_TEXT_STATUS_PLEASE_REPLY);
+
+          if ($paypal_txn != '') {
+            $message .= "\n\n" . ' PayPal Trans ID: ' . $result->fields['txn_id'];
+            $html_msg['EMAIL_PAYPAL_TRANSID'] = $result->fields['txn_id'];
+          }
+
+          zen_mail($this->customer['name'], $this->customer['email_address'], EMAIL_TEXT_SUBJECT . ' #' . $order_number_string, $message, STORE_NAME, EMAIL_FROM, $html_msg, 'order_status');
+          $customer_notified = 1;
+        }
+
+
+        //send extra emails
+        if (SEND_EXTRA_ORDERS_STATUS_ADMIN_EMAILS_TO_STATUS == '1' and SEND_EXTRA_ORDERS_STATUS_ADMIN_EMAILS_TO != '') {
+          zen_mail('', SEND_EXTRA_ORDERS_STATUS_ADMIN_EMAILS_TO, SEND_EXTRA_ORDERS_STATUS_ADMIN_EMAILS_TO_SUBJECT . ' ' . EMAIL_TEXT_SUBJECT . ' #' . $order_number_string, $message, STORE_NAME, EMAIL_FROM, $html_msg, 'order_status_extra');
+        }
+      } elseif ($send_notify_email == -1) {
+        // hide comment
+        $customer_notified = -1;
+      }
+
+      $db->Execute("insert into " . TABLE_ORDERS_STATUS_HISTORY . "
+                  (orders_id, orders_status_id, date_added, customer_notified, comments)
+                  values ('" . (int)$this->id . "',
+                  '" . (int)$status . "',
+                  now(),
+                  '" . (int)$customer_notified . "',
+                  '" . zen_db_input($comments)  . "')");
+      $order_updated = true;
+    }
+
+    // re-enable any downloads, if status matches magic reset status
+    if ($order_updated && $status == DOWNLOADS_ORDERS_STATUS_UPDATED_VALUE) {
+      $this->reEnableAllDownloads();
+    }
+
+    // trigger any appropriate updates which should be sent back to the payment gateway:
+    if ($this->info['payment_module_code']) {
+      if (file_exists(DIR_FS_CATALOG_MODULES . 'payment/' . $this->info['payment_module_code'] . '.php')) {
+        require_once(DIR_FS_CATALOG_MODULES . 'payment/' . $this->info['payment_module_code'] . '.php');
+        require_once(DIR_FS_CATALOG_LANGUAGES . $this->language['directory'] . '/modules/payment/' . $this->info['payment_module_code'] . '.php');
+        $module = new $this->info['payment_module_code'];
+        if (method_exists($module, '_doStatusUpdate')) {
+          $response = $module->_doStatusUpdate($this->id, $status, $comments, $customer_notified, $this->info['orders_status']);
+        }
+      }
+    }
+
+    zen_record_admin_activity('Order ' . $this->id . ' updated.', 'info');
+    $this->notify('ADMIN_ORDER_UPDATED', $this->id, $fields);
+    return $order_updated;
+  }
+
+  /**
+   * Delete the specified order from the database, optionally returning product counts back into inventory
+   */
+  public function delete_order($order_id, $restock = false) {
+    global $db;
+    $this->notify('NOTIFIER_ADMIN_ZEN_REMOVE_ORDER', array(), $order_id, $restock);
+    if ($restock === true) {
+      $result = $db->Execute("select products_id, products_quantity
+                             from " . TABLE_ORDERS_PRODUCTS . "
+                             where orders_id = " . (int)$order_id);
+      foreach($result as $row)
+      {
+        $db->Execute("UPDATE " . TABLE_PRODUCTS . "
+                      SET products_quantity = products_quantity + " . $row['products_quantity'] . ", products_ordered = products_ordered - " . $row['products_quantity'] . " 
+                      WHERE products_id = " . (int)$row['products_id']);
+      }
+    }
+
+    $db->Execute("delete from " . TABLE_ORDERS . " where orders_id = " . (int)$order_id);
+    $db->Execute("delete from " . TABLE_ORDERS_TOTAL . " where orders_id = " . (int)$order_id);
+    $db->Execute("delete from " . TABLE_ORDERS_PRODUCTS . " where orders_id = " . (int)$order_id);
+    $db->Execute("delete from " . TABLE_ORDERS_STATUS_HISTORY . " where orders_id = " . (int)$order_id);
+    $db->Execute("delete from " . TABLE_ORDERS_PRODUCTS_DOWNLOAD . " where orders_id = " . (int)$order_id);
+    $db->Execute("delete from " . TABLE_ORDERS_PRODUCTS_ATTRIBUTES . " where orders_id = " . (int)$order_id);
+    $db->Execute("delete from " . TABLE_COUPON_GV_QUEUE . " where order_id = " . (int)$order_id . " and release_flag = 'N'");
+
+    zen_record_admin_activity('Deleted order ' . (int)$order_id . ' from database via admin console.', 'warning');
+  }
+
+  /**
+   * Purge inappropriately stored cvv data if found
+   * This shouldn't be needed, but is provided in case certain 3rd-party payment modules had done this
+   */
+  public function delete_cvv($order_id) 
+  {
+    global $db;
+    $db->Execute("update " . TABLE_ORDERS . " set cc_cvv = '" . TEXT_DELETE_CVV_REPLACEMENT . "' where orders_id = " . (int)$order_id);
+  }
+
+  /**
+   * Mask inappropriately stored cc data if found
+   * This shouldn't be needed, but is provided in case certain 3rd-party payment modules had done this
+   */
+  public function mask_cc($order_id)
+  {
+    global $db;
+    $result  = $db->Execute("select cc_number from " . TABLE_ORDERS . " where orders_id = " . (int)$order_id);
+    if ($result->EOF) return false;
+    $old_num = $result->fields['cc_number'];
+    $new_num = substr($old_num, 0, 4) . str_repeat('*', (strlen($old_num) - 8)) . substr($old_num, -4);
+    $db->Execute("update " . TABLE_ORDERS . " set cc_number = '" . $new_num . "' where orders_id = " . (int)$order_id);
+  }
+
+  public function doRefund($order_id = null)
+  {
+    if (!$order_id) $order_id = $this->id;
+    if (!$this->info['payment_module_code']) return;
+    if (file_exists(DIR_FS_CATALOG_MODULES . 'payment/' . $this->info['payment_module_code'] . '.php')) {
+      require_once(DIR_FS_CATALOG_MODULES . 'payment/' . $this->info['payment_module_code'] . '.php');
+      require_once(DIR_FS_CATALOG_LANGUAGES . $_SESSION['language'] . '/modules/payment/' . $this->info['payment_module_code'] . '.php');
+      $module = new $this->info['payment_module_code'];
+      if (method_exists($module, '_doRefund')) {
+        $module->_doRefund($order_id);
+        $this->notify('ADMIN_ORDER_REFUNDED', $order_id);
+        zen_record_admin_activity('Order ' . $order_id . ' refund processed. See order comments for details.', 'info');
+      }
+    }
+  }
+
+  public function doAuth($order_id = null)
+  {
+    if (!$order_id) $order_id = $this->id;
+    if (!$this->info['payment_module_code']) return;
+    if (file_exists(DIR_FS_CATALOG_MODULES . 'payment/' . $this->info['payment_module_code'] . '.php')) {
+      require_once(DIR_FS_CATALOG_MODULES . 'payment/' . $this->info['payment_module_code'] . '.php');
+      require_once(DIR_FS_CATALOG_LANGUAGES . $this->language['directory'] . '/modules/payment/' . $this->info['payment_module_code'] . '.php');
+      $module = new $this->info['payment_module_code'];
+      if (method_exists($module, '_doAuth')) {
+        $module->_doAuth($order_id, $this->info['total'], $this->info['currency']);
+        $this->notify('ADMIN_ORDER_PAYMENT_AUTH', $order_id, $this->info['total'], $this->info['currency']);
+        zen_record_admin_activity('Order ' . $order_id . ' auth processed. See order comments for details.', 'info');
+      }
+    }
+  }
+
+  public function doCapture($order_id = null)
+  {
+    if (!$order_id) $order_id = $this->id;
+    if (!$this->info['payment_module_code']) return;
+    if (file_exists(DIR_FS_CATALOG_MODULES . 'payment/' . $this->info['payment_module_code'] . '.php')) {
+      require_once(DIR_FS_CATALOG_MODULES . 'payment/' . $this->info['payment_module_code'] . '.php');
+      require_once(DIR_FS_CATALOG_LANGUAGES . $this->language['directory'] . '/modules/payment/' . $this->info['payment_module_code'] . '.php');
+      $module = new $this->info['payment_module_code'];
+      if (method_exists($module, '_doCapt')) {
+        $module->_doCapt($order_id, 'Complete', $this->info['total'], $this->info['currency']);
+        $this->notify('ADMIN_ORDER_PAYMENT_CAPTURE', $order_id, $this->info['total'], $this->info['currency']);
+        zen_record_admin_activity('Order ' . $order_id . ' capture processed. See order comments for details.', 'info');
+      }
+    }
+  }
+
+  public function doVoid($order_id = null)
+  {
+    if (!$order_id) $order_id = $this->id;
+    if (!$this->info['payment_module_code']) return;
+    if (file_exists(DIR_FS_CATALOG_MODULES . 'payment/' . $this->info['payment_module_code'] . '.php')) {
+      require_once(DIR_FS_CATALOG_MODULES . 'payment/' . $this->info['payment_module_code'] . '.php');
+      require_once(DIR_FS_CATALOG_LANGUAGES . $this->language['directory'] . '/modules/payment/' . $this->info['payment_module_code'] . '.php');
+      $module = new $this->info['payment_module_code'];
+      if (method_exists($module, '_doVoid')) {
+        $module->_doVoid($order_id);
+        $this->notify('ADMIN_ORDER_PAYMENT_VOID', $order_id);
+        zen_record_admin_activity('Order ' . $order_id . ' void processed. See order comments for details.', 'info');
+      }
+    }
+  }
+
+  public function doGetPaymentDetailsFromGateway($order_id = null)
+  {
+    if (!$order_id) $order_id = $this->id;
+    if (!$this->info['payment_module_code']) return;
+    // @TODO
+  }
+
+  /**
+   * Build order search query, mainly used in Admin order-search screen
+   */
+  public function build_search_query($keywords = null, $products_search_string = null, $customer_id = null, $status = null, $sort_order = 'desc')
+  {
+    global $db, $zco_notifier;
+    $search = '';
+    $new_table = '';
+    $new_fields = '';
+    $search_distinct = '';
+
+    // Only one or the other search
+    
+    // create search_orders_products filter
+    if (isset($products_search_string) && zen_not_null($products_search_string)) {
+      $keywords = $db->prepare_input($products_search_string);
+      $search_distinct = ' distinct ';
+      $new_table = " left join " . TABLE_ORDERS_PRODUCTS . " op on (op.orders_id = o.orders_id) ";
+      $search = " and (op.products_model like '%" . $keywords . "%' or op.products_name like '" . $keywords . "%')";
+      if (substr(strtoupper($products_search_string), 0, 3) == 'ID:') {
+        $keywords = trim(substr($products_search_string, 3));
+        $search = " and op.products_id = '" . (int)$keywords . "'";
+      }
+    } else {
+      // create search filter
+      if (isset($keywords) && zen_not_null($keywords)) {
+        $keywords = $db->prepare_input($keywords);
+        $search_distinct = ' ';
+        $search = " and (o.customers_city like '%" . $keywords . "%' or o.customers_postcode like '%" . $keywords . "%' or o.date_purchased like '%" . $keywords . "%' or o.billing_name like '%" . $keywords . "%' or o.billing_company like '%" . $keywords . "%' or o.billing_street_address like '%" . $keywords . "%' or o.delivery_city like '%" . $keywords . "%' or o.delivery_postcode like '%" . $keywords . "%' or o.delivery_name like '%" . $keywords . "%' or o.delivery_company like '%" . $keywords . "%' or o.delivery_street_address like '%" . $keywords . "%' or o.billing_city like '%" . $keywords . "%' or o.billing_postcode like '%" . $keywords . "%' or o.customers_email_address like '%" . $keywords . "%' or o.customers_name like '%" . $keywords . "%' or o.customers_company like '%" . $keywords . "%' or o.customers_street_address  like '%" . $keywords . "%' or o.customers_telephone like '%" . $keywords . "%' or o.ip_address  like '%" . $keywords . "%')";
+        $new_table = '';
+      }
+    } // eof: search orders or orders_products
+
+    $new_fields = ", o.customers_company, o.customers_email_address, o.customers_street_address, o.delivery_company, o.delivery_name, o.delivery_street_address, o.billing_company, o.billing_name, o.billing_street_address, o.payment_module_code, o.shipping_module_code, o.ip_address, o.language_code ";
+
+
+    $orders_query_raw = "select " . $search_distinct . " o.orders_id, o.customers_id, o.customers_name, o.payment_method, o.shipping_method, o.date_purchased, o.last_modified, o.currency, o.currency_value, s.orders_status_name, ot.text as order_total" .
+                          $new_fields . "
+                          from (" . TABLE_ORDERS . " o " .
+                          $new_table . ")
+                          left join " . TABLE_ORDERS_STATUS . " s on (o.orders_status = s.orders_status_id and s.language_id = " . (int)$_SESSION['languages_id'] . ")
+                          left join " . TABLE_ORDERS_TOTAL . " ot on (o.orders_id = ot.orders_id and ot.class = 'ot_total') ";
+
+    if (isset($customer_id)) {
+      $orders_query_raw .= " WHERE o.customers_id = " . (int)$customer_id;
+
+    } elseif ($status) {
+      $orders_query_raw .= " WHERE s.orders_status_id = " . (int)$status . $search;
+
+    } else {
+      $orders_query_raw .= (trim($search) != '') ? preg_replace('/ *AND /i', ' WHERE ', $search) : '';
+    }
+
+    if ($sort_order == 'desc') {
+      $orders_query_raw .= " order by o.orders_id DESC";
+    }
+
+    $zco_notifier->notify('NOTIFY_BUILD_ORDER_SEARCH_QUERY_RAW', [], $orders_query_raw);
+    return $orders_query_raw;
+  }
+
 
 }

--- a/includes/functions/functions_lookups.php
+++ b/includes/functions/functions_lookups.php
@@ -1378,6 +1378,7 @@
 
 /**
  * get customer order comments
+ * @deprecated use $order->status_history[0]['comments'] instead, after instantiating the order, since this data is already in the order object and saves re-querying the db
  */
   function zen_get_orders_comments($orders_id) {
     global $db;

--- a/includes/library/zencart/CheckoutFlow/src/flowSteps/Process.php
+++ b/includes/library/zencart/CheckoutFlow/src/flowSteps/Process.php
@@ -204,7 +204,7 @@ class Process extends AbstractFlowStep
     protected function manageOrderSendEmails()
     {
         $this->notify('NOTIFY_CHECKOUTFLOW_PROCESS_MANAGE_ORDER_SEND_EMAILS_START');
-        $GLOBALS['order']->send_order_email($GLOBALS['insert_id']);
+        $GLOBALS['order']->send_order_confirmation_email($GLOBALS['insert_id']);
         $this->notify('NOTIFY_CHECKOUT_PROCESS_AFTER_SEND_ORDER_EMAIL');
         $this->notify('NOTIFY_CHECKOUTFLOW_PROCESS_MANAGE_ORDER_SEND_EMAILS_END');
     }

--- a/includes/modules/checkout_process.php
+++ b/includes/modules/checkout_process.php
@@ -93,7 +93,7 @@ $order->create_add_products($insert_id);
 $_SESSION['order_number_created'] = $insert_id;
 $zco_notifier->notify('NOTIFY_CHECKOUT_PROCESS_AFTER_ORDER_CREATE_ADD_PRODUCTS');
 //send email notifications
-$order->send_order_email($insert_id);
+$order->send_order_confirmation_email($insert_id);
 $zco_notifier->notify('NOTIFY_CHECKOUT_PROCESS_AFTER_SEND_ORDER_EMAIL');
 
 // clear slamming protection since payment was accepted

--- a/ipn_main_handler.php
+++ b/ipn_main_handler.php
@@ -354,7 +354,7 @@ Processing...
         $_SESSION['order_number_created'] = $insert_id;
         $GLOBALS[$_SESSION['payment']]->transaction_id = $_POST['txn_id'];
         $zco_notifier->notify('NOTIFY_CHECKOUT_PROCESS_AFTER_ORDER_CREATE_ADD_PRODUCTS');
-        $order->send_order_email($insert_id);
+        $order->send_order_confirmation_email($insert_id);
         ipn_debug_email('Breakpoint: 5m - emailing customer');
         $zco_notifier->notify('NOTIFY_CHECKOUT_PROCESS_AFTER_SEND_ORDER_EMAIL');
 


### PR DESCRIPTION
Move queries out of `/admin/orders.php` and share them from the main `order` class, as part of data automatically queried when an order is retrieved.