### PR TITLE
 zc_install - db install errors don't halt installer #528 

### DIFF
--- a/zc_install/includes/classes/class.zcDatabaseInstaller.php
+++ b/zc_install/includes/classes/class.zcDatabaseInstaller.php
@@ -122,8 +122,8 @@ class zcDatabaseInstaller
       if ($this->completeLine)
       {
         if (get_magic_quotes_runtime() > 0) $this->newLine = stripslashes($this->newLine);
-        $output = (trim(str_replace(';','',$this->newLine)) != '' && !$this->ignoreLine) ? $this->tryExecute($this->newLine) : '';
-        $this->doJsonProgressLoggingUpdate();
+        $error = (trim(str_replace(';','',$this->newLine)) != '' && !$this->ignoreLine) ? $this->tryExecute($this->newLine) : '';
+        $this->doJsonProgressLoggingUpdate($error);
         $this->newLine = "";
         $this->ignoreLine = FALSE;
         $this->completeLine = FALSE;
@@ -161,6 +161,10 @@ class zcDatabaseInstaller
     {
       $this->writeUpgradeExceptions($this->line, $this->db->error_number . ': ' . $this->db->error_text);
       error_log("MySQL error " . $this->db->error_number . " encountered during zc_install:\n" . $this->db->error_text . "\n" . $this->line . "\n---------------\n\n");
+        return 1;
+    } else 
+    {
+    	return 0;
     }
   }
   public function parserDropTableIfExists ()
@@ -456,7 +460,7 @@ class zcDatabaseInstaller
     $parseString[0] = strtoupper($parseString[0]);
     return $parseString;
   }
-  private function doJsonProgressLoggingUpdate()
+  private function doJsonProgressLoggingUpdate($error)
   {
     if (isset($this->extendedOptions['doJsonProgressLogging']))
     {
@@ -466,8 +470,16 @@ class zcDatabaseInstaller
       if ($fp)
       {
         $arr = array('total'=>'0', 'progress'=>$progress, 'message'=>$this->extendedOptions['message']);
+        
+        if($error){
+        	$arr['error_message'] = TEXT_ERROR_DATABASE_INSTALL;
+        }
+        
         fwrite($fp, json_encode($arr));
         fclose($fp);
+        if($error){
+        	die('!');
+        }
       }
     }
   }

--- a/zc_install/includes/languages/lngEnglish.php
+++ b/zc_install/includes/languages/lngEnglish.php
@@ -143,6 +143,8 @@ define('TEXT_ERROR_PROBLEMS_WRITING_CONFIGUREPHP_FILES', 'There were problems pr
 define('TEXT_ERROR_COULD_NOT_READ_CFGFILE_TEMPLATE', 'Could not read the master config file layout: %s. Please ensure the file exists and is readable.');
 define('TEXT_ERROR_COULD_NOT_WRITE_CONFIGFILE', 'Could not write the generated config file: %s. Please ensure the file exists and is writable.');
 
+define('TEXT_ERROR_DATABASE_INSTALL', 'There was a problem during the database installation.  Please check the files in the /logs/ folder for details');
+
 define('TEXT_ERROR_STORE_CONFIGURE', "Main /includes/configure.php file does not exist (isn't readable) or is not writeable");
 define('TEXT_ERROR_PHP_VERSION', str_replace(array("\n", "\r"), '', 'Incorrect PHP Version.
 <p>The PHP version you are using (' . PHP_VERSION . ') is too old, and this version of Zen Cart&reg; cannot be used on this server in its present configuration.</p>

--- a/zc_install/includes/template/partials/partial_modal_progress_bar.php
+++ b/zc_install/includes/template/partials/partial_modal_progress_bar.php
@@ -12,5 +12,6 @@
 </div>
 <div id="progress-bar-container" class="modal-body">
 <div id="progress-bar" class="progress"></div>
+<div id="error-message"></div>
 </div>
 </div>

--- a/zc_install/includes/template/templates/database_default.php
+++ b/zc_install/includes/template/templates/database_default.php
@@ -200,6 +200,11 @@ function updateStatus() {
           $("#progress-bar").html('<span class="meter" style="width:'+data.progress+'%;"></span>');
           t = setTimeout("updateStatus()", 200);
         }
+        if(data.error_message)
+        {
+            $('#error-message').html(data.error_message);
+            clearTimeout(t);
+        }    
       } else
       {
         t = setTimeout("updateStatus()", 10);

--- a/zc_install/sql/install/mysql_zencart.sql
+++ b/zc_install/sql/install/mysql_zencart.sql
@@ -46,7 +46,7 @@ CREATE TABLE upgrade_exceptions (
 DROP TABLE IF EXISTS address_book;
 CREATE TABLE address_book (
   address_book_id int(11) NOT NULL auto_increment,
-  customers_id int(11) NOT NULL default '0' --TEMPORARY, removed comma to force sql error
+  customers_id int(11) NOT NULL default '0',
   entry_gender char(1) NOT NULL default '',
   entry_company varchar(64) default NULL,
   entry_firstname varchar(32) NOT NULL default '',

--- a/zc_install/sql/install/mysql_zencart.sql
+++ b/zc_install/sql/install/mysql_zencart.sql
@@ -46,7 +46,7 @@ CREATE TABLE upgrade_exceptions (
 DROP TABLE IF EXISTS address_book;
 CREATE TABLE address_book (
   address_book_id int(11) NOT NULL auto_increment,
-  customers_id int(11) NOT NULL default '0',
+  customers_id int(11) NOT NULL default '0' --TEMPORARY, removed comma to force sql error
   entry_gender char(1) NOT NULL default '',
   entry_company varchar(64) default NULL,
   entry_firstname varchar(32) NOT NULL default '',


### PR DESCRIPTION
This fix causes the installer to abort if there is an SQL error during install.

Fixes #528 