### PR TITLE
Enhance Developer Mode Installation Fixes #1162

### DIFF
--- a/admin/includes/init_includes/init_admin_auth.php
+++ b/admin/includes/init_includes/init_admin_auth.php
@@ -18,7 +18,9 @@ $val = getenv('HABITAT');
 $habitat = ($val == 'zencart' || (isset($_SERVER['USER']) && $_SERVER['USER'] == 'vagrant'));
 
 // admin folder rename required
-if ((!defined('ADMIN_BLOCK_WARNING_OVERRIDE') || ADMIN_BLOCK_WARNING_OVERRIDE == '') && ($habitat == false))
+if ((!defined('ADMIN_BLOCK_WARNING_OVERRIDE') || ADMIN_BLOCK_WARNING_OVERRIDE == '') 
+  && (!defined('DEVELOPER_MODE') || DEVELOPER_MODE == 'false') 
+  && ($habitat == false))
 {
   if ($page != FILENAME_ALERT_PAGE)
   {

--- a/admin/includes/init_includes/init_ajax_admin_auth.php
+++ b/admin/includes/init_includes/init_ajax_admin_auth.php
@@ -14,7 +14,9 @@ $val = getenv('HABITAT');
 $habitat = ($val == 'zencart' || (isset($_SERVER['USER']) && $_SERVER['USER'] == 'vagrant'));
 
 // admin folder rename required
-if ((!defined('ADMIN_BLOCK_WARNING_OVERRIDE') || ADMIN_BLOCK_WARNING_OVERRIDE == '') && ($habitat == false))
+if ((!defined('ADMIN_BLOCK_WARNING_OVERRIDE') || ADMIN_BLOCK_WARNING_OVERRIDE == '') 
+  && (!defined('DEVELOPER_MODE') || DEVELOPER_MODE == 'false') 
+  && ($habitat == false))
 {
   if (basename($_SERVER['SCRIPT_FILENAME']) != FILENAME_ALERT_PAGE . '.php')
   {

--- a/zc_install/ajaxAdminSetup.php
+++ b/zc_install/ajaxAdminSetup.php
@@ -11,6 +11,7 @@ define('DIR_FS_INSTALL', __DIR__ . '/');
 define('DIR_FS_ROOT', realpath(__DIR__ . '/../') . '/');
 
 require(DIR_FS_INSTALL . 'includes/application_top.php');
+require(DIR_FS_INSTALL . DIR_WS_INSTALL_TEMPLATE . 'common/developer_mode_helper.php');
 
 $adminDir = $_POST['adminDir'];
 $wordlist = file(DIR_FS_INSTALL . 'includes/wordlist.csv');
@@ -24,7 +25,8 @@ $word3[$pos] = strtoupper($word3[$pos]);
 $word2 = zen_create_random_value(3, 'chars');
 $adminNewDir = $adminDir;
 $result = FALSE;
-if ($adminDir == 'admin' && (!defined('DEVELOPER_MODE') || DEVELOPER_MODE == false))
+
+if ($adminDir == 'admin' && DEVELOPER_MODE == false)
 {
   $adminNewDir =  $word1 . '-' . $word2 . '-' . $word3;
   $result = @rename(DIR_FS_ROOT . $adminDir, DIR_FS_ROOT . $adminNewDir);

--- a/zc_install/includes/catalog-configure-template.php
+++ b/zc_install/includes/catalog-configure-template.php
@@ -53,6 +53,12 @@ define('DB_DATABASE', '%%_DB_DATABASE_%%');
 define('SQL_CACHE_METHOD', '%%_SQL_CACHE_METHOD_%%');
 
 /**
+ * Define whether you want to run Zen Cart in developer mode or not.
+ * This should be set to 'false' for production sites as it disables several security features.
+ */
+define('DEVELOPER_MODE', '%%_DEVELOPER_MODE_%%');
+
+/**
  * Reserved for future use
  */
 define('SESSION_STORAGE', '%%_SESSION_STORAGE_%%');

--- a/zc_install/includes/classes/class.zcConfigureFileWriter.php
+++ b/zc_install/includes/classes/class.zcConfigureFileWriter.php
@@ -36,6 +36,7 @@ class zcConfigureFileWriter
     $replaceVars['DB_DATABASE'] = trim($inputs['db_name']);
     $replaceVars['SQL_CACHE_METHOD'] = trim($inputs['sql_cache_method']);
     $replaceVars['HTTP_SERVER_ADMIN'] = trim($inputs['http_server_admin']);
+    $replaceVars['DEVELOPER_MODE'] = trim($inputs['developer_mode']);
     $replaceVars['SESSION_STORAGE'] = 'reserved for future use';
 
     $this->replaceVars = $replaceVars;

--- a/zc_install/includes/languages/lngEnglish.php
+++ b/zc_install/includes/languages/lngEnglish.php
@@ -34,6 +34,47 @@ define('TEXT_SYSTEM_SETUP_CATALOG_HTTPS_URL', 'Storefront HTTPS URL');
 define('TEXT_SYSTEM_SETUP_CATALOG_PHYSICAL_PATH', 'Storefront Physical Path');
 define('TEXT_SYSTEM_SETUP_AGREE_LICENSE', 'Agree to license terms: ');
 define('TEXT_SYSTEM_SETUP_CLICK_TO_AGREE_LICENSE', '(Check the box to agree to GPL 2 license terms. Click the title in the left column to view the license.)');
+define('TEXT_SYSTEM_SETUP_DEVELOPER_MODE', 'Install in Developer Mode');
+define('TEXT_SYSTEM_SETUP_CLICK_FOR_DEVELOPER_MODE', 'Install in developer mode');
+define('TEXT_WARN_DEVELOPER_MODE', 'Do not use for production sites as it disables several security features.');
+define('TEXT_HELP_TITLE_DEVELOPERMODE', 'Zen Cart Developer Mode');
+define('TEXT_HELP_CONTENT_DEVELOPERMODE', "<div>
+	<p>
+		Ticking the check box will install Zen Cart in developer mode which will disable several built in and critical security features.
+		<br>
+		The following headline security items are diabled: 
+	</p>
+	<hr>
+	<ul style='list-style-type:square'>
+		<li>
+			The requirement to remove the zc_install folder after installation is not enforced.
+			<ul style='list-style-type:circle'>
+				<li>
+					This can permit unauthorized persons to ovewrite your installation
+				</li>
+			</ul>
+		</li>
+		<li>
+			A constant default password is assigned for the admin interface.
+			<ul style='list-style-type:circle'>
+				<li>
+					This can permit unauthorized persons to take over your installation
+				</li>
+			</ul>
+		</li>
+		<li>
+			The admin folder is not renamed.
+			<ul style='list-style-type:circle'>
+				<li>
+					This can encourage attacks on your installation
+				</li>
+			</ul>
+		</li>
+	</ul>
+</div>
+<div class='alert-box alert'>
+	<strong>IMPORTANT:</strong> Do NOT use this mode for production sites.
+</div>");
 define('TEXT_SYSTEM_SETUP_ERROR_DIALOG_TITLE', 'There are some problems');
 define('TEXT_SYSTEM_SETUP_ERROR_DIALOG_CONTINUE', 'Continue anyway');
 define('TEXT_SYSTEM_SETUP_ERROR_CATALOG_PHYSICAL_PATH', 'There appears to be a problem with the ' . TEXT_SYSTEM_SETUP_CATALOG_PHYSICAL_PATH);

--- a/zc_install/includes/modules/pages/admin_setup/header_php.php
+++ b/zc_install/includes/modules/pages/admin_setup/header_php.php
@@ -8,23 +8,29 @@
 
   @unlink(DEBUG_LOG_FOLDER . '/progress.json');
   require (DIR_FS_INSTALL . 'includes/classes/class.zcDatabaseInstaller.php');
-  $changedDir = (bool)$_POST['changedDir'];
-  $adminDir = $_POST['adminDir'];
-  $adminNewDir = $_POST['adminNewDir'];
-  if (defined('DEVELOPER_MODE') && DEVELOPER_MODE === true)
+  require(DIR_FS_INSTALL . DIR_WS_INSTALL_TEMPLATE . 'common/developer_mode_helper.php');
+  $adminConfigSettings = $_POST;
+  $changedDir = (bool)$adminConfigSettings['changedDir'];
+  $adminDir = $adminConfigSettings['adminDir'];
+  $adminNewDir = $adminConfigSettings['adminNewDir'];
+  
+  if (DEVELOPER_MODE === true)
   {
+    $adminConfigSettings['developer_mode'] = 'true';
     $admin_password = 'developer1';
   } else {
+    $adminConfigSettings['developer_mode'] = 'false';
     $admin_password = zen_create_PADSS_password();
   }
-  if (isset($_POST['upgrade_mode']) && $_POST['upgrade_mode'] == 'yes')
+  if (isset($adminConfigSettings['upgrade_mode']) && $adminConfigSettings['upgrade_mode'] == 'yes')
   {
     $isUpgrade = TRUE;
-  } else if (isset($_POST['http_server_catalog']))
+  } else if (isset($adminConfigSettings['http_server_catalog']))
   {
     $isUpgrade = FALSE;
     require (DIR_FS_INSTALL . 'includes/classes/class.zcConfigureFileWriter.php');
-    $result = new zcConfigureFileWriter($_POST);
+    $result = new zcConfigureFileWriter($adminConfigSettings);
 
     $errors = $result->errors;
   }
+  

--- a/zc_install/includes/template/common/developer_mode_helper.php
+++ b/zc_install/includes/template/common/developer_mode_helper.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @package Installer
+ * @copyright Copyright 2003-2016 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: Author: DrByte  Mon Dec 28 14:43:01 2015 -0500 New in v1.6.0 $
+ */
+   if (!defined('DEVELOPER_MODE') && ($adminConfigSettings['developer_mode'] = 'checked'))
+  {
+    define('DEVELOPER_MODE', true);
+  } else {
+    define('DEVELOPER_MODE', false);
+  }

--- a/zc_install/includes/template/templates/completion_default.php
+++ b/zc_install/includes/template/templates/completion_default.php
@@ -7,6 +7,7 @@
  */
 ?>
 <?php require(DIR_FS_INSTALL . DIR_WS_INSTALL_TEMPLATE . 'partials/partial_modal_help.php'); ?>
+<?php require(DIR_FS_INSTALL . DIR_WS_INSTALL_TEMPLATE . 'common/developer_mode_helper.php'); ?>
 
 	<div align="center" class="alert-box success">
 		<div align="center" class="showModal button warning radius" id="NGINXCONF">

--- a/zc_install/includes/template/templates/system_setup_default.php
+++ b/zc_install/includes/template/templates/system_setup_default.php
@@ -33,13 +33,25 @@ require(DIR_FS_INSTALL . DIR_WS_INSTALL_TEMPLATE . 'partials/partial_modal_help.
     </div>
   </fieldset>
   <fieldset>
+    <legend>Installation Mode</legend>
+    <div class="row">
+      <div class="small-3 columns">
+        <label class="inline" for="developer_mode"><a href="#" class="hasHelpText" id="DEVELOPERMODE"><?php echo TEXT_SYSTEM_SETUP_DEVELOPER_MODE; ?></a></label>
+      </div>
+      <div class="small-9 columns">
+        <input type="checkbox" name="developer_mode" id="developer_mode" tabindex="2" > <label class="inline" for="developer_mode"><?php echo TEXT_SYSTEM_SETUP_CLICK_FOR_DEVELOPER_MODE; ?></label>
+        <span class="alert-box warning"><?php echo TEXT_WARN_DEVELOPER_MODE; ?></span>
+      </div>
+    </div>
+  </fieldset>  
+  <fieldset>
     <legend><?php echo TEXT_SYSTEM_SETUP_ADMIN_SETTINGS; ?></legend>
     <div class="row">
       <div class="small-3 columns">
         <label class="inline" for="http_server_admin"><a href="#" class="hasHelpText" id="ADMINSERVERDOMAIN"><?php echo TEXT_SYSTEM_SETUP_ADMIN_SERVER_DOMAIN; ?></a></label>
       </div>
       <div class="small-9 columns">
-        <input id="http_server_admin" type="text" value="<?php echo $adminServer; ?>" name="http_server_admin" tabindex="2" placeholder="ie: https:/www.your_domain.com" required>
+        <input id="http_server_admin" type="text" value="<?php echo $adminServer; ?>" name="http_server_admin" tabindex="3" placeholder="ie: https:/www.your_domain.com" required>
         <small class="error"><?php echo TEXT_HELP_CONTENT_ADMINSERVERDOMAIN; ?></small>
       </div>
     </div>
@@ -51,7 +63,7 @@ require(DIR_FS_INSTALL . DIR_WS_INSTALL_TEMPLATE . 'partials/partial_modal_help.
         <label class="inline" for="enable_ssl_catalog"><a href="#" class="hasHelpText" id="ENABLESSLCATALOG"><?php echo TEXT_SYSTEM_SETUP_CATALOG_ENABLE_SSL; ?></a></label>
       </div>
       <div class="small-9 columns">
-        <input class="checkbox" id="enable_ssl_catalog" type="checkbox" value="true" name="enable_ssl_catalog" tabindex="3" <?php echo $enableSslCatalog; ?>><label class="inline" for="enable_ssl_catalog"><?php echo TEXT_SYSTEM_SETUP_CATALOG_ENABLE_SSL; ?></label>
+        <input class="checkbox" id="enable_ssl_catalog" type="checkbox" value="true" name="enable_ssl_catalog" tabindex="4" <?php echo $enableSslCatalog; ?>><label class="inline" for="enable_ssl_catalog"><?php echo TEXT_SYSTEM_SETUP_CATALOG_ENABLE_SSL; ?></label>
       </div>
     </div>
     <div class="row">
@@ -59,7 +71,7 @@ require(DIR_FS_INSTALL . DIR_WS_INSTALL_TEMPLATE . 'partials/partial_modal_help.
         <label class="inline" for="http_server_catalog"><a href="#" class="hasHelpText" id="HTTPSERVERCATALOG"><?php echo TEXT_SYSTEM_SETUP_CATALOG_HTTP_SERVER_DOMAIN; ?></a></label>
       </div>
       <div class="small-9 columns">
-        <input id="http_server_catalog" type="url" value="<?php echo $catalogHttpServer; ?>" name="http_server_catalog" tabindex="4" placeholder="ie: http:/www.your_domain.com" required>
+        <input id="http_server_catalog" type="url" value="<?php echo $catalogHttpServer; ?>" name="http_server_catalog" tabindex="5" placeholder="ie: http:/www.your_domain.com" required>
         <small class="error"><?php echo TEXT_HELP_CONTENT_HTTPSERVERCATALOG; ?></small>
       </div>
     </div>
@@ -68,7 +80,7 @@ require(DIR_FS_INSTALL . DIR_WS_INSTALL_TEMPLATE . 'partials/partial_modal_help.
         <label class="inline" for="http_url_catalog"><a href="#" class="hasHelpText" id="HTTPURLCATALOG"><?php echo TEXT_SYSTEM_SETUP_CATALOG_HTTP_URL; ?></a></label>
       </div>
       <div class="small-9 columns">
-        <input id="http_url_catalog" type="url" value="<?php echo $catalogHttpUrl; ?>" name="http_url_catalog" tabindex="5" placeholder="ie: http:/www.your_domain.com">
+        <input id="http_url_catalog" type="url" value="<?php echo $catalogHttpUrl; ?>" name="http_url_catalog" tabindex="6" placeholder="ie: http:/www.your_domain.com">
         <small class="error"><?php echo TEXT_HELP_CONTENT_HTTPURLCATALOG; ?></small>
       </div>
     </div>
@@ -77,7 +89,7 @@ require(DIR_FS_INSTALL . DIR_WS_INSTALL_TEMPLATE . 'partials/partial_modal_help.
         <label class="inline" for="https_server_catalog"><a href="#" class="hasHelpText" id="HTTPSSERVERCATALOG"><?php echo TEXT_SYSTEM_SETUP_CATALOG_HTTPS_SERVER_DOMAIN; ?></a></label>
       </div>
       <div class="small-9 columns">
-        <input id="https_server_catalog" type="url" value="<?php echo $catalogHttpsServer; ?>" name="https_server_catalog" tabindex="6" placeholder="ie: https:/www.your_domain.com" required>
+        <input id="https_server_catalog" type="url" value="<?php echo $catalogHttpsServer; ?>" name="https_server_catalog" tabindex="7" placeholder="ie: https:/www.your_domain.com" required>
         <small class="error"><?php echo TEXT_FORM_VALIDATION_CATALOG_HTTPS_URL; ?></small>
       </div>
     </div>
@@ -86,7 +98,7 @@ require(DIR_FS_INSTALL . DIR_WS_INSTALL_TEMPLATE . 'partials/partial_modal_help.
         <label class="inline" for="https_url_catalog"><a href="#" class="hasHelpText" id="HTTPSURLCATALOG"><?php echo TEXT_SYSTEM_SETUP_CATALOG_HTTPS_URL; ?></a></label>
       </div>
       <div class="small-9 columns">
-        <input id="https_url_catalog" type="url" value="<?php echo $catalogHttpsUrl; ?>" name="https_url_catalog" tabindex="7" placeholder="ie: https:/www.your_domain.com">
+        <input id="https_url_catalog" type="url" value="<?php echo $catalogHttpsUrl; ?>" name="https_url_catalog" tabindex="8" placeholder="ie: https:/www.your_domain.com">
         <small class="error"><?php echo TEXT_HELP_CONTENT_HTTPSURLCATALOG; ?></small>
       </div>
     </div>
@@ -95,12 +107,12 @@ require(DIR_FS_INSTALL . DIR_WS_INSTALL_TEMPLATE . 'partials/partial_modal_help.
         <label class="inline" for="physical_path"><a href="#" class="hasHelpText" id="PHYSICALPATH"><?php echo TEXT_SYSTEM_SETUP_CATALOG_PHYSICAL_PATH; ?></a></label>
       </div>
       <div class="small-9 columns">
-        <input id="physical_path" type="text" value="<?php echo $documentRoot; ?>" name="physical_path" tabindex="8"  placeholder="ie: /yourserver/users/yourname/public_html/zencart" required>
+        <input id="physical_path" type="text" value="<?php echo $documentRoot; ?>" name="physical_path" tabindex="9"  placeholder="ie: /yourserver/users/yourname/public_html/zencart" required>
         <small class="error"><?php echo TEXT_HELP_CONTENT_PHYSICALPATH; ?></small>
       </div>
     </div>
   </fieldset>
-  <input type="submit" id="btnsubmit" class="radius button" name="btnsubmit" value="<?php echo TEXT_CONTINUE; ?>" tabindex="9" >
+  <input type="submit" id="btnsubmit" class="radius button" name="btnsubmit" value="<?php echo TEXT_CONTINUE; ?>" tabindex="10" >
 </form>
 
 <?php


### PR DESCRIPTION
Fixes #1162 
- Override zc_install folder removal requirement in developer mode
 - Introduce option to select developer mode during installation
 - Can live side by side with other options such as process outlined in https://github.com/zencart/zencart/issues/404#issuecomment-234328537