### PR TITLE
Click on on admin link when timed out gives security error

### DIFF
--- a/admin/includes/init_includes/init_admin_auth.php
+++ b/admin/includes/init_includes/init_admin_auth.php
@@ -40,10 +40,8 @@ if ($zcRequest->readGet('cmd') != FILENAME_ALERT_PAGE && !$authError) {
   if (! ($zcRequest->readGet('cmd') == FILENAME_LOGIN)) {
     if (! isset($_SESSION ['admin_id'])) {
       if (! ($zcRequest->readGet('cmd') == FILENAME_PASSWORD_FORGOTTEN)) {
-          $redirectTo = zen_admin_href_link(FILENAME_LOGIN, 'camefrom=' . $zcRequest->readGet('cmd')
-          . '&' . zen_get_all_get_params(array('cmd'))
-        );
-          $authError = AUTH_ERROR;
+          $redirectTo = zen_admin_href_link(FILENAME_LOGIN, 'camefrom=' . $zcRequest->readGet('cmd') . '&' . zen_get_all_get_params(array('cmd')));
+          zen_redirect($redirectTo);
       }
     }
     if (! in_array($page, array(


### PR DESCRIPTION
Repro: Allow admin to timeout (or logout from a separate tab).
Then click on a command - for example
    admin/index.php?cmd=template_select
This redirects to URL:
    admin/index.php?cmd=login&camefrom=denied
And puts you on the security error page once you login.