### PR TITLE
session_write_close is a void function

### DIFF
--- a/includes/functions/sessions.php
+++ b/includes/functions/sessions.php
@@ -135,7 +135,8 @@ if (!defined('IS_ADMIN_FLAG')) {
   }
 
   function zen_session_write_close() {
-    return session_write_close();
+    session_write_close();
+    return;
   }
 
   function zen_session_destroy() {


### PR DESCRIPTION
It should not be used as a return value lest someone "check it".