### PR TITLE
Fix language constants in zc_install

### DIFF
--- a/zc_install/includes/classes/class.zcDatabaseInstaller.php
+++ b/zc_install/includes/classes/class.zcDatabaseInstaller.php
@@ -366,10 +366,10 @@ class zcDatabaseInstaller
     $title  =  $values[3];
     $sql = "select configuration_group_title from " . $this->dbPrefix . "configuration_group where configuration_group_title='".$title."'";
     $result = $this->db->Execute($sql);
-    if ($result->RecordCount() >0 ) return sprintf(REASON_CONFIGURATION_GROUP_KEY_ALREADY_EXISTS,$title);
+    if ($result->RecordCount() >0 ) return sprintf(REASON_CONFIG_GROUP_KEY_ALREADY_EXISTS,$title);
     $sql = "select configuration_group_title from " . $this->dbPrefix . "configuration_group where configuration_group_id='".$id."'";
     $result = $this->db->Execute($sql);
-    if ($result->RecordCount() >0 ) return sprintf(REASON_CONFIGURATION_GROUP_ID_ALREADY_EXISTS,$id);
+    if ($result->RecordCount() >0 ) return sprintf(REASON_CONFIG_GROUP_ID_ALREADY_EXISTS,$id);
     return FALSE;
   }
   public function checkProductTypeLayoutKey($line)

--- a/zc_install/includes/languages/lngEnglish.php
+++ b/zc_install/includes/languages/lngEnglish.php
@@ -267,6 +267,8 @@ define('REASON_TABLE_ALREADY_EXISTS','Cannot create table %s because it already 
 define('REASON_TABLE_DOESNT_EXIST','Cannot drop table %s because it does not exist.');
 define('REASON_TABLE_NOT_FOUND','Cannot execute because table %s does not exist.');
 define('REASON_CONFIG_KEY_ALREADY_EXISTS','Cannot insert configuration_key "%s" because it already exists');
+define('REASON_CONFIG_GROUP_KEY_ALREADY_EXISTS','Cannot insert configuration_group_key "%s" because it already exists');
+define('REASON_CONFIG_GROUP_ID_ALREADY_EXISTS','Cannot insert configuration_group_id "%s" because it already exists');
 define('REASON_COLUMN_ALREADY_EXISTS','Cannot ADD column %s because it already exists.');
 define('REASON_COLUMN_DOESNT_EXIST_TO_DROP','Cannot DROP column %s because it does not exist.');
 define('REASON_COLUMN_DOESNT_EXIST_TO_CHANGE','Cannot CHANGE column %s because it does not exist.');


### PR DESCRIPTION
Defines were spelled inconsistently, and language file definitions were missing.