### PR TITLE
Fixed:#1138 "There was a security error" msg NOT shown after excessive logins

### DIFF
--- a/admin/includes/functions/admin_access.php
+++ b/admin/includes/functions/admin_access.php
@@ -379,9 +379,10 @@ function zen_validate_user_login($admin_name, $admin_pass)
         $sql = "UPDATE " . TABLE_ADMIN . " SET lockout_expires = " . (time() + ADMIN_LOGIN_LOCKOUT_TIMER) . " WHERE admin_name = :adminname: ";
         $sql = $db->bindVars($sql, ':adminname:', $admin_name, 'string');
         $db->Execute($sql);
-        zen_session_destroy();
         zen_record_admin_activity('Too many login failures. Account locked for ' . ADMIN_LOGIN_LOCKOUT_TIMER / 60 . ' minutes', 'warning');
         sleep(15);
+		$error = true;
+		$message = ERROR_SECURITY_ERROR;
         $redirect = zen_href_link(FILENAME_DEFAULT, '', 'SSL');
         return array($error, $expired, $message, $redirect);
       } else

--- a/admin/login.php
+++ b/admin/login.php
@@ -34,7 +34,7 @@ if (isset($_POST['action']) && $_POST['action'] != '') {
             zen_record_admin_activity(TEXT_ERROR_ATTEMPTED_ADMIN_LOGIN_WITHOUT_USERNAME, 'warning');
         } else {
             list($error, $expired, $message, $redirect) = zen_validate_user_login($admin_name, $admin_pass);
-            if ($redirect != '') zen_redirect($redirect);
+            if ($error == false && $redirect != '') zen_redirect($redirect);
         }
     } elseif ($_POST['action'] == 'rs' . $_SESSION['securityToken']) {
         $expired = true;


### PR DESCRIPTION
//To guaranty the redirection will not happen in this case.
$error = true;

Do I need submit same fix for v1.6.0 ?