### PR TITLE
Fixed:#1138 "There was a security error" msg NOT shown after excessive logins

### DIFF
--- a/admin/includes/functions/admin_access.php
+++ b/admin/includes/functions/admin_access.php
@@ -400,7 +400,9 @@ function zen_validate_user_login($admin_name, $admin_pass)
         $sql = "UPDATE " . TABLE_ADMIN . " SET lockout_expires = " . (time() + ADMIN_LOGIN_LOCKOUT_TIMER) . " WHERE admin_name = :adminname: ";
         $sql = $db->bindVars($sql, ':adminname:', $admin_name, 'string');
         $db->Execute($sql);
-        zen_session_destroy();
+        if ($_SESSION['login_attempt'] > 6) zen_session_destroy();
+        $error = true;
+        $message = ERROR_SECURITY_ERROR;
         zen_record_admin_activity('Too many login failures. Account locked for ' . ADMIN_LOGIN_LOCKOUT_TIMER / 60 . ' minutes', 'warning');
         sleep(15);
         $redirect = zen_admin_href_link(FILENAME_DEFAULT);

--- a/admin/login.php
+++ b/admin/login.php
@@ -42,7 +42,7 @@ if (isset($_POST['action']) && $_POST['action'] != '')
     } else
     {
       list($error, $expired, $message, $redirect) = zen_validate_user_login($admin_name, $admin_pass);
-      if ($redirect != '') zen_redirect($redirect);
+      if ($error == false && $redirect != '') zen_redirect($redirect);
     }
   } elseif ($_POST['action'] == 'rs' . $_SESSION['securityToken'])
   {


### PR DESCRIPTION
* Further investigation shows. IF ```zen_session_destroy()``` been removed, ```$_SESSION['login_attempt']``` will grown unlimited and when it's bigger then 9 and If user click on "Forgot Password" button, the ```header('HTTP/1.1 406 Not Acceptable')``` will take effect inside admin/password_forgotten.php.
* But IF ```zen_session_destroy()``` been called each invalid login attempt, our problem will Not be solved entirely. Because the Warning message shows 50% of times.
* Reset ```$_SESSION['login_attempt'] = 0``` isn't enough because  database attribute ```lockout_expires``` also needs to be reset. Therefore I prefer a more careful solution: 
``` if($_SESSION['login_attempt'] > 6) zen_session_destroy();``` 
* On every seventh invalid attempt ```zen_session_destroy()``` will be called and that is 86% of times.