### PR TITLE
mysql 5.7 group_by error in widget and orders report

### DIFF
--- a/includes/library/zencart/DashboardWidget/src/SalesGraphReport.php
+++ b/includes/library/zencart/DashboardWidget/src/SalesGraphReport.php
@@ -44,7 +44,7 @@ class SalesGraphReport extends AbstractWidget
     $days = array();
     $result = $db->Execute("select o.date_purchased as date_purchased, date(o.date_purchased) as dateshort, count(date_purchased) as number_of_orders, sum(ot.value) as sum_of_orders
                             from " . TABLE_ORDERS . " o left join " . TABLE_ORDERS_TOTAL . " ot on (o.orders_id = ot.orders_id and class = 'ot_total') 
-                            group by date(date_purchased)
+                            group by date(date_purchased), date_purchased
                             having o.date_purchased >= (CURDATE() - INTERVAL 3 DAY)
                             order by date_purchased DESC");
     foreach($result as $row) {


### PR DESCRIPTION
After upgrading my server to Ubuntu 16.04, which has:
- PHP Version: 7.0.8-0ubuntu0.16.04.2 (Zend: 3.0.0) 
- MySQL 5.7.13-0ubuntu0.16.04.2

I got the following error:

PHP Fatal error:  1055:Expression # 1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'zc160.o.date_purchased' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by ::

> select o.date_purchased as date_purchased, date(o.date_purchased) as dateshort, count(date_purchased) as number_of_orders, sum(ot.value) as sum_of_orders
>                             from orders o left join orders_total ot on (o.orders_id = ot.orders_id and class = 'ot_total') 
>                             group by date(date_purchased)
>                             having o.date_purchased >= (CURDATE() - INTERVAL 3 DAY)
>                             order by date_purchased DESC ==> (as called by) /home/zc160/public_html/includes/library/zencart/DashboardWidget/src/SalesGraphReport.php on line 49 <== in /home/zc160/public_html/includes/classes/db/mysql/query_factory.php on line 167

After some searching on the internet, I found that adding `date_purchased` to the `GROUP BY`, the problem was solved
