### PR TITLE
#1138 There was a security error msg NOT shown after excessive logins

### DIFF
--- a/admin/includes/functions/admin_access.php
+++ b/admin/includes/functions/admin_access.php
@@ -400,10 +400,10 @@ function zen_validate_user_login($admin_name, $admin_pass)
         $sql = "UPDATE " . TABLE_ADMIN . " SET lockout_expires = " . (time() + ADMIN_LOGIN_LOCKOUT_TIMER) . " WHERE admin_name = :adminname: ";
         $sql = $db->bindVars($sql, ':adminname:', $admin_name, 'string');
         $db->Execute($sql);
-        zen_session_destroy();
         zen_record_admin_activity('Too many login failures. Account locked for ' . ADMIN_LOGIN_LOCKOUT_TIMER / 60 . ' minutes', 'warning');
         sleep(15);
-        $redirect = zen_admin_href_link(FILENAME_DEFAULT);
+        $redirect = '';
+        $message = ERROR_SECURITY_ERROR;
         return array($error, $expired, $message, $redirect);
       } else
       {


### PR DESCRIPTION
I now understand the function **_sess_gc()** will clean up any expired database sessions entries based on time().
The question is, if the zen_session_destroy() function call is still **necessary** in the calling stack from original code base in v160 ?
```
# Invalid login attempt
zen_session_name zenAdminID
zen_session_start
_sess_open /var/lib/php5/sessions zenAdminID
_sess_read o3ro312cjh4adoa5a0lsekect4
_sess_gc
zen_session_name
_sess_write o3ro312cjh4adoa5a0lsekect4
_sess_close

# After login_attempt > 6
zen_session_name zenAdminID
zen_session_start
_sess_open /var/lib/php5/sessions zenAdminID
_sess_read o3ro312cjh4adoa5a0lsekect4
zen_session_name
zen_session_destroy
_sess_destroy o3ro312cjh4adoa5a0lsekect4
_sess_close
zen_session_name

# Valid login
zen_session_name zenAdminID
zen_session_start
_sess_open /var/lib/php5/sessions zenAdminID
_sess_read o3ro312cjh4adoa5a0lsekect4
_sess_gc
zen_session_name
zen_session_recreate
zen_session_name
_sess_write o3ro312cjh4adoa5a0lsekect4
_sess_close

# logout
zen_session_name zenAdminID
zen_session_start
_sess_open /var/lib/php5/sessions zenAdminID
_sess_read o3ro312cjh4adoa5a0lsekect4
zen_session_name
zen_session_destroy
_sess_destroy o3ro312cjh4adoa5a0lsekect4
_sess_close
```
My answer:
In case **logout**, zen_session_destroy() is still necessary for relaxing the burden of _sess_gc() and garbage collector.
In case **After login_attempt > 6**, zen_session_destroy() isn't necessary because an ordinary user likely will start the reset password process, which in the end recreate new session. And IF the slam prevention been triggered, the _sess_gc() will eventually be called to clean up the zombie session.

Fixes #1138 
