### PR TITLE
fixes banner statistics widget-key in dashboard_widgets_to_users

### DIFF
--- a/zc_install/sql/install/mysql_zencart.sql
+++ b/zc_install/sql/install/mysql_zencart.sql
@@ -3448,7 +3448,7 @@ INSERT INTO dashboard_widgets_to_users (widget_key, admin_id, widget_row, widget
 ,('new-orders', 1, 2, 0, 'fa-shopping-cart', 'bg-light-blue-gradient', 2, 1)
 ,('logs', 1, 4, 2, 'fa-thumbs-o-up', 'bg-light-blue-gradient', 2, 1)
 ,('whos-online', 1, 0, 1, 'fa-area-chart', 'bg-light-blue-gradient', 1, 1)
-,('banner_statistics', 1, 3, 2, 'fa-area-chart', 'bg-light-blue-gradient', 1, 1)
+,('banner-statistics', 1, 3, 2, 'fa-area-chart', 'bg-light-blue-gradient', 1, 1)
 ,('counter-history-graph', 1, 3, 1, 'fa-calendar', 'bg-light-blue-gradient', 1, 1)
 ,('sales-graph-report', 1, 0, 0, 'fa-line-chart', 'bg-light-blue-gradient', 2, 1)
 ;

--- a/zc_install/sql/updates/mysql_upgrade_zencart_160.sql
+++ b/zc_install/sql/updates/mysql_upgrade_zencart_160.sql
@@ -311,7 +311,7 @@ INSERT INTO dashboard_widgets_to_users (widget_key, admin_id, widget_row, widget
 ,('new-orders', 1, 2, 0, 'fa-shopping-cart', 'bg-light-blue-gradient', 2, 1)
 ,('logs', 1, 4, 2, 'fa-thumbs-o-up', 'bg-light-blue-gradient', 2, 1)
 ,('whos-online', 1, 0, 1, 'fa-area-chart', 'bg-light-blue-gradient', 1, 1)
-,('banner_statistics', 1, 3, 2, 'fa-area-chart', 'bg-light-blue-gradient', 1, 1)
+,('banner-statistics', 1, 3, 2, 'fa-area-chart', 'bg-light-blue-gradient', 1, 1)
 ,('counter-history-graph', 1, 3, 1, 'fa-calendar', 'bg-light-blue-gradient', 1, 1)
 ,('sales-graph-report', 1, 0, 0, 'fa-line-chart', 'bg-light-blue-gradient', 2, 1)
 ;


### PR DESCRIPTION
the current widget_key for banner statistics is incorrect (banner_statistics versus banner-statistics) causing the banner statistics dashboard widget to not display