### PR TITLE
Move search-validation language texts to english.php

### DIFF
--- a/includes/languages/english.php
+++ b/includes/languages/english.php
@@ -223,6 +223,18 @@
   define('FORM_REQUIRED_INFORMATION', '* Required information');
   define('ENTRY_REQUIRED_SYMBOL', '*');
 
+  // search validation errors
+  define('TEXT_NO_PRODUCTS', 'There is no product that matches the search criteria.');
+  define('ERROR_AT_LEAST_ONE_INPUT', 'At least one of the fields in the search form must be entered.');
+  define('ERROR_INVALID_FROM_DATE', 'Invalid From Date.');
+  define('ERROR_INVALID_TO_DATE', 'Invalid To Date.');
+  define('ERROR_TO_DATE_LESS_THAN_FROM_DATE', 'To Date must be greater than or equal to From Date.');
+  define('ERROR_PRICE_FROM_MUST_BE_NUM', 'Price From must be a number.');
+  define('ERROR_PRICE_TO_MUST_BE_NUM', 'Price To must be a number.');
+  define('ERROR_PRICE_TO_LESS_THAN_PRICE_FROM', 'Price To must be greater than or equal to Price From.');
+  define('ERROR_INVALID_KEYWORDS', 'Invalid keywords.');
+
+
   // constants for use in zen_prev_next_display function
   define('TEXT_RESULT_PAGE', '');
   define('TEXT_DISPLAY_NUMBER_OF_PRODUCTS', 'Displaying <strong>%d</strong> to <strong>%d</strong> (of <strong>%d</strong> products)');

--- a/includes/languages/english/advanced_search.php
+++ b/includes/languages/english/advanced_search.php
@@ -40,13 +40,5 @@
   define('TABLE_HEADING_WEIGHT', 'Weight');
   define('TABLE_HEADING_BUY_NOW', 'Buy Now');
 
-  define('TEXT_NO_PRODUCTS', 'There is no product that matches the search criteria.');
   define('KEYWORD_FORMAT_STRING', 'keywords');
-  define('ERROR_AT_LEAST_ONE_INPUT', 'At least one of the fields in the search form must be entered.');
-  define('ERROR_INVALID_FROM_DATE', 'Invalid From Date.');
-  define('ERROR_INVALID_TO_DATE', 'Invalid To Date.');
-  define('ERROR_TO_DATE_LESS_THAN_FROM_DATE', 'To Date must be greater than or equal to From Date.');
-  define('ERROR_PRICE_FROM_MUST_BE_NUM', 'Price From must be a number.');
-  define('ERROR_PRICE_TO_MUST_BE_NUM', 'Price To must be a number.');
-  define('ERROR_PRICE_TO_LESS_THAN_PRICE_FROM', 'Price To must be greater than or equal to Price From.');
-  define('ERROR_INVALID_KEYWORDS', 'Invalid keywords.');
+  

--- a/includes/languages/english/advanced_search_result.php
+++ b/includes/languages/english/advanced_search_result.php
@@ -39,14 +39,3 @@ define('TABLE_HEADING_QUANTITY', 'Quantity');
 define('TABLE_HEADING_PRICE', 'Price');
 define('TABLE_HEADING_WEIGHT', 'Weight');
 define('TABLE_HEADING_BUY_NOW', 'Buy Now');
-
-define('TEXT_NO_PRODUCTS', 'There is no product that matches the search criteria.');
-
-define('ERROR_AT_LEAST_ONE_INPUT', 'At least one of the fields in the search form must be entered.');
-define('ERROR_INVALID_FROM_DATE', 'Invalid From Date.');
-define('ERROR_INVALID_TO_DATE', 'Invalid To Date.');
-define('ERROR_TO_DATE_LESS_THAN_FROM_DATE', 'To Date must be greater than or equal to From Date.');
-define('ERROR_PRICE_FROM_MUST_BE_NUM', 'Price From must be a number.');
-define('ERROR_PRICE_TO_MUST_BE_NUM', 'Price To must be a number.');
-define('ERROR_PRICE_TO_LESS_THAN_PRICE_FROM', 'Price To must be greater than or equal to Price From.');
-define('ERROR_INVALID_KEYWORDS', 'Invalid keywords.');


### PR DESCRIPTION
This relocation allows the defines to load on pages other than the search page, and prevents minor PHP notices about missing constants when the js validation error text is built for those other pages.

It may unfortunately cause a bit of grief to translators of language packs. Apologies.

Closes #1257