### PR TITLE
removed code from application_top that is repeated in extra_configure…

### DIFF
--- a/includes/application_top.php
+++ b/includes/application_top.php
@@ -88,10 +88,6 @@ if (defined('STRICT_ERROR_REPORTING') && STRICT_ERROR_REPORTING == true) {
 } else {
   error_reporting(0);
 }
-/*
- * Get time zone info from PHP config
- */
-@date_default_timezone_set(date_default_timezone_get());
 /**
  * check for and include load application parameters
  */


### PR DESCRIPTION
While reading through the source I noticed the time zone is set twice.  Once in application_top and then shortly after in includes/extra_configures/set_time_zone.php

This removes the code from application_top as it is more configurable via set_time_zone.php