### PR TITLE
Fix: checkout_shipping: No method chosen after change virtual to mixed

### DIFF
--- a/docs/changed_files-v1-5-5.html
+++ b/docs/changed_files-v1-5-5.html
@@ -104,6 +104,7 @@ CHANGED files:
 <li>/includes/languages/english/modules/payment/payeezyjszc.php</li>
 <li>/includes/modules/pages/checkout_payment/jscript_main.php</li>
 <li>/includes/modules/pages/checkout_payment/jscript_payeezy.php</li>
+<li>/includes/modules/pages/checkout_shipping/header_php.php</li>
 <li>/includes/modules/pages/payer_auth_verifier/header_php.php</li>
 <li>/includes/modules/pages/shopping_cart/header_php.php</li>
 <li>/includes/modules/payment/authorizenet.php</li>

--- a/docs/whatsnew_1.5.5.html
+++ b/docs/whatsnew_1.5.5.html
@@ -169,6 +169,7 @@ OSI Certified is a certification mark of the Open Source Initiative.
 <li>Template fix: fix "back" button on address-book edit screens during checkout</li>
 <li>Multilanguage: make hreflang tag appear for all languages, instead of only for "other than current" language</li>
 <li>Fix admin link to whois resource</li>
+<li>Fix checkout_shipping: No method chosen after cart goes from virtual to mixed</li>
 </ul>
 
 <h1>v1.5.5a vs v1.5.5</h1>

--- a/includes/modules/pages/checkout_shipping/header_php.php
+++ b/includes/modules/pages/checkout_shipping/header_php.php
@@ -199,7 +199,7 @@ if (isset($_SESSION['cart']->cartID)) {
       }
     }
     $checkval = $_SESSION['shipping']['id'];
-    if (!in_array($checkval, $checklist) && $_SESSION['shipping']['id'] != 'free_free') {
+    if (!in_array($checkval, $checklist)) {
       $messageStack->add('checkout_shipping', ERROR_PLEASE_RESELECT_SHIPPING_METHOD, 'error');
     }
   }


### PR DESCRIPTION
Fix checkout_shipping: No method chosen after cart goes from virtual to mixed

Thanks @lat9

Ref https://www.zen-cart.com/showthread.php?220727-checkout_shipping-No-method-chosen-after-cart-goes-from-virtual-to-mixed