### PR TITLE
Fix broken unit test and add composer script for running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,20 @@ language: php
 
 sudo: false
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 php:
   - 7.1
   - 7.0
   - 5.6
   - 5.5
   - nightly
-  - hhvm
 
 matrix:
   fast_finish: true
   allow_failures:
-    - php: hhvm
     - php: nightly
 
 env:
@@ -23,13 +25,14 @@ env:
   - secure: RceQiWqq7eknG2MPN8IlpdH7nfGaqe7xm17vQndfbXPuED8a87dU4lJHPWCInaqcYte1IDmYsqR59+Ksq8ryC0CbScCf+QKT6kY6FwnzzPCzTU88FrYRXXRbJdfodHb3QTRY747ek4sBdUyaG8Jq28lHH8ZbM6onqrOyylf+pA8=
 
 addons:
-  #uncomment the following to trigger webtests
+  #uncomment the following to trigger sauce webtests
 #  sauce_connect: true
 
 services: memcached
 
 git:
   submodules: false
+  depth: 2
 
 before_install:
   - travis_retry composer self-update -q

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
             "homepage": "https://github.com/zencart/zencart/graphs/contributors"
         }
     ],
+    "__comment": "compatible with PHP 5.5-7.1",
     "require": {
         "php": ">=5.5"
     },
@@ -28,5 +29,9 @@
     "autoload-dev": {
         "classmap": ["testFramework"]
     },
-    "include-path": ["includes/"]
+    "include-path": ["includes/"],
+    "scripts": {
+        "tests": "phpunit --verbose -c testFramework/unittests/phpunit.xml",
+        "webtests": "phpunit --verbose -c testFramework/webtests/phpunit.xml --debug"
+    }
 }

--- a/testFramework/unittests/testsSundry/DiscountCouponsTest.php
+++ b/testFramework/unittests/testsSundry/DiscountCouponsTest.php
@@ -365,7 +365,7 @@ class testDiscountCoupons extends zcDiscountCouponTest
         $this->coupon->include_shipping = 'true';
         $this->coupon->process();
         $result = $this->coupon->output;
-        $this->assertTrue($result[0]['value'] == 33.25);
+        $this->assertTrue($result[0]['value'] == 39.00);
         $this->assertEquals($GLOBALS['order']->info['total'], 0);
         $this->assertEquals($GLOBALS['order']->info['shipping_cost'], 0);
     }


### PR DESCRIPTION
With this, one can type `composer tests` to run the unit test suite, without needing to remember the other parameters that are required.