### PR TITLE
Move product-type detection logic up a step, so it cascades to other types

### DIFF
--- a/admin/includes/modules/prod_cat_header_code.php
+++ b/admin/includes/modules/prod_cat_header_code.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2015 Zen Cart Development Team
+ * @copyright Copyright 2003-2016 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: prod_cat_header_code.php 3009 2006-02-11 15:41:10Z wilt $
@@ -12,11 +12,7 @@ if (!defined('IS_ADMIN_FLAG')) {
 
   $currencies = new currencies();
 
-  if (isset($_GET['product_type'])) {
-    $product_type = zen_db_prepare_input($_GET['product_type']);
-  } else {
-    $product_type='1';
-  }
+  $product_type = (isset($_POST['products_id']) ? zen_get_products_type($_POST['products_id']) : isset($_GET['product_type']) ? $_GET['product_type'] : 1);
 
   $type_admin_handler = $zc_products->get_admin_handler($product_type);
 

--- a/admin/product.php
+++ b/admin/product.php
@@ -33,7 +33,6 @@
       } else {
         $delete_linked = 'true';
       }
-      $product_type = zen_get_products_type($_POST['products_id']);
         if (file_exists(DIR_WS_MODULES . $zc_products->get_handler($product_type) . '/delete_product_confirm.php')) {
           require(DIR_WS_MODULES . $zc_products->get_handler($product_type) . '/delete_product_confirm.php');
          } else {


### PR DESCRIPTION
Product-type detection logic wasn't cascading to delete/copy modules. 
Moving it up a step, and removing the interception in products.php makes it more universal.

Ref: https://www.zen-cart.com/showthread.php?221596-product_type-incorrectly-set-in-admin-product-php&p=1323232#post1323232
