### PR TITLE
Prevent DB_CHARSET from being set to blank during upgrades

### DIFF
--- a/zc_install/includes/classes/class.zcConfigureFileWriter.php
+++ b/zc_install/includes/classes/class.zcConfigureFileWriter.php
@@ -27,9 +27,15 @@ class zcConfigureFileWriter
     $replaceVars['DIR_WS_CATALOG'] = preg_replace('~//~', '/', '/' . trim($inputs['dir_ws_http_catalog'], ' /\\') . '/');
     $replaceVars['DIR_WS_HTTPS_CATALOG'] = preg_replace('~//~', '/', '/' . trim($inputs['dir_ws_https_catalog'], ' /\\') . '/');
     $replaceVars['DIR_FS_CATALOG'] = rtrim($inputs['physical_path'], ' /\\') . '/';
+
     $replaceVars['DB_TYPE'] = trim($inputs['db_type']);
+    if ($replaceVars['DB_TYPE'] == '') $replaceVars['DB_TYPE'] = 'mysql';
+
     $replaceVars['DB_PREFIX'] = trim($inputs['db_prefix']);
+
     $replaceVars['DB_CHARSET'] = trim($inputs['db_charset']);
+    if ($replaceVars['DB_CHARSET'] == '') $replaceVars['DB_CHARSET'] = 'utf8';
+
     $replaceVars['DB_SERVER'] = trim($inputs['db_host']);
     $replaceVars['DB_SERVER_USERNAME'] = trim($inputs['db_user']);
     $replaceVars['DB_SERVER_PASSWORD'] = trim($inputs['db_password']);


### PR DESCRIPTION
The constant was added in v150, so upgrades from prior versions were getting this set to blank, resulting in errors.
Ref https://www.zen-cart.com/showthread.php?221539-upgrade-DB_CHARSET-is-blank


This commit also includes same safety check for empty db-type.