### PR TITLE
Change transaction_id field for authorizenet history to varchar

### DIFF
--- a/includes/modules/payment/authorizenet.php
+++ b/includes/modules/payment/authorizenet.php
@@ -655,9 +655,9 @@ class authorizenet extends base {
    */
   function tableCheckup() {
     global $db, $sniffer;
-    $fieldOkay1 = (method_exists($sniffer, 'field_type')) ? $sniffer->field_type(TABLE_AUTHORIZENET, 'transaction_id', 'bigint(20)', true) : -1;
+    $fieldOkay1 = (method_exists($sniffer, 'field_type')) ? $sniffer->field_type(TABLE_AUTHORIZENET, 'transaction_id', 'varchar(32)', true) : -1;
     if ($fieldOkay1 !== true) {
-      $db->Execute("ALTER TABLE " . TABLE_AUTHORIZENET . " CHANGE transaction_id transaction_id bigint(20) default NULL");
+      $db->Execute("ALTER TABLE " . TABLE_AUTHORIZENET . " CHANGE transaction_id transaction_id varchar(32) default NULL");
     }
   }
 }

--- a/includes/modules/payment/authorizenet_aim.php
+++ b/includes/modules/payment/authorizenet_aim.php
@@ -792,9 +792,9 @@ class authorizenet_aim extends base {
    */
   function tableCheckup() {
     global $db, $sniffer;
-    $fieldOkay1 = (method_exists($sniffer, 'field_type')) ? $sniffer->field_type(TABLE_AUTHORIZENET, 'transaction_id', 'bigint(20)', true) : -1;
+    $fieldOkay1 = (method_exists($sniffer, 'field_type')) ? $sniffer->field_type(TABLE_AUTHORIZENET, 'transaction_id', 'varchar(32)', true) : -1;
     if ($fieldOkay1 !== true) {
-      $db->Execute("ALTER TABLE " . TABLE_AUTHORIZENET . " CHANGE transaction_id transaction_id bigint(20) default NULL");
+      $db->Execute("ALTER TABLE " . TABLE_AUTHORIZENET . " CHANGE transaction_id transaction_id varchar(32) default NULL");
     }
   }
  /**

--- a/includes/modules/payment/authorizenet_echeck.php
+++ b/includes/modules/payment/authorizenet_echeck.php
@@ -716,9 +716,9 @@ class authorizenet_echeck extends base {
    */
   function tableCheckup() {
     global $db, $sniffer;
-    $fieldOkay1 = (method_exists($sniffer, 'field_type')) ? $sniffer->field_type(TABLE_AUTHORIZENET, 'transaction_id', 'bigint(20)', true) : -1;
+    $fieldOkay1 = (method_exists($sniffer, 'field_type')) ? $sniffer->field_type(TABLE_AUTHORIZENET, 'transaction_id', 'varchar(32)', true) : -1;
     if ($fieldOkay1 !== true) {
-      $db->Execute("ALTER TABLE " . TABLE_AUTHORIZENET . " CHANGE transaction_id transaction_id bigint(20) default NULL");
+      $db->Execute("ALTER TABLE " . TABLE_AUTHORIZENET . " CHANGE transaction_id transaction_id varchar(32) default NULL");
     }
   }
   /**

--- a/zc_install/sql/install/mysql_zencart.sql
+++ b/zc_install/sql/install/mysql_zencart.sql
@@ -207,7 +207,7 @@ CREATE TABLE authorizenet (
   response_code int(1) NOT NULL default '0',
   response_text varchar(255) NOT NULL default '',
   authorization_type varchar(50) NOT NULL default '',
-  transaction_id bigint(20) default NULL,
+  transaction_id varchar(32) default NULL,
   sent longtext NOT NULL,
   received longtext NOT NULL,
   time varchar(50) NOT NULL default '',

--- a/zc_install/sql/updates/mysql_upgrade_zencart_139.sql
+++ b/zc_install/sql/updates/mysql_upgrade_zencart_139.sql
@@ -63,7 +63,7 @@ update orders set cc_cvv = '' where cc_cvv != '' and orders_status != 1;
 # force USPS module into production mode if not already
 UPDATE configuration SET configuration_value = 'production' where configuration_key = 'MODULE_SHIPPING_USPS_SERVER';
 
-ALTER TABLE authorizenet CHANGE transaction_id transaction_id bigint(20) default NULL;
+#ALTER TABLE authorizenet CHANGE transaction_id transaction_id bigint(20) default NULL;
 ALTER TABLE paypal CHANGE COLUMN notify_version notify_version varchar(6) NOT NULL default '';
 
 ALTER TABLE orders_products ADD INDEX idx_prod_id_orders_id_zen (products_id,orders_id);


### PR DESCRIPTION
While the Authorize.net specifications indicate the transaction_id will be a numeric BIGINT value, other emulators (such as E-Processing) use string values, which trigger type errors. Changing to `varchar(32)` to accommodate this emulator anomaly.