### PR TITLE
Fix group-by problem in admin reports/widgets

### DIFF
--- a/includes/library/zencart/DashboardWidget/src/SalesGraphReport.php
+++ b/includes/library/zencart/DashboardWidget/src/SalesGraphReport.php
@@ -42,10 +42,12 @@ class SalesGraphReport extends AbstractWidget
     }
 
     $days = array();
-    $result = $db->Execute("select o.date_purchased as date_purchased, date(o.date_purchased) as dateshort, count(date_purchased) as number_of_orders, sum(ot.value) as sum_of_orders
+    $result = $db->Execute("select date(o.date_purchased) as date_purchased,
+                            count(date_purchased) as number_of_orders, 
+                            sum(ot.value) as sum_of_orders
                             from " . TABLE_ORDERS . " o left join " . TABLE_ORDERS_TOTAL . " ot on (o.orders_id = ot.orders_id and class = 'ot_total') 
                             group by date(date_purchased)
-                            having o.date_purchased >= (CURDATE() - INTERVAL 3 DAY)
+                            having date_purchased >= (CURDATE() - INTERVAL 3 DAY)
                             order by date_purchased DESC");
     foreach($result as $row) {
         $days[] = array('count' => $row['number_of_orders'], 'sales' => $currencies->format($row['sum_of_orders']));

--- a/includes/library/zencart/ListingQueryAndOutput/src/definitions/ReportStatsCustomers.php
+++ b/includes/library/zencart/ListingQueryAndOutput/src/definitions/ReportStatsCustomers.php
@@ -50,8 +50,8 @@ class ReportStatsCustomers extends AbstractLeadDefinition
                     'fkeyFieldRight' => 'orders_id',
                 ),
             ),
-            'selectList' => array('sum(op.products_quantity * op.final_price)+sum(op.onetime_charges)  as ordersum'),
-            'groupBys' => array('customers_id'),
+            'selectList' => array('c.customers_id, c.customers_firstname, c.customers_lastname, sum(op.products_quantity * op.final_price)+sum(op.onetime_charges)  as ordersum'),
+            'groupBys' => array('customers_id, customers_firstname, customers_lastname'),
             'orderBys' => array(array('field' => 'ordersum DESC')),
             'isPaginated' => true,
             'pagination' => array(

--- a/includes/library/zencart/QueryBuilder/src/QueryBuilder.php
+++ b/includes/library/zencart/QueryBuilder/src/QueryBuilder.php
@@ -75,7 +75,9 @@ class QueryBuilder extends \base
             $this->initParts($listingQuery);
         }
         $this->notify('NOTIFY_QUERYBUILDER_PROCESSQUERY_START');
-        $this->query ['select'] = "SELECT " . (issetorArray($listingQuery, 'isDistinct', false) ? ' DISTINCT ' : '') . $this->parts ['mainTableAlias'] . ".*";
+        $this->query ['select'] = "SELECT " . (issetorArray($listingQuery, 'isDistinct', false) ? ' DISTINCT ' : '');
+        if (count($this->parts ['groupBys']) == 0) $this->query ['select'] .= $this->parts ['mainTableAlias'] . ".*";
+        $this->processSelectList();
         $this->preProcessJoins();
         $this->query ['joins'] = '';
         $this->query ['table'] = ' FROM ';
@@ -84,7 +86,6 @@ class QueryBuilder extends \base
         $this->processWhereClause();
         $this->processGroupBys();
         $this->processOrderBys();
-        $this->processSelectList();
         $this->setFinalQuery($listingQuery);
         $this->processBindVars();
         $this->notify('NOTIFY_QUERYBUILDER_PROCESSQUERY_END');
@@ -315,7 +316,8 @@ class QueryBuilder extends \base
             return;
         }
         foreach ($this->parts ['selectList'] as $selectList) {
-            $this->query ['select'] .= ", " . $selectList;
+            if (trim($this->query ['select']) != 'SELECT') $this->query ['select'] .= ", ";
+            $this->query ['select'] .= $selectList;
         }
         $this->notify('NOTIFY_QUERYBUILDER_PROCESSSELECTLIST_END');
     }


### PR DESCRIPTION
1. Rewrite the `select`/`having` logic for the salesgraph widget
2. Reframe the Stats-Customers report to specify the fields for `select`/`group by`, and rework the QueryBuilder to not use `*` as the `select` fields for the `main join table`, since the `groupBy` param would then need to list all those fields as well (ie: not `c.*`, but rather `c.customer_id, c.customer_gender, c.customer_first_name, c.customer_last_name, etc etc etc` in order to comply with `full group by` rules.

Closes #1213 