### PR TITLE
Forces visitor to https if full site is setup for https and http is e…

### DIFF
--- a/includes/modules/pages/contact_us/header_php.php
+++ b/includes/modules/pages/contact_us/header_php.php
@@ -91,7 +91,7 @@ if (isset($_GET['action']) && ($_GET['action'] == 'send')) {
 } // end action==send
 
 
-if (ENABLE_SSL == 'true' && $request_type != 'SSL') {
+if ($request_type != 'SSL' && (ENABLE_SSL == 'true' || substr(HTTP_SERVER, 0, 5) == 'https')) {
   zen_redirect(zen_href_link(FILENAME_CONTACT_US, '', 'SSL'));
 }
 


### PR DESCRIPTION
…ntered.

Per https://www.zen-cart.com/content.php?56-how-do-i-enable-ssl-after-i-have-installed-zen-cart,
if one is to set the entire site to https, then it is recommended that
SSL_ENABLED be set to false, but if the uri entered begins with http, then
the redirect to force the page to load via SSL is not activated and the
customer could enter enter data to the webpage without using the SSL.

Fixes #1369