### PR TITLE
Refactor each() to foreach() for compatibility with PHP 7.2

### DIFF
--- a/admin/categories.php
+++ b/admin/categories.php
@@ -312,8 +312,7 @@
           }
         }
 
-        reset($products);
-        while (list($key, $value) = each($products)) {
+        foreach($products as $key => $value) {
           $category_ids = '';
 
           for ($i=0, $n=sizeof($value['categories']); $i<$n; $i++) {
@@ -336,8 +335,7 @@
           zen_remove_category($categories[$i]['id']);
         }
 
-        reset($products_delete);
-        while (list($key) = each($products_delete)) {
+        foreach($products_delete as $key) {
           zen_remove_product($key);
         }
       }

--- a/admin/coupon_admin.php
+++ b/admin/coupon_admin.php
@@ -782,8 +782,7 @@ function check_form(form_name) {
                 <td>
 <?php
 /* Re-Post all POST'ed variables */
-    reset($_POST);
-    while (list($key, $value) = each($_POST)) {
+    foreach($_POST as $key => $value) {
       if (!is_array($_POST[$key])) {
         echo zen_draw_hidden_field($key, htmlspecialchars(stripslashes($value), ENT_COMPAT, CHARSET, TRUE));
       }

--- a/admin/gv_mail.php
+++ b/admin/gv_mail.php
@@ -313,8 +313,7 @@ function check_form(form_name) {
                 <td>
 <?php
 /* Re-Post all POST'ed variables */
-    reset($_POST);
-    while (list($key, $value) = each($_POST)) {
+    foreach($_POST as $key => $value) {
       if (!is_array($_POST[$key])) {
         echo zen_draw_hidden_field($key, htmlspecialchars(stripslashes($value), ENT_COMPAT, CHARSET, TRUE));
       }

--- a/admin/includes/classes/object_info.php
+++ b/admin/includes/classes/object_info.php
@@ -32,8 +32,7 @@ class objectInfo
     function objectInfo($object_array)
     {
         if (!is_array($object_array)) return;
-        reset($object_array);
-        while (list($key, $value) = each($object_array)) {
+        foreach($object_array as $key => $value) {
             $this->$key = zen_db_prepare_input($value);
         }
     }
@@ -44,8 +43,7 @@ class objectInfo
     function updateObjectInfo($object_array)
     {
         if (!is_array($object_array)) return;
-        reset($object_array);
-        while (list($key, $value) = each($object_array)) {
+        foreach($object_array as $key => $value) {
             $this->$key = zen_db_prepare_input($value);
         }
     }

--- a/admin/includes/classes/split_page_results.php
+++ b/admin/includes/classes/split_page_results.php
@@ -102,7 +102,7 @@ class splitPageResults
             if ($parameters != '') {
                 if (substr($parameters, -1) == '&') $parameters = substr($parameters, 0, -1);
                 $pairs = explode('&', $parameters);
-                while (list(, $pair) = each($pairs)) {
+                foreach($pairs as $pair) {
                     list($key, $value) = explode('=', $pair);
                     $display_links .= zen_draw_hidden_field(rawurldecode($key), rawurldecode($value));
                 }

--- a/admin/includes/classes/upload.php
+++ b/admin/includes/classes/upload.php
@@ -27,7 +27,7 @@
           return true;
         } else {
 // self destruct
-           while(list($key,) = each($this)) {
+           foreach($this as $key => $value) {
              $this->$key = null;
            }
 

--- a/admin/includes/functions/functions_admin_menu.php
+++ b/admin/includes/functions/functions_admin_menu.php
@@ -38,8 +38,7 @@
 ////
 // Alias function for module configuration keys
   function zen_mod_select_option($select_array, $key_name, $key_value) {
-    reset($select_array);
-    while (list($key, $value) = each($select_array)) {
+    foreach($select_array as $key => $value) {
       if (is_int($key)) $key = $value;
       $string .= '<br><input type="radio" name="configuration[' . $key_name . ']" value="' . $key . '"';
       if ($key_value == $key) $string .= ' CHECKED';

--- a/admin/includes/modules/document_general/preview_info.php
+++ b/admin/includes/modules/document_general/preview_info.php
@@ -133,8 +133,7 @@ if (!defined('IS_ADMIN_FLAG')) {
         <td align="right" class="smallText">
 <?php
 /* Re-Post all POST'ed variables */
-      reset($_POST);
-      while (list($key, $value) = each($_POST)) {
+      foreach($_POST as $key => $value) {
         if (!is_array($_POST[$key])) {
           echo zen_draw_hidden_field($key, htmlspecialchars(stripslashes($value), ENT_COMPAT, CHARSET, TRUE));
         }

--- a/admin/includes/modules/document_general/preview_info_meta_tags.php
+++ b/admin/includes/modules/document_general/preview_info_meta_tags.php
@@ -107,8 +107,7 @@ if (!defined('IS_ADMIN_FLAG')) {
         <td align="right" class="smallText">
 <?php
 /* Re-Post all POST'ed variables */
-      reset($_POST);
-      while (list($key, $value) = each($_POST)) {
+      foreach($_POST as $key => $value) {
         if (!is_array($_POST[$key])) {
           echo zen_draw_hidden_field($key, htmlspecialchars(stripslashes($value), ENT_COMPAT, CHARSET, TRUE));
         }

--- a/admin/includes/modules/document_product/preview_info.php
+++ b/admin/includes/modules/document_product/preview_info.php
@@ -140,8 +140,7 @@ if (!defined('IS_ADMIN_FLAG')) {
         <td align="right" class="smallText">
 <?php
 /* Re-Post all POST'ed variables */
-      reset($_POST);
-      while (list($key, $value) = each($_POST)) {
+      foreach($_POST as $key => $value) {
         if (!is_array($_POST[$key])) {
           echo zen_draw_hidden_field($key, htmlspecialchars(stripslashes($value), ENT_COMPAT, CHARSET, TRUE));
         }

--- a/admin/includes/modules/document_product/preview_info_meta_tags.php
+++ b/admin/includes/modules/document_product/preview_info_meta_tags.php
@@ -104,8 +104,7 @@ if (!defined('IS_ADMIN_FLAG')) {
         <td align="right" class="smallText">
 <?php
 /* Re-Post all POST'ed variables */
-      reset($_POST);
-      while (list($key, $value) = each($_POST)) {
+      foreach($_POST as $key => $value) {
         if (!is_array($_POST[$key])) {
           echo zen_draw_hidden_field($key, htmlspecialchars(stripslashes($value), ENT_COMPAT, CHARSET, TRUE));
         }

--- a/admin/includes/modules/product/preview_info.php
+++ b/admin/includes/modules/product/preview_info.php
@@ -139,8 +139,7 @@ if (!defined('IS_ADMIN_FLAG')) {
         <td align="right" class="smallText">
 <?php
 /* Re-Post all POST'ed variables */
-      reset($_POST);
-      while (list($key, $value) = each($_POST)) {
+      foreach($_POST as $key => $value) {
         if (!is_array($_POST[$key])) {
           echo zen_draw_hidden_field($key, htmlspecialchars(stripslashes($value), ENT_COMPAT, CHARSET, TRUE)) . "\n";
         }

--- a/admin/includes/modules/product/preview_info_meta_tags.php
+++ b/admin/includes/modules/product/preview_info_meta_tags.php
@@ -105,8 +105,7 @@ if (!defined('IS_ADMIN_FLAG')) {
         <td align="right" class="smallText">
 <?php
 /* Re-Post all POST'ed variables */
-      reset($_POST);
-      while (list($key, $value) = each($_POST)) {
+      foreach($_POST as $key => $value) {
         if (!is_array($_POST[$key])) {
           echo zen_draw_hidden_field($key, htmlspecialchars(stripslashes($value), ENT_COMPAT, CHARSET, TRUE));
         }

--- a/admin/includes/modules/product_free_shipping/preview_info.php
+++ b/admin/includes/modules/product_free_shipping/preview_info.php
@@ -140,8 +140,7 @@ if (!defined('IS_ADMIN_FLAG')) {
         <td align="right" class="smallText">
 <?php
 /* Re-Post all POST'ed variables */
-      reset($_POST);
-      while (list($key, $value) = each($_POST)) {
+      foreach($_POST as $key => $value) {
         if (!is_array($_POST[$key])) {
           echo zen_draw_hidden_field($key, htmlspecialchars(stripslashes($value), ENT_COMPAT, CHARSET, TRUE));
         }

--- a/admin/includes/modules/product_free_shipping/preview_info_meta_tags.php
+++ b/admin/includes/modules/product_free_shipping/preview_info_meta_tags.php
@@ -104,8 +104,7 @@ if (!defined('IS_ADMIN_FLAG')) {
         <td align="right" class="smallText">
 <?php
 /* Re-Post all POST'ed variables */
-      reset($_POST);
-      while (list($key, $value) = each($_POST)) {
+      foreach($_POST as $key => $value) {
         if (!is_array($_POST[$key])) {
           echo zen_draw_hidden_field($key, htmlspecialchars(stripslashes($value), ENT_COMPAT, CHARSET, TRUE));
         }

--- a/admin/includes/modules/product_music/preview_info.php
+++ b/admin/includes/modules/product_music/preview_info.php
@@ -129,8 +129,7 @@ if (!defined('IS_ADMIN_FLAG')) {
         <td align="right" class="smallText">
 <?php
 /* Re-Post all POST'ed variables */
-      reset($_POST);
-      while (list($key, $value) = each($_POST)) {
+      foreach($_POST as $key => $value) {
         if (!is_array($_POST[$key])) {
           echo zen_draw_hidden_field($key, htmlspecialchars(stripslashes($value), ENT_COMPAT, CHARSET, TRUE));
         }

--- a/admin/includes/modules/product_music/preview_info_meta_tags.php
+++ b/admin/includes/modules/product_music/preview_info_meta_tags.php
@@ -104,8 +104,7 @@ if (!defined('IS_ADMIN_FLAG')) {
         <td align="right" class="smallText">
 <?php
 /* Re-Post all POST'ed variables */
-      reset($_POST);
-      while (list($key, $value) = each($_POST)) {
+      foreach($_POST as $key => $value) {
         if (!is_array($_POST[$key])) {
           echo zen_draw_hidden_field($key, htmlspecialchars(stripslashes($value), ENT_COMPAT, CHARSET, TRUE));
         }

--- a/admin/includes/modules/products_previous_next.php
+++ b/admin/includes/modules/products_previous_next.php
@@ -84,8 +84,7 @@ if (!defined('IS_ADMIN_FLAG')) {
   $counter = 0;
 // if invalid product id skip
   if (sizeof($id_array)) {
-    reset ($id_array);
-    while (list($key, $value) = each ($id_array)) {
+    foreach($id_array as $key => $value) {
       if ($value == $products_filter) {
         $position = $counter;
         if ($key == 0) {

--- a/admin/mail.php
+++ b/admin/mail.php
@@ -259,8 +259,7 @@ function check_form(form_name) {
               <td>
 <?php
   /* Re-Post all POST'ed variables */
-  reset($_POST);
-  while (list($key, $value) = each($_POST)) {
+  foreach($_POST as $key => $value) {
     if (!is_array($_POST[$key])) {
       echo zen_draw_hidden_field($key, stripslashes($value));
     }

--- a/admin/modules.php
+++ b/admin/modules.php
@@ -59,7 +59,7 @@
     switch ($action) {
       case 'save':
         if (!$is_ssl_protected && in_array($class, array('paypaldp', 'authorizenet_aim', 'authorizenet_echeck'))) break;
-        while (list($key, $value) = each($_POST['configuration'])) {
+        foreach($_POST['configuration'] as $key => $value) {
           if (is_array( $value ) ) {
             $value = implode( ", ", $value);
             $value = preg_replace ("/, --none--/", "", $value);
@@ -328,8 +328,7 @@ require('includes/admin_html_head.php');
     case 'edit':
       if (!$is_ssl_protected && in_array($_GET['module'], array('paypaldp', 'authorizenet_aim', 'authorizenet_echeck'))) break;
       $keys = '';
-      reset($mInfo->keys);
-      while (list($key, $value) = each($mInfo->keys)) {
+      foreach($mInfo->keys as $key => $value) {
         $keys .= '<b>' . $value['title'] . '</b><br>' . $value['description'] . '<br>';
         if ($value['set_function']) {
           eval('$keys .= ' . $value['set_function'] . "'" . $value['value'] . "', '" . $key . "');");
@@ -352,8 +351,7 @@ require('includes/admin_html_head.php');
 
       if ($mInfo->status == '1') {
         $keys = '';
-        reset($mInfo->keys);
-        while (list(, $value) = each($mInfo->keys)) {
+        foreach($mInfo->keys as $value) {
           $keys .= '<b>' . $value['title'] . '</b><br>';
           if ($value['use_function']) {
             $use_function = $value['use_function'];

--- a/admin/popup_image.php
+++ b/admin/popup_image.php
@@ -22,8 +22,7 @@
 
   require('includes/application_top.php');
 
-  reset($_GET);
-  while (list($key, ) = each($_GET)) {
+  foreach($_GET as $key => $value) {
     switch ($key) {
       case 'banner':
         $banners_id = zen_db_prepare_input($_GET['banner']);

--- a/admin/reviews.php
+++ b/admin/reviews.php
@@ -206,8 +206,9 @@ require('includes/admin_html_head.php');
 <?php
     if (zen_not_null($_POST)) {
 /* Re-Post all POST'ed variables */
-      reset($_POST);
-      while(list($key, $value) = each($_POST)) echo zen_draw_hidden_field($key, $value);
+      foreach($_POST as $key => $value) {
+        echo zen_draw_hidden_field($key, $value);
+      }
 ?>
       <tr>
         <td align="right" class="smallText"><?php echo '<a href="' . zen_admin_href_link(FILENAME_REVIEWS, (isset($_GET['page']) ? 'page=' . $_GET['page'] . '&' : '') . (isset($_GET['status']) ? 'status=' . $_GET['status'] . '&' : '') . 'rID=' . $rInfo->reviews_id . '&action=edit') . '">' . zen_image_button('button_back.gif', IMAGE_BACK) . '</a> ' . zen_image_submit('button_update.gif', IMAGE_UPDATE) . ' <a href="' . zen_admin_href_link(FILENAME_REVIEWS, (isset($_GET['page']) ? 'page=' . $_GET['page'] . '&' : '') . (isset($_GET['status']) ? 'status=' . $_GET['status'] . '&' : '') . 'rID=' . $rInfo->reviews_id) . '">' . zen_image_button('button_cancel.gif', IMAGE_CANCEL) . '</a>'; ?></td>

--- a/admin/salemaker.php
+++ b/admin/salemaker.php
@@ -336,7 +336,7 @@ function SetCategories() {
   $prev_sales = $db->Execute("select sale_categories_all from " . TABLE_SALEMAKER_SALES);
   while (!$prev_sales->EOF) {
     $prev_categories = explode(',', $prev_sales->fields['sale_categories_all']);
-    while(list($key,$value) = each($prev_categories)) {
+    foreach($prev_categories as $key => $value) {
       if ($value) $prev_categories_array[$value]++;
     }
     $prev_sales->MoveNext();

--- a/admin/salemaker_popup.php
+++ b/admin/salemaker_popup.php
@@ -44,8 +44,8 @@
   $salemaker_sales = $db->Execute($salemaker_sales_query_raw);
   while (!$salemaker_sales->EOF) {
     $categories = explode(',', $salemaker_sales->fields['sale_categories_all']);
-  while (list($key,$value) = each($categories)) {
-    if ($value == $_GET['cid']) {
+    foreach($categories as $key => $value) {
+      if ($value == $_GET['cid']) {
 ?>
               <tr>
                 <td  class="dataTableContent" align="left"><?php echo $salemaker_sales->fields['sale_name']; ?></td>

--- a/admin/template_select.php
+++ b/admin/template_select.php
@@ -154,7 +154,7 @@ require('includes/admin_html_head.php');
 
       $contents = array('form' => zen_draw_form('zones', FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&action=insert'));
       $contents[] = array('text' => TEXT_INFO_INSERT_INTRO);
-      while (list ($key, $value) = each($template_info) ) {
+      foreach($template_info as $key => $value) {
         $template_array[] = array('id' => $key, 'text' => $value['name']);
       }
       $lns = $db->Execute("select name, languages_id from " . TABLE_LANGUAGES);
@@ -171,8 +171,7 @@ require('includes/admin_html_head.php');
 
       $contents = array('form' => zen_draw_form('templateselect', FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id . '&action=save'));
       $contents[] = array('text' => TEXT_INFO_EDIT_INTRO);
-      reset($template_info);
-      while (list ($key, $value) = each($template_info) ) {
+      foreach($template_info as $key => $value) {
         $template_array[] = array('id' => $key, 'text' => $value['name']);
       }
       $contents[] = array('text' => '<br>' . TEXT_INFO_TEMPLATE_NAME . '<br>' . zen_draw_pull_down_menu('ln', $template_array, $templates->fields['template_dir']));
@@ -198,7 +197,7 @@ require('includes/admin_html_head.php');
         $contents[] = array('text' => '<br>' . TEXT_INFO_TEMPLATE_VERSION  . $template_info[$tInfo->template_dir]['version']);
         $contents[] = array('text' => '<br>' . TEXT_INFO_TEMPLATE_DESCRIPTION  . '<br />' . $template_info[$tInfo->template_dir]['description']);
         $contents[] = array('text' => '<br>' . TEXT_INFO_TEMPLATE_INSTALLED  . '<br />');
-        while (list ($key, $value) = each($template_info) ) {
+        foreach($template_info as $key => $value) {
           $contents[] = array('text' => '<a href="' . DIR_WS_CATALOG_TEMPLATE . $key . '/images/' . $value['screenshot'] . '" target = "_blank">' . zen_image_button('button_preview.gif', IMAGE_PREVIEW) . '</a>&nbsp;&nbsp;' . $value['name']);
         }
       }

--- a/includes/classes/category_tree.php
+++ b/includes/classes/category_tree.php
@@ -71,8 +71,7 @@ class category_tree extends base {
     }
     if (zen_not_null($cPath)) {
       $new_path = '';
-      reset($cPath_array);
-      while (list($key, $value) = each($cPath_array)) {
+      foreach($cPath_array as $key => $value) {
         unset($parent_id);
         unset($first_id);
         if ($product_type == 'all') {

--- a/includes/classes/db/mysql/query_factory.php
+++ b/includes/classes/db/mysql/query_factory.php
@@ -197,7 +197,7 @@ class queryFactory extends base {
       $obj->result = $zp_result_array;
       if (sizeof($zp_result_array) > 0 ) {
         $obj->EOF = false;
-        while (list($key, $value) = each($zp_result_array[0])) {
+        foreach($zp_result_array[0] as $key => $value) {
           $obj->fields[$key] = $value;
         }
       }
@@ -221,7 +221,7 @@ class queryFactory extends base {
             $zp_result_array = mysqli_fetch_array($zp_db_resource);
             if ($zp_result_array) {
               $obj->result[$zp_ii] = array();
-              while (list($key, $value) = each($zp_result_array)) {
+              foreach($zp_result_array as $key => $value) {
                 if (!preg_match('/^[0-9]/', $key)) {
                   $obj->result[$zp_ii][$key] = $value;
                 }
@@ -232,7 +232,7 @@ class queryFactory extends base {
             }
             $zp_ii++;
           }
-          while (list($key, $value) = each($obj->result[$obj->cursor])) {
+          foreach($obj->result[$obj->cursor] as $key => $value) {
             if (!preg_match('/^[0-9]/', $key)) {
               $obj->fields[$key] = $value;
             }
@@ -269,7 +269,7 @@ class queryFactory extends base {
         if ($obj->RecordCount() > 0) {
           $zp_result_array = mysqli_fetch_array($zp_db_resource);
           if ($zp_result_array) {
-            while (list($key, $value) = each($zp_result_array)) {
+            foreach($zp_result_array as $key => $value) {
               if (!preg_match('/^[0-9]/', $key)) {
                 $obj->fields[$key] = $value;
               }
@@ -315,7 +315,7 @@ class queryFactory extends base {
           $zp_result_array = @mysqli_fetch_array($zp_db_resource);
           if ($zp_result_array) {
             $obj->result[$zp_ii] = array();
-            while (list($key, $value) = each($zp_result_array)) {
+            foreach($zp_result_array as $key => $value) {
               $obj->result[$zp_ii][$key] = $value;
             }
           } else {
@@ -390,7 +390,6 @@ class queryFactory extends base {
         $insertString .= $value['fieldName'] . ", ";
       }
       $insertString = substr($insertString, 0, strlen($insertString)-2) . ') VALUES (';
-      reset($tableData);
       foreach ($tableData as $key => $value) {
         $bindVarValue = $this->getBindVarValue($value['value'], $value['type']);
         $insertString .= $bindVarValue . ", ";
@@ -599,7 +598,7 @@ class queryFactoryResult implements Countable, Iterator {
       if ($this->cursor >= sizeof($this->result)) {
         $this->EOF = true;
       } else {
-        while(list($key, $value) = each($this->result[$this->cursor])) {
+        foreach($this->result[$this->cursor] as $key => $value) {
           $this->fields[$key] = $value;
         }
       }
@@ -608,7 +607,7 @@ class queryFactoryResult implements Countable, Iterator {
       if (!$zp_result_array) {
         $this->EOF = true;
       } else {
-        while (list($key, $value) = each($zp_result_array)) {
+        foreach($zp_result_array as $key => $value) {
           if (!preg_match('/^[0-9]/', $key)) {
             $this->fields[$key] = $value;
           }
@@ -624,7 +623,7 @@ class queryFactoryResult implements Countable, Iterator {
     $this->cursor++;
     if ($this->cursor < $this->limit) {
       $zp_result_array = $this->result[$this->result_random[$this->cursor]];
-      while (list($key, $value) = each($zp_result_array)) {
+      foreach($zp_result_array as $key => $value) {
         if (!preg_match('/^[0-9]/', $key)) {
           $this->fields[$key] = $value;
         }
@@ -685,7 +684,7 @@ class queryFactoryResult implements Countable, Iterator {
         $this->cursor = sizeof($this->result);
         $this->EOF = true;
       } else {
-        while(list($key, $value) = each($this->result[$zp_row])) {
+        foreach($this->result[$zp_row] as $key => $value) {
           $this->fields[$key] = $value;
         }
         $this->cursor = $zp_row;
@@ -693,7 +692,7 @@ class queryFactoryResult implements Countable, Iterator {
       }
     } else if (@mysqli_data_seek($this->resource, $zp_row)) {
       $zp_result_array = @mysqli_fetch_array($this->resource);
-      while (list($key, $value) = each($zp_result_array)) {
+      foreach($zp_result_array as $key => $value) {
         $this->fields[$key] = $value;
       }
       $this->cursor = $zp_row;

--- a/includes/classes/http_client.php
+++ b/includes/classes/http_client.php
@@ -85,8 +85,7 @@ if (!defined('IS_ADMIN_FLAG')) {
  **/
     function setHeaders($headers) {
       if (is_array($headers)) {
-        reset($headers);
-        while (list($name, $value) = each($headers)) {
+        foreach($headers as $name => $value) {
           $this->requestHeaders[$name] = $value;
         }
       }
@@ -184,8 +183,7 @@ if (!defined('IS_ADMIN_FLAG')) {
 
       if (is_array($query_params)) {
         $postArray = array();
-        reset($query_params);
-        while (list($k, $v) = each($query_params)) {
+        foreach($query_params as $k => $v) {
           $postArray[] = urlencode($k) . '=' . urlencode($v);
         }
 
@@ -315,8 +313,7 @@ if (!defined('IS_ADMIN_FLAG')) {
         $this->request = $command;
         $cmd = $command . "\r\n";
         if (is_array($this->requestHeaders)) {
-          reset($this->requestHeaders);
-          while (list($k, $v) = each($this->requestHeaders)) {
+          foreach($this->requestHeaders as $k => $v) {
             $cmd .= $k . ': ' . $v . "\r\n";
           }
         }

--- a/includes/classes/navigation_history.php
+++ b/includes/classes/navigation_history.php
@@ -38,7 +38,7 @@ class navigationHistory extends base {
 
     if (count(zcRequest::all('get')) > 0) {
       $tmp = zcRequest::all('get');
-      while (list($key, $value) = each($tmp)) {
+      foreach ($tmp as $key => $value) {
         if ($key != 'main_page') {
           $get_vars[$key] = $value;
         }
@@ -111,7 +111,7 @@ class navigationHistory extends base {
                               'post' => $page['post']);
     } else {
       $tmp = zcRequest::all('get');
-      while (list($key, $value) = each($tmp)) {
+      foreach ($tmp as $key => $value) {
         if ($key != 'main_page') {
           $get_vars[$key] = $value;
         }
@@ -143,12 +143,12 @@ class navigationHistory extends base {
   function debug() {
     for ($i=0, $n=sizeof($this->path); $i<$n; $i++) {
       echo $this->path[$i]['page'] . '?';
-      while (list($key, $value) = each($this->path[$i]['get'])) {
+      foreach($this->path[$i]['get'] as $key => $value) {
         echo $key . '=' . $value . '&';
       }
       if (sizeof($this->path[$i]['post']) > 0) {
         echo '<br />';
-        while (list($key, $value) = each($this->path[$i]['post'])) {
+        foreach($this->path[$i]['post'] as $key => $value) {
           echo '&nbsp;&nbsp;<strong>' . $key . '=' . $value . '</strong><br />';
         }
       }
@@ -163,7 +163,7 @@ class navigationHistory extends base {
   }
 
   function unserialize($broken) {
-    for(reset($broken);$kv=each($broken);) {
+    foreach($broken as $kv) {
       $key=$kv['key'];
       if (gettype($this->$key)!="user function")
       $this->$key=$kv['value'];

--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -525,8 +525,7 @@ class order extends base {
       $this->notify('NOTIFY_ORDER_CART_ADD_PRODUCT_LIST', array('index'=>$index, 'products'=>$products[$i]));
       if ($products[$i]['attributes']) {
         $subindex = 0;
-        reset($products[$i]['attributes']);
-        while (list($option, $value) = each($products[$i]['attributes'])) {
+        foreach ($products[$i]['attributes'] as $option => $value) {
 
           $attributes_query = "select popt.products_options_name, poval.products_options_values_name,
                                       pa.options_values_price, pa.price_prefix

--- a/includes/classes/order_total.php
+++ b/includes/classes/order_total.php
@@ -27,8 +27,7 @@ class order_total extends base {
     if (defined('MODULE_ORDER_TOTAL_INSTALLED') && zen_not_null(MODULE_ORDER_TOTAL_INSTALLED)) {
       $module_list = explode(';', MODULE_ORDER_TOTAL_INSTALLED);
 
-      reset($module_list);
-      while (list(, $value) = each($module_list)) {
+      foreach($module_list as $value) {
         $lang_file = null;
         $module_file = DIR_WS_MODULES . 'order_total/' . $value;
         if (IS_ADMIN_FLAG === true) {
@@ -60,8 +59,7 @@ class order_total extends base {
     global $order;
     $order_total_array = array();
     if (is_array($this->modules)) {
-      reset($this->modules);
-      while (list(, $value) = each($this->modules)) {
+      foreach($this->modules as $value) {
         $class = substr($value, 0, strrpos($value, '.'));
         if (!isset($GLOBALS[$class])) continue;
         $GLOBALS[$class]->process();
@@ -84,8 +82,7 @@ class order_total extends base {
     global $template, $current_page_base;
     $output_string = '';
     if (is_array($this->modules)) {
-      reset($this->modules);
-      while (list(, $value) = each($this->modules)) {
+      foreach($this->modules as $value) {
         $class = substr($value, 0, strrpos($value, '.'));
         $size = sizeof($GLOBALS[$class]->output);
 
@@ -119,8 +116,7 @@ class order_total extends base {
   function credit_selection() {
     $selection_array = array();
     if (is_array($this->modules)) {
-      reset($this->modules);
-      while (list(, $value) = each($this->modules)) {
+      foreach($this->modules as $value) {
         $class = substr($value, 0, strrpos($value, '.'));
         if ($GLOBALS[$class]->credit_class ) {
           $selection = $GLOBALS[$class]->credit_selection();
@@ -140,8 +136,7 @@ class order_total extends base {
   //
   function update_credit_account($i) {
     if (MODULE_ORDER_TOTAL_INSTALLED) {
-      reset($this->modules);
-      while (list(, $value) = each($this->modules)) {
+      foreach($this->modules as $value) {
         $class = substr($value, 0, strrpos($value, '.'));
         if ( $GLOBALS[$class]->credit_class ) {
           $GLOBALS[$class]->update_credit_account($i);
@@ -159,8 +154,7 @@ class order_total extends base {
 
   function collect_posts() {
     if (MODULE_ORDER_TOTAL_INSTALLED) {
-      reset($this->modules);
-      while (list(, $value) = each($this->modules)) {
+      foreach($this->modules as $value) {
         $class = substr($value, 0, strrpos($value, '.'));
         if ( $GLOBALS[$class]->credit_class ) {
           $post_var = 'c' . $GLOBALS[$class]->code;
@@ -178,9 +172,8 @@ class order_total extends base {
   function pre_confirmation_check($returnOrderTotalOnly = false) {
     global $order, $credit_covers;
     if (MODULE_ORDER_TOTAL_INSTALLED) {
-      reset($this->modules);
       $orderInfoSaved = $order->info;
-      while (list(, $value) = each($this->modules)) {
+      foreach($this->modules as $value) {
         $class = substr($value, 0, strrpos($value, '.'));
         $GLOBALS[$class]->process();
         $GLOBALS[$class]->output = array();
@@ -199,8 +192,7 @@ class order_total extends base {
   //
   function apply_credit() {
     if (MODULE_ORDER_TOTAL_INSTALLED) {
-      reset($this->modules);
-      while (list(, $value) = each($this->modules)) {
+      foreach($this->modules as $value) {
         $class = substr($value, 0, strrpos($value, '.'));
         if ( $GLOBALS[$class]->credit_class) {
           $GLOBALS[$class]->apply_credit();
@@ -213,8 +205,7 @@ class order_total extends base {
   //
   function clear_posts() {
     if (MODULE_ORDER_TOTAL_INSTALLED) {
-      reset($this->modules);
-      while (list(, $value) = each($this->modules)) {
+      foreach($this->modules as $value) {
         $class = substr($value, 0, strrpos($value, '.'));
         if ( $GLOBALS[$class]->credit_class && method_exists($GLOBALS[$class], 'clear_posts')) {
           $GLOBALS[$class]->clear_posts();

--- a/includes/classes/payment.php
+++ b/includes/classes/payment.php
@@ -35,7 +35,6 @@ class payment extends base {
 
         $include_modules[] = array('class' => $module, 'file' => $module . '.php');
       } else {
-        reset($this->modules);
 
         // Free Payment Only shows
         if (constant('MODULE_PAYMENT_FREECHARGER_STATUS') and ($_SESSION['cart']->show_total()==0 and (!isset($_SESSION['shipping']['cost']) || $_SESSION['shipping']['cost'] == 0))) {
@@ -45,7 +44,7 @@ class payment extends base {
           }
         } else {
           // All Other Payment Modules show
-          while (list(, $value) = each($this->modules)) {
+          foreach($this->modules as $value) {
             // double check that the module really exists before adding to the array
             if (file_exists(DIR_FS_CATALOG . DIR_WS_MODULES . '/payment/' . $value)) {
               $class = substr($value, 0, strrpos($value, '.'));
@@ -139,8 +138,7 @@ class payment extends base {
       '    }' . "\n" .
       '  }' . "\n\n";
 
-      reset($this->modules);
-      while (list(, $value) = each($this->modules)) {
+      foreach($this->modules as $value) {
         $class = substr($value, 0, strrpos($value, '.'));
         if ($GLOBALS[$class]->enabled) {
           $js .= $GLOBALS[$class]->javascript_validation();
@@ -169,8 +167,7 @@ class payment extends base {
   function selection() {
     $selection_array = array();
     if (is_array($this->modules)) {
-      reset($this->modules);
-      while (list(, $value) = each($this->modules)) {
+      foreach($this->modules as $value) {
         $class = substr($value, 0, strrpos($value, '.'));
         if ($GLOBALS[$class]->enabled) {
           $selection = $GLOBALS[$class]->selection();
@@ -189,8 +186,7 @@ class payment extends base {
   function in_special_checkout() {
     $result = false;
     if (is_array($this->modules)) {
-      reset($this->modules);
-      while (list(, $value) = each($this->modules)) {
+      foreach($this->modules as $value) {
         $class = substr($value, 0, strrpos($value, '.'));
         if ($GLOBALS[$class]->enabled && method_exists($GLOBALS[$class], 'in_special_checkout')) {
           $module_result = $GLOBALS[$class]->in_special_checkout();

--- a/includes/classes/shipping.php
+++ b/includes/classes/shipping.php
@@ -33,8 +33,7 @@ class shipping extends base {
       if ( (zen_not_null($module)) && (in_array(substr($module['id'], 0, strpos($module['id'], '_')) . '.' . substr($PHP_SELF, (strrpos($PHP_SELF, '.')+1)), $this->modules)) ) {
         $include_modules[] = array('class' => substr($module['id'], 0, strpos($module['id'], '_')), 'file' => substr($module['id'], 0, strpos($module['id'], '_')) . '.' . substr($PHP_SELF, (strrpos($PHP_SELF, '.')+1)));
       } else {
-        reset($this->modules);
-        while (list(, $value) = each($this->modules)) {
+        foreach($this->modules as $value) {
           $class = substr($value, 0, strrpos($value, '.'));
           $include_modules[] = array('class' => $class, 'file' => $value);
         }
@@ -155,8 +154,7 @@ class shipping extends base {
     if (is_array($this->modules)) {
       $include_quotes = array();
 
-      reset($this->modules);
-      while (list(, $value) = each($this->modules)) {
+      foreach($this->modules as $value) {
         $class = substr($value, 0, strrpos($value, '.'));
         if (zen_not_null($module)) {
           if ( ($module == $class) && (isset($GLOBALS[$class]) && $GLOBALS[$class]->enabled) ) {
@@ -185,8 +183,7 @@ class shipping extends base {
     if (is_array($this->modules)) {
       $rates = array();
 
-      reset($this->modules);
-      while (list(, $value) = each($this->modules)) {
+      foreach($this->modules as $value) {
         $class = substr($value, 0, strrpos($value, '.'));
         if ($GLOBALS[$class]->enabled) {
           $quotes = $GLOBALS[$class]->quotes;
@@ -254,8 +251,7 @@ class shipping extends base {
         // attributes weight
         if (isset($products[$i]['attributes']) && is_array($products[$i]['attributes'])) {
           $include_reduce_insurance = false;
-          reset($products[$i]['attributes']);
-          while (list($option, $value) = each($products[$i]['attributes'])) {
+          foreach($products[$i]['attributes'] as $option => $value) {
 //            echo ' $products[$i][id]: ' . $products[$i]['id'] . ' product_is_always_free_shipping: ' . $products[$i]['product_is_always_free_shipping'] . ' $option: ' . $option . ' $value: ' . $value . '<br>';
             $sql = "select products_attributes_weight, products_attributes_weight_prefix
                     from " . TABLE_PRODUCTS_ATTRIBUTES . "

--- a/includes/classes/shopping_cart.php
+++ b/includes/classes/shopping_cart.php
@@ -101,8 +101,7 @@ class shoppingCart extends base {
     $this->notify('NOTIFIER_CART_RESTORE_CONTENTS_START');
     // insert current cart contents in database
     if (is_array($this->contents)) {
-      reset($this->contents);
-      while (list($products_id, ) = each($this->contents)) {
+      foreach($this->contents as $products_id => $data) {
         //          $products_id = urldecode($products_id);
         $qty = $this->contents[$products_id]['qty'];
         $product_query = "select products_id
@@ -122,8 +121,7 @@ class shoppingCart extends base {
           $db->Execute($sql);
 
           if (isset($this->contents[$products_id]['attributes'])) {
-            reset($this->contents[$products_id]['attributes']);
-            while (list($option, $value) = each($this->contents[$products_id]['attributes'])) {
+            foreach($this->contents[$products_id]['attributes'] as $option => $value) {
 
               //clr 031714 udate query to include attribute value. This is needed for text attributes.
               $attr_value = $this->contents[$products_id]['attributes_values'][$option];
@@ -285,8 +283,7 @@ class shoppingCart extends base {
       }
 
       if (is_array($attributes)) {
-        reset($attributes);
-        while (list($option, $value) = each($attributes)) {
+        foreach($attributes as $option => $value) {
           //CLR 020606 check if input was from text box.  If so, store additional attribute information
           //CLR 020708 check if text input is blank, if so do not add to attribute lists
           //CLR 030228 add htmlspecialchars processing.  This handles quotes and other special chars in the user input.
@@ -317,8 +314,7 @@ class shoppingCart extends base {
 
           if (!$blank_value) {
             if (is_array($value) ) {
-              reset($value);
-              while (list($opt, $val) = each($value)) {
+              foreach($value as $opt => $val) {
                 $this->contents[$products_id]['attributes'][$option.'_chk'.$val] = $val;
               }
             } else {
@@ -331,8 +327,7 @@ class shoppingCart extends base {
 
               //              if (zen_session_is_registered('customer_id')) zen_db_query("insert into " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . " (customers_id, products_id, products_options_id, products_options_value_id, products_options_value_text) values ('" . (int)$customer_id . "', '" . zen_db_input($products_id) . "', '" . (int)$option . "', '" . (int)$value . "', '" . zen_db_input($attr_value) . "')");
               if (is_array($value) ) {
-                reset($value);
-                while (list($opt, $val) = each($value)) {
+                foreach($value as $opt => $val) {
                   $products_options_sort_order= zen_get_attributes_options_sort_order(zen_get_prid($products_id), $option, $opt);
                   $sql = "insert into " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . "
                                         (customers_id, products_id, products_options_id, products_options_value_id, products_options_sort_order)
@@ -410,8 +405,7 @@ class shoppingCart extends base {
     }
 
     if (is_array($attributes)) {
-      reset($attributes);
-      while (list($option, $value) = each($attributes)) {
+      foreach($attributes as $option => $value) {
         //CLR 020606 check if input was from text box.  If so, store additional attribute information
         //CLR 030108 check if text input is blank, if so do not update attribute lists
         //CLR 030228 add htmlspecialchars processing.  This handles quotes and other special chars in the user input.
@@ -430,8 +424,7 @@ class shoppingCart extends base {
 
         if (!$blank_value) {
           if (is_array($value) ) {
-            reset($value);
-            while (list($opt, $val) = each($value)) {
+            foreach($value as $opt => $val) {
               $this->contents[$products_id]['attributes'][$option.'_chk'.$val] = $val;
             }
           } else {
@@ -446,8 +439,7 @@ class shoppingCart extends base {
             $attr_value = zen_db_input($attr_value);
           }
           if (is_array($value) ) {
-            reset($value);
-            while (list($opt, $val) = each($value)) {
+            foreach($value as $opt => $val) {
               $products_options_sort_order= zen_get_attributes_options_sort_order(zen_get_prid($products_id), $option, $opt);
               $sql = "update " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . "
                         set products_options_value_id = '" . (int)$val . "'
@@ -488,8 +480,7 @@ class shoppingCart extends base {
   function cleanup() {
     global $db;
     $this->notify('NOTIFIER_CART_CLEANUP_START');
-    reset($this->contents);
-    while (list($key,) = each($this->contents)) {
+    foreach($this->contents as $key => $data) {
       if (!isset($this->contents[$key]['qty']) || $this->contents[$key]['qty'] <= 0) {
         unset($this->contents[$key]);
         // remove from database
@@ -525,8 +516,7 @@ class shoppingCart extends base {
     $this->notify('NOTIFIER_CART_COUNT_CONTENTS_START');
     $total_items = 0;
     if (is_array($this->contents)) {
-      reset($this->contents);
-      while (list($products_id, ) = each($this->contents)) {
+      foreach($this->contents as $products_id => $data) {
         $total_items += $this->get_quantity($products_id);
       }
     }
@@ -628,9 +618,8 @@ class shoppingCart extends base {
     if (!is_array($this->contents)) {
       return '';
     }
-    reset($this->contents);
     $product_id_list = array();
-    while (list($products_id, ) = each($this->contents)) {
+    foreach($this->contents as $products_id => $data) {
       $product_id_list[] = $products_id;
     }
     return implode(',', $product_id_list);
@@ -657,8 +646,7 @@ class shoppingCart extends base {
 // By default, Price Factor is based on Price and is called from function zen_get_attributes_price_factor
 // Setting a define for ATTRIBUTES_PRICE_FACTOR_FROM_SPECIAL to 1 to calculate the Price Factor from Special rather than Price switches this to be based on Special, if it exists
     if (!defined('ATTRIBUTES_PRICE_FACTOR_FROM_SPECIAL')) define('ATTRIBUTES_PRICE_FACTOR_FROM_SPECIAL', 1);
-    reset($this->contents);
-    while (list($products_id, ) = each($this->contents)) {
+    foreach($this->contents as $products_id => $data) {
       $total_before_discounts = 0;
       $freeShippingTotal = $productTotal = $totalOnetimeCharge = $totalOnetimeChargeNoDiscount = 0;
       $qty = $this->contents[$products_id]['qty'];
@@ -731,8 +719,7 @@ class shoppingCart extends base {
       $savedProductTotal = $productTotal;
       $attributesTotal = 0;
       if (isset($this->contents[$products_id]['attributes'])) {
-        reset($this->contents[$products_id]['attributes']);
-        while (list($option, $value) = each($this->contents[$products_id]['attributes'])) {
+        foreach($this->contents[$products_id]['attributes'] as $option => $value) {
           $productTotal = 0;
           $adjust_downloads ++;
           /*
@@ -902,8 +889,7 @@ class shoppingCart extends base {
       $productTotal = $savedProductTotal + $attributesTotal;
       // attributes weight
       if (isset($this->contents[$products_id]['attributes'])) {
-        reset($this->contents[$products_id]['attributes']);
-        while (list($option, $value) = each($this->contents[$products_id]['attributes'])) {
+        foreach($this->contents[$products_id]['attributes'] as $option => $value) {
           $attribute_weight_query = "select products_attributes_weight, products_attributes_weight_prefix
                                        from " . TABLE_PRODUCTS_ATTRIBUTES . "
                                        where products_id = '" . (int)$prid . "'
@@ -978,8 +964,7 @@ class shoppingCart extends base {
 
     if (isset($this->contents[$products_id]['attributes'])) {
 
-      reset($this->contents[$products_id]['attributes']);
-      while (list($option, $value) = each($this->contents[$products_id]['attributes'])) {
+      foreach($this->contents[$products_id]['attributes'] as $option => $value) {
         $attributes_price = 0;
         $attribute_price_query = "select *
                                     from " . TABLE_PRODUCTS_ATTRIBUTES . "
@@ -1079,9 +1064,7 @@ class shoppingCart extends base {
     $attributes_price_onetime = 0;
 
     if (isset($this->contents[$products_id]['attributes'])) {
-
-      reset($this->contents[$products_id]['attributes']);
-      while (list($option, $value) = each($this->contents[$products_id]['attributes'])) {
+      foreach($this->contents[$products_id]['attributes'] as $option => $value) {
 
         $attribute_price_query = "select *
                                     from " . TABLE_PRODUCTS_ATTRIBUTES . "
@@ -1149,8 +1132,7 @@ class shoppingCart extends base {
     $attribute_weight = 0;
 
     if (isset($this->contents[$products_id]['attributes'])) {
-      reset($this->contents[$products_id]['attributes']);
-      while (list($option, $value) = each($this->contents[$products_id]['attributes'])) {
+      foreach($this->contents[$products_id]['attributes'] as $option => $value) {
         $attribute_weight_query = "select products_attributes_weight, products_attributes_weight_prefix
                                     from " . TABLE_PRODUCTS_ATTRIBUTES . "
                                     where products_id = '" . (int)$products_id . "'
@@ -1195,8 +1177,7 @@ class shoppingCart extends base {
     if (!is_array($this->contents)) return false;
 
     $products_array = array();
-    reset($this->contents);
-    while (list($products_id, ) = each($this->contents)) {
+    foreach($this->contents as $products_id => $data) {
       $products_query = "select p.products_id, p.master_categories_id, p.products_status, pd.products_name, p.products_model, p.products_image,
                                   p.products_price, p.products_weight, p.products_tax_class_id,
                                   p.products_quantity_order_min, p.products_quantity_order_units, p.products_quantity_order_max,
@@ -1259,9 +1240,8 @@ class shoppingCart extends base {
             $this->remove($products_id);
           } else {
             if (isset($this->contents[$products_id]['attributes'])) {
-              reset($this->contents[$products_id]['attributes']);
               $chkcount = 0;
-              while (list(, $value) = each($this->contents[$products_id]['attributes'])) {
+              foreach($this->contents[$products_id]['attributes'] as $value) {
                 $chkcount ++;
                 $chk_attributes_exist_query = "select products_id
                                           from " . TABLE_PRODUCTS_ATTRIBUTES . " pa
@@ -1438,8 +1418,7 @@ class shoppingCart extends base {
     $gift_voucher = 0;
 
     if ( $this->count_contents() > 0 ) {
-      reset($this->contents);
-      while (list($products_id, ) = each($this->contents)) {
+      foreach($this->contents as $products_id => $data) {
         $free_ship_check = $db->Execute("select products_virtual, products_model, products_price, product_is_always_free_shipping from " . TABLE_PRODUCTS . " where products_id = '" . zen_get_prid($products_id) . "'");
         $virtual_check = false;
         if (preg_match('/^GIFT/', addslashes($free_ship_check->fields['products_model']))) {
@@ -1456,8 +1435,7 @@ class shoppingCart extends base {
         // product_is_always_free_shipping = 2 is special requires shipping
         // Example: Product with download
         if (isset($this->contents[$products_id]['attributes']) and $free_ship_check->fields['product_is_always_free_shipping'] != 2) {
-          reset($this->contents[$products_id]['attributes']);
-          while (list(, $value) = each($this->contents[$products_id]['attributes'])) {
+          foreach($this->contents[$products_id]['attributes'] as $value) {
             $virtual_check_query = "select count(*) as total
                                       from " . TABLE_PRODUCTS_ATTRIBUTES . " pa, "
                                       . TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD . " pad
@@ -1568,7 +1546,7 @@ class shoppingCart extends base {
    * @private
    */
   function unserialize($broken) {
-    for(reset($broken);$kv=each($broken);) {
+    foreach($broken as $kv) {
       $key=$kv['key'];
       if (gettype($this->$key)!="user function")
       $this->$key=$kv['value'];
@@ -1603,8 +1581,7 @@ class shoppingCart extends base {
 
     // reset($this->contents); // breaks cart
     $check_contents = $this->contents;
-    reset($check_contents);
-    while (list($products_id, ) = each($check_contents)) {
+    foreach($check_contents as $products_id => $data) {
       $test_id = zen_get_prid($products_id);
 //$messageStack->add_session('header', 'Product: ' . $products_id . ' test_id: ' . $test_id . '<br>', 'error');
       if ($test_id == $chk_products_id) {
@@ -1642,8 +1619,7 @@ class shoppingCart extends base {
 
     // reset($this->contents); // breaks cart
     $check_contents = $this->contents;
-    reset($check_contents);
-    while (list($products_id, ) = each($check_contents)) {
+    foreach($check_contents as $products_id => $data) {
       $test_id = zen_get_prid($products_id);
       if ($test_id == $chk_products_id) {
         $in_cart_mixed_qty_discount_quantity += $check_contents[$products_id]['qty'];
@@ -1670,8 +1646,7 @@ class shoppingCart extends base {
     // compute total quantity for field
     $in_cart_check_qty=0;
 
-    reset($this->contents);
-    while (list($products_id, ) = each($this->contents)) {
+    foreach($this->contents as $products_id => $data) {
       $testing_id = zen_get_prid($products_id);
       // check if field it true
       $product_check = $db->Execute("select " . $check_what . " as check_it from " . TABLE_PRODUCTS . " where products_id='" . $testing_id . "' limit 1");
@@ -2080,7 +2055,7 @@ class shoppingCart extends base {
     if (is_array($_POST['products_id']) && sizeof($_POST['products_id']) > 0) {
 //echo '<pre>'; echo var_dump($_POST['products_id']); echo '</pre>';
       $products_list = $_POST['products_id'];
-      while ( list( $key, $val ) = each($products_list) ) {
+      foreach($products_list as $key => $val) {
         $prodId = preg_replace('/[^0-9a-f:.]/', '', $key);
         if (is_numeric($val) && $val > 0) {
 

--- a/includes/classes/upload.php
+++ b/includes/classes/upload.php
@@ -40,7 +40,7 @@ class upload extends base {
         return true;
       } else {
         // self destruct
-        while(list($key,) = each($this)) {
+        foreach($this as $key => $val) {
           $this->$key = null;
         }
 

--- a/includes/functions/audience.php
+++ b/includes/functions/audience.php
@@ -103,8 +103,7 @@ function parsed_query_string($read_string) {
   // this will also in the future be used to reconstruct queries from query_keys_list field in query_builder table.
 
   $allwords = explode( " ", $read_string );
-  reset( $allwords );
-  while( list( $key, $val ) = each( $allwords ) ) {
+  foreach( $allwords as $key => $val) {
     // find "{TABLE_" and extract that tablename
     if( substr( $val, 0, 7) == "{TABLE_"  && substr( $val, -1) == "}" ) { //check for leading and trailing {} braces
       $val = substr( $val, 2, strlen($val)-2);  // strip off braces.  Could also use str_replace(array('{','}'),'',$val);

--- a/includes/functions/functions_general.php
+++ b/includes/functions/functions_general.php
@@ -154,8 +154,7 @@
     }
     $get_url = '';
     if (is_array($_GET) && (sizeof($_GET) > 0)) {
-      reset($_GET);
-      while (list($key, $value) = each($_GET)) {
+      foreach($_GET as $key => $value) {
         if (!in_array($key, $exclude_array)) {
           if (!is_array($value)) {
             if (strlen($value) > 0) {
@@ -186,8 +185,7 @@
     $exclude_array = array_merge($exclude_array, array(zen_session_name(), 'cmd', 'error', 'x', 'y'));
     $fields = '';
     if (is_array($_GET) && (sizeof($_GET) > 0)) {
-      reset($_GET);
-      while (list($key, $value) = each($_GET)) {
+      foreach($_GET as $key => $value) {
         if (!in_array($key, $exclude_array)) {
           if (!is_array($value)) {
             if (strlen($value) > 0) {
@@ -671,9 +669,9 @@ function zen_get_minutes_since($timestamp) {
     $uprid = $prid;
     if ( !is_array($params) || strstr($prid, ':')) return $prid;
 
-    while (list($option, $value) = each($params)) {
+    foreach($params as $option => $value) {
       if (is_array($value)) {
-        while (list($opt, $val) = each($value)) {
+        foreach($value as $opt => $val) {
           $uprid = $uprid . '{' . $option . '}' . trim($opt);
         }
       } else {
@@ -767,7 +765,7 @@ function zen_get_minutes_since($timestamp) {
 
     $get_string = '';
     if (sizeof($array) > 0) {
-      while (list($key, $value) = each($array)) {
+      foreach($array as $key => $value) {
         if ( (!in_array($key, $exclude)) && ($key != 'x') && ($key != 'y') ) {
           $get_string .= $key . $equals . $value . $separator;
         }
@@ -1100,8 +1098,7 @@ function zen_get_minutes_since($timestamp) {
         return trim(zen_sanitize_string(stripslashes($string)));
       }
     } elseif (is_array($string)) {
-      reset($string);
-      while (list($key, $value) = each($string)) {
+      foreach($string as $key => $value) {
         $string[$key] = zen_db_prepare_input($value);
       }
     }
@@ -1118,15 +1115,13 @@ function zen_get_minutes_since($timestamp) {
  */
   function zen_db_perform($table, $data, $action = 'insert', $parameters = '') {
     global $db;
-    reset($data);
     if (strtolower($action) == 'insert') {
       $query = 'INSERT INTO ' . $table . ' (';
-      while (list($columns, ) = each($data)) {
+      foreach($data as $columns => $value) {
         $query .= $columns . ', ';
       }
       $query = substr($query, 0, -2) . ') VALUES (';
-      reset($data);
-      while (list(, $value) = each($data)) {
+      foreach($data as $value) {
         switch ((string)$value) {
           case 'now()':
             $query .= 'now(), ';
@@ -1142,7 +1137,7 @@ function zen_get_minutes_since($timestamp) {
       $query = substr($query, 0, -2) . ')';
     } elseif (strtolower($action) == 'update') {
       $query = 'UPDATE ' . $table . ' SET ';
-      while (list($columns, $value) = each($data)) {
+      foreach($data as $columns => $value) {
         switch ((string)$value) {
           case 'now()':
             $query .= $columns . ' = now(), ';

--- a/includes/functions/functions_prices.php
+++ b/includes/functions/functions_prices.php
@@ -798,7 +798,7 @@ If a special exist * 10+9
     $salemaker_sales = $db->Execute("select sale_id, sale_status, sale_name, sale_categories_all, sale_deduction_value, sale_deduction_type, sale_pricerange_from, sale_pricerange_to, sale_specials_condition, sale_categories_selected, sale_date_start, sale_date_end, sale_date_added, sale_date_last_modified, sale_date_status_change from " . TABLE_SALEMAKER_SALES . " where sale_status='1'");
     while (!$salemaker_sales->EOF) {
       $categories = explode(',', $salemaker_sales->fields['sale_categories_all']);
-      while (list($key,$value) = each($categories)) {
+      foreach($categories as $key => $value) {
         if ($value == $check_category) {
           $sale_exists = 'true';
           $sale_maker_discount = $salemaker_sales->fields['sale_deduction_value'];
@@ -889,7 +889,7 @@ If a special exist * 10
     $salemaker_sales = $db->Execute("select sale_id, sale_status, sale_name, sale_categories_all, sale_deduction_value, sale_deduction_type, sale_pricerange_from, sale_pricerange_to, sale_specials_condition, sale_categories_selected, sale_date_start, sale_date_end, sale_date_added, sale_date_last_modified, sale_date_status_change from " . TABLE_SALEMAKER_SALES . " where sale_status='1'");
     while (!$salemaker_sales->EOF) {
       $categories = explode(',', $salemaker_sales->fields['sale_categories_all']);
-      while (list($key,$value) = each($categories)) {
+      foreach($categories as $key => $value) {
         if ($value == $check_category) {
           $sale_maker_discount = $salemaker_sales->fields['sale_deduction_value'];
           $sale_maker_discount_type = $salemaker_sales->fields['sale_deduction_type'];

--- a/includes/init_includes/init_sefu.php
+++ b/includes/init_includes/init_sefu.php
@@ -26,7 +26,7 @@ if (SEARCH_ENGINE_FRIENDLY_URLS == 'true') {
       $i++;
     }
     if (sizeof($GET_array) > 0) {
-      while (list($key, $value) = each($GET_array)) {
+      foreach($GET_array as $key => $value) {
         $_GET[$key] = $value;
       }
     }

--- a/includes/modules/order_total/ot_coupon.php
+++ b/includes/modules/order_total/ot_coupon.php
@@ -63,9 +63,8 @@ class ot_coupon {
     }
     $this->deduction = $od_amount['total'];
     if ($od_amount['total'] > 0) {
-      reset($order->info['tax_groups']);
       $tax = 0;
-      while (list($key, $value) = each($order->info['tax_groups'])) {
+      foreach($order->info['tax_groups'] as $key => $value) {
         if ($od_amount['tax_groups'][$key]) {
           $order->info['tax_groups'][$key] -= $od_amount['tax_groups'][$key];
           $order->info['tax_groups'][$key] = zen_round($order->info['tax_groups'][$key], $currencies->get_decimal_places($_SESSION['currency']));

--- a/includes/modules/order_total/ot_group_pricing.php
+++ b/includes/modules/order_total/ot_group_pricing.php
@@ -31,9 +31,8 @@ class ot_group_pricing {
     $od_amount = $this->calculate_deductions($order_total['total']);
     $this->deduction = $od_amount['total'];
     if ($od_amount['total'] > 0) {
-      reset($order->info['tax_groups']);
       $tax = 0;
-      while (list($key, $value) = each($order->info['tax_groups'])) {
+      foreach($order->info['tax_groups'] as $key => $value) {
         if ($od_amount['tax_groups'][$key]) {
           $order->info['tax_groups'][$key] -= $od_amount['tax_groups'][$key];
           $tax += $od_amount['tax_groups'][$key];

--- a/includes/modules/order_total/ot_gv.php
+++ b/includes/modules/order_total/ot_gv.php
@@ -66,9 +66,8 @@ class ot_gv {
       $od_amount = $this->calculate_deductions($this->get_order_total());
       $this->deduction = $od_amount['total'];
       if ($od_amount['total'] > 0) {
-        reset($order->info['tax_groups']);
         $tax = 0;
-        while (list($key, $value) = each($order->info['tax_groups'])) {
+        foreach($order->info['tax_groups'] as $key => $value) {
           if ($od_amount['tax_groups'][$key]) {
             $order->info['tax_groups'][$key] -= $od_amount['tax_groups'][$key];
             $tax += $od_amount['tax_groups'][$key];

--- a/includes/modules/order_total/ot_tax.php
+++ b/includes/modules/order_total/ot_tax.php
@@ -42,7 +42,7 @@
         }
       }
       if (count($order->info['tax_groups']) > 1 && isset($order->info['tax_groups'][0])) unset($order->info['tax_groups'][0]);
-      while (list($key, $value) = each($order->info['tax_groups'])) {
+      foreach($order->info['tax_groups'] as $key => $value) {
         if (SHOW_SPLIT_TAX_CHECKOUT == 'true')
         {
           if ($value > 0 or ($value == 0 && STORE_TAX_DISPLAY_STATUS == 1 )) {

--- a/includes/modules/pages/checkout_success/header_php.php
+++ b/includes/modules/pages/checkout_success/header_php.php
@@ -161,8 +161,7 @@ submit_form();
 </script>' . "\n" . '</head>';
   echo '<body style="text-align: center; min-width: 600px;">' . "\n" . '<div style="text-align: center;  width: 600px;  margin-left: auto;  margin-right: auto; margin-top:20%;"><p>This page will automatically redirect you back to ' . STORE_NAME . ' for your order confirmation details.<br />If you are not redirected within 5 seconds, please click the button below to continue.</p>';
   echo "\n" . '<form action="' . zen_href_link(FILENAME_CHECKOUT_SUCCESS, zen_get_all_get_params(array('action')), 'SSL', false) . '" method="post" name="formpost" />' . "\n";
-  reset($_POST);
-  while (list($key, $value) = each($_POST)) {
+  foreach($_POST as $key => $value) {
     if (!is_array($_POST[$key])) {
       echo zen_draw_hidden_field($key, htmlspecialchars(stripslashes($value), ENT_COMPAT, CHARSET, TRUE)) . "\n";
     }

--- a/includes/modules/pages/page/header_php.php
+++ b/includes/modules/pages/page/header_php.php
@@ -78,7 +78,7 @@ $last_v = 0;
 $previous_vssl = '0';
 $next_item_v = 0;
 $next_vssl = 0;
-while (list($key, $value) = each ($vert_links)) {
+foreach($vert_links as $key => $value) {
   if ($value == $ezpage_id) {
     $position_v = $counter;
     $previous_vssl = '0';
@@ -103,7 +103,7 @@ if ($previous_v == -1) $previous_v = $last_v;
 //prev/next for horiz now
 reset ($horiz_links);
 $counter = 0;
-while (list($key, $value) = each ($horiz_links)) {
+foreach($horiz_links as $key => $value) {
 if ($value == $ezpage_id) {
 $position_h = $counter;
 $previous_hssl = '0';

--- a/includes/modules/payment/authorizenet_aim.php
+++ b/includes/modules/payment/authorizenet_aim.php
@@ -648,7 +648,7 @@ class authorizenet_aim extends base {
 
     // concatenate the submission data into $data variable after sanitizing to protect delimiters
     $data = '';
-    while(list($key, $value) = each($submit_data)) {
+    foreach($submit_data as $key => $value) {
       if ($key != 'x_delim_char' && $key != 'x_encap_char') {
         $value = str_replace(array($this->delimiter, $this->encapChar,'"',"'",'&amp;','&', '='), '', $value);
       }

--- a/includes/modules/payment/authorizenet_echeck.php
+++ b/includes/modules/payment/authorizenet_echeck.php
@@ -574,7 +574,7 @@ class authorizenet_echeck extends base {
 
     // concatenate the submission data into $data variable after sanitizing to protect delimiters
     $data = '';
-    while(list($key, $value) = each($submit_data)) {
+    foreach($submit_data as $key => $value) {
       if ($key != 'x_delim_char' && $key != 'x_encap_char') {
         $value = str_replace(array($this->delimiter, $this->encapChar,'"',"'",'&amp;','&', '='), '', $value);
       }

--- a/includes/modules/require_languages.php
+++ b/includes/modules/require_languages.php
@@ -25,7 +25,7 @@ if (file_exists($language_page_directory . $template_dir . '/' . $current_page_b
 
 // set language or template language file
 $directory_array = $template->get_template_part($language_page_directory . $template_dir_select, '/^'.$current_page_base . '/');
-while(list ($key, $value) = each($directory_array)) {
+foreach($directory_array as $key => $value) {
   //echo "I AM LOADING: " . $language_page_directory . $template_dir_select . $value . '<br />';
   require_once($language_page_directory . $template_dir_select . $value);
 }
@@ -33,10 +33,8 @@ while(list ($key, $value) = each($directory_array)) {
 // load master language file(s) if lang files loaded previously were "overrides" and not masters.
 if ($template_dir_select != '') {
   $directory_array = $template->get_template_part($language_page_directory, '/^'.$current_page_base . '/');
-  while(list ($key, $value) = each($directory_array)) {
+  foreach($directory_array as $key => $value) {
     //echo "I AM LOADING MASTER: " . $language_page_directory . $value.'<br />';
     require_once($language_page_directory . $value);
   }
 }
-
-?>

--- a/includes/modules/sideboxes/currencies.php
+++ b/includes/modules/sideboxes/currencies.php
@@ -22,7 +22,7 @@
 
       reset($currencies->currencies);
       $currencies_array = array();
-      while (list($key, $value) = each($currencies->currencies)) {
+      foreach($currencies->currencies as $key => $value) {
         $currencies_array[] = array('id' => $key, 'text' => $value['title']);
       }
 

--- a/includes/modules/tpl_css_js_generator.php
+++ b/includes/modules/tpl_css_js_generator.php
@@ -66,7 +66,7 @@ if (!isset($use_default_handler) || (isset($use_default_handler) && $use_default
           '/' . 'stylesheet-responsive',
           '/' . 'font',
   );
-  while(list ($key, $value) = each($sheets_array_primary)) {
+  foreach($sheets_array_primary as $key => $value) {
     $perpagefile = $template->get_template_dir(ltrim($value, '/') . '.css', DIR_WS_TEMPLATE, $current_page_base, 'css') . $value . '.css';
     if (file_exists($perpagefile)) {
       $stylesheets[] = $perpagefile;
@@ -81,7 +81,7 @@ if (!isset($use_default_handler) || (isset($use_default_handler) && $use_default
   $directory_array = $template->get_template_part($template->get_template_dir('^[^(inline|print)].*\.css',DIR_WS_TEMPLATE, $current_page_base,'css'), '/^[^(inline|print)]/', '.css');
   sort($directory_array);
   $directory_array  = array_diff($directory_array, $deduplicate);
-  while(list ($key, $value) = each($directory_array)) {
+  foreach($directory_array as $key => $value) {
     $stylesheets[] = $template->get_template_dir('.css',DIR_WS_TEMPLATE, $current_page_base,'css') . '/' . $value;
   }
 
@@ -90,7 +90,7 @@ if (!isset($use_default_handler) || (isset($use_default_handler) && $use_default
    */
   $directory_array = $template->get_template_part($template->get_template_dir('^inline.*\.css',DIR_WS_TEMPLATE, $current_page_base,'css'), '/^inline/', '.css');
   sort($directory_array);
-  while(list ($key, $value) = each($directory_array)) {
+  foreach($directory_array as $key => $value) {
     $inline_css[] = $template->get_template_dir('.css',DIR_WS_TEMPLATE, $current_page_base,'css') . '/' . $value;
   }
   $sheets_array = array('/inline_' . $_SESSION['language'] . '_stylesheet',
@@ -105,7 +105,7 @@ if (!isset($use_default_handler) || (isset($use_default_handler) && $use_default
   );
 
   $sheets_array = array_intersect($sheets_array_primary, $sheets_array);
-  while(list ($key, $value) = each($sheets_array)) {
+  foreach($sheets_array as $key => $value) {
     $perpagefile = $template->get_template_dir(ltrim($value, '/') . '.css', DIR_WS_TEMPLATE, $current_page_base, 'css') . $value . '.css';
     if (file_exists($perpagefile)) $inline_css[] = $perpagefile;
   }
@@ -116,7 +116,7 @@ if (!isset($use_default_handler) || (isset($use_default_handler) && $use_default
    */
   $directory_array = $template->get_template_part($template->get_template_dir('^print.*\.css',DIR_WS_TEMPLATE, $current_page_base,'css'), '/^print/', '.css');
   sort($directory_array);
-  while(list ($key, $value) = each($directory_array)) {
+  foreach($directory_array as $key => $value) {
     $printsheets[] = $template->get_template_dir('.css',DIR_WS_TEMPLATE, $current_page_base,'css') . '/' . $value;
   }
 
@@ -125,7 +125,7 @@ if (!isset($use_default_handler) || (isset($use_default_handler) && $use_default
    */
   $directory_array = $template->get_template_part($template->get_template_dir('^jscript_.*\.php',DIR_WS_TEMPLATE, $current_page_base, 'jscript'), '/^jscript_/', '.php');
   sort($directory_array);
-  while(list ($key, $value) = each($directory_array)) {
+  foreach($directory_array as $key => $value) {
     /**
      * include content from all site-wide jscript_*.php files from includes/templates/YOURTEMPLATE/jscript, alphabetically.
      * These .php files can be manipulated by PHP when they're called, and are copied in-full to the browser page
@@ -142,7 +142,7 @@ if (!isset($use_default_handler) || (isset($use_default_handler) && $use_default
    */
   $directory_array = $template->get_template_part($page_directory, '/^jscript_/');
   sort($directory_array);
-  while(list ($key, $value) = each($directory_array)) {
+  foreach($directory_array as $key => $value) {
     /**
      * include content from all page-specific jscript_*.php files from includes/modules/pages/PAGENAME, alphabetically.
      * These .PHP files can be manipulated by PHP when they're called, and are copied in-full to the browser page
@@ -159,7 +159,7 @@ if (!isset($use_default_handler) || (isset($use_default_handler) && $use_default
    */
   $directory_array = $template->get_template_part($template->get_template_dir('\.js',DIR_WS_TEMPLATE, $current_page_base,'jscript'), '/.*/', '.js');
   sort($directory_array);
-  while(list ($key, $value) = each($directory_array)) {
+  foreach($directory_array as $key => $value) {
     if (preg_match('~^.*_top.js$~', $value)) {
       $jsfilesTop[] = $template->get_template_dir('\.js',DIR_WS_TEMPLATE, $current_page_base,'jscript') . '/' . $value;
     } else {
@@ -172,7 +172,7 @@ if (!isset($use_default_handler) || (isset($use_default_handler) && $use_default
    */
   $directory_array = $template->get_template_part($page_directory, '/^.*/', '.js');
   sort($directory_array);
-  while(list ($key, $value) = each($directory_array)) {
+  foreach($directory_array as $key => $value) {
     if (preg_match('~^.*_top.js$~', $value)) {
       $jsfilesTop[] = $page_directory . '/' . $value;
     } else {

--- a/includes/templates/template_default/templates/tpl_modules_media_manager.php
+++ b/includes/templates/template_default/templates/tpl_modules_media_manager.php
@@ -19,13 +19,13 @@
 <h2 id="mediaManagerHeading"><?php echo TEXT_PRODUCT_COLLECTIONS; ?></h2>
 
 <?php
-  while (list($za_media_key, $za_media) = each($za_media_manager)) {
+  foreach($za_media_manager as $za_media_key => $za_media) {
 ?>
 <div class="rowWrapper">
       <div class="mediaTitle"><?php echo $za_media['text']; ?></div>
 <?php
     $zv_counter1 = 0;
-    while(list($za_clip_key, $za_clip) = each($za_media_manager[$za_media_key]['clips'])) {
+    foreach($za_media_manager[$za_media_key]['clips'] as $za_clip_key => $za_clip) {
 ?>
       <div class="mediaTypeLink"><a href="<?php echo zen_href_link(DIR_WS_MEDIA  . $za_clip['clip_filename'], '', 'NONSSL', false, true, true); ?>" target="_blank"><?php echo '<span class="mediaClipFilename">' . $za_clip['clip_filename'] . '</span>' . (!empty($za_clip['clip_type']) ? '<span class="mediaClipType"> (' . $za_clip['clip_type'] . ')</span>' : ''); ?></a></div>
 
@@ -35,5 +35,4 @@
     </div>
 <?php
   }
-  }
-?>
+}


### PR DESCRIPTION
An RFC for PHP 7.2 has been voted on for inclusion in PHP 7.2.  It proposes to deprecate the `each()` function for PHP 7.2 and removes it in 8.0.

The `each()` function is exponentially slower and wastes resources vs `foreach()`, so we're refactoring it now whether PHP 7.2 finally does adopt it or not.

Things to note when refactoring: 
1. `foreach()` doesn't need a `reset()` to be called before it runs, so those can be removed.
2. There are 3 syntax formats, depending on how the parameters are presented in the `list()` call:

a) `while(list($key, $value) = each($foo))`
This becomes `foreach($foo as $key => $value)`

b) `while(list(, $value) = each($foo))`
This becomes `foreach($foo as $value)`

c) `while(list($key, ) = each($foo))`
This becomes `foreach($foo as $key => $value)`
