### PR TITLE
Tax rate and description reversed for cases where there is no active tax rate

### DIFF
--- a/includes/functions/functions_taxes.php
+++ b/includes/functions/functions_taxes.php
@@ -153,7 +153,7 @@
       }
     } else {
       // no tax at this level, set rate to 0 and description of unknown
-      $rates_array[0] = TEXT_UNKNOWN_TAX_RATE;
+      $rates_array[TEXT_UNKNOWN_TAX_RATE] = 0;
     }
     return $rates_array;
   }


### PR DESCRIPTION
I don't actively use these tax groups but came to my attention due to "A non-numeric value encountered" notice in PHP 7.1
Effective result should be the same as the text would have evaluated to 0