### PR TITLE
Fix some problems that cause multiple error logs to be generated

### DIFF
--- a/admin/includes/functions/html_output.php
+++ b/admin/includes/functions/html_output.php
@@ -11,7 +11,7 @@
    * @deprecated in version 1.6.0. Use zen_admin_href_link() instead
    */
   function zen_href_link($page = '', $parameters = '', $connection = 'NONSSL', $add_session_id = true) {
-    trigger_error ('The function zen_href_link is deprecated, use zen_admin_href_link instead. Note that the parameters are different too.', E_USER_NOTICE);
+    //trigger_error ('The function zen_href_link is deprecated, use zen_admin_href_link instead. Note that the parameters are different too.', E_USER_NOTICE);
     return zen_admin_href_link($page, $parameters, $add_session_id);
   }
 

--- a/app/Controllers/AbstractAdminController.php
+++ b/app/Controllers/AbstractAdminController.php
@@ -16,7 +16,7 @@ use ZenCart\View\ViewFactory as View;
  * Class AbstractAdminController
  * @package App\Controllers
  */
-abstract class AbstractAdminController
+abstract class AbstractAdminController extends \base
 {
     /**
      * @var array

--- a/testFramework/behat/features/bootstrap/ZenCartSpecificSteps.php
+++ b/testFramework/behat/features/bootstrap/ZenCartSpecificSteps.php
@@ -30,11 +30,11 @@ trait ZenCartSpecificSteps
         if (!defined('CWD')) {
             define('CWD', getcwd());
         }
-        $file_contents = file_get_contents(CWD . '/includes/dist-configure.php');
+//        $file_contents = file_get_contents(CWD . '/includes/dist-configure.php');
         $fp = fopen(CWD . '/includes/configure.php', 'w');
         chmod(CWD . '/includes/configure.php', 0777);
         if ($fp) {
-            fputs($fp, $file_contents);
+//            fputs($fp, $file_contents);
             fclose($fp);
         }
 

--- a/testFramework/behat/features/testFeatures/testInstaller.feature
+++ b/testFramework/behat/features/testFeatures/testInstaller.feature
@@ -32,6 +32,7 @@ Feature: Installer
     And I press button "btnsubmit"
 
     Then I should see "Installation completed"
+    Then I set a configuration value "SEND_EMAILS", "false"
 
     Given I do a first admin login with <param>"admin_user_main", <param>"admin_password_install", <param>"admin_password_main"
     Then I should see "Initial Setup Wizard"


### PR DESCRIPTION
Send emails need to be suppressed as we don't have any email environment in Behat
The deprecation of zen_href_link in admin needs to be revisited due to use of common code between admin/store
The reset install method in Behat was copying across the dist-configure which generated errors as there was then no database credentials