### PR TITLE
Support table prefixes for 1.3.8 upgrade in zc_installer

### DIFF
--- a/zc_install/sql/updates/mysql_upgrade_zencart_139.sql
+++ b/zc_install/sql/updates/mysql_upgrade_zencart_139.sql
@@ -72,10 +72,10 @@ ALTER TABLE orders ADD INDEX idx_cust_id_orders_id_zen (customers_id,orders_id);
 # fix counter_history race condition
 #NEXT_X_ROWS_AS_ONE_COMMAND:5
 CREATE TABLE counter_history_clean as
-SELECT startdate, counter, session_counter FROM counter_history WHERE 1 GROUP BY startdate, counter, session_counter;
+SELECT startdate, counter, session_counter
+FROM counter_history WHERE 1 GROUP BY startdate, counter, session_counter;
 DROP TABLE counter_history;
-RENAME TABLE counter_history_clean
-TO counter_history;
+RENAME TABLE counter_history_clean TO counter_history;
 
 ALTER TABLE counter_history ADD PRIMARY KEY(startdate);
 


### PR DESCRIPTION
Prior to ZC 1.5.5, the zc_installer included code to process the upgrade
script from ZC 1.3.8 to 1.3.9; however, in the redevelopment for ZC 1.5.5,
operations did not include processing SQL commands such as only DROP TABLE
though DROP TABLE IF EXISTS was supported.  This code was replaced and
expanded to support DROP TABLE and DROP TABLE IF EXISTS.

Also the code did not support the SQL command of RENAME TABLE.

To support the revised code the ZC 1.3.9 sql (upgrades 1.3.8 to 1.3.9)
required minor modification as well.

No other related/earlier SQL was identified as needing this change.
Fixes #1386 