### PR TITLE
Remove authnet test from v139 upgrade step

### DIFF
--- a/zc_install/includes/systemChecks.yml
+++ b/zc_install/includes/systemChecks.yml
@@ -361,11 +361,6 @@ systemChecks:
           - checkType: configValue
             fieldName: SHOW_SPLIT_TAX_CHECKOUT
             expectedResult: 'Show Split Tax Lines'
-          - checkType: fieldSchema
-            tableName: authorizenet
-            fieldName: transaction_id
-            fieldCheck: Type
-            expectedResult: 'BIGINT(20)'
 
   checkDBVersion138:
     runLevel: dbVersion


### PR DESCRIPTION
... because this field has changed and requiring it to be of the old schema may throw false errors during upgrades