### PR TITLE
Remove back quote when parsing

### DIFF
--- a/zc_install/includes/classes/class.zcDatabaseInstaller.php
+++ b/zc_install/includes/classes/class.zcDatabaseInstaller.php
@@ -98,6 +98,7 @@ class zcDatabaseInstaller
     if (substr($this->line,0,28) == '#NEXT_X_ROWS_AS_ONE_COMMAND:') $this->keepTogetherLines = substr($this->line,28);
     if (substr($this->line,0,1) != '#' && substr($this->line,0,1) != '-' && $this->line != '')
     {
+      $this->line = str_replace('`','', $this->line);
       $this->parseLineContent();
       $this->newLine .= $this->line . ' ';
       if ( substr($this->line,-1) ==  ';')


### PR DESCRIPTION
Standard queries support the possibility of using a back quote (`) to encompass a field or table within a query; however, this compiler has difficulty addressing those when a table has a prefix.  The upgrade script for upgrade from ZC 1.5.4 to ZC 1.5.5 includes a query that has the table (and fields) back quoted (specifically layout_boxes).

Two ways seen to possibly address this and the database to function with a database prefix (DB_PREFIX) are to:
1) Modify the upgrade sql to remove the back quotes around the table name.
This will restrict/necessitate that all queries in the future not be
permitted to have back quotes around table names although the database
supports such a query to be presented and thus require tighter control on
future upgrade scripts.
2) Remove the back quotes from all such queries during processing, the
effect of this has not yet been fully investigated with regards to the
breadth of applicability of ZC to database servers; however, on the
surface, it appears that there would be no negative impact.
3) At all locations where a table name is presented for processing that
the table name as identified on a "per word" basis be modified to remove
at least the front back quote, if it exists and prepend it to the query
that remains, but to not add a back quote if it does not exist around the
table name. (This would be a solution that maintains the back quote if it
existed to begin with and would require revision to many of the functions
of this class.)

Option 2 is presented in this commit.