### PR TITLE
Space before parenthesis multi

### DIFF
--- a/zc_install/includes/classes/class.zcDatabaseInstaller.php
+++ b/zc_install/includes/classes/class.zcDatabaseInstaller.php
@@ -103,7 +103,16 @@ class zcDatabaseInstaller
       if ( substr($this->line,-1) ==  ';')
       {
         if (substr($this->newLine,-1)==' ') $this->newLine = substr($this->newLine,0,(strlen($this->newLine)-1));
-        if (substr($this->newLine,-1)==')') $this->newLine = substr($this->newLine,0,(strlen($this->newLine)-1)) . ' )';
+        $numRight = 0;
+        while (substr($this->newLine,-1)==')')
+        {
+          $numRight++;
+          $this->newLine = substr($this->newLine,0,(strlen($this->newLine)-1));
+        }
+        for ($i = 0; $i < $numRight; $i++)
+        {
+          $this->newLine = $this->newLine . ' )';
+        }
         $this->keepTogetherCount++;
         if ($this->keepTogetherCount == $this->keepTogetherLines)
         {

--- a/zc_install/includes/classes/class.zcDatabaseInstaller.php
+++ b/zc_install/includes/classes/class.zcDatabaseInstaller.php
@@ -103,6 +103,7 @@ class zcDatabaseInstaller
       if ( substr($this->line,-1) ==  ';')
       {
         if (substr($this->newLine,-1)==' ') $this->newLine = substr($this->newLine,0,(strlen($this->newLine)-1));
+        if (substr($this->newLine,-1)==')') $this->newLine = substr($this->newLine,0,(strlen($this->newLine)-1)) . ' )';
         $this->keepTogetherCount++;
         if ($this->keepTogetherCount == $this->keepTogetherLines)
         {


### PR DESCRIPTION
Add right parenthesis separation
    
    In the upgrade sql for from version 1.3.8 to 1.3.9 as provided in ZC 1.5.5, there are a few sql queries that include an internal sql query.  When evaluating a line that reads `FROM this_table);`.  The existing code will remove the ending semicolon; however, then it considers the right parenthesis as part of the table name.  It appears that there are three potential solutions:
    1) place the parenthesis on the next line.
    2) add a space into the sql query file between the table name and the following characters within the sql query itself.
    3) add a space into the sql query as read from the file.
    
    This commit addresses internally adding one space at the end of the sql
    query prior to each parenthesis that ends the string as it was read from
    the file.  It does not consider that there might be multiple spaces before
    the parenthesis, just that there is a non-right parenthetical value to the
    left of the last character before adding back the parentheses with a
    preceding space.
    
    There is still a limitation on this solution, but it is a solution to an
    observed issue.  The concept can be carried forward to insert more spaces,
    or to effectively find the first character that needs the first space in it.