### PR TITLE
Restore price manager entry of specials by percent

### DIFF
--- a/admin/products_price_manager.php
+++ b/admin/products_price_manager.php
@@ -621,22 +621,30 @@ function updateSpecialsGross() {
   var taxRate = getTaxRate();
   var grossSpecialsValue = document.forms["new_prices"].specials_price.value;
 
-  if (taxRate > 0) {
-    grossSpecialsValue = grossSpecialsValue * ((taxRate / 100) + 1);
-  }
+  if (/^\d+(\.\d+)?%$/.test(grossSpecialsValue)) {
+    document.forms["new_prices"].specials_price_gross.value = grossSpecialsValue.slice(0, grossSpecialsValue.length - 1) + "%";
+  } else {
+    if (taxRate > 0) {
+      grossSpecialsValue = grossSpecialsValue * ((taxRate / 100) + 1);
+    }
 
-  document.forms["new_prices"].specials_price_gross.value = doRound(grossSpecialsValue, 4);
+    document.forms["new_prices"].specials_price_gross.value = doRound(grossSpecialsValue, 4);
+  }
 }
 
 function updateSpecialsNet() {
   var taxRate = getTaxRate();
   var netSpecialsValue = document.forms["new_prices"].specials_price_gross.value;
 
-  if (taxRate > 0) {
-    netSpecialsValue = netSpecialsValue / ((taxRate / 100) + 1);
-  }
+  if (/^\d+(\.\d+)?%$/.test(netSpecialsValue)) {
+    document.forms["new_prices"].specials_price.value = netSpecialsValue.slice(0, netSpecialsValue.length - 1) + "%";
+  } else {
+    if (taxRate > 0) {
+      netSpecialsValue = netSpecialsValue / ((taxRate / 100) + 1);
+    }
 
-  document.forms["new_prices"].specials_price.value = doRound(netSpecialsValue, 4);
+    document.forms["new_prices"].specials_price.value = doRound(netSpecialsValue, 4);
+  }
 }
 //--></script>
 <?php } ?>


### PR DESCRIPTION
In issue #750, the price manager data entry was modified to support display
of the specials price for both gross and net costs instead of just for
one or the other.  Unfortunately in that proposal, the ability to enter
a value with a percentage was not maintained.  Today when trying to test
other operations, I realized my oversight and worked to correct it.

This commit will disregard tax differences in data entry if a percent is
entered and apply the same percentage to both fields, otherwise if the
data entered is a number, then the appropriate "conversion" as applicable
will be performed while typing.