### PR TITLE
Incorporate sanitizer code related to manufacturers.

### DIFF
--- a/admin/includes/init_includes/init_sanitize.php
+++ b/admin/includes/init_includes/init_sanitize.php
@@ -177,7 +177,7 @@ $group = array(
 );
 $sanitizer->addSimpleSanitization('CONVERT_INT', $group);
 
-$group = array('img_dir', 'products_previous_image', 'products_image_manual', 'products_attributes_filename');
+$group = array('img_dir', 'products_previous_image', 'products_image_manual', 'products_attributes_filename', 'manufacturers_image_manual');
 $sanitizer->addSimpleSanitization('FILE_DIR_REGEX', $group);
 
 $group = array(
@@ -214,7 +214,7 @@ $sanitizer->addSimpleSanitization('SANITIZE_EMAIL', $group);
 $group = array('products_description', 'coupon_desc', 'file_contents', 'categories_description', 'message_html', 'banners_html_text', 'pages_html_text', 'comments', 'products_options_comment');
 $sanitizer->addSimpleSanitization('PRODUCT_DESC_REGEX', $group);
 
-$group = array('products_url');
+$group = array('products_url', 'manufacturers_url');
 $sanitizer->addSimpleSanitization('PRODUCT_URL_REGEX', $group);
 
 $group = array('coupon_min_order');


### PR DESCRIPTION
The image file is not sanitized similar to the products image as well the
manufacturers_url will convert an ampersand `&` to ampersand `&amp;`.  With this
sanitization, an ampersand (for example in a URI) will not be rewritten.

This was discovered while helping out with a manufacturer plugin and is
discussed in the ZC forum at:
https://www.zen-cart.com/showthread.php?222079-Cannot-modify-header-information-headers-already-sent&p=1328124#post1328124

Although, there a different/additional sanitization was suggested for manufacturers_name to be equivalent to products_name.