### PR TITLE
AIM - update module to work with https when ENABLE_SSL is set to false

### DIFF
--- a/includes/modules/payment/authorizenet_aim.php
+++ b/includes/modules/payment/authorizenet_aim.php
@@ -131,7 +131,7 @@ class authorizenet_aim extends base {
     global $order, $db;
     if (IS_ADMIN_FLAG === false) {
       // if store is not running in SSL, cannot offer credit card module, for PCI reasons
-      if (MODULE_PAYMENT_AUTHORIZENET_AIM_TESTMODE == 'Production' && (!defined('ENABLE_SSL') || ENABLE_SSL != 'true')) $this->enabled = FALSE;
+      if (MODULE_PAYMENT_AUTHORIZENET_AIM_TESTMODE == 'Production' && substr(HTTP_SERVER, 6) != 'https:' && (!defined('ENABLE_SSL') || ENABLE_SSL != 'true')) $this->enabled = FALSE;
     }
     // check other reasons for the module to be deactivated:
     if ($this->enabled && (int)MODULE_PAYMENT_AUTHORIZENET_AIM_ZONE > 0 && isset($order->billing['country']['id'])) {


### PR DESCRIPTION
Authorize.net AIM functionality is supported only when the site supports SSL communication with the client. The suggestion for setup in the ZC forum for a site that is to be hosted entirely by SSL is to modify the includes/configure.php file such that 1) HTTP_SERVER begins with https: and to change ENABLE_SSL to false. In the current and past versions of ZC to include version 1.5.5 and below, authorize.net AIM is disabled to the customer if ENABLE_SSL was false (not true is the actual test). This commit adds a check that if HTTP_SERVER doesn't begin with https: then if the remaining/existing checks evaluate as true that the payment module would be set to false/be disabled. This continues to support the store front side of offering payment communication securely as offered by current SSL. 

This solution was proposed in the ZC forum: https://www.zen-cart.com/showthread.php?222122-Help!-Authorize-net-(AIM)-has-disappeared-from-checkout!&p=1328484#post1328484