### PR TITLE
Reduce db hits during product-stock checking

### DIFF
--- a/includes/classes/ajax/zcAjaxPayment.php
+++ b/includes/classes/ajax/zcAjaxPayment.php
@@ -120,7 +120,7 @@ class zcAjaxPayment extends base
     $stock_check = array();
     if (STOCK_CHECK=='true') {
       for($i = 0, $n = sizeof ($order->products); $i<$n; $i++) {
-        if ($stock_check[$i] = zen_check_stock ($order->products[$i]['id'], $order->products[$i]['qty'])) {
+        if ($stock_check[$i] = zen_check_stock ($order->products[$i]['id'], $order->products[$i]['qty'], $order->products[$i]['quantity_on_hand'])) {
           $flagAnyOutOfStock = true;
         }
       }

--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -494,6 +494,7 @@ class order extends base {
       $this->products[$index] = array('qty' => $products[$i]['quantity'],
                                       'name' => $products[$i]['name'],
                                       'model' => $products[$i]['model'],
+                                      'quantity_on_hand' => $products[$i]['products_quantity'],
                                       'tax_groups'=>$taxRates,
                                       'tax_description' => zen_get_tax_description($products[$i]['tax_class_id'], $taxCountryId, $taxZoneId),
                                       'price' => $products[$i]['price'],

--- a/includes/classes/shopping_cart.php
+++ b/includes/classes/shopping_cart.php
@@ -1182,7 +1182,7 @@ class shoppingCart extends base {
       $products_query = "select p.products_id, p.master_categories_id, p.products_status, pd.products_name, p.products_model, p.products_image,
                                   p.products_price, p.products_weight, p.products_tax_class_id,
                                   p.products_quantity_order_min, p.products_quantity_order_units, p.products_quantity_order_max,
-                                  p.product_is_free, p.products_priced_by_attribute,
+                                  p.product_is_free, p.products_priced_by_attribute, p.products_quantity,
                                   p.products_discount_type, p.products_discount_type_from, p.products_virtual, p.product_is_always_free_shipping,
                                   p.products_quantity_mixed, p.products_mixed_discount_quantity
                            from " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_DESCRIPTION . " pd
@@ -1342,6 +1342,7 @@ class shoppingCart extends base {
                                   'image' => $products->fields['products_image'],
                                   'price' => ($products->fields['product_is_free'] =='1' ? 0 : $products_price),
         //                                    'quantity' => $this->contents[$products_id]['qty'],
+                                  'quantity_on_hand' => $products->fields['products_quantity'],
                                   'quantity' => $new_qty,
                                   'weight' => $products->fields['products_weight'] + $this->attributes_weight($products_id),
                                   // fix here

--- a/includes/functions/functions_lookups.php
+++ b/includes/functions/functions_lookups.php
@@ -259,8 +259,8 @@ function zen_get_zone_class_title($zone_class_id) {
  * @param int $products_quantity  Quantity to compare against
  * @return string status message
 */
-  function zen_check_stock($products_id, $products_quantity) {
-    $stock_left = zen_get_products_stock($products_id) - $products_quantity;
+  function zen_check_stock($products_id, $products_quantity, $products_quantity_on_hand) {
+    $stock_left = $products_quantity_on_hand - $products_quantity;
 
     return ($stock_left < 0) ? '<span class="markProductOutOfStock">' . STOCK_MARK_PRODUCT_OUT_OF_STOCK . '</span>' : '';
   }

--- a/includes/library/zencart/CheckoutFlow/src/flowSteps/AbstractFlowStep.php
+++ b/includes/library/zencart/CheckoutFlow/src/flowSteps/AbstractFlowStep.php
@@ -87,7 +87,7 @@ abstract class AbstractFlowStep extends \base
         if ((STOCK_CHECK == 'true') && (STOCK_ALLOW_CHECKOUT != 'true')) {
             $products = $this->session->get('cart')->get_products();
             for ($i = 0, $n = sizeof($products); $i < $n; $i++) {
-                if (zen_check_stock($products[$i]['id'], $products[$i]['quantity'])) {
+                if (zen_check_stock($products[$i]['id'], $products[$i]['quantity'], $products[$i]['quantity_on_hand'])) {
                     throw new CheckoutRedirectException(array('redirect' => zen_href_link(FILENAME_SHOPPING_CART)));
                     break;
                 }

--- a/includes/modules/pages/checkout_confirmation/header_php.php
+++ b/includes/modules/pages/checkout_confirmation/header_php.php
@@ -106,7 +106,7 @@ $flagAnyOutOfStock = false;
 $stock_check = array();
 if (STOCK_CHECK == 'true') {
   for ($i=0, $n=sizeof($order->products); $i<$n; $i++) {
-    if ($stock_check[$i] = zen_check_stock($order->products[$i]['id'], $order->products[$i]['qty'])) {
+    if ($stock_check[$i] = zen_check_stock($order->products[$i]['id'], $order->products[$i]['qty'], $order->products[$i]['quantity_on_hand'])) {
       $flagAnyOutOfStock = true;
     }
   }


### PR DESCRIPTION
Closes #1346 

it also seems the `$products_id` would no longer be needed in the `zen_check_stock` function.  although i did leave it there.

in exploring this situation, i also came across times when ZC will automatically adjust the quantity in cart to the amount on hand.  and other times when it would alert the user that the current quantity is too much without giving any additional info about the quantity.  it seems like ZC should automatically adjust in both cases.