### PR TITLE
Sync parameters for setting/testing cookies

### DIFF
--- a/includes/functions/functions_general.php
+++ b/includes/functions/functions_general.php
@@ -867,19 +867,6 @@ function zen_get_minutes_since($timestamp) {
     }
   }
 
-/**
- * Alias to setcookie() but with reasonable defaults
- * @param string $name cookie name
- * @param string $value
- * @param int $expire
- * @param string $path
- * @param string $domain
- * @param int $secure flag
- */
-  function zen_setcookie($name, $value = '', $expire = 0, $path = '/', $domain = '', $secure = 0) {
-    setcookie($name, $value, $expire, $path, $domain, $secure);
-  }
-
   /**
    * Determine visitor's IP address, resolving any proxies where possible.
    *

--- a/includes/init_includes/init_sessions.php
+++ b/includes/init_includes/init_sessions.php
@@ -61,7 +61,7 @@ $_SERVER['REMOTE_ADDR'] = $ipAddress;
  */
 $session_started = false;
 if (SESSION_FORCE_COOKIE_USE == 'True') {
-  zen_setcookie('cookie_test', 'please_accept_for_session', time()+60*60*24*30, '/', (zen_not_null($current_domain) ? $current_domain : ''));
+  setcookie('cookie_test', 'please_accept_for_session', time()+60*60*24*30, $path, (zen_not_null($cookieDomain) ? $domainPrefix . $cookieDomain : ''), $secureFlag);
 
   if (isset($_COOKIE['cookie_test'])) {
     zen_session_start();


### PR DESCRIPTION
When testing to set Force Cookie Use capability, we're not passing all the parameters that are also used by the logic which sets the session cookie. This syncs them to be the same.