### PR TITLE
Refactor to use new request class vars instead of direct $_GET vars

### DIFF
--- a/includes/classes/shopping_cart.php
+++ b/includes/classes/shopping_cart.php
@@ -372,7 +372,7 @@ class shoppingCart extends base {
    * @global object access to the db object
    */
   function update_quantity($products_id, $quantity = '', $attributes = '') {
-    global $db, $messageStack;
+    global $db, $messageStack, $mainPage;
     if ($this->display_debug_messages) $messageStack->add_session('header', 'FUNCTION ' . __FUNCTION__ . ' $products_id: ' . $products_id . ' $quantity: ' . $quantity, 'caution');
 
     if (!is_numeric($quantity) || $quantity < 0) {
@@ -389,7 +389,7 @@ class shoppingCart extends base {
     if (STOCK_ALLOW_CHECKOUT == 'false' && ($quantity > $chk_current_qty)) {
       $quantity = $chk_current_qty;
       if (!$this->flag_duplicate_msgs_set) {
-        $messageStack->add_session('shopping_cart', ($this->display_debug_messages ? '$_GET[main_page]: ' . $_GET['main_page'] . ' FUNCTION ' . __FUNCTION__ . ': ' : '') . WARNING_PRODUCT_QUANTITY_ADJUSTED . zen_get_products_name($products_id), 'caution');
+        $messageStack->add_session('shopping_cart', ($this->display_debug_messages ? '$mainPage: ' . $mainPage . ' FUNCTION ' . __FUNCTION__ . ': ' : '') . WARNING_PRODUCT_QUANTITY_ADJUSTED . zen_get_products_name($products_id), 'caution');
       }
     }
 // eof: adjust new quantity to be same as current in stock
@@ -2170,7 +2170,7 @@ class shoppingCart extends base {
    * @param url parameters
    */
   function actionNotify($goto, $parameters) {
-    global $db;
+    global $db, $mainPage;
     if ($_SESSION['customer_id']) {
       if (isset($_GET['products_id'])) {
         $notify = $_GET['products_id'];
@@ -2179,7 +2179,7 @@ class shoppingCart extends base {
       } elseif (isset($_POST['notify'])) {
         $notify = $_POST['notify'];
       } else {
-        zen_redirect(zen_href_link($_GET['main_page'], zen_get_all_get_params(array('action', 'notify', 'main_page'))));
+        zen_redirect(zen_href_link($mainPage, zen_get_all_get_params(array('action', 'notify', 'main_page'))));
       }
       if (!is_array($notify)) $notify = array($notify);
       for ($i=0, $n=sizeof($notify); $i<$n; $i++) {
@@ -2195,7 +2195,7 @@ class shoppingCart extends base {
           $db->Execute($sql);
         }
       }
-     zen_redirect(zen_href_link($_GET['main_page'], zen_get_all_get_params(array('action', 'notify', 'main_page'))));
+     zen_redirect(zen_href_link($mainPage, zen_get_all_get_params(array('action', 'notify', 'main_page'))));
 
     } else {
       $_SESSION['navigation']->set_snapshot();
@@ -2209,7 +2209,7 @@ class shoppingCart extends base {
    * @param url parameters
    */
   function actionNotifyRemove($goto, $parameters) {
-    global $db;
+    global $db, $mainPage;
     if ($_SESSION['customer_id'] && isset($_GET['products_id'])) {
       $check_query = "select count(*) as count
                         from " . TABLE_PRODUCTS_NOTIFICATIONS . "
@@ -2223,7 +2223,7 @@ class shoppingCart extends base {
                   and customers_id = '" . $_SESSION['customer_id'] . "'";
         $db->Execute($sql);
       }
-      zen_redirect(zen_href_link($_GET['main_page'], zen_get_all_get_params(array('action', 'main_page'))));
+      zen_redirect(zen_href_link($mainPage, zen_get_all_get_params(array('action', 'main_page'))));
     } else {
       $_SESSION['navigation']->set_snapshot();
       zen_redirect(zen_href_link(FILENAME_LOGIN, '', 'SSL'));

--- a/includes/classes/split_page_results.php
+++ b/includes/classes/split_page_results.php
@@ -3,7 +3,7 @@
  * split_page_results Class.
  *
  * @package classes
- * @copyright Copyright 2003-2016 Zen Cart Development Team
+ * @copyright Copyright 2003-2017 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: Author: DrByte  Sat Jan 9 13:13:41 2016 -0500 Modified in v1.5.5 $
@@ -97,7 +97,7 @@ class splitPageResults extends base {
 
   // display split-page-number-links
   function display_links($max_page_links, $parameters = '', $outputAsUnorderedList = false) {
-    global $request_type;
+    global $request_type, $mainPage;
     if ($max_page_links == '') $max_page_links = 1;
 
     if ($this->number_of_pages == 1) return;
@@ -110,7 +110,7 @@ class splitPageResults extends base {
     if (zen_not_null($parameters) && (substr($parameters, -1) != '&')) $parameters .= '&';
 
     // previous button - not displayed on first page
-    $link = '<a href="' . zen_href_link($_GET['main_page'], $parameters . $this->page_name . '=' . ($this->current_page_number - 1), $request_type) . '" title=" ' . PREVNEXT_TITLE_PREVIOUS_PAGE . ' ">' . PREVNEXT_BUTTON_PREV . '</a>';
+    $link = '<a href="' . zen_href_link($mainPage, $parameters . $this->page_name . '=' . ($this->current_page_number - 1), $request_type) . '" title=" ' . PREVNEXT_TITLE_PREVIOUS_PAGE . ' ">' . PREVNEXT_BUTTON_PREV . '</a>';
     if ($this->current_page_number > 1) {
       $display_links_string .= $link . '&nbsp;&nbsp;';
       $ul_elements .= '  <li class="pagination-previous" aria-label="Previous page">' . $link . '</li>' . "\n";
@@ -127,7 +127,7 @@ class splitPageResults extends base {
     if ($this->number_of_pages % $max_page_links) $max_window_num++;
 
     // previous group of pages
-    $link = '<a href="' . zen_href_link($_GET['main_page'], $parameters . $this->page_name . '=' . (($cur_window_num - 1) * $max_page_links), $request_type) . '" title=" ' . sprintf(PREVNEXT_TITLE_PREV_SET_OF_NO_PAGE, $max_page_links) . ' ">...</a>';
+    $link = '<a href="' . zen_href_link($mainPage, $parameters . $this->page_name . '=' . (($cur_window_num - 1) * $max_page_links), $request_type) . '" title=" ' . sprintf(PREVNEXT_TITLE_PREV_SET_OF_NO_PAGE, $max_page_links) . ' ">...</a>';
     if ($cur_window_num > 1) {
       $display_links_string .= $link;
       $ul_elements .= '  <li class="ellipsis">' . $link . '</li>' . "\n";
@@ -142,7 +142,7 @@ class splitPageResults extends base {
         $ul_elements .= '  <li class="current active">' . $jump_to_page . '</li>' . "\n";
         $counter_actual_page_links++;
       } else {
-        $link = '<a href="' . zen_href_link($_GET['main_page'], $parameters . $this->page_name . '=' . $jump_to_page, $request_type) . '" title=" ' . sprintf(PREVNEXT_TITLE_PAGE_NO, $jump_to_page) . ' ">' . $jump_to_page . '</a>';
+        $link = '<a href="' . zen_href_link($mainPage, $parameters . $this->page_name . '=' . $jump_to_page, $request_type) . '" title=" ' . sprintf(PREVNEXT_TITLE_PAGE_NO, $jump_to_page) . ' ">' . $jump_to_page . '</a>';
         $display_links_string .= '&nbsp;' . $link . '&nbsp;';
         $ul_elements .= '  <li>' . $link . '</li>' . "\n";
         $counter_actual_page_links++;
@@ -151,7 +151,7 @@ class splitPageResults extends base {
 
     // next group of pages
     if ($cur_window_num < $max_window_num) {
-      $link = '<a href="' . zen_href_link($_GET['main_page'], $parameters . $this->page_name . '=' . (($cur_window_num) * $max_page_links + 1), $request_type) . '" title=" ' . sprintf(PREVNEXT_TITLE_NEXT_SET_OF_NO_PAGE, $max_page_links) . ' ">...</a>';
+      $link = '<a href="' . zen_href_link($mainPage, $parameters . $this->page_name . '=' . (($cur_window_num) * $max_page_links + 1), $request_type) . '" title=" ' . sprintf(PREVNEXT_TITLE_NEXT_SET_OF_NO_PAGE, $max_page_links) . ' ">...</a>';
       $display_links_string .= $link . '&nbsp;';
       $ul_elements .= '  <li class="ellipsis">' . $link . '</li>' . "\n";
     } else {
@@ -160,7 +160,7 @@ class splitPageResults extends base {
 
     // next button
     if (($this->current_page_number < $this->number_of_pages) && ($this->number_of_pages != 1)) {
-      $link = '<a href="' . zen_href_link($_GET['main_page'], $parameters . 'page=' . ($this->current_page_number + 1), $request_type) . '" title=" ' . PREVNEXT_TITLE_NEXT_PAGE . ' ">' . PREVNEXT_BUTTON_NEXT . '</a>';
+      $link = '<a href="' . zen_href_link($mainPage, $parameters . 'page=' . ($this->current_page_number + 1), $request_type) . '" title=" ' . PREVNEXT_TITLE_NEXT_PAGE . ' ">' . PREVNEXT_BUTTON_NEXT . '</a>';
       $display_links_string .= '&nbsp;' . $link . '&nbsp;';
       $ul_elements .= '  <li class="pagination-next" aria-label="Next page">' . $link . '</li>' . "\n";
     } else {

--- a/includes/functions/functions_general.php
+++ b/includes/functions/functions_general.php
@@ -4,7 +4,7 @@
  * General functions used throughout Zen Cart
  *
  * @package functions
- * @copyright Copyright 2003-2016 Zen Cart Development Team
+ * @copyright Copyright 2003-2017 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: Author: zcwilt  Fri Apr 22 22:16:43 2015 +0000 Modified in v1.5.5 $
@@ -647,11 +647,12 @@ function zen_get_minutes_since($timestamp) {
  * @return string
  */
   function zen_create_sort_heading($sortby, $colnum, $heading) {
+    global $mainPage;
     $sort_prefix = '';
     $sort_suffix = '';
 
     if ($sortby) {
-      $sort_prefix = '<a href="' . zen_href_link($_GET['main_page'], zen_get_all_get_params(array('page', 'info', 'sort')) . 'page=1&sort=' . $colnum . ($sortby == $colnum . 'a' ? 'd' : 'a')) . '" title="' . zen_output_string(TEXT_SORT_PRODUCTS . ($sortby == $colnum . 'd' || substr($sortby, 0, 1) != $colnum ? TEXT_ASCENDINGLY : TEXT_DESCENDINGLY) . TEXT_BY . $heading) . '" class="productListing-heading">' ;
+      $sort_prefix = '<a href="' . zen_href_link($mainPage, zen_get_all_get_params(array('page', 'info', 'sort')) . 'page=1&sort=' . $colnum . ($sortby == $colnum . 'a' ? 'd' : 'a')) . '" title="' . zen_output_string(TEXT_SORT_PRODUCTS . ($sortby == $colnum . 'd' || substr($sortby, 0, 1) != $colnum ? TEXT_ASCENDINGLY : TEXT_DESCENDINGLY) . TEXT_BY . $heading) . '" class="productListing-heading">' ;
       $sort_suffix = (substr($sortby, 0, 1) == $colnum ? (substr($sortby, 1, 1) == 'a' ? PRODUCT_LIST_SORT_ORDER_ASCENDING : PRODUCT_LIST_SORT_ORDER_DESCENDING) : '') . '</a>';
     }
 

--- a/includes/templates/template_default/common/main_template_vars.php
+++ b/includes/templates/template_default/common/main_template_vars.php
@@ -29,14 +29,14 @@
  * }<br />
  *
  * @package templateSystem
- * @copyright Copyright 2003-2016 Zen Cart Development Team
+ * @copyright Copyright 2003-2017 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: main_template_vars.php 2620 2005-12-20 00:52:57Z drbyte $
  */
   // Notifier hook to allow for dynamic changes to template operation
   $zco_notifier->notify('NOTIFY_MAIN_TEMPLATE_VARS_START', $template_dir);
 
-  $body_id = ($this_is_home_page) ? 'indexHome' : base::camelize($_GET['main_page']) . 'Body';
+  $body_id = ($this_is_home_page) ? 'indexHome' : base::camelize($mainPage) . 'Body';
   $bodyClasses = (isset($bodyClasses)) ? trim($bodyClasses) : FALSE; // just in case someone has left junk in it from an observer class, or has done something to prevent it from being set
 
   $homepage_link = zen_href_link(FILENAME_DEFAULT . '.php', '', $request_type, TRUE, TRUE, TRUE);
@@ -94,7 +94,7 @@
   if (file_exists(DIR_WS_MODULES . 'pages/' . $current_page_base . '/main_template_vars.php')) {
     $body_code = DIR_WS_MODULES . 'pages/' . $current_page_base . '/main_template_vars.php';
   } else {
-    $body_code = $template->get_template_dir('tpl_' . preg_replace('/.php/', '',$_GET['main_page']) . '_default.php',DIR_WS_TEMPLATE, $current_page_base,'templates'). '/tpl_' . $_GET['main_page'] . '_default.php';
+    $body_code = $template->get_template_dir('tpl_' . preg_replace('/.php/', '',$mainPage) . '_default.php',DIR_WS_TEMPLATE, $current_page_base,'templates'). '/tpl_' . $mainPage . '_default.php';
   }
 
   $zco_notifier->notify('NOTIFY_MAIN_TEMPLATE_VARS_END', $template_dir, $body_code);

--- a/includes/templates/template_default/listingboxes/tpl_listingbox_productliststd.php
+++ b/includes/templates/template_default/listingboxes/tpl_listingbox_productliststd.php
@@ -3,7 +3,7 @@
  * Module Template
  *
  * @package templateSystem
- * @copyright Copyright 2003-2015 Zen Cart Development Team
+ * @copyright Copyright 2003-2017 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id:  $
@@ -15,7 +15,7 @@
   <h2 class="centerBoxHeading"><?php echo $tplVars['listingBox']['title']; ?></h2>
 <?php
     if (isset($tplVars['listingBox']['showMultiForm']) && $tplVars['listingBox']['showMultiForm']) {
-      echo zen_draw_form('multiple_products_cart_quantity', zen_href_link($_GET['main_page'], zen_get_all_get_params(array('action')) . 'action=multiple_products_add_product'), 'post', 'enctype="multipart/form-data"');
+      echo zen_draw_form('multiple_products_cart_quantity', zen_href_link($mainPage, zen_get_all_get_params(array('action')) . 'action=multiple_products_add_product'), 'post', 'enctype="multipart/form-data"');
     }
 ?>
 <?php if (isset($tplVars['listingBox']['paginator']) && $tplVars['listingBox']['paginator']['show'] && $tplVars['listingBox']['paginator']['showTop']) { ?>

--- a/includes/templates/template_default/listingboxes/tpl_listingbox_tabular.php
+++ b/includes/templates/template_default/listingboxes/tpl_listingbox_tabular.php
@@ -3,7 +3,7 @@
  * Module Template
  *
  * @package templateSystem
- * @copyright Copyright 2003-2015 Zen Cart Development Team
+ * @copyright Copyright 2003-2017 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id:  $
@@ -14,7 +14,7 @@
 <h2 class="centerBoxHeading"><?php echo $tplVars['listingBox']['title']; ?></h2>
 <?php
     if (isset($tplVars['listingBox']['showMultiForm']) && $tplVars['listingBox']['showMultiForm']) {
-      echo zen_draw_form('multiple_products_cart_quantity', zen_href_link($_GET['main_page'], zen_get_all_get_params(array('action')) . 'action=multiple_products_add_product'), 'post', 'enctype="multipart/form-data"');
+      echo zen_draw_form('multiple_products_cart_quantity', zen_href_link($mainPage, zen_get_all_get_params(array('action')) . 'action=multiple_products_add_product'), 'post', 'enctype="multipart/form-data"');
     }
 ?>
 <?php if (isset($tplVars['listingBox']['paginator']) && $tplVars['listingBox']['paginator']['show'] && $tplVars['listingBox']['paginator']['showTop']) { ?>

--- a/includes/templates/template_default/sideboxes/tpl_no_notifications.php
+++ b/includes/templates/template_default/sideboxes/tpl_no_notifications.php
@@ -3,13 +3,12 @@
  * Side Box Template
  *
  * @package templateSystem
- * @copyright Copyright 2003-2005 Zen Cart Development Team
+ * @copyright Copyright 2003-2017 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: tpl_no_notifications.php 2982 2006-02-07 07:56:41Z birdbrain $
  */
   $content = "";
   $content .= '<div id="' . str_replace('_', '-', $box_id . 'Content') . '" class="sideBoxContent centeredContent">';
-  $content .= '<a href="' . zen_href_link($_GET['main_page'], zen_get_all_get_params(array('action')) . 'action=notify', $request_type) . '">' . zen_image(DIR_WS_TEMPLATE_IMAGES . OTHER_IMAGE_BOX_NOTIFY_YES, OTHER_BOX_NOTIFY_YES_ALT) . '<br />' . sprintf(BOX_NOTIFICATIONS_NOTIFY, zen_get_products_name($_GET['products_id'])) .'</a>';
+  $content .= '<a href="' . zen_href_link($mainPage, zen_get_all_get_params(array('action')) . 'action=notify', $request_type) . '">' . zen_image(DIR_WS_TEMPLATE_IMAGES . OTHER_IMAGE_BOX_NOTIFY_YES, OTHER_BOX_NOTIFY_YES_ALT) . '<br />' . sprintf(BOX_NOTIFICATIONS_NOTIFY, zen_get_products_name($_GET['products_id'])) .'</a>';
   $content .= '</div>';
-?>

--- a/includes/templates/template_default/sideboxes/tpl_yes_notifications.php
+++ b/includes/templates/template_default/sideboxes/tpl_yes_notifications.php
@@ -3,13 +3,12 @@
  * Side Box Template
  *
  * @package templateSystem
- * @copyright Copyright 2003-2005 Zen Cart Development Team
+ * @copyright Copyright 2003-2017 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: tpl_yes_notifications.php 2982 2006-02-07 07:56:41Z birdbrain $
  */
   $content = "";
   $content .= '<div id="' . str_replace('_', '-', $box_id . 'Content') . '" class="sideBoxContent centeredContent">';
-  $content .= '<a href="' . zen_href_link($_GET['main_page'], zen_get_all_get_params(array('action')) . 'action=notify_remove', $request_type) . '">' . zen_image(DIR_WS_TEMPLATE_IMAGES . OTHER_IMAGE_BOX_NOTIFY_REMOVE, OTHER_BOX_NOTIFY_REMOVE_ALT) . '<br />' . sprintf(BOX_NOTIFICATIONS_NOTIFY_REMOVE, zen_get_products_name($_GET['products_id'])) .'</a>';
+  $content .= '<a href="' . zen_href_link($mainPage, zen_get_all_get_params(array('action')) . 'action=notify_remove', $request_type) . '">' . zen_image(DIR_WS_TEMPLATE_IMAGES . OTHER_IMAGE_BOX_NOTIFY_REMOVE, OTHER_BOX_NOTIFY_REMOVE_ALT) . '<br />' . sprintf(BOX_NOTIFICATIONS_NOTIFY_REMOVE, zen_get_products_name($_GET['products_id'])) .'</a>';
   $content .= '</div>';
-?>

--- a/includes/templates/template_default/templates/tpl_modules_listing_display_order.php
+++ b/includes/templates/template_default/templates/tpl_modules_listing_display_order.php
@@ -3,7 +3,7 @@
  * Module Template
  *
  * @package templateSystem
- * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @copyright Copyright 2003-2017 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id:  $
@@ -16,8 +16,8 @@
 <div id="sorter">
 <label for="disp-order-sorter"><?php echo TEXT_INFO_SORT_BY; ?></label>
 <?php
-  echo zen_draw_form('sorter_form', zen_href_link($_GET['main_page']), 'get');
-  echo zen_draw_hidden_field('main_page', $_GET['main_page']);
+  echo zen_draw_form('sorter_form', zen_href_link($mainPage), 'get');
+  echo zen_draw_hidden_field('main_page', $mainPage);
 //  echo zen_draw_hidden_field('disp_order', $_GET['disp_order']);
   echo zen_hide_session_id();
 ?>
@@ -32,4 +32,6 @@
     <option value="5" <?php echo ($tplVars['listingBox']['filter']['displayOrder'] == '5' ? 'selected="selected"' : ''); ?>><?php echo TEXT_INFO_SORT_BY_PRODUCTS_MODEL; ?></option>
     <option value="6" <?php echo ($tplVars['listingBox']['filter']['displayOrder'] == '6' ? 'selected="selected"' : ''); ?>><?php echo TEXT_INFO_SORT_BY_PRODUCTS_DATE_DESC; ?></option>
     <option value="7" <?php echo ($tplVars['listingBox']['filter']['displayOrder'] == '7' ? 'selected="selected"' : ''); ?>><?php echo TEXT_INFO_SORT_BY_PRODUCTS_DATE; ?></option>
-    </select></form></div>
+    </select>
+  </form>
+</div>

--- a/includes/templates/template_default/templates/tpl_product_reviews_default.php
+++ b/includes/templates/template_default/templates/tpl_product_reviews_default.php
@@ -3,7 +3,7 @@
  * Page Template
  *
  * @package templateSystem
- * @copyright Copyright 2003-2015 Zen Cart Development Team
+ * @copyright Copyright 2003-2017 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: Modified in v1.6.0 $
@@ -28,7 +28,7 @@
           //   $link = '<p>' . '<a href="' . zen_href_link(zen_get_info_page($review->fields['products_id']), 'products_id=' . $review->fields['products_id'] ) . '">' . MORE_INFO_TEXT . '</a>' . '</p>';
           $link = '';
         } else {
-          $link= '<a href="' . zen_href_link($_GET['main_page'], zen_get_all_get_params(array('action', 'reviews_id')) . 'action=buy_now') . '">' . zen_image_button(BUTTON_IMAGE_IN_CART, BUTTON_IN_CART_ALT) . '</a>';
+          $link= '<a href="' . zen_href_link($mainPage, zen_get_all_get_params(array('action', 'reviews_id')) . 'action=buy_now') . '">' . zen_image_button(BUTTON_IMAGE_IN_CART, BUTTON_IN_CART_ALT) . '</a>';
         }
         $the_button = $link;
         $products_link = '';

--- a/includes/templates/template_default/templates/tpl_product_reviews_info_default.php
+++ b/includes/templates/template_default/templates/tpl_product_reviews_info_default.php
@@ -3,7 +3,7 @@
  * Page Template
  *
  * @package templateSystem
- * @copyright Copyright 2003-2015 Zen Cart Development Team
+ * @copyright Copyright 2003-2017 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: tpl_product_reviews_info_default.php 2993 2006-02-08 07:14:52Z birdbrain  Modified in v1.6.0 $
@@ -29,7 +29,7 @@
           //   $link = '<p>' . '<a href="' . zen_href_link(zen_get_info_page($review_info->fields['products_id']), 'products_id=' . $review_info->fields['products_id'] ) . '">' . MORE_INFO_TEXT . '</a>' . '</p>';
           $link = '';
         } else {
-          $link= '<a href="' . zen_href_link($_GET['main_page'], zen_get_all_get_params(array('action', 'reviews_id')) . 'action=buy_now') . '">' . zen_image_button(BUTTON_IMAGE_IN_CART, BUTTON_IN_CART_ALT) . '</a>';
+          $link= '<a href="' . zen_href_link($mainPage, zen_get_all_get_params(array('action', 'reviews_id')) . 'action=buy_now') . '">' . zen_image_button(BUTTON_IMAGE_IN_CART, BUTTON_IN_CART_ALT) . '</a>';
         }
 
         $the_button = $link;


### PR DESCRIPTION
Most use of $_GET should be accessed via zcRequest ... or use other vars already sanitized by the Request class or other filters.