### PR TITLE
Assign default language in an odd/rare situation.

### DIFF
--- a/includes/init_includes/init_languages.php
+++ b/includes/init_includes/init_languages.php
@@ -20,6 +20,7 @@ if (!isset($_SESSION['language']) || isset($_GET['language'])) {
   } else {
     if (LANGUAGE_DEFAULT_SELECTOR=='Browser') {
       $lng->get_browser_language();
+      if (!zen_not_null($lng->language['id'])) $lng->set_language(DEFAULT_LANGUAGE);
     } else {
       $lng->set_language(DEFAULT_LANGUAGE);
     }


### PR DESCRIPTION
Addresses an odd and rare situation that could maybe exist.
Basically, if the language selection is set to the browser, the browser
returns a language that is not installed, and if the store no longer has
a language assigned to a language['id'] of 1 (as could be seen if
installed a new language and then removed the base language).

Other than a specific/direct database edit that could cause an issue such
as a default no longer being defined or to disrupt the language table
assignment of an appropriate language_id to the default language, then this
should ensure that the language['id'] would be set if the browser does not
come back with a favorable result.