### PR TITLE
Add .gitignore/.htaccess to admin backups dir

### DIFF
--- a/admin/backups/.gitignore
+++ b/admin/backups/.gitignore
@@ -1,0 +1,4 @@
+*
+!.htaccess
+!index.php
+!.gitignore

--- a/admin/backups/.htaccess
+++ b/admin/backups/.htaccess
@@ -1,0 +1,43 @@
+#
+# @copyright Copyright 2003-2016 Zen Cart Development Team
+# @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+# @version $Id: .htaccess  Modified in v1.6.0 $
+#
+# This is used with Apache WebServers
+#
+# The following blocks direct HTTP requests to all filetypes in this directory recursively, except certain approved exceptions
+# It also prevents the ability of any scripts to run. No type of script, be it PHP, PERL or whatever, can normally be executed if ExecCGI is disabled.
+# Will also prevent people from seeing what is in the dir. and any sub-directories
+#
+# For this to work, you must include either 'All' or at least: 'Limit' and 'Indexes' parameters to the AllowOverride configuration in your apache/conf/httpd.conf file.
+# Example:
+#<Directory "/usr/local/apache/htdocs">
+#  AllowOverride Limit Indexes
+#</Directory>
+###############################
+
+<Limit GET POST PUT>
+  <IfModule mod_authz_core.c>
+    Require all denied
+  </IfModule>
+  <IfModule !mod_authz_core.c>
+    Order Allow,Deny
+    Deny from all
+  </IfModule>
+</Limit>
+
+#NOBODY SHOULD BE SNOOPING HERE
+
+# deny *everything*
+<FilesMatch ".*">
+  <IfModule mod_authz_core.c>
+    Require all denied
+  </IfModule>
+  <IfModule !mod_authz_core.c>
+    Order Allow,Deny
+    Deny from all
+  </IfModule>
+</FilesMatch>
+
+IndexIgnore */*
+


### PR DESCRIPTION
Add .gitignore/.htaccess to admin backups dir
This helps keep db backups out of version-control, and specifically denies unauthorized downloads.