### PR TITLE
Reduce db queries for prices

### DIFF
--- a/includes/functions/functions_prices.php
+++ b/includes/functions/functions_prices.php
@@ -199,8 +199,12 @@
 
     $show_display_price = $show_sale_discount = '';
     $priceinfo['normal']  = $display_normal_price  = zen_get_products_base_price($products_id);
-    $priceinfo['special'] = $display_special_price = zen_get_products_special_price($products_id, true);
     $priceinfo['sale']    = $display_sale_price    = zen_get_products_special_price($products_id, false);
+    if ($priceinfo['sale'] !== false) {
+      $priceinfo['special'] = $display_special_price = zen_get_products_special_price($products_id, true);
+    } else {
+      $priceinfo['special'] = $display_special_price = false;
+    }
 
     if (SHOW_SALE_DISCOUNT_STATUS == '1' and ($display_special_price != 0 or $display_sale_price != 0)) {
       if ($display_sale_price) {
@@ -508,8 +512,12 @@
     }
 
     $new_products_price = zen_get_products_base_price($product_id);
-    $new_special_price = zen_get_products_special_price($product_id, true);
     $new_sale_price = zen_get_products_special_price($product_id, false);
+    if ($new_sale_price !== false) {
+      $new_special_price = zen_get_products_special_price($product_id, true);
+    } else {
+      $new_special_price = false;
+    }
 
     $discount_type_id = zen_get_products_sale_discount_type($product_id);
 
@@ -942,8 +950,12 @@ If a special exist * 10
 
     $show_display_price = '';
     $display_normal_price = zen_get_products_base_price($products_id);
-    $display_special_price = zen_get_products_special_price($products_id, true);
     $display_sale_price = zen_get_products_special_price($products_id, false);
+    if ($display_sale_price !== false) {
+      $display_special_price = zen_get_products_special_price($products_id, true);
+    } else {
+      $display_special_price = false;
+    }
 
     $products_actual_price = $display_normal_price;
 


### PR DESCRIPTION
In several of the price functions, both the special and sales price is sought.
Both are obtained through the same function `zen_get_products_special_price` with a switch to either return only the specials price (true) or to return the overall special price (false) (sale price if present otherwise special price if a special, and false if neither)
If a product is not on special and does not have a sale then the returning result is `false` and therefore there is no further determination of the special necessary (ie. no further database query needed). If the result is anything other than `false`, then there may be a special and the value of that special (if present) remains to be determined.

While there remain other means of gaining efficiency in this process (such as returning all data collected from a one time database search/review), this at least reduces the redundancy of querying the database for results of the first `zen_get_products_special_price` call.  Though perhaps caching also helps in this overall concept, but the recommended modification mitigates the need to use the cache.