### PR TITLE
fixes #1483 search results

### DIFF
--- a/includes/library/zencart/ListingQueryAndOutput/src/filters/SearchResults.php
+++ b/includes/library/zencart/ListingQueryAndOutput/src/filters/SearchResults.php
@@ -67,7 +67,7 @@ class SearchResults extends AbstractFilter implements FilterInterface
             'fkeyFieldLeft' => 'tax_zone_id',
             'fkeyFieldRight' => 'geo_zone_id',
             'fkeyTable' => 'TABLE_TAX_RATES',
-            'customAnd' => 'AND (gz.zone_country_id IS null OR gz.zone_country_id = 0 OR gz.zone_country_id = :zoneCountryId:) AND (gz.zone_id IS null OR gz.zone_id = 0 OR gz.zone_id = :zoneId:)',
+            'customAnd' => 'AND (zone_country_id IS null OR zone_country_id = 0 OR zone_country_id = :zoneCountryId:) AND (zone_id IS null OR zone_id = 0 OR zone_id = :zoneId:)',
             'addColumns' => FALSE
         );
 
@@ -205,7 +205,7 @@ class SearchResults extends AbstractFilter implements FilterInterface
             );
         } else {
             $this->listingQuery ['whereClauses'] [] = array(
-                'custom' => "(pd.products_name LIKE '%:keywords" . $ptr . ":%' OR p.products_model LIKE '%:keywords" . $ptr . ":%' OR m.manufacturers_name LIKE '%:keywords" . $ptr . ":%'"
+                'custom' => "(products_name LIKE '%:keywords" . $ptr . ":%' OR products_model LIKE '%:keywords" . $ptr . ":%' OR manufacturers_name LIKE '%:keywords" . $ptr . ":%'"
             );
             $this->listingQuery['bindVars'] [] = array(
                 ':keywords' . $ptr . ':',
@@ -213,14 +213,14 @@ class SearchResults extends AbstractFilter implements FilterInterface
                 'noquotestring'
             );
             $this->listingQuery['whereClauses'] [] = array(
-                'custom' => " OR (mtpd.metatags_keywords LIKE '%:keywords" . $ptr . ":%' AND mtpd.metatags_keywords !='')"
+                'custom' => " OR (metatags_keywords LIKE '%:keywords" . $ptr . ":%' AND metatags_keywords !='')"
             );
             $this->listingQuery ['whereClauses'] [] = array(
-                'custom' => " OR (mtpd.metatags_description LIKE '%:keywords" . $ptr . ":%' AND mtpd.metatags_description !='')"
+                'custom' => " OR (metatags_description LIKE '%:keywords" . $ptr . ":%' AND metatags_description !='')"
             );
             if ($searchDescription == '1') {
                 $this->listingQuery['whereClauses'] [] = array(
-                    'custom' => " OR pd.products_description LIKE '%:keywords" . $ptr . ":%'"
+                    'custom' => " OR products_description LIKE '%:keywords" . $ptr . ":%'"
                 );
             }
             $this->listingQuery['whereClauses'] [] = array(
@@ -298,13 +298,13 @@ class SearchResults extends AbstractFilter implements FilterInterface
 
         $map = [];
         $map[] = array(DISPLAY_PRICE_WITH_TAX == 'true', $priceFrom, ':priceFrom:',
-                     " AND (p.products_price_sorter * IF(gz.geo_zone_id IS null, 1, 1 + (tr.tax_rate / 100)) >= :priceFrom:)");
+                     " AND (products_price_sorter * IF(geo_zone_id IS null, 1, 1 + (tax_rate / 100)) >= :priceFrom:)");
         $map[] = array(DISPLAY_PRICE_WITH_TAX == 'true', $priceTo, ':priceTo:',
-                       " AND (p.products_price_sorter * IF(gz.geo_zone_id IS null, 1, 1 + (tr.tax_rate / 100)) >= :priceFrom:)");
+                       " AND (products_price_sorter * IF(geo_zone_id IS null, 1, 1 + (tax_rate / 100)) >= :priceFrom:)");
         $map[] = array(DISPLAY_PRICE_WITH_TAX == 'false', $priceFrom, ':priceFrom:',
-                       " AND (p.products_price_sorter >= :priceFrom:)");
+                       " AND (products_price_sorter >= :priceFrom:)");
         $map[] = array(DISPLAY_PRICE_WITH_TAX == 'false', $priceTo, ':priceTo:',
-                       "  AND (p.products_price_sorter <= :priceTo:)");
+                       "  AND (products_price_sorter <= :priceTo:)");
 
         $this->handleTaxWhereClausesMap($map);
 
@@ -313,7 +313,7 @@ class SearchResults extends AbstractFilter implements FilterInterface
         }
         if (((zen_not_null($priceFrom))) || (zen_not_null($priceTo))) {
             $this->listingQuery ['whereClauses'] [] = array(
-                'custom' => "   GROUP BY p.products_id, tr.tax_priority"
+                'custom' => "   GROUP BY products_id, tax_priority"
             );
         }
     }


### PR DESCRIPTION
i'm throwing caution to the wind...

it does not seem like we need field prefixes on db tables here, and in fact they are the cause of the search result errors in v160.  hard coding them here seems to be a problem.

if for some reason we want to keep these hardcoded table prefixes, then it seems that we would need to add them to:

includes/database_tables.php 

although i have not tested that.


