### PR TITLE
Correct array operation when calling zen_option_name_base_expects_no_…

### DIFF
--- a/includes/functions/functions_lookups.php
+++ b/includes/functions/functions_lookups.php
@@ -256,7 +256,7 @@
         $sql2 = $db->bindVars($sql2, ':option_id:', $option_id, 'integer');
       }
       $sql2 = rtrim($sql2, ','); // Need to remove the final comma off of the above.
-      $sql2 = ')';
+      $sql2 .= ')';
     } else {
       $sql2 = ' = :option_id:';
       $sql2 = $db->bindVars($sql2, ':option_id:', $option_name_id[0], 'integer');


### PR DESCRIPTION
…values

The way the code ended up being written was that if an array is presented
to the function then the code would error because the last internal
line of code would set the $sql2 to just a right parentheses instead
of adding a parenthesis at the end of the string.