### PR TITLE
Improve handling of zero quantity added to cart

### DIFF
--- a/includes/classes/shopping_cart.php
+++ b/includes/classes/shopping_cart.php
@@ -1858,10 +1858,16 @@ class shoppingCart extends base {
           }
         }
       }
-      if (!is_numeric($_POST['cart_quantity']) || $_POST['cart_quantity'] < 0) {
+      if (!is_numeric($_POST['cart_quantity']) || $_POST['cart_quantity'] <= 0) {
         // adjust quantity when not a value
-        $chk_link = '<a href="' . zen_href_link(zen_get_info_page($_POST['products_id']), 'cPath=' . (zen_get_generated_category_path_rev(zen_get_products_category_id($_POST['products_id']))) . '&products_id=' . $_POST['products_id']) . '">' . zen_get_products_name($_POST['products_id']) . '</a>';
-        $messageStack->add_session('header', ERROR_CORRECTIONS_HEADING . ERROR_PRODUCT_QUANTITY_UNITS_SHOPPING_CART . $chk_link . ' ' . PRODUCTS_ORDER_QTY_TEXT . zen_output_string_protected($_POST['cart_quantity']), 'caution');
+        // If use an extra_cart_actions file to prevent processing by this function,
+        //   then be sure to set $_POST['shopping_cart_zero_or_less'] to a value other than true
+        //   to display success on add to cart and not display the below message.
+        if (!isset($_POST['shopping_cart_zero_or_less'])) {
+          $chk_link = '<a href="' . zen_href_link(zen_get_info_page($_POST['products_id']), 'cPath=' . (zen_get_generated_category_path_rev(zen_get_products_category_id($_POST['products_id']))) . '&products_id=' . $_POST['products_id']) . '">' . zen_get_products_name($_POST['products_id']) . '</a>';
+          $messageStack->add_session('header', ERROR_CORRECTIONS_HEADING . ERROR_PRODUCT_QUANTITY_UNITS_SHOPPING_CART . $chk_link . ' ' . PRODUCTS_ORDER_QTY_TEXT . zen_output_string_protected($_POST['cart_quantity']), 'caution');
+          $_POST['shopping_cart_zero_or_less'] = true;
+        }
         $_POST['cart_quantity'] = 0;
       }
       // verify qty to add
@@ -1966,7 +1972,9 @@ class shoppingCart extends base {
       // no errors
 // display message if all is good and not on shopping_cart page
       if (DISPLAY_CART == 'false' && $_GET['main_page'] != FILENAME_SHOPPING_CART && $messageStack->size('shopping_cart') == 0) {
-        $messageStack->add_session('header', ($this->display_debug_messages ? 'FUNCTION ' . __FUNCTION__ . ': ' : '') . SUCCESS_ADDED_TO_CART_PRODUCT, 'success');
+        if (!isset($_POST['shopping_cart_zero_or_less']) || $_POST['shopping_cart_zero_or_less'] !== true) {
+          $messageStack->add_session('header', ($this->display_debug_messages ? 'FUNCTION ' . __FUNCTION__ . ': ' : '') . SUCCESS_ADDED_TO_CART_PRODUCT, 'success');
+        }
         zen_redirect(zen_href_link($goto, zen_get_all_get_params($parameters)));
       } else {
         zen_redirect(zen_href_link(FILENAME_SHOPPING_CART));


### PR DESCRIPTION
Fixes #1364.

Adds a message for a zero (or empty) quantity being added to the cart which is most important for a store that does not display the shopping cart after adding product to the cart because the `actionAddProduct` function will display success for such a condition.  This also added a check of the `$_POST` array for existence of a key `shopping_cart_zero_or_less` such that if the key exists and is not set to `true`, then the success message will still be displayed.
- If the store is set to show the shopping cart after adding a product:
  - If the `$_POST['cart_quantity']` entered is non-numeric or is less than or equal to zero and `$_POST['shopping_cart_zero_or_less']` is not set, then a message is displayed about an error about adding the product.
  - If the `$_POST['cart_quantity']` entered is non-numeric or is less than or equal to zero and `$_POST['shopping_cart_zero_or_less']` is set to anything then no message is displayed.

- If the store is set to **NOT** show the shopping cart after adding a product:
  - If the `$_POST['cart_quantity']` entered is non-numeric or is less than or equal to zero and `$_POST['shopping_cart_zero_or_less']` does not exist, then a message is displayed about an error adding the product to the cart and also the success message is **not** displayed.  
  - If the `$_POST['cart_quantity']` entered is non-numeric or less than or equal to zero and `$_POST['shopping_cart_zero_or_less']` is set to something other than true, then the success message is displayed.
  - If the `$_POST['cart_quantity']` entered is non-numeric or less than or equal to zero and `$_POST['shopping_cart_zero_or_less']` is set to true, then no message is displayed about either condition.