### PR TITLE
removing obsolete menuBox function

### DIFF
--- a/admin/includes/classes/box.php
+++ b/admin/includes/classes/box.php
@@ -41,20 +41,4 @@ if (!defined('IS_ADMIN_FLAG')) {
 
       return $this->heading . $this->contents;
     }
-
-    function menuBox($heading, $contents) {
-      $this->table_data_parameters = 'class="menuBoxHeading"';
-      if (isset($heading[0]['link'])) {
-        $this->table_data_parameters .= ' onmouseover="this.style.cursor=\'hand\'" onclick="document.location.href=\'' . $heading[0]['link'] . '\'"';
-        $heading[0]['text'] = '&nbsp;<a href="' . $heading[0]['link'] . '" class="menuBoxHeadingLink">' . $heading[0]['text'] . '</a>&nbsp;';
-      } else {
-        $heading[0]['text'] = '&nbsp;' . $heading[0]['text'] . '&nbsp;';
-      }
-      $this->heading = $this->tableBlock($heading);
-
-      $this->table_data_parameters = 'class="menuBoxContent"';
-      $this->contents = $this->tableBlock($contents);
-
-      return $this->heading . $this->contents;
-    }
   }


### PR DESCRIPTION
Looks like this has not been used since Zen Cart 1.0 was released, and can be safely removed
It used to build the old Osc menu structure

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zencart/zencart/1549)
<!-- Reviewable:end -->
