### PR TITLE
Add missing define for editors

### DIFF
--- a/admin/includes/defined_paths.php
+++ b/admin/includes/defined_paths.php
@@ -71,6 +71,7 @@ if (!defined('DIR_FS_CATALOG_TEMPLATES')) define('DIR_FS_CATALOG_TEMPLATES', DIR
 if (!defined('DIR_FS_BACKUP')) define('DIR_FS_BACKUP', DIR_FS_ADMIN . 'backups/');
 if (!defined('DIR_FS_EMAIL_TEMPLATES')) define('DIR_FS_EMAIL_TEMPLATES', DIR_FS_CATALOG . 'email/');
 if (!defined('SQL_CACHE_METHOD')) define('SQL_CACHE_METHOD', 'none');
+if (!defined('DIR_WS_EDITORS')) define('DIR_WS_EDITORS', 'editors/');
 
 if (!defined('DIR_FS_SQL_CACHE')) define('DIR_FS_SQL_CACHE', DIR_FS_CATALOG . 'cache'); // trailing slash omitted
 if (!defined('DIR_FS_LOGS')) define('DIR_FS_LOGS', DIR_FS_CATALOG . 'logs'); // trailing slash omitted


### PR DESCRIPTION
This missing define causes a messagestack warning when a editor is selected by default (configuration->store->HTML Editor)
This started after https://github.com/zencart/zencart/commit/a803651f9ec532cef7456b010c0b9542e1787be1
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zencart/zencart/1554)
<!-- Reviewable:end -->
