### PR TITLE
zc156-Align admin zen_get_prid/zen_get_uprid, fixes #1559.

### DIFF
--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -609,24 +609,30 @@
       return $default_zone;
     }
   }
-
-  function zen_get_uprid($prid, $params) {
+  
+function zen_get_uprid($prid, $params) 
+{
     $uprid = $prid;
-    if ( (is_array($params)) && (!strstr($prid, '{')) ) {
-      while (list($option, $value) = each($params)) {
-        $uprid = $uprid . '{' . $option . '}' . $value;
-      }
+    if (is_array($params) && strpos($prid, ':') === false) {
+        foreach ($params as $option => $value) {
+            if (is_array($value)) {
+                foreach ($value as $opt => $val) {
+                    $uprid .= ('{' . $option . '}' . trim($opt));
+                }
+            } else {
+                $uprid .= ('{' . $option . '}' . trim($value));
+            }
+        }
+        $uprid = $prid . ':' . md5($uprid);
     }
-
     return $uprid;
-  }
+}
 
-
-  function zen_get_prid($uprid) {
-    $pieces = explode('{', $uprid);
-
+function zen_get_prid($uprid) 
+{
+    $pieces = explode(':', $uprid);
     return $pieces[0];
-  }
+}
 
 
   function zen_get_languages() {

--- a/includes/functions/functions_general.php
+++ b/includes/functions/functions_general.php
@@ -572,29 +572,23 @@ if (!defined('IS_ADMIN_FLAG')) {
 
 ////
 // Return a product ID with attributes
-  function zen_get_uprid($prid, $params) {
-//print_r($params);
+function zen_get_uprid($prid, $params) 
+{
     $uprid = $prid;
-    if ( (is_array($params)) && (!strstr($prid, ':')) ) {
-      while (list($option, $value) = each($params)) {
-        if (is_array($value)) {
-          while (list($opt, $val) = each($value)) {
-            $uprid = $uprid . '{' . $option . '}' . trim($opt);
-          }
-        } else {
-        //CLR 030714 Add processing around $value. This is needed for text attributes.
-            $uprid = $uprid . '{' . $option . '}' . trim($value);
+    if (is_array($params) && strpos($prid, ':') === false) {
+        foreach ($params as $option => $value) {
+            if (is_array($value)) {
+                foreach ($value as $opt => $val) {
+                    $uprid .= ('{' . $option . '}' . trim($opt));
+                }
+            } else {
+                $uprid .= ('{' . $option . '}' . trim($value));
+            }
         }
-      }      //CLR 030228 Add else stmt to process product ids passed in by other routines.
-      $md_uprid = '';
-
-      $md_uprid = md5($uprid);
-      return $prid . ':' . $md_uprid;
-    } else {
-      return $prid;
+        $uprid = $prid . ':' . md5($uprid);
     }
-  }
-
+    return $uprid;
+}
 
 ////
 // Return a product ID from a product ID with attributes


### PR DESCRIPTION
Ensure that the admin versions of the functions are the same as their storefront counterparts.

Also re-factors the functions and changes the use of the deprecated "each()" function to use their foreach() equivalent.