### PR TITLE
add  autocapitalize="none" and spellcheck="false" to Login fields

### DIFF
--- a/admin/login.php
+++ b/admin/login.php
@@ -96,7 +96,7 @@ if ($expired && $message == '') $message = sprintf(ERROR_PASSWORD_EXPIRED . ' ' 
                           <div class="form-group">
                             <label class="col-xs-4 col-offset-xs-1 col-sm-4 col-md-6 control-label" for="admin_name-<?php echo $_SESSION['securityToken']; ?>"><?php echo TEXT_ADMIN_NAME; ?>:</label>
                             <div class="col-xs-6 col-sm-7 col-md-6">
-                              <?php echo zen_draw_input_field('admin_name', zen_output_string($admin_name), 'class="form-control" id="admin_name-' . $_SESSION['securityToken'] . '" autocomplete="off" autofocus placeholder="' . TEXT_ADMIN_NAME . '"'); ?>
+                              <?php echo zen_draw_input_field('admin_name', zen_output_string($admin_name), 'class="form-control" id="admin_name-' . $_SESSION['securityToken'] . '" autocapitalize="none" spellcheck="false" autocomplete="off" autofocus placeholder="' . TEXT_ADMIN_NAME . '"'); ?>
                             </div>
                           </div>
                           <div class="form-group">
@@ -141,7 +141,7 @@ if ($expired && $message == '') $message = sprintf(ERROR_PASSWORD_EXPIRED . ' ' 
                           <div class="form-group">
                             <label class="col-xs-4 col-offset-xs-1 col-sm-4 col-md-6 control-label" for="admin_name-<?php echo $_SESSION['securityToken']; ?>"><?php echo TEXT_ADMIN_NAME; ?>:</label>
                             <div class="col-xs-6 col-sm-7 col-md-6">
-                              <?php echo zen_draw_input_field('admin_name-' . $_SESSION['securityToken'], zen_output_string($admin_name), 'class="form-control" id="admin_name" autocomplete="off" placeholder="' . TEXT_ADMIN_NAME . '"'); ?>
+                              <?php echo zen_draw_input_field('admin_name-' . $_SESSION['securityToken'], zen_output_string($admin_name), 'class="form-control" id="admin_name" autocapitalize="none" spellcheck="false" autocomplete="off" placeholder="' . TEXT_ADMIN_NAME . '"'); ?>
                             </div>
                           </div>
                           <div class="form-group">


### PR DESCRIPTION
These 2 tags will help a user when accessing the admin on a mobile phone or tablet.
Normally on these devices the first character will automatically be a capital. This is very annoying (to me) having to think about this every time I log in.
Also no spell check should be done.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zencart/zencart/1561)
<!-- Reviewable:end -->
