### PR TITLE
Turn error reporting on if autoloader-debug is on

### DIFF
--- a/includes/application_top.php
+++ b/includes/application_top.php
@@ -81,7 +81,7 @@ define('DEBUG_AUTOLOAD', false);
  * Note STRICT_ERROR_REPORTING should never be set to true on a production site. <br />
  * It is mainly there to show php warnings during testing/bug fixing phases.<br />
  */
-if ((DEBUG_AUTOLOAD) || ((defined('STRICT_ERROR_REPORTING') && STRICT_ERROR_REPORTING == true))) {
+if (DEBUG_AUTOLOAD || (defined('STRICT_ERROR_REPORTING') && STRICT_ERROR_REPORTING == true)) {
   @ini_set('display_errors', TRUE);
   error_reporting(version_compare(PHP_VERSION, 5.3, '>=') ? E_ALL & ~E_DEPRECATED & ~E_NOTICE : version_compare(PHP_VERSION, 5.4, '>=') ? E_ALL & ~E_DEPRECATED & ~E_NOTICE & ~E_STRICT : E_ALL & ~E_NOTICE);
 } else {

--- a/includes/application_top.php
+++ b/includes/application_top.php
@@ -81,7 +81,7 @@ define('DEBUG_AUTOLOAD', false);
  * Note STRICT_ERROR_REPORTING should never be set to true on a production site. <br />
  * It is mainly there to show php warnings during testing/bug fixing phases.<br />
  */
-if (defined('STRICT_ERROR_REPORTING') && STRICT_ERROR_REPORTING == true) {
+if ((DEBUG_AUTOLOAD) || ((defined('STRICT_ERROR_REPORTING') && STRICT_ERROR_REPORTING == true))) {
   @ini_set('display_errors', TRUE);
   error_reporting(version_compare(PHP_VERSION, 5.3, '>=') ? E_ALL & ~E_DEPRECATED & ~E_NOTICE : version_compare(PHP_VERSION, 5.4, '>=') ? E_ALL & ~E_DEPRECATED & ~E_NOTICE & ~E_STRICT : E_ALL & ~E_NOTICE);
 } else {


### PR DESCRIPTION
Adds php error reporting if `DEBUG_AUTOLOAD` (used for debugging files in the `auto_loaders` folder) is turned on. 
Fixes #1557