### PR TITLE
Allow downloadable files to be hosted externally, including AWS

### DIFF
--- a/admin/attributes_controller.php
+++ b/admin/attributes_controller.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2016 Zen Cart Development Team
+ * @copyright Copyright 2003-2017 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: DrByte  Thu Mar 3 12:16:32 2016 -0500 Modified in v1.5.5 $
+ * @version GIT: $Id: Author: DrByte  Modified in v1.5.6 $
  */
 require('includes/application_top.php');
 
@@ -71,10 +71,13 @@ if (isset($_POST['categories_update_id'])) {
 }
 
 if ($action == 'new_cat') {
-  $sql = "SELECT *
-          FROM " . TABLE_PRODUCTS_TO_CATEGORIES . "
-          WHERE categories_id = '" . $current_category_id . "'
-          ORDER BY products_id";
+  $sql = "SELECT ptc.*, products_name
+          FROM " . TABLE_PRODUCTS_TO_CATEGORIES . " ptc
+          LEFT JOIN " . TABLE_PRODUCTS_DESCRIPTION . " pd
+          ON ptc.products_id = pd.products_id
+          AND pd.language_id = '" . (int)$_SESSION['languages_id'] . "'
+          WHERE ptc.categories_id = '" . $current_category_id . "'
+          ORDER BY products_name";
   $new_product_query = $db->Execute($sql);
   $products_filter = (!$new_product_query->EOF) ? $new_product_query->fields['products_id'] : '';
   zen_redirect(zen_href_link(FILENAME_ATTRIBUTES_CONTROLLER, 'products_filter=' . $products_filter . '&current_category_id=' . $current_category_id));
@@ -1644,7 +1647,7 @@ function zen_js_option_values_list($selectedName, $fieldName) {
                     $download_display = $db->Execute($download_display_query_raw);
                     if ($download_display->RecordCount() > 0) {
                       $filename_is_missing = '';
-                      if (!file_exists(DIR_FS_DOWNLOAD . $download_display->fields['products_attributes_filename'])) {
+                      if ( !zen_orders_products_downloads($download_display->fields['products_attributes_filename']) ) {
                         $filename_is_missing = zen_image(DIR_WS_IMAGES . 'icon_status_red.gif');
                       } else {
                         $filename_is_missing = zen_image(DIR_WS_IMAGES . 'icon_status_green.gif');

--- a/admin/downloads_manager.php
+++ b/admin/downloads_manager.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @copyright Copyright 2003-2017 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version GIT: $Id: Author: DrByte  Jun 30 2014 Modified in v1.5.4 $
+ * @version $Id:  Modified in v1.5.6 $
  */
 
   require('includes/application_top.php');
@@ -147,15 +147,12 @@ function go_option() {
       $padInfo = new objectInfo($padInfo_array);
     }
 
-// Moved to /admin/includes/configure.php
-  if (!defined('DIR_FS_DOWNLOAD')) define('DIR_FS_DOWNLOAD', DIR_FS_CATALOG . 'download/');
-
-  $filename_is_missing='';
-  if ( !file_exists(DIR_FS_DOWNLOAD . $products_downloads_query->fields['products_attributes_filename']) ) {
-    $filename_is_missing = zen_image(DIR_WS_IMAGES . 'icon_status_red.gif');
-  } else {
-    $filename_is_missing = zen_image(DIR_WS_IMAGES . 'icon_status_green.gif');
-  }
+    $filename_is_missing='';
+    if ( !zen_orders_products_downloads($products_downloads_query->fields['products_attributes_filename']) ) {
+      $filename_is_missing = zen_image(DIR_WS_IMAGES . 'icon_status_red.gif');
+    } else {
+      $filename_is_missing = zen_image(DIR_WS_IMAGES . 'icon_status_green.gif');
+    }
 ?>
 <?php
       if (isset($padInfo) && is_object($padInfo) && ($products_downloads_query->fields['products_attributes_id'] == $padInfo->products_attributes_id)) {

--- a/admin/includes/classes/AdminRequestSanitizer.php
+++ b/admin/includes/classes/AdminRequestSanitizer.php
@@ -358,7 +358,7 @@ class AdminRequestSanitizer extends base
      */
     private function filterFileDirRegex($parameterName)
     {
-        $filedirRegex = '~[^0-9a-z' . preg_quote('.!@#$%^& ()`_+-~/' . '\\', '~') . ']~i';
+        $filedirRegex = '~[^0-9a-z' . preg_quote('.!@#$%&()_-~/`+^ ' . '\\', '~') . ']~i';
         if (isset($_POST[$parameterName])) {
             $this->debugMessages[] = 'PROCESSING FILE_DIR_REGEX == ' . $parameterName;
             $_POST[$parameterName] = preg_replace($filedirRegex, '', $_POST[$parameterName]);
@@ -475,13 +475,32 @@ class AdminRequestSanitizer extends base
      */
     private function filterProductUrlRegex($parameterName)
     {
-        $urlRegex = '~([^a-z0-9\'!#$&%@();:/=?_\~\[\]-]|[><])~i';
+        $urlRegex = '~([^0-9a-z' . preg_quote("'.!@#$%&()_-~/;:=?[]", '~') . ']|[><])~i';
         if (isset($_POST[$parameterName])) {
             $this->debugMessages[] = 'PROCESSING PRODUCT_URL_REGEX == ' . $parameterName;
             foreach ($_POST[$parameterName] as $pKey => $pValue) {
                 $newValue = filter_var($_POST[$parameterName][$pKey], FILTER_SANITIZE_URL);
                 if ($newValue === false) {
                     $newValue = preg_replace($urlRegex, '', $_POST[$parameterName][$pKey]);
+                }
+                $_POST[$parameterName][$pKey] = $newValue;
+                $this->postKeysAlreadySanitized[] = $parameterName;
+            }
+        }
+    }
+
+    /**
+     * @param $parameterName
+     */
+    private function filterFilePathOrUrlRegex($parameterName)
+    {
+        $regex = '~([^0-9a-z' . preg_quote("'.!@#$%&()_-~/;:=?[]`+^ " . '\\', '~') . ']|[><])~i';
+        if (isset($_POST[$parameterName])) {
+            $this->debugMessages[] = 'PROCESSING PRODUCT_URL_REGEX == ' . $parameterName;
+            foreach ($_POST[$parameterName] as $pKey => $pValue) {
+                $newValue = filter_var($_POST[$parameterName][$pKey], FILTER_SANITIZE_URL);
+                if ($newValue === false) {
+                    $newValue = preg_replace($regex, '', $_POST[$parameterName][$pKey]);
                 }
                 $_POST[$parameterName][$pKey] = $newValue;
                 $this->postKeysAlreadySanitized[] = $parameterName;

--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -2601,7 +2601,7 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
       if ($check_valid == true) {
         $valid_downloads = '';
         while (!$download_display->EOF) {
-          if (!file_exists(DIR_FS_DOWNLOAD . $download_display->fields['products_attributes_filename'])) {
+          if (!file_exists(zen_get_download_handler($download_display->fields['products_attributes_filename']))) {
             $valid_downloads .= '<br />&nbsp;&nbsp;' . zen_image(DIR_WS_IMAGES . 'icon_status_red.gif') . ' Invalid: ' . $download_display->fields['products_attributes_filename'];
             // break;
           } else {
@@ -3361,19 +3361,41 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
  * check that the specified download filename exists on the filesystem
  */
   function zen_orders_products_downloads($check_filename) {
-    global $db;
+    global $zco_notifier;
 
-    $valid_downloads = true;
-    if (!defined('DIR_FS_DOWNLOAD')) define('DIR_FS_DOWNLOAD', DIR_FS_CATALOG . 'download/');
+    $handler = zen_get_download_handler($check_filename);
 
-    if (!file_exists(DIR_FS_DOWNLOAD . $check_filename)) {
-      $valid_downloads = false;
-    // break;
-    } else {
-      $valid_downloads = true;
+    if ($handler == 'local') {
+      return file_exists(DIR_FS_DOWNLOAD . $check_filename);
     }
 
-    return $valid_downloads;
+    /**
+     * An observer hooking this notifier should set $handler to blank if it tries a validation and fails.
+     * Or, if validation passes, simply set $handler to the service name (first chars before first colon in filename)
+     * Or, or there is no way to verify, do nothing to $handler.
+     */
+    $zco_notifier->notify('NOTIFY_TEST_DOWNLOADABLE_FILE_EXISTS', $check_filename, $handler);
+
+    // if handler is set but isn't local (internal) then we simply return true since there's no way to "test"
+    if ($handler != '') return true;
+
+    // else if the notifier caused $handler to be empty then that means it failed verification, so we return false
+    return false;
+  }
+
+/**
+ * check if the specified download filename matches a handler for an external download service
+ * If yes, it will be because the filename contains colons as delimiters ... service:filename:filesize
+ */
+  function zen_get_download_handler($filename) {
+    $file_parts = explode(':', $filename);
+
+    // if the filename doesn't contain any colons, then there's no delimiter to return, so must be using built-in file handling
+    if (sizeof($file_parts) < 2) {
+      return 'local';
+    }
+
+    return $file_parts[0];
   }
 
 /**

--- a/admin/includes/init_includes/init_sanitize.php
+++ b/admin/includes/init_includes/init_sanitize.php
@@ -31,6 +31,7 @@ $adminSanitizerTypes = array(
     'SANITIZE_EMAIL_AUDIENCE' => array('type' => 'builtin'),
     'PRODUCT_DESC_REGEX' => array('type' => 'builtin'),
     'PRODUCT_URL_REGEX' => array('type' => 'builtin'),
+    'FILE_PATH_OR_URL' => array('type' => 'builtin'),
     'CURRENCY_VALUE_REGEX' => array('type' => 'builtin'),
     'FLOAT_VALUE_REGEX' => array('type' => 'builtin'),
     'PRODUCT_NAME_DEEP_REGEX' => array('type' => 'builtin'),
@@ -182,7 +183,7 @@ $group = array(
 );
 $sanitizer->addSimpleSanitization('CONVERT_INT', $group);
 
-$group = array('img_dir', 'products_previous_image', 'products_image_manual', 'products_attributes_filename', 'manufacturers_image_manual');
+$group = array('img_dir', 'products_previous_image', 'products_image_manual', 'manufacturers_image_manual');
 $sanitizer->addSimpleSanitization('FILE_DIR_REGEX', $group);
 
 $group = array(
@@ -223,6 +224,9 @@ $sanitizer->addSimpleSanitization('PRODUCT_DESC_REGEX', $group);
 
 $group = array('products_url', 'manufacturers_url');
 $sanitizer->addSimpleSanitization('PRODUCT_URL_REGEX', $group);
+
+$group = array('products_attributes_filename');
+$sanitizer->addSimpleSanitization('FILE_PATH_OR_URL', $group);
 
 $group = array('coupon_min_order');
 $sanitizer->addSimpleSanitization('CURRENCY_VALUE_REGEX', $group);

--- a/includes/classes/observers/auto.downloads_via_aws.php
+++ b/includes/classes/observers/auto.downloads_via_aws.php
@@ -1,0 +1,230 @@
+<?php
+/**
+ * @package plugins
+ * @copyright Copyright 2003-2017 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: Designed for v1.5.6  $
+ */
+
+/**
+ * This observer class is intended to allow downloadable files to be served
+ * from Amazon AWS S3 buckets, and also automatically expire the links
+ * so that customers can't share them or otherwise steal the files
+ *
+ */
+class zcObserverDownloadsViaAws extends base {
+
+  // this is where you can configure your AWS settings:
+  // --------------------------------------------------
+  // Alternatively, you can define them as constants in
+  // the extra_configures folder: AMAZON_S3_ACCESS_KEY
+  // and AMAZON_S3_ACCESS_SECRET
+  // --------------------------------------------------
+  /**
+   * You may set your Amazon AWS S3 Access Key and Secret Key here, as long as you're not committing this file to a version-control system like git.
+   * @var string
+   */
+  private $aws_key = 'MY_AMAZON_S3_ACCESS_KEY';
+  /**
+   * @var string
+   */
+  private $aws_secret = 'MY_AMAZON_S3_SECRET_XXXXXXXXX';
+
+  /**
+   * This is used to calculate a link that's good for 30 seconds,
+   * which is plenty of time for it to get started, & prevents
+   * unauthorized sharing and theft. Default is 30 seconds.
+   * @var integer
+   */
+  private $link_expiry_time = 30;
+
+  /**
+   * URL to Amazon S3 server
+   * @var string URL
+   */
+  private $aws_server = 'https://s3.amazonaws.com';
+
+  /**
+   * Class constructor
+   */
+  public function __construct() {
+    // read config from constants if available
+    if ($this->aws_key === 'MY_AMAZON_S3_ACCESS_KEY' && defined('AMAZON_S3_ACCESS_KEY')) $this->aws_key = AMAZON_S3_ACCESS_KEY;
+    if ($this->aws_secret === 'MY_AMAZON_S3_SECRET_XXXXXXXXX' && defined('AMAZON_S3_ACCESS_SECRET')) $this->aws_secret = AMAZON_S3_ACCESS_SECRET;
+
+    // if not configured, then don't activate
+    if ($this->aws_key === 'MY_AMAZON_S3_ACCESS_KEY' || $this->aws_key === '' || $this->aws_secret === '' || $this->aws_secret === 'MY_AMAZON_S3_SECRET_XXXXXXXXX') return false;
+
+    // attach listener
+    $this->attach($this, array('NOTIFY_CHECK_DOWNLOAD_HANDLER', 'NOTIFY_DOWNLOAD_READY_TO_START', 'NOTIFY_MODULE_DOWNLOAD_TEMPLATE_DETAILS', 'NOTIFY_TEST_DOWNLOADABLE_FILE_EXISTS'));
+  }
+
+
+  /**
+   * Parse the file details for display on template page
+   *
+   * @param string $eventID name of the observer event fired
+   * @param array $array $download->fields data
+   * @param array $data array passed by reference
+   */
+  protected function updateNotifyModuleDownloadTemplateDetails(&$class, $eventID, $array, &$data)
+  {
+    // available fields:
+    //   $data['service'] = 'local'
+    //   $data['filename'] = db query result from orders_products_filename
+    //   $data['expiry_timestamp']
+    //   $data['expiry']
+    //   $data['downloads_remaining']
+    //   $data['unlimited_downloads']
+    //   $data['file_exists']
+    //   $data['is_downloadable']
+    //   $data['filesize']
+    //   $data['date_purchased_day']
+    //   $data['download_maxdays']
+    //   $data['products_name']
+    //   $data['orders_products_download_id'] = id for URL link
+    //   $data['download_count']
+
+    $file_parts = $this->parseFileParts($data['filename']);
+
+    if ($file_parts === false) return;
+    if ($file_parts[0] != 'aws') return;
+
+    $data['service'] = $file_parts[0];
+
+    // use just the filename portion, skipping the bucket name for customer-facing display purposes
+    $data['filename'] = substr($file_parts[1], strrpos($file_parts[1], '/') + 1);
+
+    $data['filesize'] = isset($file_parts[2]) ? number_format($file_parts[2], 0) : '';
+    $data['filesize_units'] = '';
+
+    $data['is_downloadable'] = $data['file_exists'] = $this->testFileExists($data['filename']);
+  }
+
+  /**
+   * This observer should set $handler to blank if it fails to validate whether $filename exists on the external service.
+   * If validation passes, simply set $handler to the service name (first chars before first colon in filename) (or do nothing since it's probably already correct).
+   * If there is no way to verify, do nothing to $handler.
+   *
+   * @param string $eventID name of the observer event fired
+   * @param string $filename filename to verify exists
+   * @param string $handler  name of external service handler
+   */
+  protected function updateNotifyTestDownloadableFileExists(&$class, $eventID, $filename, &$handler)
+  {
+    $result = $this->testFileExists($filename);
+
+    if ($result === false) {
+      $handler = '';
+    }
+  }
+
+  /**
+   *
+   * @param string $eventID name of the observer event fired
+   * @param array $var deprecated array, used only for backward compatibility
+   * @param array $fields data feeding all download activities
+   * @param string $origin_filename  (mutable)
+   * @param string $browser_filename (mutable)
+   * @param string $source_directory (mutable)
+   * @param boolean $file_exists (mutable)
+   */
+  protected function updateNotifyCheckDownloadHandler(&$class, $eventID, $var, &$fields, &$origin_filename, &$browser_filename, &$source_directory, &$file_exists, &$service, &$isExpired, &$download_timestamp)
+  {
+    $file_parts = $this->parseFileParts($origin_filename);
+    if ($file_parts[0] == 'aws') {
+      $origin_filename  = $file_parts[1];
+      $browser_filename = substr($origin_filename, strrpos($origin_filename, '/') + 1);
+      $source_directory = $file_parts[0];
+      $file_exists = true;
+      $service = $file_parts[0];
+    }
+  }
+
+  /**
+   * This fires when the download module wants to redirect to the external download service
+   * So, this method parses the passed file, obtains the URL, and does the redirect
+   *
+   * @param string $eventID name of the observer event fired
+   * @param string $ipaddress customer IP
+   * @param string $service (mutable)
+   * @param string $origin_filename (mutable)
+   * @param string $browser_filename (mutable)
+   * @param string $source_directory (mutable)
+   * @param integer $downloadFilesize (mutable)
+   * @param string $mime_type (mutable)
+   * @param array $fields  array of data from db query feeding the download page
+   * @param string $browser_extra_headers (mutable)
+   */
+  protected function updateNotifyDownloadReadyToStart(&$class, $eventID, $ipaddress, &$service, &$origin_filename, &$browser_filename, &$source_directory, &$downloadFilesize, $mime_type, $fields, $browser_extra_headers)
+  {
+    // verify that the passed file is indeed intended for aws
+    if ($source_directory != 'aws') {
+      $file_parts = $this->parseFileParts($origin_filename);
+      if ($file_parts[0] != 'aws') return false;
+      $origin_filename  = $file_parts[1];
+      $browser_filename = substr($origin_filename, strrpos($origin_filename, '/') + 1);
+      $source_directory = $file_parts[0];
+      $downloadFilesize = $file_parts[2];
+    }
+
+    // prepare AWS URL
+    $url = $this->buildRedirectUrl($origin_filename);
+
+    // redirect to external download script
+    header("HTTP/1.1 303 See Other");
+    zen_redirect($url);
+
+    zen_exit();
+  }
+
+  /**
+   * parse file details to determine if its download should be handled by AWS
+   * If AWS, the filename will use colons as delimiters ... aws:bucket/filename:filesize
+   *
+   * @param string $filename
+   * @return boolean|array
+   */
+  private function parseFileParts($filename) {
+
+    $file_parts = explode(':', $filename);
+
+    if (count($file_parts) === 1) return false;
+
+    return $file_parts;
+  }
+
+  /**
+   * Prepare signed expiring URL for AWS redirect
+   *
+   * @param string $bucketAndFilename
+   * @return string $url
+   */
+  private function buildRedirectUrl($bucketAndFilename) {
+
+    // this calculates a link that's good for 30 seconds, which is plenty of time for it to get started, and prevents theft
+    $expires = time() + $this->link_expiry_time;
+
+    $raw_request = "GET\n\n\n" . $expires . "\n/" . $bucketAndFilename;
+    $sig = urlencode(base64_encode((hash_hmac("sha1", utf8_encode($raw_request), $this->aws_secret, true))));
+
+    $params = 'AWSAccessKeyId=' . $this->aws_key . '&Expires=' . $expires . '&Signature=' . $sig;
+
+    return $this->aws_server . '/' . $bucketAndFilename . '?' . $params;
+  }
+
+  /**
+   * Use AWS SDK to test whether the bucket+file (designated by $filename) exists
+   * If it does not exist, return false
+   *
+   * @param string $filename
+   * @return boolean Result of SDK test
+   */
+  private function testFileExists($filename)
+  {
+    // @TODO: could optionally add an AWS SDK call to actually check that the object (bucket+file) exists
+    // but for now we're simply assuming that it does
+    return true;
+  }
+
+}

--- a/includes/classes/observers/auto.downloads_via_redirect.php
+++ b/includes/classes/observers/auto.downloads_via_redirect.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * @package plugins
+ * @copyright Copyright 2003-2017 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: Designed for v1.5.6  $
+ */
+
+/**
+ * This observer class is intended to allow downloadable files to be served
+ * by redirecting the customer's browser page to a temporary symlink on
+ * the server; the symlinked file expires to help prevent theft
+ */
+class zcObserverDownloadsViaRedirect extends base {
+
+  /**
+   * Folder where the symlink redirect folders will be generated. The folder requires "writable by PHP" permissions.
+   * This is the path from the root of the filesystem.
+   * @var string
+   */
+  private $pubFolder = DIR_FS_DOWNLOAD_PUBLIC;
+
+  /**
+   * Folder off the webroot where the "pub" symlinks will be accessible. Usually this is "pub".
+   * @var string
+   */
+  private $wsPubFolder = 'pub';
+
+  /**
+   * Number of seconds before garbage-collection purges
+   * the leftover symlink folders.
+   * Default = 3600 = 1 hour
+   *
+   * @var integer
+   */
+  protected $gc_cleanup_time = 3600;
+
+  /**
+   * Class constructor
+   */
+  public function __construct() {
+
+    if (DOWNLOAD_BY_REDIRECT != 'true') return false;
+
+    $this->pubFolder = DIR_FS_DOWNLOAD_PUBLIC;
+    $this->wsPubFolder = DIR_WS_DOWNLOAD_PUBLIC;
+
+    // attach listener
+    $this->attach($this, array('NOTIFY_DOWNLOAD_READY_TO_REDIRECT'));
+
+    if (defined('SYMLINK_GARBAGE_COLLECTION_THRESHOLD') && (int)SYMLINK_GARBAGE_COLLECTION_THRESHOLD > 300) $this->gc_cleanup_time = (int)SYMLINK_GARBAGE_COLLECTION_THRESHOLD;
+  }
+
+  /**
+   * This fires when the download module is ready to process redirects
+   *
+   * @param string $eventID name of the observer event fired
+   * @param array $array deprecated BC data
+   * @param string $origin_filename (mutable)
+   * @param string $browser_filename (mutable)
+   * @param string $source_directory (mutable)
+   * @param boolean $link_create_status (mutable)
+   */
+  protected function updateNotifyDownloadReadyToRedirect(&$class, $eventID, $array, &$service, &$origin_filename, &$browser_filename, &$source_directory, &$link_create_status)
+  {
+    $this->garbageCollectionUnlinkTempFolders($this->pubFolder);
+    $tempdir = $this->generateRandomName() . '-' . time();
+    umask(0000);
+    mkdir($this->pubFolder . $tempdir, octdec(DOWNLOAD_CHMOD));
+    $download_link = str_replace(array('/','\\'), '_', $browser_filename);
+    $link_create_status = @symlink($source_directory . $origin_filename, $this->pubFolder . $tempdir . '/' . $download_link);
+
+    if ($link_create_status==true) {
+      $this->notify('NOTIFY_DOWNLOAD_VIA_SYMLINK___BEGINS', array($download_link, $origin_filename, $tempdir));
+      header("HTTP/1.1 303 See Other");
+      zen_redirect($this->wsPubFolder . $tempdir . '/' . $download_link, 303);
+      zen_exit();
+    }
+  }
+
+  /**
+   * Returns a random name, 16 to 20 characters long
+   * There are more than 10^28 combinations
+   * This is used to build a random directory foldername. And, the directory is "hidden", ie: starts with '.'
+   * @return string
+   */
+  private function generateRandomName()
+  {
+    $letters = 'abcdefghijklmnopqrstuvwxyz';
+    $dirname = '.';
+    if (defined('DOWNLOADS_SKIP_DOT_PREFIX_ON_REDIRECT') && DOWNLOADS_SKIP_DOT_PREFIX_ON_REDIRECT === TRUE) $dirname = '';
+    $length = floor(zen_rand(16,20));
+    for ($i = 1; $i <= $length; $i++) {
+      $q = floor(zen_rand(0,25));
+      $dirname .= $letters[$q];
+    }
+    return $dirname;
+  }
+
+  /**
+   * Garbage collection for temporary download files/folders
+   *
+   * Unlinks (deletes) all subdirectories and files in $dir
+   * Works only on one subdir level, will not recurse
+   *
+   * @param string $dir folder whose contents will be inspected for cleanup
+   */
+  private function garbageCollectionUnlinkTempFolders($dir)
+  {
+    $h1 = opendir($dir);
+    while ($subdir = readdir($h1)) {
+      // Ignore non directories
+      if (!is_dir($dir . $subdir)) continue;
+      // Ignore . and .. and VCS folders
+      if ($subdir == '.' || $subdir == '..' || $subdir == '.git' || $subdir == '.svn') continue;
+      // Loop and unlink files in subdirectory
+      $h2 = opendir($dir . $subdir);
+      list($fn, $exptime) = explode('-', $subdir);
+      if ($exptime + SYMLINK_GARBAGE_COLLECTION_THRESHOLD > time()) continue;
+      while ($file = readdir($h2)) {
+        if ($file == '.' || $file == '..') continue;
+        @unlink($dir . $subdir . '/' . $file);
+      }
+      closedir($h2);
+      @rmdir($dir . $subdir);
+    }
+    closedir($h1);
+  }
+
+}

--- a/includes/classes/observers/auto.downloads_via_streaming.php
+++ b/includes/classes/observers/auto.downloads_via_streaming.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * @package plugins
+ * @copyright Copyright 2003-2017 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: Designed for v1.5.6  $
+ */
+
+/**
+ * This observer class is intended to allow downloadable files to be served
+ * by streaming as a direct memory-feed from disk-to-browser, handled
+ * completely by PHP. This can be a RAM drain. Redirect is better.
+ *
+ */
+class zcObserverDownloadsViaStreaming extends base {
+
+  /**
+   * Class constructor
+   */
+  public function __construct() {
+    $this->attach($this, array('NOTIFY_DOWNLOAD_READY_TO_STREAM'));
+  }
+
+  /**
+   * This fires when the download module is ready to stream a download to the browser
+   *
+   * @param string $eventID name of the observer event fired
+   * @param array $array deprecated BC data
+   * @param string $origin_filename (mutable)
+   * @param string $browser_filename (mutable)
+   * @param string $source_directory (mutable)
+   * @param integer $downloadFilesize (mutable)
+   */
+  protected function updateNotifyDownloadReadyToStream(&$class, $eventID, $array, &$service, &$origin_filename, &$browser_filename, &$source_directory, &$downloadFilesize)
+  {
+    global $messageStack;
+
+    if ((int)$downloadFilesize > 0) header("Content-Length: " . (string) $downloadFilesize);
+
+    $disabled_funcs = @ini_get("disable_functions");
+
+    if (DOWNLOAD_IN_CHUNKS != 'true' && !strstr($disabled_funcs,'readfile')) {
+      $this->notify('NOTIFY_DOWNLOAD_WITHOUT_REDIRECT___COMPLETED', $origin_filename);
+
+      // close the session, since it is not needed for streaming the file contents
+      session_write_close();
+
+      // Dump the file to the browser. This will work on all systems, but will need considerable resources
+      readfile($source_directory . $origin_filename);
+
+    } else {
+      // override PHP timeout to 25 minutes, if allowed
+      @set_time_limit(1500);
+
+      $this->notify('NOTIFY_DOWNLOAD_IN_CHUNKS___COMPLETED', $origin_filename);
+
+      // loop with fread($fp, xxxx) to allow streaming in chunk sizes below the PHP memory_limit
+      $handle = @fopen($source_directory . $origin_filename, "rb");
+      if ($handle) {
+
+        // close the session, since it is not needed for streaming the file contents
+        session_write_close();
+
+        // stream the file in 4K chunks
+        while (!@feof($handle)) {
+          echo(fread($handle, 4096));
+          @flush();
+        }
+        fclose($handle);
+
+      } else {
+        // Throw error condition -- this should never happen!
+        $msg = 'Please contact store owner.  ERROR: Cannot read file: ' . $origin_filename;
+        $messageStack->add_session('default', $msg, 'error');
+        error_log($msg);
+        zen_mail('', STORE_OWNER_EMAIL_ADDRESS, ERROR_CUSTOMER_DOWNLOAD_FAILURE, "Unable to open file '" . $origin_filename . " for reading.  Check the file permissions.", STORE_NAME, EMAIL_FROM);
+      }
+      $this->notify('NOTIFY_DOWNLOAD_WITHOUT_REDIRECT_VIA_CHUNKS___COMPLETED');
+    }
+    zen_exit();
+  }
+
+}

--- a/includes/classes/observers/auto.downloads_via_url.php
+++ b/includes/classes/observers/auto.downloads_via_url.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * @package plugins
+ * @copyright Copyright 2003-2017 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: Designed for v1.5.6  $
+ */
+
+/**
+ * This observer could be used to allow file-downloads to be served from any publicly accessible URL
+ * as long as the URL doesn't require special authentications that the download customer would not
+ * know the credentials for. Thus it could conveniently serve files from Dropbox and others.
+ *
+ */
+class zcObserverDownloadsViaUrl extends base {
+
+  public function __construct() {
+    $this->attach($this, array('NOTIFY_CHECK_DOWNLOAD_HANDLER', 'NOTIFY_DOWNLOAD_READY_TO_START', 'NOTIFY_MODULE_DOWNLOAD_TEMPLATE_DETAILS', 'NOTIFY_MODULE_DOWNLOADABLE_FILE_EXISTS'));
+  }
+
+  /**
+   * Parse the file details for display on template page
+   *
+   * @param string $eventID name of the observer event fired
+   * @param array $array $download->fields data
+   * @param array $data array passed by reference
+   */
+  protected function updateNotifyModuleDownloadTemplateDetails(&$class, $eventID, $array, &$data)
+  {
+    // available fields:
+    //   $data['service'] = 'local'
+    //   $data['filename'] = db query result from orders_products_filename
+    //   $data['expiry_timestamp']
+    //   $data['expiry']
+    //   $data['downloads_remaining']
+    //   $data['unlimited_downloads']
+    //   $data['file_exists']
+    //   $data['is_downloadable']
+    //   $data['filesize']
+    //   $data['date_purchased_day']
+    //   $data['download_maxdays']
+    //   $data['products_name']
+    //   $data['orders_products_download_id'] = id for URL link
+    //   $data['download_count']
+
+    $file_parts = $this->parseFileParts($data['filename']);
+
+    if ($file_parts === false) return;
+
+    $data['service'] = $file_parts[0];
+
+    // use just the filename portion, for customer-facing display purposes
+    $data['filename'] = substr($file_parts[1], strrpos($file_parts[1], '/') + 1);
+
+    $data['filesize'] = isset($file_parts[2]) ? number_format($file_parts[2], 0) : '';
+    $data['filesize_units'] = '';
+
+    $data['is_downloadable'] = $data['file_exists'] = $this->testFileExists($data['filename']);
+  }
+
+  /**
+   * This observer should set $handler to blank if it fails to validate whether $filename exists at the destination URL.
+   * If validation passes, simply set $handler to the service name (first chars before first colon in filename).
+   * If there is no way to verify, do nothing to $handler.
+   *
+   * @param string $eventID name of the observer event fired
+   * @param string $filename filename to verify exists
+   * @param string $handler  name of external service handler
+   */
+  protected function updateNotifyTestDownloadableFileExists(&$class, $eventID, $filename, &$handler)
+  {
+      $result = $this->testFileExists($filename);
+
+    if ($result === false) {
+      $handler = '';
+    }
+  }
+
+  /**
+   *
+   * @param string $eventID name of the observer event fired
+   * @param array $var deprecated array, used only for backward compatibility
+   * @param array $fields data feeding all download activities
+   * @param string $origin_filename  (mutable)
+   * @param string $browser_filename (mutable)
+   * @param string $source_directory (mutable)
+   * @param boolean $file_exists (mutable)
+   * @param string $service (mutable)
+   */
+  protected function updateNotifyCheckDownloadHandler(&$class, $eventID, $var, &$fields, &$origin_filename, &$browser_filename, &$source_directory, &$file_exists, &$service)
+  {
+    $file_parts = $this->parseFileParts($origin_filename);
+    if ($file_parts[0] == 'http' || $file_parts[0] == 'https') {
+      $origin_filename  = $file_parts[1];
+      $browser_filename = substr($origin_filename, strrpos($origin_filename, '/') + 1);
+      $source_directory = $file_parts[0];
+      $file_exists = true;
+      $service = $file_parts[0];
+    }
+  }
+
+  /**
+   * This fires when the download module wants to redirect to the external download URL
+   * So, this method parses the passed file, obtains the URL, and does the redirect
+   *
+   * @param string $eventID name of the observer event fired
+   * @param string $ipaddress customer IP
+   * @param string $service (mutable)
+   * @param string $origin_filename (mutable)
+   * @param string $browser_filename (mutable)
+   * @param string $source_directory (mutable)
+   * @param integer $downloadFilesize (mutable)
+   * @param string $mime_type (mutable)
+   * @param array $fields  array of data from db query feeding the download page
+   * @param string $browser_extra_headers (mutable)
+   */
+  protected function updateNotifyDownloadReadyToStart(&$class, $eventID, $ipaddress, &$service, &$origin_filename, &$browser_filename, &$source_directory, &$downloadFilesize, $mime_type, $fields, $browser_extra_headers)
+  {
+    // verify that the passed "file" is an http/https URL
+    if ($source_directory != 'http' && $source_directory != 'https') {
+      $file_parts = $this->parseFileParts($origin_filename);
+      if ($file_parts[0] != 'http' && $file_parts[0] != 'https') return;
+      $origin_filename  = $file_parts[1];
+      $browser_filename = substr($origin_filename, strrpos($origin_filename, '/') + 1);
+      $source_directory = $file_parts[0];
+      $downloadFilesize = $file_parts[2];
+    }
+
+    // prepare redirect URL
+    $url = $this->buildRedirectUrl($service . ':' . $origin_filename);
+
+    // redirect to external download script
+    header("HTTP/1.1 303 See Other");
+    zen_redirect($url);
+
+    zen_exit();
+  }
+
+  /**
+   * parse file details to determine if its download should be handled by a simple HTTP URL
+   * Evidence is the that filename will use colons as delimiters ... http://domain/filename:filesize
+   * (filesize is optional)
+   *
+   * @param string $filename
+   * @return boolean|array
+   */
+  private function parseFileParts($filename)
+  {
+
+    $file_parts = explode(':', $filename);
+    if (preg_match('~^(https?://)(?!=.*)~', $filename, $matches)) {
+//       $file_parts[1] = ltrim($file_parts[1], '/');
+      return $file_parts;
+    }
+
+    return false;
+  }
+
+  /**
+   * return URL for redirect
+   *
+   * @param string $url
+   * @return string $url
+   */
+  private function buildRedirectUrl($url)
+  {
+      return $url;
+  }
+
+  /**
+   * Use a tool to test whether the file at $filename exists
+   * If it does not exist, return false
+   *
+   * @param string $filename
+   * @return boolean Result of test
+   */
+  private function testFileExists($filename)
+  {
+    //@TODO maybe try a CURL request to see if the file exists ... but request only the headers, not the full file response.
+    return true;
+  }
+}

--- a/includes/languages/english.php
+++ b/includes/languages/english.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * @package languageDefines
- * @copyright Copyright 2003-2016 Zen Cart Development Team
+ * @copyright Copyright 2003-2017 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: DrByte  Tue Jan 5 15:06:15 2016 -0500 Modified in v1.5.5 $
+ * @version $Id: Author: DrByte  Modified in v1.5.6 $
  */
 
 // FOLLOWING WERE moved to meta_tags.php
@@ -460,7 +460,9 @@
 // Downloads Controller
   define('DOWNLOADS_CONTROLLER_ON_HOLD_MSG','NOTE: Downloads are not available until payment has been confirmed');
   define('TEXT_FILESIZE_BYTES', ' bytes');
+  define('TEXT_FILESIZE_KBS', ' KB');
   define('TEXT_FILESIZE_MEGS', ' MB');
+  define('TEXT_FILESIZE_UNKNOWN', 'Unknown');
 
 // shopping cart errors
   define('ERROR_PRODUCT','<br />The item: ');

--- a/includes/modules/downloads.php
+++ b/includes/modules/downloads.php
@@ -3,15 +3,31 @@
  * downloads module - prepares information for use in downloadable files delivery
  *
  * @package modules
- * @copyright Copyright 2003-2006 Zen Cart Development Team
+ * @copyright Copyright 2003-2017 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: downloads.php 3018 2006-02-12 21:04:04Z wilt $
+ * @version $Id: downloads.php  Modified in v1.5.6 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
 }
-if (!($_GET['main_page']==FILENAME_ACCOUNT_HISTORY_INFO)) {
+
+if (!defined('TEXT_FILESIZE_KBS')) define('TEXT_FILESIZE_KBS', ' KB');
+if (!defined('TEXT_FILESIZE_MEGS')) define('TEXT_FILESIZE_MEGS', ' MB');
+if (!defined('TEXT_FILESIZE_UNKNOWN')) define('TEXT_FILESIZE_UNKNOWN', 'Unknown');
+
+$last_order = isset($_GET['order_id']) ? $_GET['order_id'] : 0;
+$customer_lookup_method = 'customerid';
+$show_footer_link_to_my_account = ($current_page != FILENAME_ACCOUNT_HISTORY_INFO);
+
+// adjustments for inquiries for customers without accounts
+if (isset($order) && isset($_POST['order_id'])) {
+  $last_order = $_POST['order_id'];
+  $customer_lookup_method = 'email';
+  $show_footer_link_to_my_account = false;
+}
+
+if ($last_order == 0 && $current_page != FILENAME_ACCOUNT_HISTORY_INFO) {
   // Get last order id for checkout_success
   $orders_lookup_query = "select orders_id
                      from " . TABLE_ORDERS . "
@@ -20,34 +36,81 @@ if (!($_GET['main_page']==FILENAME_ACCOUNT_HISTORY_INFO)) {
 
   $orders_lookup = $db->Execute($orders_lookup_query);
   $last_order = $orders_lookup->fields['orders_id'];
-} else {
-  $last_order = $_GET['order_id'];
 }
 
-// Now get all downloadable products in that order
-$downloads_query = "select date_format(o.date_purchased, '%Y-%m-%d') as date_purchased_day,
-                             opd.download_maxdays, op.products_name, opd.orders_products_download_id,
-                             opd.orders_products_filename, opd.download_count, opd.download_maxdays
-                      from " . TABLE_ORDERS . " o, " . TABLE_ORDERS_PRODUCTS . " op, "
-. TABLE_ORDERS_PRODUCTS_DOWNLOAD . " opd
-                      where o.customers_id = '" . (int)$_SESSION['customer_id'] . "'
-                      and (o.orders_status >= '" . DOWNLOADS_CONTROLLER_ORDERS_STATUS . "'
-                      and o.orders_status <= '" . DOWNLOADS_CONTROLLER_ORDERS_STATUS_END . "')
-                      and o.orders_id = '" . (int)$last_order . "'
-                      and o.orders_id = op.orders_id
-                      and op.orders_products_id = opd.orders_products_id
-                      and opd.orders_products_filename != ''";
-
-$downloads = $db->Execute($downloads_query);
+$downloads = array();
 
 // If there is a download in the order and they cannot get it, tell customer about download rules
 $downloads_check_query = $db->Execute("select o.orders_id, opd.orders_products_download_id
-                          from " .
-TABLE_ORDERS . " o, " .
-TABLE_ORDERS_PRODUCTS_DOWNLOAD . " opd
-                          where
-                          o.orders_id = opd.orders_id
+                          from " . TABLE_ORDERS . " o, " . TABLE_ORDERS_PRODUCTS_DOWNLOAD . " opd
+                          where o.orders_id = opd.orders_id
                           and o.orders_id = '" . (int)$last_order . "'
                           and opd.orders_products_filename != ''
                           ");
-?>
+
+$downloadsOnThisOrder = $downloads_check_query->RecordCount();
+
+if ($downloadsOnThisOrder) {
+  if ($customer_lookup_method === 'email') {
+    $lookup_clause = " AND o.customers_email_address = :email_address ";
+    $lookup_clause = $db->bindVars($lookup_clause, ':email_address', $_SESSION['email_address'], 'string');
+  }
+  if ($customer_lookup_method === 'customerid') {
+    $lookup_clause = " AND o.customers_id = '" . (int)$_SESSION['customer_id'] . "'";
+  }
+  // Now get all downloadable products in that order
+  $downloads_query = "select date_format(o.date_purchased, '%Y-%m-%d') as date_purchased_day,
+                             opd.download_maxdays, op.products_name, opd.orders_products_download_id,
+                             opd.orders_products_filename, opd.download_count, opd.download_maxdays
+                        from " . TABLE_ORDERS . " o, " . TABLE_ORDERS_PRODUCTS . " op, " . TABLE_ORDERS_PRODUCTS_DOWNLOAD . " opd
+                        where o.orders_id = '" . (int)$last_order . "'
+                        and (o.orders_status >= '" . DOWNLOADS_CONTROLLER_ORDERS_STATUS . "'
+                        and o.orders_status <= '" . DOWNLOADS_CONTROLLER_ORDERS_STATUS_END . "')" .
+                        $lookup_clause . "
+                        and o.orders_id = op.orders_id
+                        and op.orders_products_id = opd.orders_products_id
+                        and opd.orders_products_filename != ''";
+  $result = $db->Execute($downloads_query);
+
+  foreach($result as $data) {
+    $data['service'] = 'local';
+    $data['filename'] = $data['orders_products_filename'];
+    list($dt_year, $dt_month, $dt_day) = explode('-', $data['date_purchased_day']);
+    $data['expiry_timestamp'] = mktime(23, 59, 59, $dt_month, $dt_day + $data['download_maxdays'], $dt_year);
+    $data['expiry'] = date('Y-m-d H:i:s', $data['expiry_timestamp']);
+    $data['downloads_remaining'] = (int)$data['download_count'];
+    $data['unlimited_downloads'] = ($data['download_maxdays'] === 0);
+    $data['file_exists'] = file_exists(DIR_FS_DOWNLOAD . $data['orders_products_filename']);
+    $data['counts_not_expired'] = $data['downloads_remaining'] > 0 && $data['expiry_timestamp'] > time();
+    $data['is_downloadable'] = $data['file_exists'] && ($data['counts_not_expired'] === true || $data['unlimited_downloads']);
+    $data['link_url'] = zen_href_link(FILENAME_DOWNLOAD, 'order=' . $last_order . '&id=' . $data['orders_products_download_id']);
+
+    // calculate filesize/units
+    $data['filesize'] = $data['file_exists'] ? filesize(DIR_FS_DOWNLOAD . $data['orders_products_filename']) : 0;
+    $zv_filesize_units = '';
+    $zv_filesize = TEXT_FILESIZE_UNKNOWN;
+    if ($data['filesize'] > 0) {
+      $zv_filesize = $data['filesize'];
+      if ($zv_filesize >= 11000) {
+        $zv_filesize = number_format($zv_filesize/1024/1024,1);
+        $zv_filesize_units = TEXT_FILESIZE_MEGS;
+      } else if ($zv_filesize >= 1024) {
+        $zv_filesize = number_format($zv_filesize/1024,1);
+        $zv_filesize_units = TEXT_FILESIZE_KBS;
+      } else {
+        $zv_filesize = number_format($zv_filesize);
+        $zv_filesize_units = TEXT_FILESIZE_BYTES;
+      }
+    }
+    $data['filesize'] = $zv_filesize;
+    $data['filesize_units'] = $zv_filesize_units;
+
+    // pubsub
+    $zco_notifier->notify('NOTIFY_MODULE_DOWNLOAD_TEMPLATE_DETAILS', $data, $data);
+
+    $downloads[] = $data;
+  }
+}
+
+$numberOfDownloads = count($downloads);
+$downloadsNotAvailableYet = $downloadsOnThisOrder && $numberOfDownloads < 1;

--- a/includes/modules/pages/download/header_php.php
+++ b/includes/modules/pages/download/header_php.php
@@ -2,17 +2,18 @@
 /**
  * download header_php.php
  *
+ * NOTE: Download-by-Redirect often works only on Unix/Linux hosts since
+ *       Windows hosts require special setup (and Windows servers couldn't do any symlinking in PHP versions older than 5.3.0)
+ *
  * @package page
- * @copyright Copyright 2003-2016 Zen Cart Development Team
+ * @copyright Copyright 2003-2017 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: DrByte  Mar 22 15:35:01 2016 -0500 Modified in v1.5.5 $
+ * @version $Id: Author: DrByte  Modified in v1.5.6 $
  */
+
 // This should be first line of the script:
 $zco_notifier->notify('NOTIFY_HEADER_START_DOWNLOAD');
-
-define('SYMLINK_GARBAGE_COLLECTION_THRESHOLD', 1*60*60); // 1 hour default
-
 
 require(DIR_WS_MODULES . zen_get_module_directory('require_languages.php'));
 
@@ -28,247 +29,180 @@ if ((isset($_GET['order']) && !is_numeric($_GET['order'])) || (isset($_GET['id']
 }
 
 // Check that order_id, customer_id and filename match
+$lookup_clause = " AND o.customers_id = :customersID";
+
+//@TODO - might need alternate lookup clause for guest checkout scenario ...
+// $lookup_clause = " AND o.customers_email_address = :emailAddress ";
+
 $sql = "SELECT date_format(o.date_purchased, '%Y-%m-%d')
           AS date_purchased_day, opd.download_maxdays, opd.download_count, opd.download_maxdays, opd.orders_products_filename, o.*
           FROM " . TABLE_ORDERS . " o, " . TABLE_ORDERS_PRODUCTS . " op, " . TABLE_ORDERS_PRODUCTS_DOWNLOAD . " opd
-          WHERE o.customers_id = customersID
-          AND o.orders_id = ordersID
+          WHERE o.orders_id = :ordersID
+          " . $lookup_clause . "
           AND o.orders_id = op.orders_id
           AND op.orders_products_id = opd.orders_products_id
-          AND opd.orders_products_download_id = downloadID
+          AND opd.orders_products_download_id = :downloadID
           AND opd.orders_products_filename != ''";
 
-$sql = $db->bindVars($sql, 'customersID', $_SESSION['customer_id'], 'integer');
-$sql = $db->bindVars($sql, 'downloadID', $_GET['id'], 'integer');
-$sql = $db->bindVars($sql, 'ordersID', $_GET['order'], 'integer');
-$downloads = $db->Execute($sql);
-if ($downloads->RecordCount() <= 0 ) die;
-
-$zco_notifier->notify('NOTIFY_CHECK_DOWNLOAD_HANDLER', array($downloads));
-
-// MySQL 3.22 does not have INTERVAL, so must calculate dates with PHP:
-list($dt_year, $dt_month, $dt_day) = explode('-', $downloads->fields['date_purchased_day']);
-$download_timestamp = mktime(23, 59, 59, $dt_month, $dt_day + $downloads->fields['download_maxdays'], $dt_year);
-
-// Die if time expired (maxdays = 0 means no time limit)
-if (($downloads->fields['download_maxdays'] != 0) && ($download_timestamp <= time())) {
-  zen_redirect(zen_href_link(FILENAME_DOWNLOAD_TIME_OUT));
-}
-// Die if remaining count is <=0 (maxdays = 0 means no time limit)
-if ($downloads->fields['download_count'] <= 0 and $downloads->fields['download_maxdays'] != 0) {
-  zen_redirect(zen_href_link(FILENAME_DOWNLOAD_TIME_OUT));
-}
-
-// FIX HERE AND GIVE ERROR PAGE FOR MISSING FILE
-// Die if file is not there
-if (!file_exists(DIR_FS_DOWNLOAD . $downloads->fields['orders_products_filename'])) die('Sorry. File not found. Please contact the webmaster to report this error.<br />c/f: ' . $downloads->fields['orders_products_filename']);
-
-// Now decrement counter (probably should skip this if download_maxdays = 0, ie: unlimited) -- move it up to lines 48-54?
-$sql = "UPDATE " . TABLE_ORDERS_PRODUCTS_DOWNLOAD . "
-          SET download_count = download_count-1
-          WHERE orders_products_download_id = :downloadID";
-
+$sql = $db->bindVars($sql, ':customersID', $_SESSION['customer_id'], 'integer');
 $sql = $db->bindVars($sql, ':downloadID', $_GET['id'], 'integer');
-$db->Execute($sql);
-
-// Returns a random name, 16 to 20 characters long
-// There are more than 10^28 combinations
-// The directory is "hidden", i.e. starts with '.'
-function zen_random_name()
-{
-  $letters = 'abcdefghijklmnopqrstuvwxyz';
-  $dirname = '.';
-  if (defined('DOWNLOADS_SKIP_DOT_PREFIX_ON_REDIRECT') && DOWNLOADS_SKIP_DOT_PREFIX_ON_REDIRECT === TRUE) $dirname = '';
-  $length = floor(zen_rand(16,20));
-  for ($i = 1; $i <= $length; $i++) {
-    $q = floor(zen_rand(0,25));
-    $dirname .= $letters[$q];
-  }
-  return $dirname;
+$sql = $db->bindVars($sql, ':ordersID', $_GET['order'], 'integer');
+if (isset($_SESSION['email_address'])) {
+  $sql = $db->bindVars($sql, ':emailAddress', $_SESSION['email_address'], 'string');
 }
+$downloads = $db->Execute($sql);
+if ($downloads->RecordCount() <= 0 ) exit(1);
 
-// Unlinks all subdirectories and files in $dir
-// Works only on one subdir level, will not recurse
-function zen_unlink_temp_dir($dir)
-{
-  $h1 = opendir($dir);
-  while ($subdir = readdir($h1)) {
-    // Ignore non directories
-    if (!is_dir($dir . $subdir)) continue;
-    // Ignore . and .. and .svn
-    if ($subdir == '.' || $subdir == '..' || $subdir == '.svn') continue;
-    // Loop and unlink files in subdirectory
-    $h2 = opendir($dir . $subdir);
-    list($fn, $exptime) = explode('-', $subdir);
-    if ($exptime + SYMLINK_GARBAGE_COLLECTION_THRESHOLD > time()) continue;
-    while ($file = readdir($h2)) {
-      if ($file == '.' || $file == '..') continue;
-      @unlink($dir . $subdir . '/' . $file);
-    }
-    closedir($h2);
-    @rmdir($dir . $subdir);
-  }
-  closedir($h1);
-}
-
-// disable gzip output buffering if active:
-@ob_end_clean();
-if (@ini_get('zlib.output_compression')) @ini_set('zlib.output_compression', 'Off');
+$source_directory = DIR_FS_DOWNLOAD;
+$service = 'local';
+$mime_type = 'application/force-download';
+$browser_headers_override = '';
+$browser_extra_headers = '';
 
 // determine filename for download
 $origin_filename = $downloads->fields['orders_products_filename'];
 $browser_filename = str_replace(' ', '_', $origin_filename);
 if (strstr($browser_filename, '/')) $browser_filename = substr($browser_filename, strrpos($browser_filename, '/')+1);
 if (strstr($browser_filename, '\\')) $browser_filename = substr($browser_filename, strrpos($browser_filename, '\\')+1);
-if (substr(DIR_FS_DOWNLOAD, -1) != '/') $origin_filename = '/' . $origin_filename;
-if (!file_exists(DIR_FS_DOWNLOAD . $origin_filename)) {
-  $msg = 'DOWNLOAD PROBLEM: Problems detected with download for ' . DIR_FS_DOWNLOAD . $origin_filename . ' because the file could not be found on the server. If the file exists, then its permissions are too low for PHP to access it. Contact your hosting company for specific help in determining correct permissions to make the file readable by PHP.';
+if (substr($source_directory, -1) != '/') $source_directory .= '/';
+
+$file_exists = file_exists($source_directory . $origin_filename);
+$downloadFilesize = (int)@filesize($source_directory . $origin_filename);
+
+// calculate days
+list($dt_year, $dt_month, $dt_day) = explode('-', $downloads->fields['date_purchased_day']);
+$download_timestamp = mktime(23, 59, 59, $dt_month, $dt_day + $downloads->fields['download_maxdays'], $dt_year);
+// determine limits
+$unlimited = $downloads->fields['download_maxdays'] == 0;
+$remainingCount = $downloads->fields['download_count'];
+$isExpired = !$unlimited && ($download_timestamp <= time() || $remainingCount <= 0);
+
+$zco_notifier->notify('NOTIFY_CHECK_DOWNLOAD_HANDLER', $downloads, $downloads->fields, $origin_filename, $browser_filename, $source_directory, $file_exists, $service, $isExpired, $download_timestamp);
+
+if ($isExpired) {
+  zen_redirect(zen_href_link(FILENAME_DOWNLOAD_TIME_OUT));
+}
+
+// FIX HERE AND GIVE ERROR PAGE FOR MISSING FILE
+// Die if file is not there
+if (!$file_exists) die('Sorry. File not found. Please contact the webmaster to report this error.<br />c/f: ' . $origin_filename);
+
+// Now decrement counter
+if (!isset($downloadsShouldDecrement) || $downloadsShouldDecrement === true) {
+  $sql = "UPDATE " . TABLE_ORDERS_PRODUCTS_DOWNLOAD . "
+            SET download_count = download_count-1
+            WHERE orders_products_download_id = :downloadID";
+  $sql = $db->bindVars($sql, ':downloadID', $_GET['id'], 'integer');
+  $db->Execute($sql);
+}
+
+// disable gzip output buffering if active:
+@ob_end_clean();
+if (@ini_get('zlib.output_compression')) @ini_set('zlib.output_compression', 'Off');
+
+
+if (!$file_exists) {
+  $msg = 'DOWNLOAD PROBLEM: Problems detected with download for ' . $source_directory . $origin_filename . '(' . $service . ')' . ' because the file could not be found on the server. If the file exists, then its permissions are too low for PHP to access it. Contact your hosting company for specific help in determining correct permissions to make the file readable by PHP.';
   zen_mail('', STORE_OWNER_EMAIL_ADDRESS, ERROR_CUSTOMER_DOWNLOAD_FAILURE, $msg, STORE_NAME, EMAIL_FROM);
 }
-$downloadFilesize = @filesize(DIR_FS_DOWNLOAD . $origin_filename);
-if (!isset($downloadFilesize) || ($downloadFilesize < 1)) {
-  $msg = 'DOWNLOAD PROBLEM: Problem detected with download for ' . DIR_FS_DOWNLOAD . $origin_filename . ' because the server is preventing PHP from reading the file size attributes, or the file is actually 0 bytes in size (which suggests the uploaded file is damaged or incomplete). Perhaps its permissions are too low for PHP to access it? Contact your hosting company for specific help in determining correct permissions to allow PHP to stat the file using the filesize() function.';
+
+if ($downloadFilesize < 1 && $service == 'local') {
+  $msg = 'DOWNLOAD PROBLEM: Problem detected with download for ' . $source_directory . $origin_filename . ' because the server is preventing PHP from reading the file size attributes, or the file is actually 0 bytes in size (which suggests the uploaded file is damaged or incomplete). Perhaps its permissions are too low for PHP to access it? Contact your hosting company for specific help in determining correct permissions to allow PHP to stat the file using the filesize() function.';
   zen_mail('', STORE_OWNER_EMAIL_ADDRESS, ERROR_CUSTOMER_DOWNLOAD_FAILURE, $msg, STORE_NAME, EMAIL_FROM);
 }
 
 
-    /**
-     * Browser detection
-     * Presently only checks for IE-specific cases.
-     */
-    $detectedBrowser = '';
-    if (preg_match('/msie/i', $_SERVER['HTTP_USER_AGENT']))
-    {
-      $version = explode(' ', stristr($_SERVER['HTTP_USER_AGENT'], 'msie'));
-      if ((int)$version[1] == 5) $detectedBrowser = 'IE5';
-      if ((int)$version[1] == 6) $detectedBrowser = 'IE6';
-      if ((int)$version[1] == 7) $detectedBrowser = 'IE7';
-      if ((int)$version[1] == 8) $detectedBrowser = 'IE8';
-      if ((int)$version[1] == 9) $detectedBrowser = 'IE9';
-    }
+/**
+ * Browser detection
+ * Presently only checks for IE-specific cases.
+ */
+$detectedBrowser = '';
+preg_match('/msie (.*?)/i', $_SERVER['HTTP_USER_AGENT'], $matches);
+if (count($matches) < 2)
+{
+  preg_match('/Trident\/\d{1,2}.\d{1,2}; rv:([0-9]*)/', $_SERVER['HTTP_USER_AGENT'], $matches);
+  if (count($matches)) $version = $matches[1];
+  if ($version > 5) {
+    $detectedBrowser = 'IE' . (int)$version;
+  }
+}
+
+$zco_notifier->notify('NOTIFY_DOWNLOAD_BROWSER_DETECTION', array(), $detectedBrowser, $_SERVER['HTTP_USER_AGENT'], $version, $browser_headers_override, $browser_extra_headers);
+
+/**
+ * Do we need to transform something?
+ * An observer class could stamp PDFs or do other pre-processing of the download media.
+ */
+$zco_notifier->notify('NOTIFY_DOWNLOAD_BEFORE_START', $_SESSION['customers_host_address'], $service, $origin_filename, $browser_filename, $source_directory, $downloadFilesize, $mime_type, $downloads->fields, $browser_headers);
+$zco_notifier->notify('NOTIFY_DOWNLOAD_READY_TO_START', $_SESSION['customers_host_address'], $service, $origin_filename, $browser_filename, $source_directory, $downloadFilesize, $mime_type, $downloads->fields, $browser_headers);
 
 
-    /**
-     * set notifier point ... we are ready to begin the actual download. An observer class could hook this notifier point and do something completely different, such as stamping PDFs etc.
-     */
-    $zco_notifier->notify('NOTIFY_DOWNLOAD_READY_TO_START', array($origin_filename, $browser_filename, $downloadFilesize, $_SESSION['customers_host_address'], $downloads->fields));
+/**
+ * Check whether any headers have already been set, because that will cause download problems:
+ */
+$hfile = $hline = '';
+if (headers_sent($hfile, $hline)) {
+  $msg = 'DOWNLOAD PROBLEM: Cannot begin download for ' . $origin_filename . ' because HTTP headers were already sent. This indicates a PHP error, probably in a language file.  Start by checking ' . $hfile . ' on line ' . $hline . '.';
+  error_log($msg);
+  zen_mail('', STORE_OWNER_EMAIL_ADDRESS, ERROR_CUSTOMER_DOWNLOAD_FAILURE, $msg, STORE_NAME, EMAIL_FROM);
+}
 
+if ($browser_headers_override == '') {
+  /**
+   * Now send the file with header() magic
+   * The "must-revalidate" and expiry times are used to prevent caching and fraudulent re-acquiring of files w/o redownloading.
+   * Certain browsers require certain header combinations, especially when related to SSL mode and caching
+   */
 
-    /**
-     * Check whether any headers have already been set, because that will cause download problems:
-     */
-    $hfile = $hline = '';
-    if (headers_sent($hfile, $hline)) {
-      $msg = 'DOWNLOAD PROBLEM: Cannot begin download for ' . $origin_filename . ' because HTTP headers were already sent. This indicates a PHP error, probably in a language file.  Start by checking ' . $hfile . ' on line ' . $hline . '.';
-      zen_mail('', STORE_OWNER_EMAIL_ADDRESS, ERROR_CUSTOMER_DOWNLOAD_FAILURE, $msg, STORE_NAME, EMAIL_FROM);
-    }
-
-    /**
-     * Now send the file with header() magic
-     * The "must-revalidate" and expiry times are used to prevent caching and fraudulent re-acquiring of files w/o redownloading.
-     * Certain browsers require certain header combinations, especially when related to SSL mode and caching
-     */
-
-    /**
-     * Set mime type
-     * These Content-Type headers should cause the downloaded file to trigger a "save as" dialog, instead of opening directly
-     * However, some browsers and some software already installed on the PC may cause this to be overridden simply based on the filename. In these cases, the user will have to manually choose "Save As" themselves.
-     * Alternatively, simply set the right handler in .htaccess
-     */
+  /**
+   * Set mime type
+   * These Content-Type headers should cause the downloaded file to trigger a "save as" dialog, instead of opening directly
+   * However, some browsers and some software already installed on the PC may cause this to be overridden simply based on the filename. In these cases, the user will have to manually choose "Save As" themselves.
+   * Alternatively, simply set the right handler in .htaccess
+   */
 //    header("Content-Type: application/x-octet-stream");
 //    header("Content-Type: application/octet-stream");
 //    header("Content-Type: application/download");
-    header("Content-Type: application/force-download");
+//    header("Content-Type: application/force-download");
+  header("Content-Type: " . $mime_type);
 
-    header('Content-Disposition: attachment; filename="' . urlencode($browser_filename) . '"');
+  header('Content-Disposition: attachment; filename="' . urlencode($browser_filename) . '"');
 
-//     relocated below
-//     if ((int)$downloadFilesize > 0) header("Content-Length: " . (string) $downloadFilesize);
-
-    header("Expires: Mon, 22 Jan 2002 00:00:00 GMT");
-    header("Last-Modified: " . gmdate("D,d M Y H:i:s") . " GMT");
-    switch($detectedBrowser)
-    {
-      case 'IE5':
-      case 'IE6':
-        header("Pragma: public");
-        header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
-        header("Cache-Control: private", FALSE);
-        header("Cache-Control: max-age=1");  // stores for only 1 second, which helps allow SSL downloads to work more reliably in IE
+  header("Expires: Mon, 22 Jan 2002 00:00:00 GMT");
+  header("Last-Modified: " . gmdate("D,d M Y H:i:s") . " GMT");
+  switch($detectedBrowser)
+  {
+    case 'IE6':
+    case 'IE7':
+    case 'IE8':
+    case 'IE9':
+      header("Pragma: public");
+      header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
+      header("Cache-Control: private", FALSE);
+      header("Cache-Control: max-age=1");  // stores for only 1 second, which helps allow SSL downloads to work more reliably in IE
       break;
-      case 'IE7':
-      case 'IE8':
-      case 'IE9':
-        header("Pragma: public");
-        header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
-        header("Cache-Control: private", FALSE);
-        header("Cache-Control: max-age=1");  // stores for only 1 second, which helps allow SSL downloads to work more reliably in IE
-        break;
-      default:
-        header("Cache-Control: no-cache, must-revalidate");
-        header("Pragma: no-cache");
-      break;
-    }
-
-    header("Content-Transfer-Encoding: binary");
-
-
-// NOTE: Redirect usually will work only on Unix/Linux hosts since Windows hosts can't do symlinking in PHP versions older than 5.3.0
-
-if (DOWNLOAD_BY_REDIRECT == 'true') {
-  zen_unlink_temp_dir(DIR_FS_DOWNLOAD_PUBLIC);
-  $tempdir = zen_random_name() . '-' . time();
-  umask(0000);
-  mkdir(DIR_FS_DOWNLOAD_PUBLIC . $tempdir, 0777);
-  $download_link = str_replace(array('/','\\'),'_',$browser_filename);
-  $link_create_status = @symlink(DIR_FS_DOWNLOAD . $origin_filename, DIR_FS_DOWNLOAD_PUBLIC . $tempdir . '/' . $download_link);
-
-  if ($link_create_status==true) {
-    $zco_notifier->notify('NOTIFY_DOWNLOAD_VIA_SYMLINK___BEGINS', $download_link, $origin_filename, $tempdir);
-    header("HTTP/1.1 303 See Other");
-    zen_redirect(DIR_WS_DOWNLOAD_PUBLIC . $tempdir . '/' . $download_link, 303);
+    default:
+      header("Cache-Control: no-cache, must-revalidate");
+      header("Pragma: no-cache");
+    break;
   }
+  header("Content-Transfer-Encoding: binary");
+
+} else {
+  header($browser_headers_override);
 }
 
-if (DOWNLOAD_BY_REDIRECT != 'true' or $link_create_status==false ) {
-  // not downloading by redirect; instead, we stream it to the browser.
-  // This happens if the symlink couldn't happen, or if set as default in Admin
+if ($browser_extra_headers != '') header($browser_extra_headers);
 
-  if ((int)$downloadFilesize > 0) header("Content-Length: " . (string) $downloadFilesize);
+// Attempt to do download-by-redirect. It won't fire if not enabled. If it's disabled or fails setup we will cascade to streaming instead.
+$link_create_status = false;
+$zco_notifier->notify('NOTIFY_DOWNLOAD_READY_TO_REDIRECT', array(), $service, $origin_filename, $browser_filename, $source_directory, $link_create_status);
+
+// We don't get here unless not downloading by redirect; instead, we stream it to the browser.
+// This happens if the symlink couldn't happen, or if set as default in Admin
+$zco_notifier->notify('NOTIFY_DOWNLOAD_READY_TO_STREAM', array(), $service, $origin_filename, $browser_filename, $source_directory, $downloadFilesize);
 
 
-  $disabled_funcs = @ini_get("disable_functions");
-  if (DOWNLOAD_IN_CHUNKS != 'true' && !strstr($disabled_funcs,'readfile')) {
-    $zco_notifier->notify('NOTIFY_DOWNLOAD_WITHOUT_REDIRECT___COMPLETED', $origin_filename);
-    // close the session, since it is not needed for streaming the file contents
-    session_write_close();
-    // Dump the file to the browser. This will work on all systems, but will need considerable resources
-    readfile(DIR_FS_DOWNLOAD . $origin_filename);
-  } else {
-    // override PHP timeout to 25 minutes, if allowed
-    @set_time_limit(1500);
-    $zco_notifier->notify('NOTIFY_DOWNLOAD_IN_CHUNKS___COMPLETED', $origin_filename);
-    // loop with fread($fp, xxxx) to allow streaming in chunk sizes below the PHP memory_limit
-    $handle = @fopen(DIR_FS_DOWNLOAD . $origin_filename, "rb");
-    if ($handle) {
-      // close the session, since it is not needed for streaming the file contents
-      session_write_close();
-      // stream the file in 4K chunks
-      while (!@feof($handle)) {
-        echo(fread($handle, 4096));
-        @flush();
-      }
-      fclose($handle);
-    } else {
-      // Throw error condition -- this should never happen!
-      $messageStack->add_session('default', 'Please contact store owner.  ERROR: Cannot read file: ' . $origin_filename, 'error');
-      zen_mail('', STORE_OWNER_EMAIL_ADDRESS, ERROR_CUSTOMER_DOWNLOAD_FAILURE, "Unable to open file '" . $origin_filename . " for reading.  Check the file permissions.", STORE_NAME, EMAIL_FROM);
-    }
-    $zco_notifier->notify('NOTIFY_DOWNLOAD_WITHOUT_REDIRECT_VIA_CHUNKS___COMPLETED');
-  }
-}
-
-// This should be last line of the script:
 $zco_notifier->notify('NOTIFY_HEADER_END_DOWNLOAD');
 
 // finally, upon completion of the download, the script should end here and not attempt to display any template components etc.

--- a/includes/templates/template_default/templates/tpl_modules_downloads.php
+++ b/includes/templates/template_default/templates/tpl_modules_downloads.php
@@ -2,21 +2,37 @@
 /**
  * Module Template
  *
+ * NOTE: The clickable download links will appear only if:
+ * - Download remaining count is > 0, AND
+ * - The file is present in the DOWNLOAD directory, AND EITHER
+ * - No expiry date is enforced (maxdays == 0), OR
+ * - The expiry date is not reached
+ *
  * @package templateSystem
- * @copyright Copyright 2003-2016 Zen Cart Development Team
+ * @copyright Copyright 2003-2017 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: DrByte  Fri Jan 8 13:28:51 2016 -0500 Modified in v1.5.5 $
+ * @version $Id: tpl_modules_downloads.php  Modified in v1.5.6 $
  */
 /**
  * require the downloads module
  */
   require(DIR_WS_MODULES . zen_get_module_directory('downloads.php'));
-?>
 
+// if download is not available yet
+if ($downloadsNotAvailableYet) {
+?>
+ <fieldset><?php echo DOWNLOADS_CONTROLLER_ON_HOLD_MSG ?></fieldset>
 <?php
+  return;
+}
+
+if ($numberOfDownloads < 1) {
+  return;
+}
+
+
 // download is available
-  if ($downloads->RecordCount() > 0) {
 ?>
 
 <h4 id="headingDownloads"><?php echo HEADING_DOWNLOAD; ?></h4>
@@ -28,77 +44,38 @@
       <th scope="col" id="dlDateHeading"><?php echo TABLE_HEADING_DOWNLOAD_DATE; ?></th>
       <th scope="col" id="dlCountHeading"><?php echo TABLE_HEADING_DOWNLOAD_COUNT; ?></th>
       <th scope="col" id="dlButtonHeading">&nbsp;</th>
-          </tr>
+  </tr>
 <!-- list of products -->
 <?php
-    while (!$downloads->EOF) {
-// MySQL 3.22 does not have INTERVAL
-      list($dt_year, $dt_month, $dt_day) = explode('-', $downloads->fields['date_purchased_day']);
-      $download_timestamp = mktime(23, 59, 59, $dt_month, $dt_day + $downloads->fields['download_maxdays'], $dt_year);
-      $download_expiry = date('Y-m-d H:i:s', $download_timestamp);
-
-      $is_downloadable = ( (file_exists(DIR_FS_DOWNLOAD . $downloads->fields['orders_products_filename']) && (($downloads->fields['download_count'] > 0 && $download_timestamp > time()) || $downloads->fields['download_maxdays'] == 0)) ) ? true : false;
-      $zv_filesize = filesize (DIR_FS_DOWNLOAD . $downloads->fields['orders_products_filename']);
-      if ($zv_filesize >= 1024) {
-        $zv_filesize = number_format($zv_filesize/1024/1024,2);
-        $zv_filesize_units = TEXT_FILESIZE_MEGS;
-      } else {
-        $zv_filesize = number_format($zv_filesize);
-        $zv_filesize_units = TEXT_FILESIZE_BYTES;
-      }
+    foreach($downloads as $file) {
 ?>
-          <tr class="tableRow">
+  <tr class="tableRow">
 <!-- left box -->
 <?php
-// The link will appear only if:
-// - Download remaining count is > 0, AND
-// - The file is present in the DOWNLOAD directory, AND EITHER
-// - No expiry date is enforced (maxdays == 0), OR
-// - The expiry date is not reached
-
-//      if ( ($downloads->fields['download_count'] > 0) && (file_exists(DIR_FS_DOWNLOAD . $downloads->fields['orders_products_filename'])) && ( ($downloads->fields['download_maxdays'] == 0) || ($download_timestamp > time())) ) {
-      if  ($is_downloadable) {
+  if ($file['is_downloadable']) {
 ?>
-      <td class=""><?php echo '<a href="' . zen_href_link(FILENAME_DOWNLOAD, 'order=' . $last_order . '&id=' . $downloads->fields['orders_products_download_id']) . '">' . $downloads->fields['products_name'] . '</a>'; ?></td>
+      <td class="downloadProductNameLink"><?php echo '<a href="' . $file['link_url'] . '" download="' . $file['filename'] . '">' . $file['products_name'] . '</a>'; ?></td>
 <?php } else { ?>
-      <td class=""><?php echo $downloads->fields['products_name']; ?></td>
+      <td class="downloadProductName"><?php echo $file['products_name']; ?></td>
 <?php
-      }
+  }
 ?>
-      <td class=""><?php echo $zv_filesize . $zv_filesize_units; ?></td>
-      <td class=""><?php echo $downloads->fields['orders_products_filename']; ?></td>
-      <td class=""><?php echo ($downloads->fields['download_maxdays'] == 0 ? TEXT_DOWNLOADS_UNLIMITED : zen_date_short($download_expiry)); ?></td>
-      <td class="centeredContent"><?php echo ($downloads->fields['download_maxdays'] == 0 ? TEXT_DOWNLOADS_UNLIMITED_COUNT : $downloads->fields['download_count']); ?></td>
-      <td class="centeredContent"><?php echo ($is_downloadable) ? '<a href="' . zen_href_link(FILENAME_DOWNLOAD, 'order=' . $last_order . '&id=' . $downloads->fields['orders_products_download_id']) . '">' . zen_image_button(BUTTON_IMAGE_DOWNLOAD, BUTTON_DOWNLOAD_ALT) . '</a>' : '&nbsp;'; ?></td>
+      <td class="downloadFilesize"><?php echo $file['filesize'] . $file['filesize_units']; ?></td>
+      <td class="downloadFilename"><?php echo $file['filename']; ?></td>
+      <td class="downloadExpiry"><?php echo ($file['unlimited_downloads'] ? TEXT_DOWNLOADS_UNLIMITED : zen_date_short($file['expiry'])); ?></td>
+      <td class="downloadCounts centeredContent"><?php echo ($file['unlimited_downloads'] ? TEXT_DOWNLOADS_UNLIMITED_COUNT : $file['download_count']); ?></td>
+      <td class="downloadButton centeredContent"><?php echo ($file['is_downloadable']) ? '<a href="' . $file['link_url'] . '" download="' . $file['filename'] . '">' . zen_image_button(BUTTON_IMAGE_DOWNLOAD, BUTTON_DOWNLOAD_ALT) . '</a>' : '&nbsp;'; ?></td>
     </tr>
 <?php
-    $downloads->MoveNext();
-    }
+    } // end foreach
 ?>
   </table>
 
 <?php
-// old way
-//    if (!strstr($PHP_SELF, FILENAME_ACCOUNT_HISTORY_INFO)) {
-// new way
-      if (!($_GET['main_page']==FILENAME_ACCOUNT_HISTORY_INFO)) {
+  if ($show_footer_link_to_my_account) {
 ?>
 <p><?php printf(FOOTER_DOWNLOAD, '<a href="' . zen_href_link(FILENAME_ACCOUNT, '', 'SSL') . '">' . HEADER_TITLE_MY_ACCOUNT . '</a>'); ?></p>
-<?php } else { ?>
 <?php
-// other pages if needed
-      }
+  }
 ?>
 
-<?php
-} // $downloads->RecordCount() > 0
-?>
-
-<?php
-// download is not available yet
-if ($downloads_check_query->RecordCount() > 0 and $downloads->RecordCount() < 1) {
-?>
- <fieldset><?php echo DOWNLOADS_CONTROLLER_ON_HOLD_MSG ?></fieldset>
-<?php
-}
-?>


### PR DESCRIPTION
Merges #327 and #347

- added support for AWS-hosted downloads (files on AWS S3) ... simply give `aws:bucketname/filename.ext:number_of_bytes` as the filename in attributes controller or download-manager
- added support for URL-based downloads, such as Dropbox or any other http/https URL which requires no authentication by the customer (NOTE: offers no theft prevention)
- cleaned up the My Account list of downloads, for simpler styling
- changed both admin and catalog to allow observers to provide details of file availability
- moved download-by-redirect and download-by-streaming to observer class

Notes:
- If using with Dropbox, set the `&dl=0` to `&dl=1` on the "sharing link" that Dropbox gives you, so that the file is immediately downloaded for the customer.
- If sharing from Google Drive, be sure to configure the Sharing Permissions properly, and obtain a shareable link that's got read-only access.

Dev tip:
- For AWS, to keep credentials out of version-control, put them into the `extra-configures` folder, and prefix the filename with `dev-` since that's in the project's `.gitignore` already.