### PR TITLE
ZC156: remove unused global, and replace tabs with spaces

### DIFF
--- a/includes/classes/categories_ul_generator.php
+++ b/includes/classes/categories_ul_generator.php
@@ -38,14 +38,14 @@ class zen_categories_ul_generator {
     
     function __construct($load_from_database = true)
     {
-        global $languages_id, $db;
+        global $db;
         $this->data = array();
-        $categories_query = "select c.categories_id, cd.categories_name, c.parent_id
-										from " . TABLE_CATEGORIES . " c, " . TABLE_CATEGORIES_DESCRIPTION . " cd
-										where c.categories_id = cd.categories_id
-										and c.categories_status=1 " .
-        								" and cd.language_id = '" . (int)$_SESSION['languages_id'] . "' " .
-        								" order by c.parent_id, c.sort_order, cd.categories_name";
+        $categories_query = "SELECT c.categories_id, cd.categories_name, c.parent_id
+                             FROM " . TABLE_CATEGORIES . " c, " . TABLE_CATEGORIES_DESCRIPTION . " cd
+                             WHERE c.categories_id = cd.categories_id
+                             AND c.categories_status = 1
+                             AND cd.language_id = " . (int)$_SESSION['languages_id'] . "
+                             ORDER BY c.parent_id, c.sort_order, cd.categories_name";
         $categories = $db->Execute($categories_query);
         while (!$categories->EOF) {
             $this->data[$categories->fields['parent_id']][$categories->fields['categories_id']] = array('name' => $categories->fields['categories_name'], 'count' => 0);
@@ -68,7 +68,7 @@ class zen_categories_ul_generator {
                 $result .= str_repeat($this->spacer_string, $this->spacer_multiplier * 1) . '<a href="' . zen_href_link(FILENAME_DEFAULT, 'cPath=' . $category_link) . '">';
                 $result .= $category['name'];
                 $result .= '</a>';
-				  
+
                 if (($this->data[$category_id]) && (($this->max_level == '0') || ($this->max_level > $level+1))) {
                     $result .= $this->buildBranch($category_id, $level+1, $submenu, $category_link . '_');
                 }


### PR DESCRIPTION
The global $language_id is unused and removed.
Replaced the tab with spaces
Cleaned up the sql query, by removing unnecessary characters and aligning lines.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zencart/zencart/1589)
<!-- Reviewable:end -->
