### PR TITLE
[v156] Add MyAccount and ContactUs buttons to checkout-success page

### DIFF
--- a/includes/languages/english/button_names.php
+++ b/includes/languages/english/button_names.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * @package languageDefines
- * @copyright Copyright 2003-2016 Zen Cart Development Team
+ * @copyright Copyright 2003-2018 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: DrByte  Fri Jan 8 01:41:14 2016 -0500 Modified in v1.5.5 $
+ * @version $Id: Author: DrByte  Modified in v1.5.6 $
  */
 
 
@@ -22,6 +22,7 @@ define('BUTTON_IMAGE_CHANGE_ADDRESS', 'button_change_address.gif');
 define('BUTTON_IMAGE_CHECKOUT', 'button_checkout.gif');
 define('BUTTON_IMAGE_CONFIRM_SEND', 'button_confirm_send.gif');
 define('BUTTON_IMAGE_CONFIRM_ORDER', 'button_confirm_order.gif');
+define('BUTTON_IMAGE_CONTACT_US', 'button_contact_us.gif');
 define('BUTTON_IMAGE_CONTINUE', 'button_continue.gif');
 define('BUTTON_IMAGE_CONTINUE_SHOPPING', 'button_continue_shopping.gif');
 define('BUTTON_IMAGE_DELETE', 'button_delete.gif');
@@ -30,6 +31,8 @@ define('BUTTON_IMAGE_DOWNLOAD', 'button_download.gif');
 define('BUTTON_IMAGE_EDIT_SMALL', 'small_edit.gif');
 define('BUTTON_IMAGE_IN_CART', 'button_in_cart.gif');
 define('BUTTON_IMAGE_LOGIN', 'button_login.gif');
+define('BUTTON_IMAGE_MY_ACCOUNT', 'button_my_account.gif');
+define('BUTTON_IMAGE_MY_ORDERS', 'button_my_orders.gif');
 define('BUTTON_IMAGE_NEXT', 'button_next.gif');
 define('BUTTON_IMAGE_PREVIOUS', 'button_prev.gif');
 define('BUTTON_IMAGE_REDEEM', 'button_redeem.gif');
@@ -74,6 +77,7 @@ define('BUTTON_CHANGE_ADDRESS_ALT', 'Change Address');
 define('BUTTON_CHECKOUT_ALT', 'Checkout');
 define('BUTTON_CONFIRM_SEND_ALT', 'Send Gift Certificate');
 define('BUTTON_CONFIRM_ORDER_ALT', 'Confirm Order');
+define('BUTTON_CONTACT_US_TEXT', 'Contact Us');
 define('BUTTON_CONTINUE_ALT', 'Continue');
 define('BUTTON_CONTINUE_SHOPPING_ALT', 'Continue Shopping');
 define('BUTTON_DELETE_ALT', 'Delete');
@@ -83,6 +87,8 @@ define('BUTTON_EDIT_SMALL_ALT', 'Edit');
 define('BUTTON_IN_CART_ALT', 'Add to Cart');
 define('BUTTON_LOGIN_ALT', 'Sign In');
 define('BUTTON_LOOKUP_ALT', 'Lookup');
+define('BUTTON_MY_ACCOUNT_TEXT', 'My Account');
+define('BUTTON_MY_ORDERS_TEXT', 'My Orders');
 define('BUTTON_NEXT_ALT', 'Next');
 define('BUTTON_PREVIOUS_ALT', 'Previous');
 define('BUTTON_REDEEM_ALT', 'Redeem');

--- a/includes/languages/english/checkout_success.php
+++ b/includes/languages/english/checkout_success.php
@@ -14,7 +14,6 @@ define('HEADING_TITLE', 'Thank You! We Appreciate your Business!');
 
 define('TEXT_SUCCESS', '');
 define('TEXT_NOTIFY_PRODUCTS', 'Please notify me of updates to these products');
-define('TEXT_SEE_ORDERS', 'You can view your order history by going to the "My Account" page and by clicking on "View All Orders".');
 define('TEXT_CONTACT_STORE_OWNER', 'Please direct any questions to customer service.');
 define('TEXT_THANKS_FOR_SHOPPING', 'Thanks for shopping with us online!');
 

--- a/includes/languages/english/checkout_success.php
+++ b/includes/languages/english/checkout_success.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * @package languageDefines
- * @copyright Copyright 2003-2016 Zen Cart Development Team
+ * @copyright Copyright 2003-2018 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: DrByte  Mon Mar 23 13:48:06 2015 -0400 Modified in v1.5.5 $
+ * @version $Id: Author: DrByte  Modified in v1.5.6 $
  */
 
 define('NAVBAR_TITLE_1', 'Checkout');
@@ -14,8 +14,8 @@ define('HEADING_TITLE', 'Thank You! We Appreciate your Business!');
 
 define('TEXT_SUCCESS', '');
 define('TEXT_NOTIFY_PRODUCTS', 'Please notify me of updates to these products');
-define('TEXT_SEE_ORDERS', 'You can view your order history by going to the <a href="' . zen_href_link(FILENAME_ACCOUNT, '', 'SSL') . '" name="linkMyAccount">My Account</a> page and by clicking on "View All Orders".');
-define('TEXT_CONTACT_STORE_OWNER', 'Please direct any questions you have to <a href="' . zen_href_link(FILENAME_CONTACT_US, '', 'SSL') . '" name="linkContactUs">customer service</a>.');
+define('TEXT_SEE_ORDERS', 'You can view your order history by going to the "My Account" page and by clicking on "View All Orders".');
+define('TEXT_CONTACT_STORE_OWNER', 'Please direct any questions to customer service.');
 define('TEXT_THANKS_FOR_SHOPPING', 'Thanks for shopping with us online!');
 
 define('TABLE_HEADING_COMMENTS', '');

--- a/includes/templates/template_default/templates/tpl_checkout_success_default.php
+++ b/includes/templates/template_default/templates/tpl_checkout_success_default.php
@@ -6,10 +6,10 @@
  * Displays confirmation details after order has been successfully processed.
  *
  * @package templateSystem
- * @copyright Copyright 2003-2016 Zen Cart Development Team
+ * @copyright Copyright 2003-2018 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: DrByte  Mon Mar 23 13:48:06 2015 -0400 Modified in v1.5.5 $
+ * @version $Id: Author: DrByte  Modified in v1.5.6 $
  */
 ?>
 <div class="centerColumn" id="checkoutSuccess">
@@ -49,7 +49,7 @@ if (isset($additional_payment_messages) && $additional_payment_messages != '') {
 }
 ?>
 <!-- eof payment-method-alerts -->
-<!--bof logoff-->
+
 <div id="checkoutSuccessLogoff">
 <?php
   if (isset($_SESSION['customer_guest_id'])) {
@@ -58,13 +58,19 @@ if (isset($additional_payment_messages) && $additional_payment_messages != '') {
     echo TEXT_CHECKOUT_LOGOFF_CUSTOMER;
   }
 ?>
-<div class="buttonRow forward"><a href="<?php echo zen_href_link(FILENAME_LOGOFF, '', 'SSL'); ?>"><?php echo zen_image_button(BUTTON_IMAGE_LOG_OFF , BUTTON_LOG_OFF_ALT); ?></a></div>
 </div>
-<!--eof logoff-->
+<div class="buttonRow forward">
+    <a href="<?php echo zen_href_link(FILENAME_CONTACT_US, '', 'SSL'); ?>" name="linkContactUs"><?php echo zen_image_button(BUTTON_IMAGE_LOG_OFF , BUTTON_CONTACT_US_TEXT); ?></a>
+    <a href="<?php echo zen_href_link(FILENAME_ACCOUNT, '', 'SSL'); ?>" name="linkMyAccount"><?php echo zen_image_button(BUTTON_IMAGE_MY_ORDERS , BUTTON_MY_ORDERS_TEXT); ?></a>
+    <a href="<?php echo zen_href_link(FILENAME_LOGOFF, '', 'SSL'); ?>" name="linkLogoff"><?php echo zen_image_button(BUTTON_IMAGE_LOG_OFF , BUTTON_LOG_OFF_ALT); ?></a>
+</div>
 
-<div id="checkoutSuccessOrderLink"><?php echo TEXT_SEE_ORDERS;?></div>
+
+<div id="checkoutSuccessOrderLink"><?php //echo TEXT_SEE_ORDERS;?></div>
 
 <div id="checkoutSuccessContactLink"><?php echo TEXT_CONTACT_STORE_OWNER;?></div>
+
+<br class="clearBoth" />
 
 <!-- bof order details -->
 <?php

--- a/includes/templates/template_default/templates/tpl_checkout_success_default.php
+++ b/includes/templates/template_default/templates/tpl_checkout_success_default.php
@@ -65,9 +65,6 @@ if (isset($additional_payment_messages) && $additional_payment_messages != '') {
     <a href="<?php echo zen_href_link(FILENAME_LOGOFF, '', 'SSL'); ?>" name="linkLogoff"><?php echo zen_image_button(BUTTON_IMAGE_LOG_OFF , BUTTON_LOG_OFF_ALT); ?></a>
 </div>
 
-
-<div id="checkoutSuccessOrderLink"><?php //echo TEXT_SEE_ORDERS;?></div>
-
 <div id="checkoutSuccessContactLink"><?php echo TEXT_CONTACT_STORE_OWNER;?></div>
 
 <br class="clearBoth" />


### PR DESCRIPTION
Instead of making the language-string contain tiny text-only links, add specific obvious buttons so people know how to take action.

<img width="415" alt="screen shot 2018-01-11 at 1 28 23 pm" src="https://user-images.githubusercontent.com/404472/34840556-561edcb4-f6d3-11e7-9a17-2f63d169e453.png">