### PR TITLE
Core schema changes to accommodate utf8mb4 index length limits

### DIFF
--- a/zc_install/ajaxLoadMainSql.php
+++ b/zc_install/ajaxLoadMainSql.php
@@ -2,9 +2,9 @@
 /**
  * ajaxLoadMainSql.php
  * @package Installer
- * @copyright Copyright 2003-2016 Zen Cart Development Team
+ * @copyright Copyright 2003-2018 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: DrByte  Fri Oct 9 15:32:07 2015 -0400 New in v1.5.5 $
+ * @version $Id: Author: DrByte  Modified in v1.5.6 $
  */
 define('IS_ADMIN_FLAG', false);
 if (!defined('__DIR__')) define('__DIR__', dirname(__FILE__));
@@ -35,10 +35,12 @@ if ($error)
   echo json_encode(array('error'=>$error, 'file'=>$file)); die();
 }
 // localization file
-if (file_exists(DIR_FS_INSTALL . 'sql/install/mysql_' . $_POST['db_charset'] . '.sql'))
+$charset = $_POST['db_charset'];
+if (!in_array(array('utf8', 'latin1'), $charset)) $charset = 'utf8';
+$file = DIR_FS_INSTALL . 'sql/install/mysql_' . $charset . '.sql';
+if (file_exists($file))
 {
   $extendedOptions = array('doJsonProgressLogging'=>TRUE, 'doJsonProgressLoggingFileName'=>DEBUG_LOG_FOLDER . '/progress.json', 'id'=>'main', 'message'=>TEXT_LOADING_CHARSET_SPECIFIC);
-  $file = DIR_FS_INSTALL . 'sql/install/mysql_' . $_POST['db_charset'] . '.sql';
   logDetails('processing file ' . $file);
   $error = $dbInstaller->parseSqlFile($file, $extendedOptions);
 }

--- a/zc_install/includes/EXAMPLE_custom_settings.php
+++ b/zc_install/includes/EXAMPLE_custom_settings.php
@@ -1,9 +1,10 @@
 <?php
 /**
  * Custom Settings used by the CLI version of zc_install
+ * NOTE: Not Currently Used
  *
  * @package installer
- * @copyright Copyright 2003-2016 Zen Cart Development Team
+ * @copyright Copyright 2003-2018 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  */
 $zc_settings = array();
@@ -84,10 +85,10 @@ $zc_settings['db_prefix'] = '';
 
 /**
  * The character-set to use when talking to the database.
- * Possible values: 'utf8' or 'latin1'.
- * Default: 'utf8'
+ * Possible values: 'utf8mb4' or older 'utf8' / 'latin1'
+ * Default: 'utf8mb4'
  */
-$zc_settings['db_charset'] = 'utf8';
+$zc_settings['db_charset'] = 'utf8mb4';
 
 /**
  * Provide the internally-resolvable hostname to connect with the MySQL database.

--- a/zc_install/includes/admin-configure-template.php
+++ b/zc_install/includes/admin-configure-template.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package Configuration Settings
- * @copyright Copyright 2003-2016 Zen Cart Development Team
+ * @copyright Copyright 2003-2018 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * File Built by %%_INSTALLER_METHOD_%% on %%_DATE_NOW_%%
@@ -64,7 +64,7 @@ define('DIR_FS_CATALOG', '%%_DIR_FS_CATALOG_%%');
  */
 define('DB_TYPE', '%%_DB_TYPE_%%'); // always 'mysql'
 define('DB_PREFIX', '%%_DB_PREFIX_%%'); // prefix for database table names -- preferred to be left empty
-define('DB_CHARSET', '%%_DB_CHARSET_%%'); // 'utf8' or 'latin1' are most common
+define('DB_CHARSET', '%%_DB_CHARSET_%%'); // 'utf8mb4' or older 'utf8' / 'latin1' are most common
 define('DB_SERVER', '%%_DB_SERVER_%%');  // address of your db server
 define('DB_SERVER_USERNAME', '%%_DB_SERVER_USERNAME_%%');
 define('DB_SERVER_PASSWORD', '%%_DB_SERVER_PASSWORD_%%');

--- a/zc_install/includes/catalog-configure-template.php
+++ b/zc_install/includes/catalog-configure-template.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package Configuration Settings
- * @copyright Copyright 2003-2016 Zen Cart Development Team
+ * @copyright Copyright 2003-2018 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * File Built by %%_INSTALLER_METHOD_%% on %%_DATE_NOW_%%
@@ -43,7 +43,7 @@ define('DIR_FS_CATALOG', '%%_DIR_FS_CATALOG_%%');
  */
 define('DB_TYPE', '%%_DB_TYPE_%%'); // always 'mysql'
 define('DB_PREFIX', '%%_DB_PREFIX_%%'); // prefix for database table names -- preferred to be left empty
-define('DB_CHARSET', '%%_DB_CHARSET_%%'); // 'utf8' or 'latin1' are most common
+define('DB_CHARSET', '%%_DB_CHARSET_%%'); // 'utf8mb4' or older 'utf8' / 'latin1' are most common
 define('DB_SERVER', '%%_DB_SERVER_%%');  // address of your db server
 define('DB_SERVER_USERNAME', '%%_DB_SERVER_USERNAME_%%');
 define('DB_SERVER_PASSWORD', '%%_DB_SERVER_PASSWORD_%%');

--- a/zc_install/includes/classes/class.zcConfigureFileWriter.php
+++ b/zc_install/includes/classes/class.zcConfigureFileWriter.php
@@ -2,9 +2,9 @@
 /**
  * file contains zcConfigureFileWriter class
  * @package Installer
- * @copyright Copyright 2003-2016 Zen Cart Development Team
+ * @copyright Copyright 2003-2018 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: DrByte  Tue Feb 16 15:03:47 2016 -0500 New in v1.5.5 $
+ * @version $Id: Author: DrByte  Modified in v1.5.6 $
  */
 /**
  *
@@ -34,7 +34,7 @@ class zcConfigureFileWriter
     $replaceVars['DB_PREFIX'] = trim($inputs['db_prefix']);
 
     $replaceVars['DB_CHARSET'] = trim($inputs['db_charset']);
-    if ($replaceVars['DB_CHARSET'] == '') $replaceVars['DB_CHARSET'] = 'utf8';
+    if ($replaceVars['DB_CHARSET'] == '') $replaceVars['DB_CHARSET'] = 'utf8mb4';
 
     $replaceVars['DB_SERVER'] = trim($inputs['db_host']);
     $replaceVars['DB_SERVER_USERNAME'] = trim($inputs['db_user']);

--- a/zc_install/includes/classes/class.zcDatabaseInstaller.php
+++ b/zc_install/includes/classes/class.zcDatabaseInstaller.php
@@ -2,9 +2,9 @@
 /**
  * file contains zcDatabaseInstaller Class
  * @package Installer
- * @copyright Copyright 2003-2016 Zen Cart Development Team
+ * @copyright Copyright 2003-2018 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: DrByte  Thu Mar 21 16:18:21 2016 -0500 New in v1.5.5 $
+ * @version $Id: Author: DrByte  Modified in v1.5.6 $
  *
  */
 /**
@@ -32,7 +32,7 @@ class zcDatabaseInstaller
     $this->dbPassword = $options['db_password'];
     $this->dbName = $options['db_name'];
     $this->dbPrefix = $options['db_prefix'];
-    $this->dbCharset = trim($options['db_charset']) == '' ? 'utf8' : $options['db_charset'];
+    $this->dbCharset = trim($options['db_charset']) == '' ? 'utf8mb4' : $options['db_charset'];
     $this->dbType = in_array($options['db_type'], $dbtypes) ? $options['db_type'] : 'mysql';
     $this->dieOnErrors = isset($options['dieOnErrors']) ? (bool)$options['dieOnErrors'] : FALSE;
     $this->errors = array();

--- a/zc_install/includes/cli_controller.php
+++ b/zc_install/includes/cli_controller.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * @package Installer
- * @copyright Copyright 2003-2016 Zen Cart Development Team
+ * @copyright Copyright 2003-2018 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: zcwilt  Wed Sep 23 20:04:38 2015 +0100 New in v1.5.5 $
+ * @version $Id: Author: zcwilt  Modified in v1.5.6 $
  */
 
 if (!file_exists(DIR_FS_INSTALL . 'includes/custom_settings.php')) {
@@ -56,7 +56,7 @@ if (count($adminDirectoryList) > 1)
 // do auto-detections
 list($adminDir, $documentRoot, $adminServer, $catalogHttpServer, $catalogHttpUrl, $catalogHttpsServer, $catalogHttpsUrl, $dir_ws_http_catalog, $dir_ws_https_catalog) = getDetectedURIs();
 $db_type = 'mysql';
-$db_charset = 'utf8';
+$db_charset = 'utf8mb4';
 $db_prefix = '';
 $sql_cache_method = 'none'; // 'file', 'database'
 $db_host = isset($zc_settings['db_host']) ? $zc_settings['db_host'] : 'localhost';

--- a/zc_install/includes/languages/lngEnglish.php
+++ b/zc_install/includes/languages/lngEnglish.php
@@ -2,9 +2,9 @@
 /**
  * Main English language file for installer
  * @package Installer
- * @copyright Copyright 2003-2016 Zen Cart Development Team
+ * @copyright Copyright 2003-2018 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: DrByte  Tue Feb 16 15:03:47 2016 -0500 New in v1.5.5 $
+ * @version $Id: Author: DrByte  Modified in v1.5.6 $
  */
 /**
  * defining language components for the page
@@ -54,8 +54,9 @@ define('TEXT_DATABASE_SETUP_DB_PREFIX', 'Store Prefix: ');
 define('TEXT_DATABASE_SETUP_SQL_CACHE_METHOD', 'SQL Cache Method: ');
 define('TEXT_DATABASE_SETUP_JSCRIPT_SQL_ERRORS1', '<p>Some errors occurred when running the SQL install file');
 define('TEXT_DATABASE_SETUP_JSCRIPT_SQL_ERRORS2', '<br>Please see error logs for more details<p>');
-define('TEXT_DATABASE_SETUP_CHARSET_OPTION_UTF8', 'UTF8 (default setting)');
-define('TEXT_DATABASE_SETUP_CHARSET_OPTION_LATIN1', 'Latin1');
+define('TEXT_DATABASE_SETUP_CHARSET_OPTION_UTF8MB4', 'utf8mb4 (default setting)');
+define('TEXT_DATABASE_SETUP_CHARSET_OPTION_UTF8', 'utf8 (older format)');
+define('TEXT_DATABASE_SETUP_CHARSET_OPTION_LATIN1', 'latin1 (much older format)');
 define('TEXT_DATABASE_SETUP_CACHE_TYPE_OPTION_NONE', 'No SQL Caching');
 define('TEXT_DATABASE_SETUP_CACHE_TYPE_OPTION_DATABASE', 'Database');
 define('TEXT_DATABASE_SETUP_CACHE_TYPE_OPTION_FILE', 'File');
@@ -231,7 +232,7 @@ define('TEXT_HELP_CONTENT_DBNAME', "What is the name of the database used to hol
 define('TEXT_HELP_TITLE_DEMODATA', TEXT_DATABASE_SETUP_LOAD_DEMO);
 define('TEXT_HELP_CONTENT_DEMODATA', "If you choose to load Demo Data, we will install a base set of products and categories, with sales and specials and attributes and more. These are useful for you to play around and see how various combinations can be set up and how they can look on your storefront.<br><br>You can certainly delete the demo products (by hand) later, or once you've toyed with the samples, you can re-run this install and choose to not install the demo data, and thus have a fully clean site for setting up your own new store.");
 define('TEXT_HELP_TITLE_DBCHARSET', 'Database Character Set');
-define('TEXT_HELP_CONTENT_DBCHARSET', "Most stores will use UTF8.<br>If you don't have a reason to use something else, use UTF8.");
+define('TEXT_HELP_CONTENT_DBCHARSET', "Most stores will use utf8mb4 or utf8.<br>If you don't have a reason to use something else, use utf8mb4.");
 define('TEXT_HELP_TITLE_DBPREFIX', 'Database Tablename Prefix');
 define('TEXT_HELP_CONTENT_DBPREFIX', "What is the prefix you would like used for database tables?  Example: <strong>zen_</strong><br><strong class='alert'>TIP: Leave empty if no prefix is needed.</strong><br />You can use prefixes to allow more than one store to share the same database.");
 define('TEXT_HELP_TITLE_SQLCACHEMETHOD', 'SQL Cache Method');

--- a/zc_install/includes/modules/pages/database/header_php.php
+++ b/zc_install/includes/modules/pages/database/header_php.php
@@ -1,14 +1,17 @@
 <?php
 /**
  * @package Installer
- * @copyright Copyright 2003-2016 Zen Cart Development Team
+ * @copyright Copyright 2003-2018 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: zcwilt  Wed Sep 23 20:04:38 2015 +0100 New in v1.5.5 $
+ * @version $Id: Author: zcwilt  Modified in v1.5.6 $
  */
 
-$dbCharset = array( array('id' => 'utf8', 'text' => TEXT_DATABASE_SETUP_CHARSET_OPTION_UTF8),
-                    array('id' => 'latin1', 'text' => TEXT_DATABASE_SETUP_CHARSET_OPTION_LATIN1));
-$dbCharsetOptions = zen_get_select_options($dbCharset, isset($db_charset) ? $db_charset : 'utf8');
+$dbCharset = array(
+                    array('id' => 'utf8mb4', 'text' => TEXT_DATABASE_SETUP_CHARSET_OPTION_UTF8MB4),
+                    array('id' => 'utf8', 'text' => TEXT_DATABASE_SETUP_CHARSET_OPTION_UTF8),
+                    array('id' => 'latin1', 'text' => TEXT_DATABASE_SETUP_CHARSET_OPTION_LATIN1),
+                );
+$dbCharsetOptions = zen_get_select_options($dbCharset, isset($db_charset) ? $db_charset : 'utf8mb4');
 $sqlCacheType = array(array('id' => 'none', 'text' => TEXT_DATABASE_SETUP_CACHE_TYPE_OPTION_NONE),
                       array('id' => 'file', 'text' => TEXT_DATABASE_SETUP_CACHE_TYPE_OPTION_FILE),
                       array('id' => 'database', 'text' => TEXT_DATABASE_SETUP_CACHE_TYPE_OPTION_DATABASE));
@@ -33,4 +36,3 @@ $db_prefix = isset($db_prefix) ? $db_prefix : '';
 // attempt to intelligently manage user-adjusted subdirectory values if they are different from detected defaults
 if ($_POST['http_server_catalog'] != $_POST['detected_http_server_catalog']) $_POST['dir_ws_http_catalog'] = rtrim(str_replace($_POST['http_server_catalog'], '', $_POST['http_url_catalog']), '/') .'/';
 if ($_POST['https_server_catalog'] != $_POST['detected_https_server_catalog']) $_POST['dir_ws_https_catalog'] = rtrim(str_replace($_POST['https_server_catalog'], '', $_POST['https_url_catalog']), '/') .'/';
-

--- a/zc_install/sql/install/mysql_zencart.sql
+++ b/zc_install/sql/install/mysql_zencart.sql
@@ -2,7 +2,7 @@
 # * Main Zen Cart SQL Load for MySQL databases
 # * @package Installer
 # * @access private
-# * @copyright Copyright 2003-2017 Zen Cart Development Team
+# * @copyright Copyright 2003-2018 Zen Cart Development Team
 # * @copyright Portions Copyright 2003 osCommerce
 # * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
 # * @version $Id: Author: DrByte  Modified in v1.5.6 $
@@ -140,7 +140,7 @@ CREATE TABLE admin_activity_log (
 
 DROP TABLE IF EXISTS admin_menus;
 CREATE TABLE admin_menus (
-  menu_key VARCHAR(255) NOT NULL DEFAULT '',
+  menu_key VARCHAR(191) NOT NULL DEFAULT '',
   language_key VARCHAR(255) NOT NULL DEFAULT '',
   sort_order INT(11) NOT NULL DEFAULT 0,
   UNIQUE KEY menu_key (menu_key)
@@ -154,11 +154,11 @@ CREATE TABLE admin_menus (
 
 DROP TABLE IF EXISTS admin_pages;
 CREATE TABLE admin_pages (
-  page_key VARCHAR(255) NOT NULL DEFAULT '',
+  page_key VARCHAR(191) NOT NULL DEFAULT '',
   language_key VARCHAR(255) NOT NULL DEFAULT '',
   main_page varchar(255) NOT NULL default '',
   page_params varchar(255) NOT NULL default '',
-  menu_key varchar(255) NOT NULL default '',
+  menu_key varchar(191) NOT NULL default '',
   display_on_menu char(1) NOT NULL default 'N',
   sort_order int(11) NOT NULL default 0,
   UNIQUE KEY page_key (page_key)
@@ -186,7 +186,7 @@ CREATE TABLE admin_profiles (
 DROP TABLE IF EXISTS admin_pages_to_profiles;
 CREATE TABLE admin_pages_to_profiles (
   profile_id int(11) NOT NULL default '0',
-  page_key varchar(255) NOT NULL default '',
+  page_key varchar(191) NOT NULL default '',
   UNIQUE KEY profile_page (profile_id, page_key),
   UNIQUE KEY page_profile (page_key, profile_id)
 ) ENGINE=MyISAM;
@@ -306,7 +306,7 @@ DROP TABLE IF EXISTS configuration;
 CREATE TABLE configuration (
   configuration_id int(11) NOT NULL auto_increment,
   configuration_title text NOT NULL,
-  configuration_key varchar(255) NOT NULL default '',
+  configuration_key varchar(180) NOT NULL default '',
   configuration_value text NOT NULL,
   configuration_description text NOT NULL,
   configuration_group_id int(11) NOT NULL default '0',
@@ -763,7 +763,7 @@ CREATE TABLE geo_zones (
 #
 DROP TABLE IF EXISTS get_terms_to_filter;
 CREATE TABLE get_terms_to_filter (
-  get_term_name varchar(255) NOT NULL default '',
+  get_term_name varchar(191) NOT NULL default '',
   get_term_table varchar(64) NOT NULL,
   get_term_name_field varchar(64) NOT NULL,
   PRIMARY KEY  (get_term_name)
@@ -890,7 +890,7 @@ CREATE TABLE media_manager (
   last_modified datetime NOT NULL default '0001-01-01 00:00:00',
   date_added datetime NOT NULL default '0001-01-01 00:00:00',
   PRIMARY KEY  (media_id),
-  KEY idx_media_name_zen (media_name)
+  KEY idx_media_name_zen (media_name(191))
 ) ENGINE=MyISAM;
 
 # --------------------------------------------------------
@@ -1405,7 +1405,7 @@ DROP TABLE IF EXISTS product_type_layout;
 CREATE TABLE product_type_layout (
   configuration_id int(11) NOT NULL auto_increment,
   configuration_title text NOT NULL,
-  configuration_key varchar(255) NOT NULL default '',
+  configuration_key varchar(180) NOT NULL default '',
   configuration_value text NOT NULL,
   configuration_description text NOT NULL,
   product_type_id int(11) NOT NULL default '0',
@@ -1890,15 +1890,17 @@ CREATE TABLE salemaker_sales (
 
 #
 # Table structure for table 'sessions'
+# requires minimum MySQL 5.0.3 for varchar(256)
+# NOTE: When using charset utf8mb4, we use InnoDB because the MyISAM engine may only support 250 chars, but PHP "could" be using 256. Alternate is to specify utf8 charset instead.
 #
 
 DROP TABLE IF EXISTS sessions;
 CREATE TABLE sessions (
-  sesskey varchar(255) NOT NULL default '',
+  sesskey varchar(256) default NULL,
   expiry int(11) unsigned NOT NULL default '0',
   value mediumblob NOT NULL,
   PRIMARY KEY  (sesskey)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB;
 
 # --------------------------------------------------------
 
@@ -1981,13 +1983,14 @@ CREATE TABLE template_select (
 
 #
 # Table structure for table 'whos_online'
+# NOTE: if session_id needs to be same length as defined in 'sessions' table.
 #
 
 DROP TABLE IF EXISTS whos_online;
 CREATE TABLE whos_online (
   customer_id int(11) default NULL,
   full_name varchar(64) NOT NULL default '',
-  session_id varchar(255) NOT NULL default '',
+  session_id varchar(256) default NULL,
   ip_address varchar(45) NOT NULL default '',
   time_entry varchar(14) NOT NULL default '',
   time_last_click varchar(14) NOT NULL default '',
@@ -1999,7 +2002,7 @@ CREATE TABLE whos_online (
   KEY idx_customer_id_zen (customer_id),
   KEY idx_time_entry_zen (time_entry),
   KEY idx_time_last_click_zen (time_last_click),
-  KEY idx_last_page_url_zen (last_page_url)
+  KEY idx_last_page_url_zen (last_page_url(191))
 ) ENGINE=MyISAM;
 
 # --------------------------------------------------------

--- a/zc_install/sql/updates/mysql_upgrade_zencart_156.sql
+++ b/zc_install/sql/updates/mysql_upgrade_zencart_156.sql
@@ -3,10 +3,10 @@
 # *
 # * @package Installer
 # * @access private
-# * @copyright Copyright 2003-2017 Zen Cart Development Team
+# * @copyright Copyright 2003-2018 Zen Cart Development Team
 # * @copyright Portions Copyright 2003 osCommerce
 # * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
-# * @version $Id: Author: DrByte  August 2017 -0500 New in v1.5.6 $
+# * @version $Id: Author: DrByte  New in v1.5.6 $
 #
 
 ############ IMPORTANT INSTRUCTIONS ###############
@@ -131,6 +131,37 @@ FROM products));
 DELETE FROM admin_pages WHERE page_key = 'linkpointReview';
 
 ALTER TABLE customers_basket DROP final_price;
+
+
+
+## support for utf8mb4 index limitations in MySQL 5.5-5.6
+ALTER TABLE admin_menus MODIFY menu_key VARCHAR(191) NOT NULL DEFAULT '';
+ALTER TABLE admin_pages MODIFY menu_key varchar(191) NOT NULL default '';
+ALTER TABLE admin_pages MODIFY page_key VARCHAR(191) NOT NULL DEFAULT '';
+ALTER TABLE admin_pages_to_profiles MODIFY page_key varchar(191) NOT NULL default '';
+ALTER TABLE get_terms_to_filter MODIFY get_term_name varchar(191) NOT NULL default '';
+ALTER TABLE configuration MODIFY configuration_key varchar(180) NOT NULL default '';
+ALTER TABLE product_type_layout MODIFY configuration_key varchar(180) NOT NULL default '';
+ALTER TABLE whos_online DROP KEY idx_last_page_url_zen;
+ALTER TABLE whos_online ADD KEY idx_last_page_url_zen (last_page_url(191));
+ALTER TABLE media_manager DROP KEY idx_media_name_zen;
+ALTER TABLE media_manager ADD KEY idx_media_name_zen (media_name(191));
+# truncate was done earlier in this file already, but if copy/pasting for some reason, do the truncate below, to cleanup the table
+#TRUNCATE TABLE whos_online;
+ALTER TABLE whos_online MODIFY session_id varchar(256) default NULL;
+# recreating sessions table since its storage engine is changing to InnoDB:
+DROP TABLE IF EXISTS sessions;
+CREATE TABLE sessions (
+  sesskey varchar(256) default NULL,
+  expiry int(11) unsigned NOT NULL default 0,
+  value mediumblob NOT NULL,
+  PRIMARY KEY  (sesskey)
+) ENGINE=InnoDB;
+
+
+
+
+
 
 #############
 


### PR DESCRIPTION
Note: the cases where the field length was changed instead of the index are either primary keys or fields whose length can afford to be shorter.

 - [x] field lengths where shorter will suffice
 - [x] lengths on hybrid indexes
 - [x] Session Length: PHP allows for 256

Supporting 256 chars in db requires MySQL 5.0.3 or newer. 