### PR TITLE
Restore display of featured, new, special, and upcoming product to ca…

### DIFF
--- a/includes/functions/functions_categories.php
+++ b/includes/functions/functions_categories.php
@@ -481,6 +481,11 @@
   function zen_get_categories_products_list($categories_id, $include_deactivated = false, $include_child = true, $parent_category = '0', $display_limit = '') {
     global $db;
     global $categories_products_id_list;
+
+    if (!isset($categories_products_id_list) || !is_array($categories_products_id_list)) {
+      $categories_products_id_list = array();
+    }
+
     $childCatID = str_replace('_', '', substr($categories_id, strrpos($categories_id, '_')));
 
     $current_cPath = ($parent_category != '0' ? $parent_category . '_' : '') . $categories_id;

--- a/includes/modules/featured_products.php
+++ b/includes/modules/featured_products.php
@@ -13,7 +13,7 @@ if (!defined('IS_ADMIN_FLAG')) {
 }
 
 // initialize vars
-$categories_products_id_list = '';
+$categories_products_id_list = array();
 $list_of_products = '';
 $featured_products_query = '';
 $display_limit = '';
@@ -89,4 +89,4 @@ if ($num_products_count > 0) {
     $zc_show_featured = true;
   }
 }
-?>
+

--- a/includes/modules/new_products.php
+++ b/includes/modules/new_products.php
@@ -13,7 +13,7 @@ if (!defined('IS_ADMIN_FLAG')) {
 }
 
 // initialize vars
-$categories_products_id_list = '';
+$categories_products_id_list = array();
 $list_of_products = '';
 $new_products_query = '';
 
@@ -89,4 +89,4 @@ if ($num_products_count > 0) {
     $zc_show_new_products = true;
   }
 }
-?>
+

--- a/includes/modules/specials_index.php
+++ b/includes/modules/specials_index.php
@@ -13,7 +13,7 @@ if (!defined('IS_ADMIN_FLAG')) {
 }
 
 // initialize vars
-$categories_products_id_list = '';
+$categories_products_id_list = array();
 $list_of_products = '';
 $specials_index_query = '';
 $display_limit = '';
@@ -87,4 +87,3 @@ if ($num_products_count > 0) {
     $zc_show_specials = true;
   }
 }
-?>

--- a/includes/modules/upcoming_products.php
+++ b/includes/modules/upcoming_products.php
@@ -13,7 +13,7 @@ if (!defined('IS_ADMIN_FLAG')) {
 }
 
 // initialize vars
-$categories_products_id_list = '';
+$categories_products_id_list = array();
 $list_of_products = '';
 $expected_query = '';
 


### PR DESCRIPTION
…tegories.

Two items addressed in this commit.  1: to restore the display of
featured, new, special, and upcoming products on category pages that are
not the main page.  This is a caused by initially referencing an empty
string element as an array which builds the string up with additional
characters to increase the size of the string.

This sets/resets the $categories_products_id_list to be an array in the
event that it is not when calling one of the above modules or if otherwise
calling the zen_get_categories_products_list function.