### PR TITLE
Force return to checkout_shipping if shipping method not selected.

### DIFF
--- a/includes/modules/pages/checkout_payment/header_php.php
+++ b/includes/modules/pages/checkout_payment/header_php.php
@@ -34,7 +34,7 @@ if ($_SESSION['cart']->count_contents() <= 0) {
   }
 
 // if no shipping method has been selected, redirect the customer to the shipping method selection page
-if (!isset($_SESSION['shipping'])) {
+if (!isset($_SESSION['shipping']) || !$_SESSION['shipping']) {
   zen_redirect(zen_href_link(FILENAME_CHECKOUT_SHIPPING, '', 'SSL'));
 }
 if (isset($_SESSION['shipping']['id']) && $_SESSION['shipping']['id'] == 'free_free' && $_SESSION['cart']->get_content_type() != 'virtual' && defined('MODULE_ORDER_TOTAL_SHIPPING_FREE_SHIPPING') && MODULE_ORDER_TOTAL_SHIPPING_FREE_SHIPPING == 'true' && defined('MODULE_ORDER_TOTAL_SHIPPING_FREE_SHIPPING_OVER') && $_SESSION['cart']->show_total() < MODULE_ORDER_TOTAL_SHIPPING_FREE_SHIPPING_OVER) {


### PR DESCRIPTION
The checkout_shipping process is expected to support moving on through
the checkout process if a shipping method is identified. If
$_SESSION['shipping'] is set to false through a call to $shipping->cheapest()
where the only available shipping method is instore (or whatever else has
been set to be ignored in that class), then a shipping method will not be
forced if the URI is then entered to goto checkout_payment.  The same is true
in the current configuration if all shipping methods are disabled or there
are no shipping methods defined.  (That it be possible to continue through
checkout without ever having selected a shipping method nor one being
available.)