### PR TITLE
v156-Enhance log formatting

### DIFF
--- a/admin/includes/extra_configures/enable_error_logging.php
+++ b/admin/includes/extra_configures/enable_error_logging.php
@@ -13,39 +13,40 @@
  * @version $Id: Author: DrByte  Sat Oct 17 20:09:58 2015 -0400 Modified in v1.5.5 $
  */
 
-function zen_debug_error_handler ($errno, $errstr, $errfile, $errline) {
-  if (!(error_reporting() & $errno)) {
-    return;
-  }
-  ob_start();
-  if (version_compare(PHP_VERSION, '5.3.6') >= 0) {
-    debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-  } else {
-    debug_print_backtrace();
-  }
-  $backtrace = ob_get_contents();
-  ob_end_clean();
-  // The following line removes the call to this zen_debug_error_handler function (as it's not relevant)
-  $backtrace = preg_replace ('/^#0\s+' . __FUNCTION__ . "[^\n]*\n/", '', $backtrace, 1);  
-  error_log('Request URI: ' . $_SERVER['REQUEST_URI'] . ', IP address: ' . (isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : 'not set') . "\n" . $backtrace);
+function zen_debug_error_handler ($errno, $errstr, $errfile, $errline) 
+{
+    if (!(error_reporting() & $errno)) {
+        return;
+    }
+    ob_start();
+    if (version_compare(PHP_VERSION, '5.3.6') >= 0) {
+        debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+    } else {
+        debug_print_backtrace();
+    }
+    $backtrace = ob_get_contents();
+    ob_end_clean();
+    // The following line removes the call to this zen_debug_error_handler function (as it's not relevant)
+    $backtrace = preg_replace ('/^#0\s+' . __FUNCTION__ . "[^\n]*\n/", '', rtrim($backtrace), 1);
+    $message = date('[d-M-Y H:i:s e]') . ' Request URI: ' . $_SERVER['REQUEST_URI'] . ', IP address: ' . (isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : 'not set') . PHP_EOL . $backtrace;
+    error_log(PHP_EOL . $message . PHP_EOL, 3, $GLOBALS['debug_logfile_path']);
   
-  return false;  // Let PHP's built-in error handler do its thing.
+    return false;  // Let PHP's built-in error handler do its thing.
 }
 
 if (!defined('DIR_FS_LOGS')) {
-  $val = realpath(dirname(DIR_FS_SQL_CACHE . '/') . '/logs');
-  if (is_dir($val) && is_writable($val)) {
-    define('DIR_FS_LOGS', $val);
-  }
-  else {
-    define('DIR_FS_LOGS', DIR_FS_SQL_CACHE);
-  }
+    $val = realpath(dirname(DIR_FS_SQL_CACHE . '/') . '/logs');
+    if (is_dir($val) && is_writable($val)) {
+        define('DIR_FS_LOGS', $val);
+    } else {
+        define('DIR_FS_LOGS', DIR_FS_SQL_CACHE);
+    }
 }
 /**
  * Specify the pages you wish to enable debugging for (ie: main_page=xxxxxxxx)
  * Using '*' will cause all pages to be enabled
  */
-  $pages_to_debug[] = '*';
+$pages_to_debug[] = '*';
 //   $pages_to_debug[] = '';
 //   $pages_to_debug[] = '';
 
@@ -55,28 +56,28 @@ if (!defined('DIR_FS_LOGS')) {
  * ... which puts it in the /logs/ folder:   /logs/myDEBUG-999999-00000000.log  (where 999999 is a random number, and 00000000 is the server's timestamp)
  *    (or if you don't have a /logs/ folder, it will use the /cache/ folder instead)
  */
-  $debug_logfile_path = DIR_FS_LOGS . '/myDEBUG-adm-' . time() . '-' . mt_rand(1000,999999) . '.log';
+$debug_logfile_path = DIR_FS_LOGS . '/myDEBUG-adm-' . time() . '-' . mt_rand(1000,999999) . '.log';
 
 /**
  * Error reporting level to log
  * Default: E_ALL ^E_NOTICE
  */
-  $errors_to_log = (version_compare(PHP_VERSION, 5.3, '>=') ? E_ALL & ~E_DEPRECATED & ~E_NOTICE : version_compare(PHP_VERSION, 5.4, '>=') ? E_ALL & ~E_DEPRECATED & ~E_NOTICE & ~E_STRICT : E_ALL & ~E_NOTICE);
+$errors_to_log = (version_compare(PHP_VERSION, 5.3, '>=') ? E_ALL & ~E_DEPRECATED & ~E_NOTICE : version_compare(PHP_VERSION, 5.4, '>=') ? E_ALL & ~E_DEPRECATED & ~E_NOTICE & ~E_STRICT : E_ALL & ~E_NOTICE);
 
 
 ///// DO NOT EDIT BELOW THIS LINE /////
 
 //////////////////// DEBUG HANDLING //////////////////////////////////
-  if (in_array('*', $pages_to_debug) || in_array($current_page_base, $pages_to_debug)) {
+if (in_array('*', $pages_to_debug) || in_array($current_page_base, $pages_to_debug)) {
     @ini_set('log_errors', 1);          // store to file
     @ini_set('log_errors_max_len', 0);  // unlimited length of message output
     @ini_set('display_errors', 0);      // do not output errors to screen/browser/client
     @ini_set('error_log', $debug_logfile_path);  // the filename to log errors into
     @ini_set('error_reporting', $errors_to_log ); // log only errors according to defined rules
     set_error_handler('zen_debug_error_handler', $errors_to_log);
-  }
+}
 
-  if (defined('IS_CLI') && IS_CLI == 'VERBOSE') {
+if (defined('IS_CLI') && IS_CLI == 'VERBOSE') {
     error_reporting(E_ALL);
     ini_set('display_errors', 1);
-  }
+}

--- a/includes/extra_configures/enable_error_logging.php
+++ b/includes/extra_configures/enable_error_logging.php
@@ -13,39 +13,40 @@
  * @version $Id: Author: DrByte  Sat Oct 17 20:09:58 2015 -0400 Modified in v1.5.5 $
  */
 
-function zen_debug_error_handler ($errno, $errstr, $errfile, $errline) {
-  if (!(error_reporting() & $errno)) {
-    return;
-  }
-  ob_start();
-  if (version_compare(PHP_VERSION, '5.3.6') >= 0) {
-    debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-  } else {
-    debug_print_backtrace();
-  }
-  $backtrace = ob_get_contents();
-  ob_end_clean();
-  // The following line removes the call to this zen_debug_error_handler function (as it's not relevant)
-  $backtrace = preg_replace ('/^#0\s+' . __FUNCTION__ . "[^\n]*\n/", '', $backtrace, 1);  
-  error_log('Request URI: ' . $_SERVER['REQUEST_URI'] . ', IP address: ' . (isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : 'not set') . "\n" . $backtrace);
+function zen_debug_error_handler ($errno, $errstr, $errfile, $errline) 
+{
+    if (!(error_reporting() & $errno)) {
+        return;
+    }
+    ob_start();
+    if (version_compare(PHP_VERSION, '5.3.6') >= 0) {
+        debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+    } else {
+        debug_print_backtrace();
+    }
+    $backtrace = ob_get_contents();
+    ob_end_clean();
+    // The following line removes the call to this zen_debug_error_handler function (as it's not relevant)
+    $backtrace = preg_replace ('/^#0\s+' . __FUNCTION__ . "[^\n]*\n/", '', rtrim($backtrace), 1);
+    $message = date('[d-M-Y H:i:s e]') . ' Request URI: ' . $_SERVER['REQUEST_URI'] . ', IP address: ' . (isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : 'not set') . PHP_EOL . $backtrace;
+    error_log(PHP_EOL . $message . PHP_EOL, 3, $GLOBALS['debug_logfile_path']);
   
-  return false;  // Let PHP's built-in error handler do its thing.
+    return false;  // Let PHP's built-in error handler do its thing.
 }
 
 if (!defined('DIR_FS_LOGS')) {
-  $val = realpath(dirname(DIR_FS_SQL_CACHE . '/') . '/logs');
-  if (is_dir($val) && is_writable($val)) {
-    define('DIR_FS_LOGS', $val);
-  }
-  else {
-    define('DIR_FS_LOGS', DIR_FS_SQL_CACHE);
-  }
+    $val = realpath(dirname(DIR_FS_SQL_CACHE . '/') . '/logs');
+    if (is_dir($val) && is_writable($val)) {
+        define('DIR_FS_LOGS', $val);
+    } else {
+        define('DIR_FS_LOGS', DIR_FS_SQL_CACHE);
+    }
 }
 /**
  * Specify the pages you wish to enable debugging for (ie: main_page=xxxxxxxx)
  * Using '*' will cause all pages to be enabled
  */
-  $pages_to_debug[] = '*';
+$pages_to_debug[] = '*';
 //   $pages_to_debug[] = '';
 //   $pages_to_debug[] = '';
 
@@ -55,28 +56,27 @@ if (!defined('DIR_FS_LOGS')) {
  * ... which puts it in the /logs/ folder:   /logs/myDEBUG-999999-00000000.log  (where 999999 is a random number, and 00000000 is the server's timestamp)
  *    (or if you don't have a /logs/ folder, it will use the /cache/ folder instead)
  */
-  $debug_logfile_path = DIR_FS_LOGS . '/myDEBUG-' . time() . '-' . mt_rand(1000,999999) . '.log';
+$debug_logfile_path = DIR_FS_LOGS . '/myDEBUG-' . time() . '-' . mt_rand(1000,999999) . '.log';
 
 /**
  * Error reporting level to log
  * Default: E_ALL ^E_NOTICE
  */
-  $errors_to_log = (version_compare(PHP_VERSION, 5.3, '>=') ? E_ALL & ~E_DEPRECATED & ~E_NOTICE : version_compare(PHP_VERSION, 5.4, '>=') ? E_ALL & ~E_DEPRECATED & ~E_NOTICE & ~E_STRICT : E_ALL & ~E_NOTICE);
-
+$errors_to_log = (version_compare(PHP_VERSION, 5.3, '>=') ? E_ALL & ~E_DEPRECATED & ~E_NOTICE : version_compare(PHP_VERSION, 5.4, '>=') ? E_ALL & ~E_DEPRECATED & ~E_NOTICE & ~E_STRICT : E_ALL & ~E_NOTICE);
 
 ///// DO NOT EDIT BELOW THIS LINE /////
 
 //////////////////// DEBUG HANDLING //////////////////////////////////
-  if (in_array('*', $pages_to_debug) || in_array($current_page_base, $pages_to_debug)) {
+if (in_array('*', $pages_to_debug) || in_array($current_page_base, $pages_to_debug)) {
     @ini_set('log_errors', 1);          // store to file
     @ini_set('log_errors_max_len', 0);  // unlimited length of message output
     @ini_set('display_errors', 0);      // do not output errors to screen/browser/client
     @ini_set('error_log', $debug_logfile_path);  // the filename to log errors into
     @ini_set('error_reporting', $errors_to_log ); // log only errors according to defined rules
     set_error_handler('zen_debug_error_handler', $errors_to_log);
-  }
+}
 
-  if (defined('IS_CLI') && IS_CLI == 'VERBOSE') {
+if (defined('IS_CLI') && IS_CLI == 'VERBOSE') {
     error_reporting(E_ALL);
     ini_set('display_errors', 1);
-  }
+}


### PR DESCRIPTION
Due to the way that the log records are currently formatted, it's sometimes "difficult" to connect the actual error to the backtrace information.  This change modifies the formatted output, grouping the debug-backtrace information with the PHP information, making it easier to debug/determine what's going on.

Also includes some re-factoring.