### PR TITLE
v160 Remove integer key data from iterator results

### DIFF
--- a/includes/classes/db/mysql/query_factory.php
+++ b/includes/classes/db/mysql/query_factory.php
@@ -299,7 +299,7 @@ class queryFactory extends base {
         return $this->Execute ($zf_sql, false, false, 0, true);
     }
 
-  function ExecuteRandomMulti($zf_sql, $zf_limit = 0, $zf_cache = false, $zf_cachetime=0, $remove_from_queryCache = false) {
+  function ExecuteRandomMulti($zf_sql, $zf_limit = 0, $zf_cache = false, $zf_cachetime=0, $remove_from_queryCache = false, $int_key = true) {
     $this->zf_sql = $zf_sql;
     $time_start = explode(' ', microtime());
     $obj = new queryFactoryResult($this->link);
@@ -328,6 +328,10 @@ class queryFactory extends base {
           if ($zp_result_array) {
             $obj->result[$zp_ii] = array();
             foreach($zp_result_array as $key => $value) {
+              $add_key = ($int_key === true ? true : !preg_match('/^[0-9]/', $key)); // mc12345678 support controlling presence of the integer key result
+
+              if (!$add_key) continue;
+
               $obj->result[$zp_ii][$key] = $value;
             }
           } else {
@@ -667,7 +671,7 @@ class queryFactoryResult implements Countable, Iterator {
   public function rewind() {
       $this->EOF = ($this->RecordCount() == 0);
       if ($this->RecordCount() !== 0) {
-          $this->Move(0);
+          $this->Move(0, false); // mc12345678 eliminate return of integer based key
       }
   }
 
@@ -705,7 +709,7 @@ class queryFactoryResult implements Countable, Iterator {
    *
    * @param int $zp_row the row to move to
    */
-  public function Move($zp_row) {
+  public function Move($zp_row, $int_key = true) {
     global $db;
     if ($this->is_cached) {
       if($zp_row >= sizeof($this->result)) {
@@ -721,6 +725,10 @@ class queryFactoryResult implements Countable, Iterator {
     } else if (@mysqli_data_seek($this->resource, $zp_row)) {
       $zp_result_array = @mysqli_fetch_array($this->resource);
       foreach($zp_result_array as $key => $value) {
+        $add_key = ($int_key === true ? true : !preg_match('/^[0-9]/', $key)); // mc12345678 support controlling presence of the integer key result
+
+        if (!$add_key) continue;
+
         $this->fields[$key] = $value;
       }
       $this->cursor = $zp_row;


### PR DESCRIPTION
In ZC 1.5.5, the iterator class was implemented allowing the use of foreach
to cycle through query results.  To support this operation, the rewind
module was written to use the Move($position) method which was written to
allow query results to be returned as both a key=>value response as well
as a position=>value response.  Therefore, the initial reset of the query
results would produce an array of both the key=>value pair and position=>value
pair.  Then when the MoveNext method was used, the key=>value pair would
be updated; however, the position=>value pair remained constant.

This commit adds continued support for code that intentionally used the
Move($position) to access the integer based field result and to also
prevent adding the integer based results to the Move($value) method returned
values.

A similar condition was identified in the ExecuteRandomMulti function.

Incorporation of this modification added a parameter to each function with
a default value that causes the function to operate as it has for all of
ZC 1.5.x.

This was ultimately an issue because mysqli_fetch_array (and the legacy
mysql_fetch_array) when not provided a resulttype as described in the
php manual (http://php.net/manual/en/mysqli-result.fetch-array.php) defaults
to providing both the integer based result and the field key based result.

Perhaps this was done to support some yet older code; however, with the
implementation of the iterator class to provide only field results
(consistently at each next result) a modification was needed at least against
the foreach implementation.