### PR TITLE
Zero-weight/freeshipping Admin Alert might not appear

### DIFF
--- a/admin/configuration.php
+++ b/admin/configuration.php
@@ -64,7 +64,7 @@ if ($gID == 7) {
   if (zen_get_configuration_key_value('SHIPPING_ORIGIN_ZIP') == 'NONE' or zen_get_configuration_key_value('SHIPPING_ORIGIN_ZIP') == '') {
     $shipping_errors .= '<br />' . ERROR_SHIPPING_ORIGIN_ZIP;
   }
-  if (zen_get_configuration_key_value('ORDER_WEIGHT_ZERO_STATUS') == '1' and ! defined('MODULE_SHIPPING_FREESHIPPER_STATUS')) {
+  if (zen_get_configuration_key_value('ORDER_WEIGHT_ZERO_STATUS') == '1' && (!defined('MODULE_SHIPPING_FREESHIPPER_STATUS') || ORDER_WEIGHT_ZERO_STATUS != 'True')) {
     $shipping_errors .= '<br />' . ERROR_ORDER_WEIGHT_ZERO_STATUS;
   }
   if (defined('MODULE_SHIPPING_USPS_STATUS') and ( MODULE_SHIPPING_USPS_USERID == 'NONE' or MODULE_SHIPPING_USPS_SERVER == 'test')) {

--- a/admin/configuration.php
+++ b/admin/configuration.php
@@ -64,7 +64,7 @@ if ($gID == 7) {
   if (zen_get_configuration_key_value('SHIPPING_ORIGIN_ZIP') == 'NONE' or zen_get_configuration_key_value('SHIPPING_ORIGIN_ZIP') == '') {
     $shipping_errors .= '<br />' . ERROR_SHIPPING_ORIGIN_ZIP;
   }
-  if (zen_get_configuration_key_value('ORDER_WEIGHT_ZERO_STATUS') == '1' && (!defined('MODULE_SHIPPING_FREESHIPPER_STATUS') || ORDER_WEIGHT_ZERO_STATUS != 'True')) {
+  if (zen_get_configuration_key_value('ORDER_WEIGHT_ZERO_STATUS') == '1' && (!defined('MODULE_SHIPPING_FREESHIPPER_STATUS') || MODULE_SHIPPING_FREESHIPPER_STATUS != 'True')) {
     $shipping_errors .= '<br />' . ERROR_ORDER_WEIGHT_ZERO_STATUS;
   }
   if (defined('MODULE_SHIPPING_USPS_STATUS') and ( MODULE_SHIPPING_USPS_USERID == 'NONE' or MODULE_SHIPPING_USPS_SERVER == 'test')) {

--- a/admin/modules.php
+++ b/admin/modules.php
@@ -26,7 +26,7 @@ if (zen_not_null($set)) {
       if (zen_get_configuration_key_value('SHIPPING_ORIGIN_ZIP') == 'NONE' or zen_get_configuration_key_value('SHIPPING_ORIGIN_ZIP') == '') {
         $shipping_errors .= '<br />' . ERROR_SHIPPING_ORIGIN_ZIP;
       }
-      if (zen_get_configuration_key_value('ORDER_WEIGHT_ZERO_STATUS') == '1' and ! defined('MODULE_SHIPPING_FREESHIPPER_STATUS')) {
+      if (zen_get_configuration_key_value('ORDER_WEIGHT_ZERO_STATUS') == '1' && (!defined('MODULE_SHIPPING_FREESHIPPER_STATUS') || ORDER_WEIGHT_ZERO_STATUS != 'True')) {
         $shipping_errors .= '<br />' . ERROR_ORDER_WEIGHT_ZERO_STATUS;
       }
       if (defined('MODULE_SHIPPING_USPS_STATUS') and ( MODULE_SHIPPING_USPS_USERID == 'NONE' or MODULE_SHIPPING_USPS_SERVER == 'test')) {

--- a/admin/modules.php
+++ b/admin/modules.php
@@ -26,7 +26,7 @@ if (zen_not_null($set)) {
       if (zen_get_configuration_key_value('SHIPPING_ORIGIN_ZIP') == 'NONE' or zen_get_configuration_key_value('SHIPPING_ORIGIN_ZIP') == '') {
         $shipping_errors .= '<br />' . ERROR_SHIPPING_ORIGIN_ZIP;
       }
-      if (zen_get_configuration_key_value('ORDER_WEIGHT_ZERO_STATUS') == '1' && (!defined('MODULE_SHIPPING_FREESHIPPER_STATUS') || ORDER_WEIGHT_ZERO_STATUS != 'True')) {
+      if (zen_get_configuration_key_value('ORDER_WEIGHT_ZERO_STATUS') == '1' && (!defined('MODULE_SHIPPING_FREESHIPPER_STATUS') || MODULE_SHIPPING_FREESHIPPER_STATUS != 'True')) {
         $shipping_errors .= '<br />' . ERROR_ORDER_WEIGHT_ZERO_STATUS;
       }
       if (defined('MODULE_SHIPPING_USPS_STATUS') and ( MODULE_SHIPPING_USPS_USERID == 'NONE' or MODULE_SHIPPING_USPS_SERVER == 'test')) {


### PR DESCRIPTION
The message "Warning: 0 weight is configured for Free Shipping and Free Shipping Module is not enabled" is intended to warn the admin that the setting _Configuration->Shipping/Packaging->Order Free Shipping 0 Weight Status_ is enabled but the `freeshipper` shipping module is not enabled.

Unfortunately, the message does **not** currently appear if `freeshipper` is installed but disabled.  This PR makes that correction in both the admin's configuration.php and modules.php scripts.