### PR TITLE
v156-notifiers-for-base-functions

### DIFF
--- a/includes/functions/functions_prices.php
+++ b/includes/functions/functions_prices.php
@@ -219,57 +219,118 @@
 
     $show_sale_discount = '';
     if (SHOW_SALE_DISCOUNT_STATUS == '1' and ($display_special_price != 0 or $display_sale_price != 0)) {
-      if ($display_sale_price) {
-        if (SHOW_SALE_DISCOUNT == 1) {
-          if ($display_normal_price != 0) {
-            $show_discount_amount = number_format(100 - (($display_sale_price / $display_normal_price) * 100),SHOW_SALE_DISCOUNT_DECIMALS);
-          } else {
-            $show_discount_amount = '';
-          }
-          $show_sale_discount = '<span class="productPriceDiscount">' . '<br />' . PRODUCT_PRICE_DISCOUNT_PREFIX . $show_discount_amount . PRODUCT_PRICE_DISCOUNT_PERCENTAGE . '</span>';
+      // -----
+      // Allows an observer to inject any override to the "Sale Price" formatting.  If an override
+      // is performed, the observer sets the 'pricing_handled' value to true.
+      //
+      $pricing_handled = false;
+      $GLOBALS['zco_notifier']->notify(
+            'NOTIFY_ZEN_GET_PRODUCTS_DISPLAY_PRICE_SALE', 
+            array(
+                'products_id' => $products_id, 
+                'display_sale_price' => $display_sale_price, 
+                'display_special_price' => $display_special_price,
+                'display_normal_price' => $display_normal_price,
+                'products_tax_class_id' => $product_check->fields['products_tax_class_id']
+            ), 
+            $pricing_handled,
+            $show_sale_discount
+      );
+      if (!$pricing_handled) {
+          if ($display_sale_price) {
+            if (SHOW_SALE_DISCOUNT == 1) {
+              if ($display_normal_price != 0) {
+                $show_discount_amount = number_format(100 - (($display_sale_price / $display_normal_price) * 100),SHOW_SALE_DISCOUNT_DECIMALS);
+              } else {
+                $show_discount_amount = '';
+              }
+              $show_sale_discount = '<span class="productPriceDiscount">' . '<br />' . PRODUCT_PRICE_DISCOUNT_PREFIX . $show_discount_amount . PRODUCT_PRICE_DISCOUNT_PERCENTAGE . '</span>';
 
-        } else {
-          $show_sale_discount = '<span class="productPriceDiscount">' . '<br />' . PRODUCT_PRICE_DISCOUNT_PREFIX . $currencies->display_price(($display_normal_price - $display_sale_price), zen_get_tax_rate($product_check->fields['products_tax_class_id'])) . PRODUCT_PRICE_DISCOUNT_AMOUNT . '</span>';
+            } else {
+              $show_sale_discount = '<span class="productPriceDiscount">' . '<br />' . PRODUCT_PRICE_DISCOUNT_PREFIX . $currencies->display_price(($display_normal_price - $display_sale_price), zen_get_tax_rate($product_check->fields['products_tax_class_id'])) . PRODUCT_PRICE_DISCOUNT_AMOUNT . '</span>';
+            }
+          } else {
+            if (SHOW_SALE_DISCOUNT == 1) {
+              $show_sale_discount = '<span class="productPriceDiscount">' . '<br />' . PRODUCT_PRICE_DISCOUNT_PREFIX . number_format(100 - (($display_special_price / $display_normal_price) * 100),SHOW_SALE_DISCOUNT_DECIMALS) . PRODUCT_PRICE_DISCOUNT_PERCENTAGE . '</span>';
+            } else {
+              $show_sale_discount = '<span class="productPriceDiscount">' . '<br />' . PRODUCT_PRICE_DISCOUNT_PREFIX . $currencies->display_price(($display_normal_price - $display_special_price), zen_get_tax_rate($product_check->fields['products_tax_class_id'])) . PRODUCT_PRICE_DISCOUNT_AMOUNT . '</span>';
+            }
+          }
         }
-      } else {
-        if (SHOW_SALE_DISCOUNT == 1) {
-          $show_sale_discount = '<span class="productPriceDiscount">' . '<br />' . PRODUCT_PRICE_DISCOUNT_PREFIX . number_format(100 - (($display_special_price / $display_normal_price) * 100),SHOW_SALE_DISCOUNT_DECIMALS) . PRODUCT_PRICE_DISCOUNT_PERCENTAGE . '</span>';
-        } else {
-          $show_sale_discount = '<span class="productPriceDiscount">' . '<br />' . PRODUCT_PRICE_DISCOUNT_PREFIX . $currencies->display_price(($display_normal_price - $display_special_price), zen_get_tax_rate($product_check->fields['products_tax_class_id'])) . PRODUCT_PRICE_DISCOUNT_AMOUNT . '</span>';
-        }
-      }
     }
 
     if ($display_special_price) {
-      $show_normal_price = '<span class="normalprice">' . $currencies->display_price($display_normal_price, zen_get_tax_rate($product_check->fields['products_tax_class_id'])) . ' </span>';
-      if ($display_sale_price && $display_sale_price != $display_special_price) {
-        $show_special_price = '&nbsp;' . '<span class="productSpecialPriceSale">' . $currencies->display_price($display_special_price, zen_get_tax_rate($product_check->fields['products_tax_class_id'])) . '</span>';
-        if ($product_check->fields['product_is_free'] == '1') {
-          $show_sale_price = '<br />' . '<span class="productSalePrice">' . PRODUCT_PRICE_SALE . '<s>' . $currencies->display_price($display_sale_price, zen_get_tax_rate($product_check->fields['products_tax_class_id'])) . '</s>' . '</span>';
-        } else {
-          $show_sale_price = '<br />' . '<span class="productSalePrice">' . PRODUCT_PRICE_SALE . $currencies->display_price($display_sale_price, zen_get_tax_rate($product_check->fields['products_tax_class_id'])) . '</span>';
-        }
-      } else {
-        if ($product_check->fields['product_is_free'] == '1') {
-          $show_special_price = '&nbsp;' . '<span class="productSpecialPrice">' . '<s>' . $currencies->display_price($display_special_price, zen_get_tax_rate($product_check->fields['products_tax_class_id'])) . '</s>' . '</span>';
-        } else {
-          $show_special_price = '&nbsp;' . '<span class="productSpecialPrice">' . $currencies->display_price($display_special_price, zen_get_tax_rate($product_check->fields['products_tax_class_id'])) . '</span>';
-        }
-        $show_sale_price = '';
+      // -----
+      // Allows an observer to inject any override to the "Special/Normal Prices'" formatting.
+      //
+      $pricing_handled = false;
+      $GLOBALS['zco_notifier']->notify(
+            'NOTIFY_ZEN_GET_PRODUCTS_DISPLAY_PRICE_SPECIAL', 
+            array(
+                'products_id' => $products_id, 
+                'display_sale_price' => $display_sale_price,
+                'display_special_price' => $display_special_price,
+                'display_normal_price' => $display_normal_price,
+                'products_tax_class_id' => $product_check->fields['products_tax_class_id'],
+                'product_is_free' => $product_check->fields['product_is_free']
+            ), 
+            $pricing_handled,
+            $show_normal_price,
+            $show_special_price,
+            $show_sale_price
+      );
+      if (!$pricing_handled) {
+          $show_normal_price = '<span class="normalprice">' . $currencies->display_price($display_normal_price, zen_get_tax_rate($product_check->fields['products_tax_class_id'])) . ' </span>';
+          if ($display_sale_price && $display_sale_price != $display_special_price) {
+            $show_special_price = '&nbsp;' . '<span class="productSpecialPriceSale">' . $currencies->display_price($display_special_price, zen_get_tax_rate($product_check->fields['products_tax_class_id'])) . '</span>';
+            if ($product_check->fields['product_is_free'] == '1') {
+              $show_sale_price = '<br />' . '<span class="productSalePrice">' . PRODUCT_PRICE_SALE . '<s>' . $currencies->display_price($display_sale_price, zen_get_tax_rate($product_check->fields['products_tax_class_id'])) . '</s>' . '</span>';
+            } else {
+              $show_sale_price = '<br />' . '<span class="productSalePrice">' . PRODUCT_PRICE_SALE . $currencies->display_price($display_sale_price, zen_get_tax_rate($product_check->fields['products_tax_class_id'])) . '</span>';
+            }
+          } else {
+            if ($product_check->fields['product_is_free'] == '1') {
+              $show_special_price = '&nbsp;' . '<span class="productSpecialPrice">' . '<s>' . $currencies->display_price($display_special_price, zen_get_tax_rate($product_check->fields['products_tax_class_id'])) . '</s>' . '</span>';
+            } else {
+              $show_special_price = '&nbsp;' . '<span class="productSpecialPrice">' . $currencies->display_price($display_special_price, zen_get_tax_rate($product_check->fields['products_tax_class_id'])) . '</span>';
+            }
+            $show_sale_price = '';
+          }
       }
     } else {
-      if ($display_sale_price) {
-        $show_normal_price = '<span class="normalprice">' . $currencies->display_price($display_normal_price, zen_get_tax_rate($product_check->fields['products_tax_class_id'])) . ' </span>';
-        $show_special_price = '';
-        $show_sale_price = '<br />' . '<span class="productSalePrice">' . PRODUCT_PRICE_SALE . $currencies->display_price($display_sale_price, zen_get_tax_rate($product_check->fields['products_tax_class_id'])) . '</span>';
-      } else {
-        if ($product_check->fields['product_is_free'] == '1') {
-          $show_normal_price = '<span class="productFreePrice"><s>' . $currencies->display_price($display_normal_price, zen_get_tax_rate($product_check->fields['products_tax_class_id'])) . '</s></span>';
-        } else {
-          $show_normal_price = '<span class="productBasePrice">' . $currencies->display_price($display_normal_price, zen_get_tax_rate($product_check->fields['products_tax_class_id'])) . '</span>';
-        }
-        $show_special_price = '';
-        $show_sale_price = '';
+      // -----
+      // Allows an observer to inject any override to the "Normal Prices'" formatting.
+      //
+      $pricing_handled = false;
+      $GLOBALS['zco_notifier']->notify(
+            'NOTIFY_ZEN_GET_PRODUCTS_DISPLAY_PRICE_NORMAL', 
+            array(
+                'products_id' => $products_id, 
+                'display_sale_price' => $display_sale_price,
+                'display_special_price' => $display_special_price,
+                'display_normal_price' => $display_normal_price,
+                'products_tax_class_id' => $product_check->fields['products_tax_class_id'],
+                'product_is_free' => $product_check->fields['product_is_free']
+            ), 
+            $pricing_handled,
+            $show_normal_price,
+            $show_special_price,
+            $show_sale_price
+      );
+      if (!$pricing_handled) {
+          if ($display_sale_price) {
+            $show_normal_price = '<span class="normalprice">' . $currencies->display_price($display_normal_price, zen_get_tax_rate($product_check->fields['products_tax_class_id'])) . ' </span>';
+            $show_special_price = '';
+            $show_sale_price = '<br />' . '<span class="productSalePrice">' . PRODUCT_PRICE_SALE . $currencies->display_price($display_sale_price, zen_get_tax_rate($product_check->fields['products_tax_class_id'])) . '</span>';
+          } else {
+            if ($product_check->fields['product_is_free'] == '1') {
+              $show_normal_price = '<span class="productFreePrice"><s>' . $currencies->display_price($display_normal_price, zen_get_tax_rate($product_check->fields['products_tax_class_id'])) . '</s></span>';
+            } else {
+              $show_normal_price = '<span class="productBasePrice">' . $currencies->display_price($display_normal_price, zen_get_tax_rate($product_check->fields['products_tax_class_id'])) . '</span>';
+            }
+            $show_special_price = '';
+            $show_sale_price = '';
+          }
       }
     }
 
@@ -279,23 +340,39 @@
     } else {
       $final_display_price = $show_normal_price . $show_special_price . $show_sale_price . $show_sale_discount;
     }
+    
+    // -----
+    // Allows an observer to inject any override to the "Free" and "Call for Price" formatting.
+    //
+    $tags_handled = false;
+    $GLOBALS['zco_notifier']->notify(
+        'NOTIFY_ZEN_GET_PRODUCTS_DISPLAY_PRICE_FREE_OR_CALL', 
+        array(
+            'product_is_free' => $product_check->fields['product_is_free'],
+            'product_is_call' => $product_check->fields['product_is_call'],
+        ), 
+        $tags_handled,
+        $free_tag,
+        $call_tag
+    );
+    if (!$tags_handled) {
+        // If Free, Show it
+        if ($product_check->fields['product_is_free'] == '1') {
+          if (OTHER_IMAGE_PRICE_IS_FREE_ON=='0') {
+            $free_tag = '<br />' . PRODUCTS_PRICE_IS_FREE_TEXT;
+          } else {
+            $free_tag = '<br />' . zen_image(DIR_WS_TEMPLATE_IMAGES . OTHER_IMAGE_PRICE_IS_FREE, PRODUCTS_PRICE_IS_FREE_TEXT);
+          }
+        }
 
-    // If Free, Show it
-    if ($product_check->fields['product_is_free'] == '1') {
-      if (OTHER_IMAGE_PRICE_IS_FREE_ON=='0') {
-        $free_tag = '<br />' . PRODUCTS_PRICE_IS_FREE_TEXT;
-      } else {
-        $free_tag = '<br />' . zen_image(DIR_WS_TEMPLATE_IMAGES . OTHER_IMAGE_PRICE_IS_FREE, PRODUCTS_PRICE_IS_FREE_TEXT);
-      }
-    }
-
-    // If Call for Price, Show it
-    if ($product_check->fields['product_is_call']) {
-      if (PRODUCTS_PRICE_IS_CALL_IMAGE_ON=='0') {
-        $call_tag = '<br />' . PRODUCTS_PRICE_IS_CALL_FOR_PRICE_TEXT;
-      } else {
-        $call_tag = '<br />' . zen_image(DIR_WS_TEMPLATE_IMAGES . OTHER_IMAGE_CALL_FOR_PRICE, PRODUCTS_PRICE_IS_CALL_FOR_PRICE_TEXT);
-      }
+        // If Call for Price, Show it
+        if ($product_check->fields['product_is_call']) {
+          if (PRODUCTS_PRICE_IS_CALL_IMAGE_ON=='0') {
+            $call_tag = '<br />' . PRODUCTS_PRICE_IS_CALL_FOR_PRICE_TEXT;
+          } else {
+            $call_tag = '<br />' . zen_image(DIR_WS_TEMPLATE_IMAGES . OTHER_IMAGE_CALL_FOR_PRICE, PRODUCTS_PRICE_IS_CALL_FOR_PRICE_TEXT);
+          }
+        }
     }
 
     return $final_display_price . $free_tag . $call_tag;

--- a/includes/functions/functions_taxes.php
+++ b/includes/functions/functions_taxes.php
@@ -62,6 +62,23 @@
   function zen_get_tax_description($class_id, $country_id = -1, $zone_id = -1) {
     global $db;
     
+    // -----
+    // Give an observer the chance to override this function's return.
+    //
+    $tax_description = '';
+    $GLOBALS['zco_notifier']->notify(
+        'NOTIFY_ZEN_GET_TAX_DESCRIPTION_OVERRIDE',
+        array(
+            'class_id' => $class_id,
+            'country_id' => $country_id,
+            'zone_id' => $zone_id
+        ),
+        $tax_description
+    );
+    if ($tax_description != '') {
+        return $tax_description;
+    }
+    
     if ( ($country_id == -1) && ($zone_id == -1) ) {
       if (isset($_SESSION['customer_id'])) {
         $country_id = $_SESSION['customer_country_id'];
@@ -104,7 +121,26 @@
 // @returns array(description => tax_rate)
   function zen_get_multiple_tax_rates($class_id, $country_id, $zone_id, $tax_description=array()) {
     global $db;
-
+    // -----
+    // Give an observer the chance to override this function's return.
+    //
+    $rates_array = '';
+    $GLOBALS['zco_notifier']->notify(
+        'NOTIFY_ZEN_GET_MULTIPLE_TAX_RATES_OVERRIDE',
+        array(
+            'class_id' => $class_id,
+            'country_id' => $country_id,
+            'zone_id' => $zone_id,
+            'tax_description' => $tax_description
+        ),
+        $rates_array
+    );
+    if (is_array($rates_array)) {
+        return $rates_array;
+    }
+    
+    $rates_array = array();
+    
     if ( ($country_id == -1) && ($zone_id == -1) ) {
       if (isset($_SESSION['customer_id'])) {
         $country_id = $_SESSION['customer_country_id'];
@@ -273,6 +309,22 @@
  function zen_get_all_tax_descriptions($country_id = -1, $zone_id = -1) 
  {
    global $db;
+    // -----
+    // Give an observer the chance to override this function's return.
+    //
+    $tax_descriptions = '';
+    $GLOBALS['zco_notifier']->notify(
+        'NOTIFY_ZEN_GET_ALL_TAX_DESCRIPTIONS_OVERRIDE',
+        array(
+            'country_id' => $country_id,
+            'zone_id' => $zone_id
+        ),
+        $tax_descriptions
+    );
+    if (is_array($tax_descriptions)) {
+        return $tax_descriptions;
+    }
+    
     if ( ($country_id == -1) && ($zone_id == -1) ) {
       if (isset($_SESSION['customer_id'])) {
         $country_id = $_SESSION['customer_country_id'];

--- a/includes/functions/html_output.php
+++ b/includes/functions/html_output.php
@@ -339,13 +339,47 @@
           $parameters = str_replace($matches[1], '', $parameters);
         }
       }
-
-      $css_button = '<input class="' . $mouse_out_class . '" ' . $css_button_js . ' type="submit" value="' . $text . '"' . $tooltip . $parameters . ' />';
+      
+      // -----
+      // Give an observer the chance to provide alternate formatting for the button (it's set to an empty
+      // string above).  If the value is still empty after the notification, create the standard-format
+      // of the button.
+      //
+      $GLOBALS['zco_notifier']->notify(
+            'NOTIFY_ZEN_CSS_BUTTON_SUBMIT', 
+            array(
+                'button_name' => $button_name,
+                'text' => $text,
+                'sec_class' => $sec_class,
+                'parameters' => $parameters,
+            ),
+            $css_button
+      );
+      if ($css_button == '') {
+        $css_button = '<input class="' . $mouse_out_class . '" ' . $css_button_js . ' type="submit" value="' . $text . '"' . $tooltip . $parameters . ' />';
+      }
     }
 
     if ($type=='button'){
       // link button
-      $css_button = '<span class="' . $mouse_out_class . '" ' . $css_button_js . $tooltip . $parameters . '>&nbsp;' . $text . '&nbsp;</span>';
+      // -----
+      // Give an observer the chance to provide alternate formatting for the button (it's set to an empty string
+      // above).  If the value is still empty after the notification, create the standard-format
+      // of the button.
+      //
+      $GLOBALS['zco_notifier']->notify(
+            'NOTIFY_ZEN_CSS_BUTTON_BUTTON', 
+            array(
+                'button_name' => $button_name,
+                'text' => $text,
+                'sec_class' => $sec_class,
+                'parameters' => $parameters,
+            ),
+            $css_button
+      );
+      if ($css_button == '') {
+        $css_button = '<span class="' . $mouse_out_class . '" ' . $css_button_js . $tooltip . $parameters . '>&nbsp;' . $text . '&nbsp;</span>';
+      }
     }
     return $css_button;
   }
@@ -384,6 +418,25 @@
  *  Output a form input field
  */
   function zen_draw_input_field($name, $value = '', $parameters = '', $type = 'text', $reinsert_value = true) {
+    // -----
+    // Give an observer the opportunity to **totally** override this function's operation.
+    //
+    $field = false;
+    $GLOBALS['zco_notifier']->notify(
+        'NOTIFY_ZEN_DRAW_INPUT_FIELD_OVERRIDE',
+        array(
+            'name' => $name,
+            'value' => $value,
+            'parameters' => $parameters,
+            'type' => $type,
+            'reinsert_value' => $reinsert_value
+        ),
+        $field
+    );
+    if ($field !== false) {
+        return $field;
+    }
+    
     $field = '<input type="' . zen_output_string($type) . '" name="' . zen_sanitize_string(zen_output_string($name)) . '"';
     if ( (isset($GLOBALS[$name]) && is_string($GLOBALS[$name])) && ($reinsert_value == true) ) {
       $field .= ' value="' . zen_output_string(stripslashes($GLOBALS[$name])) . '"';
@@ -394,7 +447,21 @@
     if (zen_not_null($parameters)) $field .= ' ' . $parameters;
 
     $field .= ' />';
-
+    
+    // -----
+    // Give an observer the opportunity to modify the just-rendered field.
+    //
+    $GLOBALS['zco_notifier']->notify(
+        'NOTIFY_ZEN_DRAW_INPUT_FIELD',
+        array(
+            'name' => $name,
+            'value' => $value,
+            'parameters' => $parameters,
+            'type' => $type,
+            'reinsert_value' => $reinsert_value
+        ),
+        $field
+    );
     return $field;
   }
 
@@ -409,6 +476,25 @@
  *  Output a selection field - alias function for zen_draw_checkbox_field() and zen_draw_radio_field()
  */
   function zen_draw_selection_field($name, $type, $value = '', $checked = false, $parameters = '') {
+    // -----
+    // Give an observer the opportunity to **totally** override this function's operation.
+    //
+    $selection = false;
+    $GLOBALS['zco_notifier']->notify(
+        'NOTIFY_ZEN_DRAW_SELECTION_FIELD_OVERRIDE',
+        array(
+            'name' => $name,
+            'value' => $value,
+            'parameters' => $parameters,
+            'type' => $type,
+            'checked' => $checked
+        ),
+        $selection
+    );
+    if ($selection !== false) {
+        return $selection;
+    }
+    
     $selection = '<input type="' . zen_output_string($type) . '" name="' . zen_output_string($name) . '"';
 
     if (zen_not_null($value)) $selection .= ' value="' . zen_output_string($value) . '"';
@@ -420,7 +506,21 @@
     if (zen_not_null($parameters)) $selection .= ' ' . $parameters;
 
     $selection .= ' />';
-
+    
+    // -----
+    // Give an observer the opportunity to modify the just-rendered field.
+    //
+    $GLOBALS['zco_notifier']->notify(
+        'NOTIFY_ZEN_DRAW_SELECTION_FIELD',
+        array(
+            'name' => $name,
+            'value' => $value,
+            'parameters' => $parameters,
+            'type' => $type,
+            'checked' => $checked
+        ),
+        $selection
+    );
     return $selection;
   }
 
@@ -442,6 +542,26 @@
  *  Output a form textarea field
  */
   function zen_draw_textarea_field($name, $width, $height, $text = '~*~*#', $parameters = '', $reinsert_value = true) {
+    // -----
+    // Give an observer the opportunity to **totally** override this function's operation.
+    //
+    $field = false;
+    $GLOBALS['zco_notifier']->notify(
+        'NOTIFY_ZEN_DRAW_TEXTAREA_FIELD_OVERRIDE',
+        array(
+            'name' => $name,
+            'width' => $width,
+            'height' => $height,
+            'text' => $text,
+            'parameters' => $parameters,
+            'reinsert_value' => $reinsert_value,
+        ),
+        $field
+    );
+    if ($field !== false) {
+        return $field;
+    }
+    
     $field = '<textarea name="' . zen_output_string($name) . '" cols="' . zen_output_string($width) . '" rows="' . zen_output_string($height) . '"';
 
     if (zen_not_null($parameters)) $field .= ' ' . $parameters;
@@ -455,7 +575,22 @@
     }
 
     $field .= '</textarea>';
-
+    
+    // -----
+    // Give an observer the opportunity to modify the just-rendered field.
+    //
+    $GLOBALS['zco_notifier']->notify(
+        'NOTIFY_ZEN_DRAW_TEXTAREA_FIELD',
+        array(
+            'name' => $name,
+            'width' => $width,
+            'height' => $height,
+            'text' => $text,
+            'parameters' => $parameters,
+            'reinsert_value' => $reinsert_value,
+        ),
+        $field
+    );
     return $field;
   }
 
@@ -505,6 +640,25 @@
  *  Pulls values from a passed array, with the indicated option pre-selected
  */
   function zen_draw_pull_down_menu($name, $values, $default = '', $parameters = '', $required = false) {
+    // -----
+    // Give an observer the opportunity to **totally** override this function's operation.
+    //
+    $field = false;
+    $GLOBALS['zco_notifier']->notify(
+        'NOTIFY_ZEN_DRAW_PULL_DOWN_MENU_OVERRIDE',
+        array(
+            'name' => $name,
+            'values' => $values,
+            'default' => $default,
+            'parameters' => $parameters,
+            'required' => $required,
+        ),
+        $field
+    );
+    if ($field !== false) {
+        return $field;
+    }
+    
     $field = '<select';
 
     if (!strstr($parameters, 'id=')) $field .= ' id="select-'.zen_output_string($name).'"';
@@ -528,7 +682,21 @@
     $field .= '</select>' . "\n";
 
     if ($required == true) $field .= TEXT_FIELD_REQUIRED;
-
+    
+    // -----
+    // Give an observer the chance to make modifications to the just-rendered field.
+    //
+    $GLOBALS['zco_notifier']->notify(
+        'NOTIFY_ZEN_DRAW_PULL_DOWN_MENU',
+        array(
+            'name' => $name,
+            'values' => $values,
+            'default' => $default,
+            'parameters' => $parameters,
+            'required' => $required,
+        ),
+        $field
+    );
     return $field;
   }
 


### PR DESCRIPTION
Add notifiers to various "base" functions, enabling observers to modify (or in some cases replace) those functions' processing and return values.  This will enable many plugins to remove the need for core-file overwrites, allowing for an easier Zen Cart upgrade path.

Please note that many of the notifier strings are in use by various plugins; please don't change the names and/or "payload".