### PR TITLE
 Fix: checkout_shipping: No method chosen after selected shipping is …

### DIFF
--- a/includes/modules/pages/checkout_shipping/header_php.php
+++ b/includes/modules/pages/checkout_shipping/header_php.php
@@ -201,6 +201,7 @@ if (isset($_SESSION['cart']->cartID)) {
     $checkval = $_SESSION['shipping']['id'];
     if (!in_array($checkval, $checklist)) {
       $messageStack->add('checkout_shipping', ERROR_PLEASE_RESELECT_SHIPPING_METHOD, 'error');
+      unset($_SESSION['shipping']); // Prepare $_SESSION to determine lowest available price/force a default selection mc12345678 2018-04-03
     }
   }
 


### PR DESCRIPTION
…no longer available

Changes in available shipping methods can occur for a number of reasons, shopping cart items added/deleted, prices changed, coupons applied, etc... When a previously selected shipping option is no longer available, ZC reports that change; however, does not then force a new selection.  As a result, the previously available selection (now removed from the options) remains internally active and could result in incorrect shipping fees to be collected (too high or too low).

This commit will stage the shipping option selection to select a new lowest price.