### PR TITLE
#1651-dev-admin-customers-notifiers

### DIFF
--- a/includes/functions/functions_customers.php
+++ b/includes/functions/functions_customers.php
@@ -314,6 +314,9 @@
             ORDER BY firstname, lastname";
 
     $sql = $db->bindVars($sql, ':customersID', $customers_id, 'integer');
+    
+    $GLOBALS['zco_notifier']->notify('NOTIFY_ADMIN_CUSTOMERS_LIST_ADDRESSES', $sql);
+    
     $addresses = $db->Execute($sql);
     $addressArray = array();
     foreach ($addresses as $address) {


### PR DESCRIPTION
Align the `develop` branch to provide the same notifications for Customers->Customers processing as the v156 branch.  Note that some functionality has been moved to the storefront/common functions_customers.php module.