### PR TITLE
Correct FirstData HCO price hash comparison

### DIFF
--- a/includes/modules/payment/firstdata_hco.php
+++ b/includes/modules/payment/firstdata_hco.php
@@ -338,7 +338,7 @@ class firstdata_hco extends base {
   function before_process() {
     global $messageStack, $order;
     $this->authorize = $_POST;
-    $this->authorize['HashValidationValue'] = $this->calc_md5_response($this->authorize['x_trans_id'], $this->authorize['x_amount']);
+    $this->authorize['HashValidationValue'] = $this->calc_md5_response($this->authorize['x_trans_id'], number_format($this->authorize['x_amount'], 2, '.', ''));
     $this->authorize['HashMatchStatus'] = ($this->authorize['x_MD5_Hash'] == $this->authorize['HashValidationValue']) ? 'PASS' : 'FAIL';
 
     $this->notify('MODULE_PAYMENT_FIRSTDATA_PAYMENTPAGES_POSTSUBMIT_HOOK', $this->authorize);


### PR DESCRIPTION
As identified in this forum thread:
https://www.zen-cart.com/showthread.php?223791-Payeezy-HCO-HASH-error
payments appear to be collected; however, not recorded in ZC because
the hash value comparison does not pass.  Per technical support when
performing the hash comparison, the total price of the purchase is to
be incorporated into the hash with two decimal places applied.

The current code will round to 2 decimal places but if the value ends with
a zero, then that zero is dropped from right to left up to the decimal
point. This corrects that specific comparison.