### PR TITLE
Add zen-get-tax-locations-notifier

### DIFF
--- a/includes/functions/functions_taxes.php
+++ b/includes/functions/functions_taxes.php
@@ -263,7 +263,23 @@
   }
 
  function zen_get_tax_locations($store_country = -1, $store_zone = -1) {
-  global $db;
+    // -----
+    // Give an observer the chance to modify the function's output.
+    //
+    $tax_address = false;
+    $zco_notifier->notify(
+        'ZEN_GET_TAX_LOCATIONS',
+        array(
+            'country' => $store_country,
+            'zone' => $store_zone
+        ),
+        $tax_address
+    );
+    if (is_array($tax_address)) {
+        return $tax_address;
+    }
+    
+    global $db;
     switch (STORE_PRODUCT_TAX_BASIS) {
 
       case 'Shipping':


### PR DESCRIPTION
Add a notifier to the `zen_get_tax_locations` function, enabling an override.  Enables "Edit Orders" (and possibly other plugins) in admin-side order reconstruction.