### PR TITLE
v156-correct-order-notifier-parm

### DIFF
--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -239,7 +239,7 @@ class order extends base {
 
       $this->info['tax_groups']["{$this->products[$index]['tax']}"] = '1';
 
-      $this->notify('NOTIFY_ORDER_QUERY_ADD_PRODUCT', $product, $index);
+      $this->notify('NOTIFY_ORDER_QUERY_ADD_PRODUCT', $this->products, $index);
 
       $index++;
       $orders_products->MoveNext();


### PR DESCRIPTION
Throwing a debug-log on PHP 7.1+:
```
PHP Notice:  Undefined variable: products in C:\xampp\htdocs\zc156\includes\classes\order.php on line 242
```