### PR TITLE
Fix error found during review for strict errors.

### DIFF
--- a/includes/templates/responsive_classic/sideboxes/tpl_information.php
+++ b/includes/templates/responsive_classic/sideboxes/tpl_information.php
@@ -11,7 +11,7 @@
   $content = '';
   $content .= '<div id="' . str_replace('_', '-', $box_id . 'Content') . '" class="sideBoxContent">';
   $content .= "\n" . '<ul class="list-links">' . "\n";
-  for ($i=0, $n=sizeof($information); $i<$j; $i++) {
+  for ($i=0, $n=sizeof($information); $i<$n; $i++) {
     $content .= '<li>' . $information[$i] . '</li>' . "\n";
   }
   $content .= '</ul>' .  "\n";


### PR DESCRIPTION
Haven't reviewed past installations to determine how this came to be different; however, the maximum was to be compared against `$j` instead of `$n`. That said, almost wonder if foreach should be used instead.  