### PR TITLE
Globalize zco_notifier for image modules

### DIFF
--- a/includes/modules/additional_images.php
+++ b/includes/modules/additional_images.php
@@ -13,7 +13,7 @@
 if (!defined('IS_ADMIN_FLAG')) {
     die('Illegal Access');
 }
-$zco_notifier->notify('NOTIFY_MODULES_ADDITIONAL_PRODUCT_IMAGES_START');
+$GLOBALS['zco_notifier']->notify('NOTIFY_MODULES_ADDITIONAL_PRODUCT_IMAGES_START');
 
 if (!defined('IMAGE_ADDITIONAL_DISPLAY_LINK_EVEN_WHEN_NO_LARGE')) define('IMAGE_ADDITIONAL_DISPLAY_LINK_EVEN_WHEN_NO_LARGE','Yes');
 $images_array = array();
@@ -53,7 +53,7 @@ if ($products_image != '' && $flag_show_product_info_additional_images != 0) {
                 // $p2 ... (r/w) ... A boolean indicator, set to true by any observer to note that the image is "acceptable".
                 //
                 $current_image_match = false;
-                $zco_notifier->notify(
+                $GLOBALS['zco_notifier']->notify(
                     'NOTIFY_MODULES_ADDITIONAL_IMAGES_FILE_MATCH',
                     array(
                         'file' => $file,
@@ -84,7 +84,7 @@ if ($products_image != '' && $flag_show_product_info_additional_images != 0) {
     }
 }
 
-$zco_notifier->notify('NOTIFY_MODULES_ADDITIONAL_PRODUCT_IMAGES_LIST', NULL, $images_array);
+$GLOBALS['zco_notifier']->notify('NOTIFY_MODULES_ADDITIONAL_PRODUCT_IMAGES_LIST', NULL, $images_array);
 
 
 // Build output based on images found
@@ -111,7 +111,7 @@ if ($num_images > 0) {
         // $p1 ... (r/o) ... The current product's name
         // $p2 ... (r/w) ... The (possibly updated) filename (including path) of the current additional image.
         //
-        $zco_notifier->notify('NOTIFY_MODULES_ADDITIONAL_IMAGES_GET_LARGE', $products_name, $products_image_large);
+        $GLOBALS['zco_notifier']->notify('NOTIFY_MODULES_ADDITIONAL_IMAGES_GET_LARGE', $products_name, $products_image_large);
 
         $flag_has_large = file_exists($products_image_large);
         $products_image_large = ($flag_has_large ? $products_image_large : $products_image_directory . $file);
@@ -126,7 +126,7 @@ if ($num_images > 0) {
         // $p1 ... (n/a) ... An empty array, not applicable.
         // $p2 ... (r/w) ... A reference to the "slashed" thumbnail image name.
         //
-        $zco_notifier->notify('NOTIFY_MODULES_ADDITIONAL_IMAGES_THUMB_SLASHES', array(), $thumb_slashes);
+        $GLOBALS['zco_notifier']->notify('NOTIFY_MODULES_ADDITIONAL_IMAGES_THUMB_SLASHES', array(), $thumb_slashes);
 
         $thumb_regular = zen_image($base_image, $products_name, SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT);
         $large_link = zen_href_link(FILENAME_POPUP_IMAGE_ADDITIONAL, 'pID=' . $_GET['products_id'] . '&pic=' . $i . '&products_image_large_additional=' . $products_image_large);
@@ -145,7 +145,7 @@ if ($num_images > 0) {
         //
         $script_link = false;
         $link_parameters = 'class="additionalImages centeredContent back"' . ' ' . 'style="width:' . $col_width . '%;"';
-        $zco_notifier->notify(
+        $GLOBALS['zco_notifier']->notify(
             'NOTIFY_MODULES_ADDITIONAL_IMAGES_SCRIPT_LINK',
             array(
                 'flag_display_large' => $flag_display_large,
@@ -181,4 +181,4 @@ if ($num_images > 0) {
     } // end for loop
 } // endif
 
-$zco_notifier->notify('NOTIFY_MODULES_ADDITIONAL_PRODUCT_IMAGES_END');
+$GLOBALS['zco_notifier']->notify('NOTIFY_MODULES_ADDITIONAL_PRODUCT_IMAGES_END');

--- a/includes/modules/main_product_image.php
+++ b/includes/modules/main_product_image.php
@@ -15,7 +15,7 @@ if (!defined('IS_ADMIN_FLAG')) {
 // -----
 // This notifier lets an observer know that the module has begun its processing.
 //
-$zco_notifier->notify('NOTIFY_MODULES_MAIN_PRODUCT_IMAGE_START');
+$GLOBALS['zco_notifier']->notify('NOTIFY_MODULES_MAIN_PRODUCT_IMAGE_START');
 
 $products_image_extension = substr($products_image, strrpos($products_image, '.'));
 $products_image_base = str_replace($products_image_extension, '', $products_image);
@@ -37,7 +37,7 @@ $products_image_large = $products_image_base . IMAGE_SUFFIX_LARGE . $products_im
 // other values have been updated for separate handling.
 //
 $main_image_handled = false;
-$zco_notifier->notify(
+$GLOBALS['zco_notifier']->notify(
     'NOTIFY_MODULES_MAIN_PRODUCT_IMAGE_FILENAME',
     $products_image,
     $main_image_handled,
@@ -74,4 +74,4 @@ if ($main_image_handled !== true) {
     // to be built into a single variable string
 }
 
-$zco_notifier->notify('NOTIFY_MODULES_MAIN_PRODUCT_IMAGE_END');
+$GLOBALS['zco_notifier']->notify('NOTIFY_MODULES_MAIN_PRODUCT_IMAGE_END');


### PR DESCRIPTION
Since some plugins incude the image-related modules in a function context, need to "globalize" the use of the $zco_notifier object.

Fixes #1687 