### PR TITLE
Remove duplicate define for sales-report-graph

### DIFF
--- a/admin/includes/extra_configures/stats_sales_report_graphs.php
+++ b/admin/includes/extra_configures/stats_sales_report_graphs.php
@@ -7,9 +7,5 @@
  * @version $Id:  New in v1.5.5 $
  */
 
-//Defined in catalog/includes/filenames.php
-//define('FILENAME_STATS_SALES_REPORT_GRAPHS', 'stats_sales_report_graphs');
-
-
-// adjust and uncomment
+// adjust and uncomment if a different value is desired
 //define('SALES_REPORT_GRAPHS_FILTER_DEFAULT', '00000000110000000000');

--- a/admin/includes/extra_configures/stats_sales_report_graphs.php
+++ b/admin/includes/extra_configures/stats_sales_report_graphs.php
@@ -7,7 +7,8 @@
  * @version $Id:  New in v1.5.5 $
  */
 
-define('FILENAME_STATS_SALES_REPORT_GRAPHS', 'stats_sales_report_graphs');
+//Defined in catalog/includes/filenames.php
+//define('FILENAME_STATS_SALES_REPORT_GRAPHS', 'stats_sales_report_graphs');
 
 
 // adjust and uncomment


### PR DESCRIPTION
…es.php

That definition is not needed on the admin side because of its equivalent catalog definition.

Found via strict related reporting where reporting was set to not report this type of issue; however, still came through for some reason.  Removing the define on the admin or conditionally defining it on the catalog side resolved the issue.