### PR TITLE
Add missing quotes to array key in coupon_restrict

### DIFF
--- a/admin/coupon_restrict.php
+++ b/admin/coupon_restrict.php
@@ -9,8 +9,8 @@
   //define('MAX_DISPLAY_RESTRICT_ENTRIES', 10);
   require('includes/application_top.php');
   $restrict_array = array();
-  $restrict_array[] = array('id'=>'Deny', text=>TEXT_PULLDOWN_DENY);
-  $restrict_array[] = array('id'=>'Allow', text=>TEXT_PULLDOWN_ALLOW);
+  $restrict_array[] = array('id'=>'Deny', 'text'=>TEXT_PULLDOWN_DENY);
+  $restrict_array[] = array('id'=>'Allow', 'text'=>TEXT_PULLDOWN_ALLOW);
 
   if ($_POST['cPath_prod'] > 0 and $_POST['manufacturers_id'] > 0) {
     $current_category_id = 0;


### PR DESCRIPTION
The array key is missing the single quotes around the word "text". It is apparently now a major bug, as the code also seems to work fine without them. So no need to fix in earlier versions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zencart/zencart/1709)
<!-- Reviewable:end -->
