### PR TITLE
Preserve address_book_id through notification

### DIFF
--- a/includes/modules/checkout_new_address.php
+++ b/includes/modules/checkout_new_address.php
@@ -133,6 +133,8 @@ if (isset($_POST['action']) && ($_POST['action'] == 'submit')) {
       $error = true;
       $messageStack->add('checkout_address', ENTRY_COUNTRY_ERROR);
     }
+    
+    $zco_notifier->notify('NOTIFY_MODULE_CHECKOUT_NEW_ADDRESS_VALIDATION', array(), $error);
 
     if ($error == false) {
       $sql_data_array = array(array('fieldName'=>'customers_id', 'value'=>$_SESSION['customer_id'], 'type'=>'integer'),
@@ -157,15 +159,16 @@ if (isset($_POST['action']) && ($_POST['action'] == 'submit')) {
         }
       }
       $db->perform(TABLE_ADDRESS_BOOK, $sql_data_array);
-      $zco_notifier->notify('NOTIFY_MODULE_CHECKOUT_ADDED_ADDRESS_BOOK_RECORD', array_merge(array('address_id' => $db->Insert_ID() ), $sql_data_array));
+      $address_book_id = $db->Insert_ID();
+      $zco_notifier->notify('NOTIFY_MODULE_CHECKOUT_ADDED_ADDRESS_BOOK_RECORD', array_merge(array('address_id' => $address_book_id ), $sql_data_array));
       switch($addressType) {
         case 'billto':
-        $_SESSION['billto'] = $db->Insert_ID();
+        $_SESSION['billto'] = $address_book_id;
         $_SESSION['payment'] = '';
         zen_redirect(zen_href_link(FILENAME_CHECKOUT_PAYMENT, '', 'SSL'));
         break;
         case 'shipto':
-        $_SESSION['sendto'] = $db->Insert_ID();
+        $_SESSION['sendto'] = $address_book_id;
         unset($_SESSION['shipping']);
         zen_redirect(zen_href_link(FILENAME_CHECKOUT_SHIPPING, '', 'SSL'));
         break;


### PR DESCRIPTION
... so it's preserved over the notification, assuming that an observer is likely to be performing additional database actions of its own.

Fixes #1711 