### PR TITLE
Add extra fallback check for jquery inclusion

### DIFF
--- a/includes/templates/responsive_classic/common/html_header.php
+++ b/includes/templates/responsive_classic/common/html_header.php
@@ -134,7 +134,10 @@ if (count($lng->catalog_languages) > 1) {
 ?>
 
 <script type="text/javascript">window.jQuery || document.write(unescape('%3Cscript type="text/javascript" src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"%3E%3C/script%3E'));</script>
+<?php if (file_exists(DIR_WS_TEMPLATE . "jscript/jquery.min.js")) { ?>
 <script type="text/javascript">window.jQuery || document.write(unescape('%3Cscript type="text/javascript" src="<?php echo $template->get_template_dir('.js',DIR_WS_TEMPLATE, $current_page_base,'jscript'); ?>/jquery.min.js"%3E%3C/script%3E'));</script>
+<?php } ?>
+<script type="text/javascript">window.jQuery || document.write(unescape('%3Cscript type="text/javascript" src="<?php echo $template->get_template_dir('.js','template_default', $current_page_base,'jscript'); ?>/jquery.min.js"%3E%3C/script%3E'));</script>
 
 <?php
 /**


### PR DESCRIPTION
Check for jquery in current template before attempting inclusion
If this still fails, pull from template_default.
