### PR TITLE
[v156] Refine Error Heading Display

### DIFF
--- a/zc_install/includes/languages/lngEnglish.php
+++ b/zc_install/includes/languages/lngEnglish.php
@@ -3,7 +3,7 @@
  * Main English language file for installer
  * @package Installer
  * @copyright Copyright 2003-2018 Zen Cart Development Team
- * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License v2.0
  * @version $Id: Author: DrByte  Modified in v1.5.6 $
  */
 /**
@@ -17,7 +17,7 @@ define('TEXT_INDEX_FATAL_ERRORS', 'Some problems that need fixing before we cont
 define('TEXT_INDEX_WARN_ERRORS', 'Some Other Issues:');
 define('TEXT_INDEX_WARN_ERRORS_ALT', 'Some Issues:');
 define('TEXT_HEADER_MAIN', 'TIP: The field titles are clickable help links which explain what each field means.');
-define('TEXT_INDEX_HEADER_MAIN', 'TIP: For some errors and warnings below, more information may be available by clicking on the error/warning title.');
+define('TEXT_INDEX_HEADER_MAIN', 'TIP: More information may be available by clicking on the titles of some errors and warnings.');
 define('TEXT_INSTALLER_CHOOSE_LANGUAGE', 'Choose Language');
 define('TEXT_HELP_CONTENT_CHOOSE_LANG', 'Zen Cart&reg; is multi-lingual, supporting as many languages as there are language packs available. Simply install the necessary language pack and your entire store can operate in multiple languages, including this installer.');
 

--- a/zc_install/includes/template/templates/index_default.php
+++ b/zc_install/includes/template/templates/index_default.php
@@ -73,12 +73,22 @@ require(DIR_FS_INSTALL . DIR_WS_INSTALL_TEMPLATE . 'partials/partial_modal_help.
 </div>
 <?php } ?>
 <?php if ($hasWarnErrors) { ?>
+    <?php foreach ($listWarnErrors as $error) { ?>
+        <?php if (strpos($error['mainErrorText'], 'PRO TIP:') === false) { ?>
+            <?php $errorHeadingFlag = true; ?>
+            
+            <?php break; ?>
+        <?php } ?>
+    <?php } ?>
+
 <div id="warnErrors" class="errorList">
-	<?php if ($adjustWarnIssues) { ?>
+    <?php if ($errorHeadingFlag) { ?>
+        <?php if ($adjustWarnIssues) { ?>
   <h2><?php echo TEXT_INDEX_WARN_ERRORS; ?></h2>
-  <?php } else { ?>
+        <?php } else { ?>
   <h2><?php echo TEXT_INDEX_WARN_ERRORS_ALT; ?></h2>
-  <?php } ?>
+        <?php } ?>
+    <?php } ?>
     <?php foreach ($listWarnErrors as $error) { ?>
     	<?php if (strpos($error['mainErrorText'], 'PRO TIP:') !== false) { ?>
     <div class="alert-box">


### PR DESCRIPTION
The install index page always says there are issues even when the only thing that shows up is a 'Pro Tip'. This PR adds logic to only show the header saying there is an issue when there are actual issues itemised as opposed to tips.