### PR TITLE
Show errors created during db test connection

### DIFF
--- a/zc_install/ajaxTestDBConnection.php
+++ b/zc_install/ajaxTestDBConnection.php
@@ -23,10 +23,11 @@ if (isset($_POST['db_name']))
   zcRegistry::setValue('db_password', $_POST['db_password']);
   zcRegistry::setValue('db_name', $_POST['db_name']);
   zcRegistry::setValue('db_charset', $_POST['db_charset']);
-  $errorList = $systemChecker -> runTests('database');
-  if (count($errorList) != 0)
+  $results = $systemChecker -> runTests('database');
+  if (count($results) != 0)
   {
-    $errorList = $errorList['newDatabaseCheck'];
+    $keys = array_keys($results); 
+    $errorList = $results[$keys[0]]; 
     $error = TRUE;
   } else
   {


### PR DESCRIPTION
Attempted install from scratch with admin/includes/local/configure.php containing 

define('ADMIN_BLOCK_WARNING_OVERRIDE', '1');

This breaks the install, but no error is given because the installer is looking at `$errorList['newDatabaseCheck']` which is not set.