### PR TITLE
PHPMailer 5 handler backward-compatibility break

### DIFF
--- a/includes/classes/vendors/PHPMailer/PHPMailerAutoload.php
+++ b/includes/classes/vendors/PHPMailer/PHPMailerAutoload.php
@@ -37,13 +37,13 @@ if (version_compare(PHP_VERSION, '5.1.2', '>=')) {
     } else {
         spl_autoload_register('PHPMailerAutoload');
     }
-} else {
+} //else { // Drop really old autoload method as deprecated in PHP 7.2.x
     /**
      * Fall back to traditional autoload for old PHP versions
      * @param string $classname The name of the class to load
      */
-    function __autoload($classname)
+/*    function __autoload($classname)
     {
         PHPMailerAutoload($classname);
-    }
-}
+    }*/
+//}


### PR DESCRIPTION
The _autoload function has been deprecated in PHP 7.2.x, unfortunately this
file is associated with a larger project, but in PHP 7.2.x this caused an
issue.