### PR TITLE
Modify handling of version check errors to provide text only results

### DIFF
--- a/includes/functions/plugin_support.php
+++ b/includes/functions/plugin_support.php
@@ -38,7 +38,7 @@ function plugin_version_check_for_updates($plugin_file_id = 0, $version_string_t
     $data = json_decode($versionServer->getPluginVersion($plugin_file_id), true);
 
     if (null === $data || isset($data['error'])) {
-        trigger_error('CURL error checking plugin versions: ' . $data['error']);
+        trigger_error('CURL error checking plugin versions: ' . print_r($data['error'], true));
         return false;
     }
 


### PR DESCRIPTION
the array $data['error'] itself can be an array, a boolean, or text.
The use of print_r outputting as text will allow the full set of data
to be pushed which in this case is a triggered error.