### PR TITLE
Prepare for filter data.

### DIFF
--- a/includes/index_filters/default_filter.php
+++ b/includes/index_filters/default_filter.php
@@ -25,6 +25,9 @@ if (isset($_GET['alpha_filter_id']) && (int)$_GET['alpha_filter_id'] > 0) {
   }
   if (!isset($select_column_list)) $select_column_list = "";
    // show the products of a specified manufacturer
+  if (!isset($do_filter_list)) {
+    $do_filter_list = false;
+  }
   if (isset($_GET['manufacturers_id']) && $_GET['manufacturers_id'] != '' ) {
     if (isset($_GET['filter_id']) && zen_not_null($_GET['filter_id'])) {
 // We are asked to show only a specific category

--- a/includes/index_filters/music_genre_filter.php
+++ b/includes/index_filters/music_genre_filter.php
@@ -25,6 +25,10 @@ if (isset($_GET['alpha_filter_id']) && (int)$_GET['alpha_filter_id'] > 0) {
 }
 if (!isset($select_column_list)) $select_column_list = "";
 
+if (!isset($do_filter_list)) {
+  $do_filter_list = false;
+}
+
   // show the products of a specified music_genre
   if (isset($_GET['music_genre_id']))
   {

--- a/includes/index_filters/record_company_filter.php
+++ b/includes/index_filters/record_company_filter.php
@@ -24,6 +24,11 @@ if (isset($_GET['alpha_filter_id']) && (int)$_GET['alpha_filter_id'] > 0) {
   $alpha_sort = '';
 }
 if (!isset($select_column_list)) $select_column_list = "";
+
+if (!isset($do_filter_list)) {
+  $do_filter_list = false;
+}
+
  // show the products of a specified record-company
   if (isset($_GET['record_company_id']))
   {

--- a/includes/modules/pages/advanced_search_result/header_php.php
+++ b/includes/modules/pages/advanced_search_result/header_php.php
@@ -15,6 +15,12 @@ $zco_notifier->notify('NOTIFY_HEADER_START_ADVANCED_SEARCH_RESULTS');
 if (!defined('KEYWORD_FORMAT_STRING')) define('KEYWORD_FORMAT_STRING','keywords');
 
 require(DIR_WS_MODULES . zen_get_module_directory('require_languages.php'));
+// set the product filters according to selected product type
+
+$typefilter = 'default';
+if (isset($_GET['typefilter'])) $typefilter = $_GET['typefilter'];
+require(zen_get_index_filters_directory($typefilter . '_filter.php'));
+
 $error = false;
 $missing_one_input = false;
 


### PR DESCRIPTION
While resolving strict notifications identified the use or existence
of the variable $do_filter_list in the advanced_search_result page.

This is defined only in the index_filters section, but also not consistently
so either $do_filter_list should be removed or more appropriately captured.

Chose to pull the two together so that whatever functionality someone
may have been using it would still be there, but at least the strict
messages would not be generated.