### PR TITLE
Pass product_type as form field with product collect_info.php

### DIFF
--- a/admin/includes/modules/document_general/collect_info.php
+++ b/admin/includes/modules/document_general/collect_info.php
@@ -130,7 +130,10 @@ for ($i = 0, $n = sizeof($tax_class_array); $i < $n; $i++) {
 </script>
 <div class="container-fluid">
     <?php
-    echo zen_draw_form('new_product', FILENAME_PRODUCT, 'cPath=' . $current_category_id . (isset($product_type) ? '&product_type=' . $product_type : '') . (isset($_GET['pID']) ? '&pID=' . $_GET['pID'] : '') . '&action=new_product_preview' . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . ( (isset($_GET['search']) && !empty($_GET['search'])) ? '&search=' . $_GET['search'] : '') . ( (isset($_POST['search']) && !empty($_POST['search']) && empty($_GET['search'])) ? '&search=' . $_POST['search'] : ''), 'post', 'enctype="multipart/form-data" class="form-horizontal"');
+    echo zen_draw_form('new_product', FILENAME_PRODUCT, 'cPath=' . $current_category_id . (isset($_GET['pID']) ? '&pID=' . $_GET['pID'] : '') . '&action=new_product_preview' . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . ( (isset($_GET['search']) && !empty($_GET['search'])) ? '&search=' . $_GET['search'] : '') . ( (isset($_POST['search']) && !empty($_POST['search']) && empty($_GET['search'])) ? '&search=' . $_POST['search'] : ''), 'post', 'enctype="multipart/form-data" class="form-horizontal"');
+    if (isset($product_type)) {
+      echo zen_draw_hidden_field('product_type', $product_type);
+    }
     ?>
   <h3 class="col-sm-11"><?php echo sprintf(TEXT_NEW_PRODUCT, zen_output_generated_category_path($current_category_id)); ?></h3>
   <div class="col-sm-1"><?php echo zen_info_image($cInfo->categories_image, $cInfo->categories_name, HEADING_IMAGE_WIDTH, HEADING_IMAGE_HEIGHT); ?></div>

--- a/admin/includes/modules/document_general/preview_info.php
+++ b/admin/includes/modules/document_general/preview_info.php
@@ -146,7 +146,7 @@ $form_action = (isset($_GET['pID'])) ? 'update_product' : 'insert_product';
       ?>
       <a href="<?php echo zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING, 'cPath=' . $cPath . (isset($_GET['pID']) ? '&pID=' . $_GET['pID'] : '') . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')); ?>" class="btn btn-default" role="button"><?php echo IMAGE_CANCEL; ?></a>
       <?php 
-      if (!(isset($_GET['read']) && ($_GET['read'] === 'only')) {
+      if (!(isset($_GET['read']) && ($_GET['read'] === 'only'))) {
         echo '</form>'; 
       } ?>
     </div>

--- a/admin/includes/modules/document_product/collect_info.php
+++ b/admin/includes/modules/document_product/collect_info.php
@@ -165,7 +165,10 @@ for ($i = 0, $n = sizeof($tax_class_array); $i < $n; $i++) {
 </script>
 <div class="container-fluid">
     <?php
-    echo zen_draw_form('new_product', FILENAME_PRODUCT, 'cPath=' . $current_category_id . (isset($product_type) ? '&product_type=' . $product_type : '') . (isset($_GET['pID']) ? '&pID=' . $_GET['pID'] : '') . '&action=new_product_preview' . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . ( (isset($_GET['search']) && !empty($_GET['search'])) ? '&search=' . $_GET['search'] : '') . ( (isset($_POST['search']) && !empty($_POST['search']) && empty($_GET['search'])) ? '&search=' . $_POST['search'] : ''), 'post', 'enctype="multipart/form-data" class="form-horizontal"');
+    echo zen_draw_form('new_product', FILENAME_PRODUCT, 'cPath=' . $current_category_id . (isset($_GET['pID']) ? '&pID=' . $_GET['pID'] : '') . '&action=new_product_preview' . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . ( (isset($_GET['search']) && !empty($_GET['search'])) ? '&search=' . $_GET['search'] : '') . ( (isset($_POST['search']) && !empty($_POST['search']) && empty($_GET['search'])) ? '&search=' . $_POST['search'] : ''), 'post', 'enctype="multipart/form-data" class="form-horizontal"');
+    if (isset($product_type)) {
+      echo zen_draw_hidden_field('product_type', $product_type);
+    }
     ?>
   <h3 class="col-sm-11"><?php echo sprintf(TEXT_NEW_PRODUCT, zen_output_generated_category_path($current_category_id)); ?></h3>
   <div class="col-sm-1"><?php echo zen_info_image($cInfo->categories_image, $cInfo->categories_name, HEADING_IMAGE_WIDTH, HEADING_IMAGE_HEIGHT); ?></div>

--- a/admin/includes/modules/document_product/preview_info.php
+++ b/admin/includes/modules/document_product/preview_info.php
@@ -160,7 +160,7 @@ $form_action = (isset($_GET['pID'])) ? 'update_product' : 'insert_product';
       ?>
       <a href="<?php echo zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING, 'cPath=' . $cPath . (isset($_GET['pID']) ? '&pID=' . $_GET['pID'] : '') . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')); ?>" class="btn btn-default" role="button"><?php echo IMAGE_CANCEL; ?></a>
       <?php 
-      if (!(isset($_GET['read']) && ($_GET['read'] === 'only')) {
+      if (!(isset($_GET['read']) && ($_GET['read'] === 'only'))) {
         echo '</form>'; 
       } ?>
     </div>

--- a/admin/includes/modules/product/collect_info.php
+++ b/admin/includes/modules/product/collect_info.php
@@ -165,7 +165,10 @@ for ($i = 0, $n = sizeof($tax_class_array); $i < $n; $i++) {
 </script>
 <div class="container-fluid">
     <?php
-    echo zen_draw_form('new_product', FILENAME_PRODUCT, 'cPath=' . $current_category_id . (isset($product_type) ? '&product_type=' . $product_type : '') . (isset($_GET['pID']) ? '&pID=' . $_GET['pID'] : '') . '&action=new_product_preview' . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . ( (isset($_GET['search']) && !empty($_GET['search'])) ? '&search=' . $_GET['search'] : '') . ( (isset($_POST['search']) && !empty($_POST['search']) && empty($_GET['search'])) ? '&search=' . $_POST['search'] : ''), 'post', 'enctype="multipart/form-data" class="form-horizontal"');
+    echo zen_draw_form('new_product', FILENAME_PRODUCT, 'cPath=' . $current_category_id . (isset($_GET['pID']) ? '&pID=' . $_GET['pID'] : '') . '&action=new_product_preview' . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . ( (isset($_GET['search']) && !empty($_GET['search'])) ? '&search=' . $_GET['search'] : '') . ( (isset($_POST['search']) && !empty($_POST['search']) && empty($_GET['search'])) ? '&search=' . $_POST['search'] : ''), 'post', 'enctype="multipart/form-data" class="form-horizontal"');
+    if (isset($product_type)) {
+      echo zen_draw_hidden_field('product_type', $product_type);
+    }
     ?>
   <h3 class="col-sm-11"><?php echo sprintf(TEXT_NEW_PRODUCT, zen_output_generated_category_path($current_category_id)); ?></h3>
   <div class="col-sm-1"><?php echo zen_info_image($cInfo->categories_image, $cInfo->categories_name, HEADING_IMAGE_WIDTH, HEADING_IMAGE_HEIGHT); ?></div>

--- a/admin/includes/modules/product/preview_info.php
+++ b/admin/includes/modules/product/preview_info.php
@@ -161,7 +161,7 @@ $form_action = (isset($_GET['pID'])) ? 'update_product' : 'insert_product';
       ?>
       <a href="<?php echo zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING, 'cPath=' . $cPath . (isset($_GET['pID']) ? '&pID=' . $_GET['pID'] : '') . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')); ?>" class="btn btn-default" role="button"><?php echo IMAGE_CANCEL; ?></a>
       <?php 
-      if (!(isset($_GET['read']) && ($_GET['read'] === 'only')) {
+      if (!(isset($_GET['read']) && ($_GET['read'] === 'only'))) {
         echo '</form>'; 
       } ?>
     </div>

--- a/admin/includes/modules/product_free_shipping/collect_info.php
+++ b/admin/includes/modules/product_free_shipping/collect_info.php
@@ -165,7 +165,10 @@ for ($i = 0, $n = sizeof($tax_class_array); $i < $n; $i++) {
 </script>
 <div class="container-fluid">
     <?php
-    echo zen_draw_form('new_product', FILENAME_PRODUCT, 'cPath=' . $current_category_id . (isset($product_type) ? '&product_type=' . $product_type : '') . (isset($_GET['pID']) ? '&pID=' . $_GET['pID'] : '') . '&action=new_product_preview' . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . ( (isset($_GET['search']) && !empty($_GET['search'])) ? '&search=' . $_GET['search'] : '') . ( (isset($_POST['search']) && !empty($_POST['search']) && empty($_GET['search'])) ? '&search=' . $_POST['search'] : ''), 'post', 'enctype="multipart/form-data" class="form-horizontal"');
+    echo zen_draw_form('new_product', FILENAME_PRODUCT, 'cPath=' . $current_category_id . (isset($_GET['pID']) ? '&pID=' . $_GET['pID'] : '') . '&action=new_product_preview' . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . ( (isset($_GET['search']) && !empty($_GET['search'])) ? '&search=' . $_GET['search'] : '') . ( (isset($_POST['search']) && !empty($_POST['search']) && empty($_GET['search'])) ? '&search=' . $_POST['search'] : ''), 'post', 'enctype="multipart/form-data" class="form-horizontal"');
+    if (isset($product_type)) {
+      echo zen_draw_hidden_field('product_type', $product_type);
+    }
     ?>
   <h3 class="col-sm-11"><?php echo sprintf(TEXT_NEW_PRODUCT, zen_output_generated_category_path($current_category_id)); ?></h3>
   <div class="col-sm-1"><?php echo zen_info_image($cInfo->categories_image, $cInfo->categories_name, HEADING_IMAGE_WIDTH, HEADING_IMAGE_HEIGHT); ?></div>

--- a/admin/includes/modules/product_free_shipping/preview_info.php
+++ b/admin/includes/modules/product_free_shipping/preview_info.php
@@ -161,7 +161,7 @@ $form_action = (isset($_GET['pID'])) ? 'update_product' : 'insert_product';
       ?>
       <a href="<?php echo zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING, 'cPath=' . $cPath . (isset($_GET['pID']) ? '&pID=' . $_GET['pID'] : '') . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')); ?>" class="btn btn-default" role="button"><?php echo IMAGE_CANCEL; ?></a>
       <?php 
-      if (!(isset($_GET['read']) && ($_GET['read'] === 'only')) {
+      if (!(isset($_GET['read']) && ($_GET['read'] === 'only'))) {
         echo '</form>'; 
       } ?>
     </div>

--- a/admin/includes/modules/product_music/collect_info.php
+++ b/admin/includes/modules/product_music/collect_info.php
@@ -188,7 +188,10 @@ for ($i = 0, $n = sizeof($tax_class_array); $i < $n; $i++) {
 </script>
 <div class="container-fluid">
     <?php
-    echo zen_draw_form('new_product', FILENAME_PRODUCT, 'cPath=' . $current_category_id . (isset($product_type) ? '&product_type=' . $product_type : '') . (isset($_GET['pID']) ? '&pID=' . $_GET['pID'] : '') . '&action=new_product_preview' . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . ( (isset($_GET['search']) && !empty($_GET['search'])) ? '&search=' . $_GET['search'] : '') . ( (isset($_POST['search']) && !empty($_POST['search']) && empty($_GET['search'])) ? '&search=' . $_POST['search'] : ''), 'post', 'enctype="multipart/form-data" class="form-horizontal"');
+    echo zen_draw_form('new_product', FILENAME_PRODUCT, 'cPath=' . $current_category_id . (isset($_GET['pID']) ? '&pID=' . $_GET['pID'] : '') . '&action=new_product_preview' . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . ( (isset($_GET['search']) && !empty($_GET['search'])) ? '&search=' . $_GET['search'] : '') . ( (isset($_POST['search']) && !empty($_POST['search']) && empty($_GET['search'])) ? '&search=' . $_POST['search'] : ''), 'post', 'enctype="multipart/form-data" class="form-horizontal"');
+    if (isset($product_type)) {
+      echo zen_draw_hidden_field('product_type', $product_type);
+    }
     ?>
   <h3 class="col-sm-11"><?php echo sprintf(TEXT_NEW_PRODUCT, zen_output_generated_category_path($current_category_id)); ?></h3>
   <div class="col-sm-1"><?php echo zen_info_image($cInfo->categories_image, $cInfo->categories_name, HEADING_IMAGE_WIDTH, HEADING_IMAGE_HEIGHT); ?></div>

--- a/admin/includes/modules/product_music/preview_info.php
+++ b/admin/includes/modules/product_music/preview_info.php
@@ -160,7 +160,7 @@ $form_action = (isset($_GET['pID'])) ? 'update_product' : 'insert_product';
       ?>
       <a href="<?php echo zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING, 'cPath=' . $cPath . (isset($_GET['pID']) ? '&pID=' . $_GET['pID'] : '') . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')); ?>" class="btn btn-default" role="button"><?php echo IMAGE_CANCEL; ?></a>
       <?php 
-      if (!(isset($_GET['read']) && ($_GET['read'] === 'only')) {
+      if (!(isset($_GET['read']) && ($_GET['read'] === 'only'))) {
         echo '</form>'; 
       } ?>
     </div>

--- a/admin/product.php
+++ b/admin/product.php
@@ -11,7 +11,7 @@ require('includes/application_top.php');
 $action = (isset($_GET['action']) ? $_GET['action'] : '');
 require(DIR_WS_CLASSES . 'currencies.php');
 $currencies = new currencies();
-$product_type = (isset($_GET['pID']) ? zen_get_products_type($_GET['pID']) : (isset($_POST['product_type']) ? $_POST['product_type'] : 1));
+$product_type = (isset($_POST['product_type']) ? $_POST['product_type'] : (isset($_GET['pID']) ? zen_get_products_type($_GET['pID']) : 1));
 $type_handler = $zc_products->get_admin_handler($product_type);
 $current_category_id = (isset($_POST['cPath']) ? $_POST['cPath'] : (isset($_GET['cPath']) ? $_GET['cPath'] : 0));
 $zco_notifier->notify('NOTIFY_BEGIN_ADMIN_PRODUCTS', $action);


### PR DESCRIPTION
…fication.

In #1736, the admin/product.php file was modified to assign the product
type based on first the url containing an assigned products_id (pID), and if
that is not present, then to pick up on a posted value (product_type).

Then in #1747, the problem identified was that it was not possible to
transition from a non-basic product type to the preview of information.
The solution proposed supported previewing information; however, because of
the above logic and posting the data instead of clicking a link, the
product type defaulted to a standard product in admin/product.php.

This works for product that have already been assigned/created and for the
first click from the categories_to_products listing to create a new product.
However, a product's id is not assigned until the product is finally
inserted.  The rewrite also modified the program flow which includes the
central focus of the admin/product.php file needing to be provided information
to be able to know/determine the product_type (and other necessary
information), which can be accomplished a few other ways as well, but the
majority of the process flow is by way of posted data instead of url related
data.

This commit adds a hidden field to the collect info page to capture the
product_type expected, removes the product_type designation from the
uri for all default Zen Cart product types, and modifies the logic to first
act on the posting of data instead of information on the uri.

Fixes #1773