### PR TITLE
Revise product type check

### DIFF
--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -1179,6 +1179,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
                 <?php echo zen_draw_form('newproduct', FILENAME_PRODUCT, 'action=new_product', 'post', 'class="form-horizontal"'); ?>
                 <?php echo (empty($_GET['search']) ? '<div class="col-sm-3"><button type="submit" class="btn btn-primary">' . IMAGE_NEW_PRODUCT . '</button></div>' : ''); ?>
                 <?php
+                // Query product types based on the ones this category is restricted to
                 $sql = "SELECT ptc.product_type_id as type_id, pt.type_name
                         FROM " . TABLE_PRODUCT_TYPES_TO_CATEGORY . " ptc,
                              " . TABLE_PRODUCT_TYPES . " pt
@@ -1187,8 +1188,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
                 $product_types = $db->Execute($sql);
 
                 if ($product_types->RecordCount() == 0) {
-// There are no restricted product types so make array of available product types.
-
+                  // There are no restricted product types so make we offer all types instead
                   $sql = "SELECT * FROM " . TABLE_PRODUCT_TYPES;
                   $product_types = $db->Execute($sql);
                 }
@@ -1196,9 +1196,10 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
                 $product_restrict_types_array = [];
 
                 foreach ($product_types as $restrict_type) {
-                  $product_restrict_types_array[] = array(
+                  $product_restrict_types_array[] = [
                     'id' => $restrict_type['type_id'],
-                    'text' => $restrict_type['type_name']);
+                    'text' => $restrict_type['type_name'],
+                  ];
                 }
 
                 ?>

--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -4,7 +4,7 @@
  * @copyright Copyright 2003-2018 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: Zen4All
+ * @version $Id: Author: Zen4All modified in v1.5.6 $
  */
 require('includes/application_top.php');
 $languages = zen_get_languages();
@@ -1111,7 +1111,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
             case 'attribute_features_copy_to_product':
               $_GET['products_update_id'] = '';
               // excluded current product from the pull down menu of products
-              $products_exclude_array = array();
+              $products_exclude_array = [];
               $products_exclude_array[] = $pInfo->products_id;
 
               $heading[] = array('text' => '<h4>' . TEXT_INFO_HEADING_ATTRIBUTE_FEATURES . $pInfo->products_id . '</h4>');
@@ -1179,33 +1179,28 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
                 <?php echo zen_draw_form('newproduct', FILENAME_PRODUCT, 'action=new_product', 'post', 'class="form-horizontal"'); ?>
                 <?php echo (empty($_GET['search']) ? '<div class="col-sm-3"><button type="submit" class="btn btn-primary">' . IMAGE_NEW_PRODUCT . '</button></div>' : ''); ?>
                 <?php
-                $sql = "SELECT ptc.product_type_id, pt.type_name
+                $sql = "SELECT ptc.product_type_id as type_id, pt.type_name
                         FROM " . TABLE_PRODUCT_TYPES_TO_CATEGORY . " ptc,
                              " . TABLE_PRODUCT_TYPES . " pt
                         WHERE ptc.category_id = " . (int)$current_category_id . "
                         AND pt.type_id = ptc.product_type_id";
-                $restrict_types = $db->Execute($sql);
-                if ($restrict_types->RecordCount() > 0) {
-                  $product_restrict_types_array = array();
-                  foreach ($restrict_types as $restrict_type) {
-                    $product_restrict_types_array[] = array(
-                      'id' => $restrict_type['product_type_id'],
-                      'text' => $restrict_type['type_name']);
-                  }
-                } else {
+                $product_types = $db->Execute($sql);
 
-// make array for product types
+                if ($product_types->RecordCount() == 0) {
+// There are no restricted product types so make array of available product types.
 
                   $sql = "SELECT * FROM " . TABLE_PRODUCT_TYPES;
                   $product_types = $db->Execute($sql);
-                  $product_types_array = [];
-                  foreach ($product_types as $product_type) {
-                    $product_types_array[] = array(
-                      'id' => $product_type['type_id'],
-                      'text' => $product_type['type_name']);
-                  }
-                  $product_restrict_types_array = $product_types_array;
                 }
+
+                $product_restrict_types_array = [];
+
+                foreach ($product_types as $restrict_type) {
+                  $product_restrict_types_array[] = array(
+                    'id' => $restrict_type['type_id'],
+                    'text' => $restrict_type['type_name']);
+                }
+
                 ?>
                 <?php
                 echo '<div class="col-sm-6">' . zen_draw_pull_down_menu('product_type', $product_restrict_types_array, '', 'class="form-control"') . '</div>';


### PR DESCRIPTION
Saw this code section that looked like it could use "improvement".  I haven't asked anyone if there is/would be problems with others code caused by making this change instead of just leaving it alone.  Looked liked something that could be improved upon and so I changed it.

There is duplication in the code to identify the product types that can be removed by reworking some of the variables and operations.  The effect of this modification is that there is no longer a variable created called `$product_types_array` that would only exist if there were no product restrictions, there is no longer a specific variable generated `$restrict_types` to identify the specific restricted product types (or absence of them).

Also applied the PHP 5.6+ use of `[]` for array declaration instead of `array()` throughout.