### PR TITLE
Remove unnecessary code from refactor of Move in method rewind

### DIFF
--- a/includes/classes/db/mysql/query_factory.php
+++ b/includes/classes/db/mysql/query_factory.php
@@ -638,7 +638,7 @@ class queryFactoryResult implements Countable, Iterator {
   public function rewind() {
       $this->EOF = ($this->RecordCount() == 0);
       if ($this->RecordCount() !== 0) {
-          $this->Move(0, false); // mc12345678 eliminate return of integer based key
+          $this->Move(0);
       }
   }
 


### PR DESCRIPTION
In #1633, there had been some ideas proposed, one of which was to
add a parameter to the call to the Move method that would specifically
rewind the query results and not offer the integer based field keys.

The functionality within the Move method was basically returned to its
previous state and the additional parameter was identified as unnecessary.

This removes the parameter and associated comment for "cleanliness".