### PR TITLE
Support adding debug backtrace data to DB Transaction log

### DIFF
--- a/includes/classes/db/mysql/query_factory.php
+++ b/includes/classes/db/mysql/query_factory.php
@@ -180,7 +180,20 @@ class queryFactory extends base {
       if (strtoupper(substr($zf_sql,0,6))=='SELECT' /*&& strstr($zf_sql,'products_id')*/) {
         $f=@fopen(DIR_FS_LOGS.'/query_selects_' . $current_page_base . '_' . time() . '.txt','a');
         if ($f) {
-          fwrite($f,  "\n\n" . 'I AM HERE ' . $current_page_base . /*zen_get_all_get_params() .*/ "\n" . 'sidebox: ' . $box_id . "\n\n" . "Explain \n" . $zf_sql.";\n\n");
+          $backtrace = '';
+
+          if (defined('STORE_DB_TRANSACTIONS_BACKTRACE') && !empty(STORE_DB_TRANSACTIONS_BACKTRACE)) {
+            ob_start();
+            debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+            $backtrace = ob_get_contents();
+            ob_end_clean();
+
+            $backtrace = preg_replace('/^#0\s+' . __FUNCTION__ . '[^\n]*\n/', '', $backtrace, 1);
+
+            $backtrace = 'query trace: ' . "\n" . $backtrace . "\n";
+          }
+
+          fwrite($f,  "\n\n" . 'I AM HERE ' . $current_page_base . /*zen_get_all_get_params() .*/ "\n" . $backtrace . 'sidebox: ' . $box_id . "\n\n" . "Explain \n" . $zf_sql.";\n\n");
           fclose($f);
         }
         unset($f);

--- a/includes/classes/db/mysql/query_factory.php
+++ b/includes/classes/db/mysql/query_factory.php
@@ -8,7 +8,7 @@
  * @copyright Portions Copyright 2003 osCommerce
  * @copyright Portions adapted from http://www.data-diggers.com/
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: zcwuilt  Modified in v1.5.6 $
+ * @version $Id: Author: zcwilt  Modified in v1.5.6 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
@@ -175,21 +175,19 @@ class queryFactory extends base {
 
   function Execute($zf_sql, $zf_limit = false, $zf_cache = false, $zf_cachetime=0, $remove_from_queryCache = false) {
     // bof: collect database queries
-    if (defined('STORE_DB_TRANSACTIONS') && STORE_DB_TRANSACTIONS=='true') {
+    if (defined('STORE_DB_TRANSACTIONS') && STORE_DB_TRANSACTIONS != 'false') {
       global $PHP_SELF, $box_id, $current_page_base;
       if (strtoupper(substr($zf_sql,0,6))=='SELECT' /*&& strstr($zf_sql,'products_id')*/) {
         $f=@fopen(DIR_FS_LOGS.'/query_selects_' . $current_page_base . '_' . time() . '.txt','a');
         if ($f) {
           $backtrace = '';
 
-          if (defined('STORE_DB_TRANSACTIONS_BACKTRACE') && !empty(STORE_DB_TRANSACTIONS_BACKTRACE)) {
+          if (STORE_DB_TRANSACTIONS == 'backtrace')) {
             ob_start();
             debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
             $backtrace = ob_get_contents();
             ob_end_clean();
-
             $backtrace = preg_replace('/^#0\s+' . __FUNCTION__ . '[^\n]*\n/', '', $backtrace, 1);
-
             $backtrace = 'query trace: ' . "\n" . $backtrace . "\n";
           }
 


### PR DESCRIPTION
While attempting to identify the cause, path, and history of queries
in a plugin, I found it necessary to identify the source of the
query(ies) beyond what is provided by the default logging.  At one point
I had corrected a relatively obvious source, but in so doing I lost any
additional markers of the flow path.  Adding the backtrace information
to this log (location within output is welcome to be moved as necessary)
greatly added useful information.

While such logs are already lengthy, this has been incorporated at the
moment as a feature that can be enabled by adding a constant and defining
it to not be falsey.  If this feature is considered accepted then I think
that in the logging section of the configuration menu, it would be worth
adding an additional option to include this data instead of "requiring"
a file modification.