### PR TITLE
Refactor zen_products_lookup()

### DIFF
--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -3539,14 +3539,13 @@ function zen_limit_image_filename($filename, $table_name, $field_name, $extensio
 
     if (empty($language)) $language = $_SESSION['languages_id'];
 
-    $product_lookup = $db->Execute("select " . zen_db_input($what_field) . " as lookup_field
-                              from " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_DESCRIPTION . " pd
-                              where  p.products_id ='" . (int)$product_id . "'
-                              and pd.products_id = p.products_id
-                              and pd.language_id = '" . (int)$language . "'");
-    $return_field = $product_lookup->fields['lookup_field'];
-    if ($return_field->EOF) return '';
-    return $return_field;
+    $product_lookup = $db->Execute("SELECT " . zen_db_input($what_field) . " AS lookup_field
+                              FROM " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_DESCRIPTION . " pd
+                              WHERE  p.products_id = " . (int)$product_id . "
+                              AND pd.products_id = p.products_id
+                              AND pd.language_id = " . (int)$language);
+    if ($product_lookup->EOF) return '';
+    return $product_lookup->fields['lookup_field'];
   }
 
   function zen_count_days($start_date, $end_date, $lookup = 'm') {


### PR DESCRIPTION
Back in what looks like #92, a statement was added to
admin/includes/functions/general.php within the zen_products_lookup
function to test if the database query resulted in no results by
checking for the End Of File (EOF) flag being set true.

It appears though that the wrong variable was tested.  The
current value tested is the lookup_field's result which has not
yet been processed to give an EOF style answer.  It would
seem that instead the product_lookup query result should be used
and if that result is at the EOF, then to return an empty quote,
otherwise return the desired field.

That said, the visual logic could be improved such that if there are no
values to be returned then there is no need to assign $return_field to
anything and that it could be moved outside.