### PR TITLE
Fix refactor error in attributes_controller

### DIFF
--- a/admin/attributes_controller.php
+++ b/admin/attributes_controller.php
@@ -450,7 +450,7 @@ if (zen_not_null($action)) {
           $products_options_query = $db->Execute("SELECT products_options_type
                                                   FROM " . TABLE_PRODUCTS_OPTIONS . "
                                                   WHERE products_options_id = " . (int)$_POST['options_id']);
-          switch ($products_options_array->fields['products_options_type']) {
+          switch ($products_options_query->fields['products_options_type']) {
             case PRODUCTS_OPTIONS_TYPE_TEXT:
             case PRODUCTS_OPTIONS_TYPE_FILE:
               $values_id = PRODUCTS_OPTIONS_VALUES_TEXT_ID;


### PR DESCRIPTION
Appears that in the rebuild of the attributes_controller that a variable
was written out incorrectly ($products_options_array was used instead of
$products_options_query). Based on further search of the file and
the just-in-time application of the code, this commit appears to be the
best/right fit for this issue that had thrown warnings while in strict
mode.