### PR TITLE
Replace $_GET['product_type'] with $_POST['product_type']

### DIFF
--- a/admin/includes/modules/update_product.php
+++ b/admin/includes/modules/update_product.php
@@ -26,7 +26,7 @@
     $manufacturers_id = (!zen_not_null($tmp_value) || $tmp_value=='' || $tmp_value == 0) ? 0 : $tmp_value;
 
     $sql_data_array = array('products_quantity' => $products_quantity,
-                            'products_type' => zen_db_prepare_input($_GET['product_type']),
+                            'products_type' => zen_db_prepare_input($_POST['product_type']),
                             'products_model' => zen_db_prepare_input($_POST['products_model']),
                             'products_price' => $products_price,
                             'products_date_available' => $products_date_available,


### PR DESCRIPTION
$_GET['product_type'] is empty, and $_POST['product_type'] is passed from the preview page.