### PR TITLE
Ensure element stText is present in DOM prior to updating

### DIFF
--- a/includes/modules/pages/address_book_process/jscript_addr_pulldowns.php
+++ b/includes/modules/pages/address_book_process/jscript_addr_pulldowns.php
@@ -42,8 +42,11 @@ function update_zone(theForm) {
     theForm.state.setAttribute('className', 'hiddenField');
     document.getElementById("stateLabel").className = 'hiddenField';
     document.getElementById("stateLabel").setAttribute('className', 'hiddenField');
-    document.getElementById("stText").className = 'hiddenField';
-    document.getElementById("stText").setAttribute('className', 'hiddenField');
+
+    if (document.getElementById("stText")) {
+      document.getElementById("stText").className = 'hiddenField';
+      document.getElementById("stText").setAttribute('className', 'hiddenField');
+    }
     document.getElementById("stBreak").className = 'hiddenField';
     document.getElementById("stBreak").setAttribute('className', 'hiddenField');
   }

--- a/includes/modules/pages/checkout_payment_address/jscript_addr_pulldowns.php
+++ b/includes/modules/pages/checkout_payment_address/jscript_addr_pulldowns.php
@@ -42,8 +42,11 @@ function update_zone(theForm) {
     theForm.state.setAttribute('className', 'hiddenField');
     document.getElementById("stateLabel").className = 'hiddenField';
     document.getElementById("stateLabel").setAttribute('className', 'hiddenField');
-    document.getElementById("stText").className = 'hiddenField';
-    document.getElementById("stText").setAttribute('className', 'hiddenField');
+
+    if (document.getElementById("stText")) {
+      document.getElementById("stText").className = 'hiddenField';
+      document.getElementById("stText").setAttribute('className', 'hiddenField');
+    }
     document.getElementById("stBreak").className = 'hiddenField';
     document.getElementById("stBreak").setAttribute('className', 'hiddenField');
   }

--- a/includes/modules/pages/checkout_shipping_address/jscript_addr_pulldowns.php
+++ b/includes/modules/pages/checkout_shipping_address/jscript_addr_pulldowns.php
@@ -42,8 +42,11 @@ function update_zone(theForm) {
     theForm.state.setAttribute('className', 'hiddenField');
     document.getElementById("stateLabel").className = 'hiddenField';
     document.getElementById("stateLabel").setAttribute('className', 'hiddenField');
-    document.getElementById("stText").className = 'hiddenField';
-    document.getElementById("stText").setAttribute('className', 'hiddenField');
+
+    if (document.getElementById("stText")) {
+      document.getElementById("stText").className = 'hiddenField';
+      document.getElementById("stText").setAttribute('className', 'hiddenField');
+    }
     document.getElementById("stBreak").className = 'hiddenField';
     document.getElementById("stBreak").setAttribute('className', 'hiddenField');
   }

--- a/includes/modules/pages/create_account/jscript_addr_pulldowns.php
+++ b/includes/modules/pages/create_account/jscript_addr_pulldowns.php
@@ -42,8 +42,10 @@ function update_zone(theForm) {
     theForm.state.setAttribute('className', 'hiddenField');
     document.getElementById("stateLabel").className = 'hiddenField';
     document.getElementById("stateLabel").setAttribute('className', 'hiddenField');
-    document.getElementById("stText").className = 'hiddenField';
-    document.getElementById("stText").setAttribute('className', 'hiddenField');
+    if (document.getElementById("stText")) {
+      document.getElementById("stText").className = 'hiddenField';
+      document.getElementById("stText").setAttribute('className', 'hiddenField');
+    }
     document.getElementById("stBreak").className = 'hiddenField';
     document.getElementById("stBreak").setAttribute('className', 'hiddenField');
   }


### PR DESCRIPTION
As noted in https://www.zen-cart.com/showthread.php?224511-Configuration-gt-Customer-Details-gt-State-Always-display-as-pulldown, the element id `stText` was removed in 1.5.5, which causes javaScript errors (which in turn breaks the correct selection of the state).  This fix checks for the existence of the element prior to updating it, so the selected state now appears in the dropdown.

To test, you must first set admin->configuration->customer details-> State - Always display as pulldown? to true. 