### PR TITLE
Display name of database in Version check

### DIFF
--- a/admin/includes/languages/english/server_info.php
+++ b/admin/includes/languages/english/server_info.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2016 Zen Cart Development Team
+ * @copyright Copyright 2003-2018 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: DrByte  Mon Oct 19 12:00:22 2015 -0400 Modified in v1.5.5 $
+ * @version $Id: Modified in v1.5.6 $
  */
 
 define('HEADING_TITLE', 'Server Information');
@@ -25,7 +25,7 @@ define('TITLE_PHP_MEMORY_LIMIT', 'PHP Memory Limit:');
 define('TITLE_PHP_FILE_UPLOADS', 'PHP File Uploads:');
 define('TITLE_PHP_UPLOAD_MAX', 'Upload Max Size:');
 define('TITLE_PHP_POST_MAX_SIZE', 'POST Max Size:');
-define('PROJECT_DATABASE_NAME','Database: ');
+define('TITLE_DATABASE_ENGINE','Database Engine: ');
 define('PROJECT_DATABASE_LABEL','Database Patch Level: ');
 define('TITLE_MYSQL_STRICT_MODE', '(in Strict mode)');
 define('TITLE_DATABASE_MYSQL_MODE', 'MySQL Mode:');

--- a/admin/includes/languages/english/server_info.php
+++ b/admin/includes/languages/english/server_info.php
@@ -25,6 +25,7 @@ define('TITLE_PHP_MEMORY_LIMIT', 'PHP Memory Limit:');
 define('TITLE_PHP_FILE_UPLOADS', 'PHP File Uploads:');
 define('TITLE_PHP_UPLOAD_MAX', 'Upload Max Size:');
 define('TITLE_PHP_POST_MAX_SIZE', 'POST Max Size:');
+define('PROJECT_DATABASE_NAME','Database: ');
 define('PROJECT_DATABASE_LABEL','Database Patch Level: ');
 define('TITLE_MYSQL_STRICT_MODE', '(in Strict mode)');
 define('TITLE_DATABASE_MYSQL_MODE', 'MySQL Mode:');

--- a/admin/server_info.php
+++ b/admin/server_info.php
@@ -18,7 +18,6 @@
          '  <div class="center"><h2> ' . PROJECT_VERSION_NAME . ' ' . PROJECT_VERSION_MAJOR . '.' . PROJECT_VERSION_MINOR . '</h2>' .
                ((PROJECT_VERSION_PATCH1 =='') ? '' : '<h3>Patch: ' . PROJECT_VERSION_PATCH1 . '::' . PROJECT_VERSION_PATCH1_SOURCE . '</h3>') .
                ((PROJECT_VERSION_PATCH2 =='') ? '' : '<h3>Patch: ' . PROJECT_VERSION_PATCH2 . '::' . PROJECT_VERSION_PATCH2_SOURCE . '</h3>') .
-         '     <h2> ' . PROJECT_DATABASE_NAME . ' ' . DB_DATABASE . '</h2>' .
          '     <h2> ' . PROJECT_DATABASE_LABEL . ' ' . PROJECT_DB_VERSION_MAJOR . '.' . PROJECT_DB_VERSION_MINOR . '</h2>' .
                ((PROJECT_DB_VERSION_PATCH1 =='') ? '' : '<h3>Patch: ' . PROJECT_DB_VERSION_PATCH1 . '::' . PROJECT_DB_VERSION_PATCH1_SOURCE . '</h3>') .
                ((PROJECT_DB_VERSION_PATCH2 =='') ? '' : '<h3>Patch: ' . PROJECT_DB_VERSION_PATCH2 . '::' . PROJECT_DB_VERSION_PATCH2_SOURCE . '</h3>') ;
@@ -101,6 +100,7 @@ pre {margin: 0; font-family: monospace;}
 <h1 class="pageHeading"><?php echo HEADING_TITLE; ?></h1>
 <div class="serverInfo">
       <div class="infocell"><strong><?php echo TITLE_SERVER_HOST; ?></strong> <?php echo $system['host'] . ' (' . $system['ip'] . ')'; ?></div>
+      <div class="infocell"><strong><?php echo TITLE_DATABASE; ?></strong> <?php echo zen_output_string_protected(DB_DATABASE); ?></div>
       <div class="infocell"><strong><?php echo TITLE_SERVER_OS; ?></strong> <?php echo $system['system'] . ' ' . $system['kernel']; ?> </div>
       <div class="infocell"><strong><?php echo TITLE_SERVER_DATE; ?></strong> <?php echo $system['date']; ?> &nbsp;</div>
       <div class="infocell"><strong><?php echo TITLE_SERVER_UP_TIME; ?></strong> <?php echo $system['uptime']; ?></div>
@@ -110,7 +110,7 @@ pre {margin: 0; font-family: monospace;}
       <div class="infocell"><strong><?php echo TITLE_PHP_UPLOAD_MAX;?></strong> <?php echo $system['php_uploadmaxsize'];?></div>
       <?php echo ($system['php_memlimit'] != '' ? '<div class="infocell"><strong>' . TITLE_PHP_MEMORY_LIMIT . '</strong> ' . $system['php_memlimit'] . '</div>' : ''); ?>
       <div class="infocell"><strong><?php echo TITLE_PHP_POST_MAX_SIZE; ?></strong> <?php echo $system['php_postmaxsize']; ?></div>
-      <div class="infocell"><strong><?php echo TITLE_DATABASE; ?></strong> <?php echo $system['db_version'] . ($system['mysql_strict_mode'] == true ? '<em> ' . TITLE_MYSQL_STRICT_MODE . '</em>' : ''); ?></div>
+      <div class="infocell"><strong><?php echo TITLE_DATABASE_ENGINE; ?></strong> <?php echo $system['db_version'] . ($system['mysql_strict_mode'] == true ? '<em> ' . TITLE_MYSQL_STRICT_MODE . '</em>' : ''); ?></div>
       <div class="infocell"><strong><?php echo TITLE_DATABASE_HOST; ?></strong> <?php echo $system['db_server'] . ' (' . $system['db_ip'] . ')'; ?></div>
       <div class="infocell"><strong><?php echo TITLE_DATABASE_DATE; ?></strong> <?php echo $system['db_date']; ?></div>
       <div class="infocell"><strong><?php echo TITLE_DATABASE_DATA_SIZE; ?></strong> <?php echo number_format(($system['database_size']/1024),0); ?> kB</div>

--- a/admin/server_info.php
+++ b/admin/server_info.php
@@ -18,6 +18,7 @@
          '  <div class="center"><h2> ' . PROJECT_VERSION_NAME . ' ' . PROJECT_VERSION_MAJOR . '.' . PROJECT_VERSION_MINOR . '</h2>' .
                ((PROJECT_VERSION_PATCH1 =='') ? '' : '<h3>Patch: ' . PROJECT_VERSION_PATCH1 . '::' . PROJECT_VERSION_PATCH1_SOURCE . '</h3>') .
                ((PROJECT_VERSION_PATCH2 =='') ? '' : '<h3>Patch: ' . PROJECT_VERSION_PATCH2 . '::' . PROJECT_VERSION_PATCH2_SOURCE . '</h3>') .
+         '     <h2> ' . PROJECT_DATABASE_NAME . ' ' . DB_DATABASE . '</h2>' .
          '     <h2> ' . PROJECT_DATABASE_LABEL . ' ' . PROJECT_DB_VERSION_MAJOR . '.' . PROJECT_DB_VERSION_MINOR . '</h2>' .
                ((PROJECT_DB_VERSION_PATCH1 =='') ? '' : '<h3>Patch: ' . PROJECT_DB_VERSION_PATCH1 . '::' . PROJECT_DB_VERSION_PATCH1_SOURCE . '</h3>') .
                ((PROJECT_DB_VERSION_PATCH2 =='') ? '' : '<h3>Patch: ' . PROJECT_DB_VERSION_PATCH2 . '::' . PROJECT_DB_VERSION_PATCH2_SOURCE . '</h3>') ;


### PR DESCRIPTION
Showing the name of the database currently in use by Zen Cart in the version check is a nice timesaver for clients who have many databases in their account.  