### PR TITLE
Fix error messages from upload class when used by admin

### DIFF
--- a/includes/classes/upload.php
+++ b/includes/classes/upload.php
@@ -249,6 +249,7 @@ class upload extends base
         }
         if (IS_ADMIN_FLAG === true) {
             $messageStack->add_session($msg, $type);
+            $messageStack->add($msg, $type);
         } else {
             if ($this->message_location == 'direct') {
                 $messageStack->add_session('header', $msg, $type);


### PR DESCRIPTION
"File too large" failure messages not appearing during admin product edit.