### PR TITLE
Refactor Contact_us header_php.php

### DIFF
--- a/includes/modules/pages/contact_us/header_php.php
+++ b/includes/modules/pages/contact_us/header_php.php
@@ -3,10 +3,10 @@
  * Contact Us Page
  *
  * @package page
- * @copyright Copyright 2003-2016 Zen Cart Development Team
+ * @copyright Copyright 2003-2018 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: DrByte  Sun Oct 18 23:02:01 2015 -0400 Modified in v1.5.5 $
+ * @version $Id: Author: DrByte modifier: mc12345678 Modified in v1.5.6 $
  */
 
 // This should be first line of the script:
@@ -26,57 +26,65 @@ if (isset($_GET['action']) && ($_GET['action'] == 'send')) {
 
   $zc_validate_email = zen_validate_email($email_address);
 
-  if ($zc_validate_email and !empty($enquiry) and !empty($name) && $error == FALSE) {
+  if (($zc_validate_email && !empty($enquiry) && !empty($name)) && $error == FALSE) {
     // if anti-spam is not triggered, prepare and send email:
-   if ($antiSpam != '') {
+    if ($antiSpam != '') {
       $zco_notifier->notify('NOTIFY_SPAM_DETECTED_USING_CONTACT_US', $_POST);
-   } elseif ($antiSpam == '') {
+    } elseif ($antiSpam == '') {
 
-    // auto complete when logged in
-    if($_SESSION['customer_id']) {
-      $sql = "SELECT customers_id, customers_firstname, customers_lastname, customers_password, customers_email_address, customers_default_address_id
-              FROM " . TABLE_CUSTOMERS . "
-              WHERE customers_id = :customersID";
+      // auto complete when logged in
+      if($_SESSION['customer_id']) {
+        $sql = "SELECT customers_id, customers_firstname, customers_lastname, customers_password, customers_email_address, customers_default_address_id
+                FROM " . TABLE_CUSTOMERS . "
+                WHERE customers_id = :customersID";
 
-      $sql = $db->bindVars($sql, ':customersID', $_SESSION['customer_id'], 'integer');
-      $check_customer = $db->Execute($sql);
-      $customer_email= $check_customer->fields['customers_email_address'];
-      $customer_name= $check_customer->fields['customers_firstname'] . ' ' . $check_customer->fields['customers_lastname'];
-    } else {
-      $customer_email = NOT_LOGGED_IN_TEXT;
-      $customer_name = NOT_LOGGED_IN_TEXT;
+        $sql = $db->bindVars($sql, ':customersID', $_SESSION['customer_id'], 'integer');
+        $check_customer = $db->Execute($sql);
+        $customer_email= $check_customer->fields['customers_email_address'];
+        $customer_name= $check_customer->fields['customers_firstname'] . ' ' . $check_customer->fields['customers_lastname'];
+      } else {
+        $customer_email = NOT_LOGGED_IN_TEXT;
+        $customer_name = NOT_LOGGED_IN_TEXT;
+      }
+
+      $zco_notifier->notify('NOTIFY_CONTACT_US_ACTION', (isset($_SESSION['customer_id']) ? $_SESSION['customer_id'] : 0), $customer_email, $customer_name, $email_address, $name, $enquiry);
+
+      // use contact us dropdown if defined
+      $send_to_array = [];
+
+      if (CONTACT_US_LIST !=''){
+        $send_to_array=explode("," ,CONTACT_US_LIST);
+        if (!isset($_POST['send_to'])) {
+          $_POST['send_to'] = 0;
+        }
+        preg_match('/\<[^>]+\>/', $send_to_array[$_POST['send_to']], $send_email_array);
+      }
+
+      $send_to_email = trim(EMAIL_FROM); // default to EMAIL_FROM 
+      $send_to_name  = trim(STORE_NAME);  // default to store name
+
+      if (!empty($send_email_array)) {
+        $send_to_email = preg_replace ("/>/", "", $send_email_array[0]);
+        $send_to_email = trim(preg_replace("/</", "", $send_to_email));
+        $send_to_name  = trim(preg_replace('/\<[^*]*/', '', $send_to_array[$_POST['send_to']]));
+      }
+
+      // Prepare extra-info details
+      $extra_info = email_collect_extra_info($name, $email_address, $customer_name, $customer_email);
+      // Prepare Text-only portion of message
+      $text_message = OFFICE_FROM . "\t" . $name . "\n" .
+      OFFICE_EMAIL . "\t" . $email_address . "\n\n" .
+      '------------------------------------------------------' . "\n\n" .
+      strip_tags($_POST['enquiry']) .  "\n\n" .
+      '------------------------------------------------------' . "\n\n" .
+      $extra_info['TEXT'];
+      // Prepare HTML-portion of message
+      $html_msg['EMAIL_MESSAGE_HTML'] = strip_tags($_POST['enquiry']);
+      $html_msg['CONTACT_US_OFFICE_FROM'] = OFFICE_FROM . ' ' . $name . '<br />' . OFFICE_EMAIL . '(' . $email_address . ')';
+      $html_msg['EXTRA_INFO'] = $extra_info['HTML'];
+      // Send message
+      zen_mail($send_to_name, $send_to_email, EMAIL_SUBJECT, $text_message, $name, $email_address, $html_msg,'contact_us');
     }
-
-    $zco_notifier->notify('NOTIFY_CONTACT_US_ACTION', (isset($_SESSION['customer_id']) ? $_SESSION['customer_id'] : 0), $customer_email, $customer_name, $email_address, $name, $enquiry);
-
-    // use contact us dropdown if defined
-    if (CONTACT_US_LIST !=''){
-      $send_to_array=explode("," ,CONTACT_US_LIST);
-      preg_match('/\<[^>]+\>/', $send_to_array[$_POST['send_to']], $send_email_array);
-      $send_to_email= preg_replace ("/>/", "", $send_email_array[0]);
-      $send_to_email= trim(preg_replace("/</", "", $send_to_email));
-      $send_to_name = trim(preg_replace('/\<[^*]*/', '', $send_to_array[$_POST['send_to']]));
-    } else {  //otherwise default to EMAIL_FROM and store name
-    $send_to_email = trim(EMAIL_FROM);
-    $send_to_name =  trim(STORE_NAME);
-    }
-
-    // Prepare extra-info details
-    $extra_info = email_collect_extra_info($name, $email_address, $customer_name, $customer_email);
-    // Prepare Text-only portion of message
-    $text_message = OFFICE_FROM . "\t" . $name . "\n" .
-    OFFICE_EMAIL . "\t" . $email_address . "\n\n" .
-    '------------------------------------------------------' . "\n\n" .
-    strip_tags($_POST['enquiry']) .  "\n\n" .
-    '------------------------------------------------------' . "\n\n" .
-    $extra_info['TEXT'];
-    // Prepare HTML-portion of message
-    $html_msg['EMAIL_MESSAGE_HTML'] = strip_tags($_POST['enquiry']);
-    $html_msg['CONTACT_US_OFFICE_FROM'] = OFFICE_FROM . ' ' . $name . '<br />' . OFFICE_EMAIL . '(' . $email_address . ')';
-    $html_msg['EXTRA_INFO'] = $extra_info['HTML'];
-    // Send message
-    zen_mail($send_to_name, $send_to_email, EMAIL_SUBJECT, $text_message, $name, $email_address, $html_msg,'contact_us');
-   }
     zen_redirect(zen_href_link(FILENAME_CONTACT_US, 'action=success', 'SSL'));
   } else {
     $error = true;
@@ -112,10 +120,10 @@ if(!empty($_SESSION['customer_id'])) {
   $name= $check_customer->fields['customers_firstname'] . ' ' . $check_customer->fields['customers_lastname'];
 }
 
-$send_to_array = array();
+$send_to_array = [];
 if (CONTACT_US_LIST !=''){
   foreach(explode(",", CONTACT_US_LIST) as $k => $v) {
-    $send_to_array[] = array('id' => $k, 'text' => preg_replace('/\<[^*]*/', '', $v));
+    $send_to_array[] = ['id' => $k, 'text' => preg_replace('/\<[^*]*/', '', $v)];
   }
 }
 

--- a/includes/modules/pages/contact_us/header_php.php
+++ b/includes/modules/pages/contact_us/header_php.php
@@ -26,7 +26,7 @@ if (isset($_GET['action']) && ($_GET['action'] == 'send')) {
 
   $zc_validate_email = zen_validate_email($email_address);
 
-  if (($zc_validate_email && !empty($enquiry) && !empty($name)) && $error == FALSE) {
+  if ($zc_validate_email && !empty($enquiry) && !empty($name) && $error == FALSE) {
     // if anti-spam is not triggered, prepare and send email:
     if ($antiSpam != '') {
       $zco_notifier->notify('NOTIFY_SPAM_DETECTED_USING_CONTACT_US', $_POST);


### PR DESCRIPTION
- Adjusted the spacing/alignment of code, though only to two spaces each.
- Applied PHP 7.x style array handling changing from `array()` to `[]` in all instances.
- Reworked the generation of `$send_to_email` and `$send_to_name` to remove the dependency on the source email from having the format of: `NAME TO DISPLAY <email@address>` where if the section of `<>` was missing then no email would be sent and a debug log would likely be created.  This modification generally expects that a proper email address has been entered in either `EMAIL_FROM` or `CONTACT_US_LIST`.  There is no change to the presence/absence of a validation check of the email address being properly entered.
- Converted use of logic and to && and added parentheses to maintain historical identification and clarity of the operator precedence.
- Added a test for the presence of posting the `send_to` field when `CONTACT_US_LIST` is populated for strict handling.
- Github identified a mix of line endings and reported that they would all be changed to "Windows Style" by normalizing them to CR|LF.