### PR TITLE
Additional tax-handling notifications

### DIFF
--- a/includes/functions/functions_taxes.php
+++ b/includes/functions/functions_taxes.php
@@ -14,6 +14,22 @@
 // TABLES: tax_rates, zones_to_geo_zones
   function zen_get_tax_rate($class_id, $country_id = -1, $zone_id = -1) {
     global $db;
+    // -----
+    // Give an observer a chance to override this function's return.
+    //
+    $tax_rate = false;
+    $GLOBALS['zco_notifier']->notify(
+        'NOTIFY_ZEN_GET_TAX_RATE_OVERRIDE', 
+        array(
+            'class_id' => $class_id, 
+            'country_id' => $country_id, 
+            'zone_id' => $zone_id
+        ), 
+        $tax_rate
+    );
+    if ($tax_rate !== false) {
+        return $tax_rate;
+    }
 
     if ( ($country_id == -1) && ($zone_id == -1) ) {
       if (isset($_SESSION['customer_id'])) {

--- a/includes/modules/order_total/ot_coupon.php
+++ b/includes/modules/order_total/ot_coupon.php
@@ -162,6 +162,11 @@ class ot_coupon {
     if (isset($_POST['dc_redeem_code']) && strtoupper($_POST['dc_redeem_code']) == 'REMOVE') {
       unset($_POST['dc_redeem_code']);
       unset($_SESSION['cc_id']);
+      
+      $GLOBALS['zco_notifier']->notify(
+          'NOTIFY_OT_COUPON_COUPON_REMOVED'
+       );
+       
       $messageStack->add_session('checkout_payment', TEXT_REMOVE_REDEEM_COUPON, 'caution');
     }
 //    print_r($_SESSION);

--- a/includes/modules/order_total/ot_coupon.php
+++ b/includes/modules/order_total/ot_coupon.php
@@ -195,6 +195,15 @@ class ot_coupon {
           $this->clear_posts();
           zen_redirect(zen_href_link(FILENAME_CHECKOUT_PAYMENT, '', 'SSL',true, false));
         }
+	
+        $GLOBALS['zco_notifier']->notify(
+            'NOTIFY_OT_COUPON_COUPON_INFO', 
+            array(
+                'coupon_result' => $coupon_result->fields, 
+                'code' => $dc_check
+            )
+        );
+	
         //$order_total = $this->get_order_total($coupon_result->fields['coupon_id']);
 
         // display all error messages at once
@@ -592,7 +601,15 @@ class ot_coupon {
     $orderTotal = $order->info['total'];
     $products = $_SESSION['cart']->get_products();
     for ($i=0, $n=sizeof($products); $i<$n; $i++) {
-      if (!is_product_valid($products[$i]['id'], $couponCode) || !is_coupon_valid_for_sales($products[$i]['id'], $couponCode)) {
+      $is_product_valid = (is_product_valid($products[$i]['id'], $couponCode) && is_coupon_valid_for_sales($products[$i]['id'], $couponCode));
+      $GLOBALS['zco_notifier']->notify(
+        'NOTIFY_OT_COUPON_PRODUCT_VALIDITY', 
+        array(
+            'is_product_valid' => $is_product_valid, 
+            'i' => $i
+        )
+      );
+      if (!$is_product_valid) {
         $products_tax = zen_get_tax_rate($products[$i]['tax_class_id']);
         $productsTaxAmount = (zen_calculate_tax($products[$i]['final_price'], $products_tax))   * $products[$i]['quantity'];
         $orderTotal -= $products[$i]['final_price'] * $products[$i]['quantity'];


### PR DESCRIPTION
functions_taxes.php: Allow override of zen_get_tax_rate return value.

ot_coupon.php: Indicate that the coupon processing is starting and then, for each product, notify whether/not the product qualifies for the discount.

ot_shipping.php: Allow override of the shipping tax, since it can vary from one location to another.