### PR TITLE
Refactor Contact_us header_php.php

### DIFF
--- a/includes/modules/pages/contact_us/header_php.php
+++ b/includes/modules/pages/contact_us/header_php.php
@@ -12,119 +12,121 @@
 // This should be first line of the script:
 $zco_notifier->notify('NOTIFY_HEADER_START_CONTACT_US');
 
-require(DIR_WS_MODULES . zen_get_module_directory('require_languages.php'));
+require DIR_WS_MODULES . zen_get_module_directory('require_languages.php');
 
 $error = false;
 $enquiry = '';
 
 if (isset($_GET['action']) && ($_GET['action'] == 'send')) {
-  $name = zen_db_prepare_input($_POST['contactname']);
-  $email_address = zen_db_prepare_input($_POST['email']);
-  $enquiry = zen_db_prepare_input(strip_tags($_POST['enquiry']));
-  $antiSpam = isset($_POST['should_be_empty']) ? zen_db_prepare_input($_POST['should_be_empty']) : '';
-  $zco_notifier->notify('NOTIFY_CONTACT_US_CAPTCHA_CHECK', $_POST);
+    $name = zen_db_prepare_input($_POST['contactname']);
+    $email_address = zen_db_prepare_input($_POST['email']);
+    $enquiry = zen_db_prepare_input(strip_tags($_POST['enquiry']));
+    $antiSpam = isset($_POST['should_be_empty']) ? zen_db_prepare_input($_POST['should_be_empty']) : '';
+    $zco_notifier->notify('NOTIFY_CONTACT_US_CAPTCHA_CHECK', $_POST);
 
-  $zc_validate_email = zen_validate_email($email_address);
+    $zc_validate_email = zen_validate_email($email_address);
 
-  if ($zc_validate_email && !empty($enquiry) && !empty($name) && $error == FALSE) {
-    // if anti-spam is not triggered, prepare and send email:
-    if ($antiSpam != '') {
-      $zco_notifier->notify('NOTIFY_SPAM_DETECTED_USING_CONTACT_US', $_POST);
-    } elseif ($antiSpam == '') {
+    if ($zc_validate_email && !empty($enquiry) && !empty($name) && $error == FALSE) {
+        // if anti-spam is not triggered, prepare and send email:
+        if ($antiSpam != '') {
+            $zco_notifier->notify('NOTIFY_SPAM_DETECTED_USING_CONTACT_US', $_POST);
+        } elseif ($antiSpam == '') {
 
-      // auto complete when logged in
-      if($_SESSION['customer_id']) {
-        $sql = "SELECT customers_id, customers_firstname, customers_lastname, customers_password, customers_email_address, customers_default_address_id
-                FROM " . TABLE_CUSTOMERS . "
-                WHERE customers_id = :customersID";
+            // auto complete when logged in
+            if ($_SESSION['customer_id']) {
+                $sql = "SELECT customers_id, customers_firstname, customers_lastname, customers_password, customers_email_address, customers_default_address_id
+                      FROM " . TABLE_CUSTOMERS . "
+                      WHERE customers_id = :customersID";
 
-        $sql = $db->bindVars($sql, ':customersID', $_SESSION['customer_id'], 'integer');
-        $check_customer = $db->Execute($sql);
-        $customer_email= $check_customer->fields['customers_email_address'];
-        $customer_name= $check_customer->fields['customers_firstname'] . ' ' . $check_customer->fields['customers_lastname'];
-      } else {
-        $customer_email = NOT_LOGGED_IN_TEXT;
-        $customer_name = NOT_LOGGED_IN_TEXT;
-      }
+                $sql = $db->bindVars($sql, ':customersID', $_SESSION['customer_id'], 'integer');
+                $check_customer = $db->Execute($sql);
+                $customer_email = $check_customer->fields['customers_email_address'];
+                $customer_name  = $check_customer->fields['customers_firstname'] . ' ' . $check_customer->fields['customers_lastname'];
+            } else {
+                $customer_email = NOT_LOGGED_IN_TEXT;
+                $customer_name = NOT_LOGGED_IN_TEXT;
+            }
 
-      $zco_notifier->notify('NOTIFY_CONTACT_US_ACTION', (isset($_SESSION['customer_id']) ? $_SESSION['customer_id'] : 0), $customer_email, $customer_name, $email_address, $name, $enquiry);
+            $zco_notifier->notify('NOTIFY_CONTACT_US_ACTION', (isset($_SESSION['customer_id']) ? $_SESSION['customer_id'] : 0), $customer_email, $customer_name, $email_address, $name, $enquiry);
 
-      // use contact us dropdown if defined
-      $send_to_array = [];
+            // declare variable
+            $send_to_array = [];
 
-      if (CONTACT_US_LIST !=''){
-        $send_to_array=explode("," ,CONTACT_US_LIST);
-        if (!isset($_POST['send_to'])) {
-          $_POST['send_to'] = 0;
+            // use contact us dropdown if defined and if a destination is provided
+            if (CONTACT_US_LIST != '' && isset($_POST['send_to'])){
+                $send_to_array = explode(",", CONTACT_US_LIST);
+
+                if (isset($send_to_array[$_POST['send_to']])) {
+                    preg_match('/\<[^>]+\>/', $send_to_array[$_POST['send_to']], $send_email_array);
+                }
+            }
+
+            $send_to_email = trim(EMAIL_FROM); // default to EMAIL_FROM
+            $send_to_name  = trim(STORE_NAME);  // default to STORE_NAME
+
+            // Assign email destination from array
+            if (!empty($send_email_array)) {
+                $send_to_email = preg_replace ("/>/", "", $send_email_array[0]);
+                $send_to_email = trim(preg_replace("/</", "", $send_to_email));
+                $send_to_name  = trim(preg_replace('/\<[^*]*/', '', $send_to_array[$_POST['send_to']]));
+            }
+
+            // Prepare extra-info details
+            $extra_info = email_collect_extra_info($name, $email_address, $customer_name, $customer_email);
+            // Prepare Text-only portion of message
+            $text_message = OFFICE_FROM . "\t" . $name . "\n" .
+            OFFICE_EMAIL . "\t" . $email_address . "\n\n" .
+            '------------------------------------------------------' . "\n\n" .
+            strip_tags($_POST['enquiry']) .  "\n\n" .
+            '------------------------------------------------------' . "\n\n" .
+            $extra_info['TEXT'];
+            // Prepare HTML-portion of message
+            $html_msg['EMAIL_MESSAGE_HTML'] = strip_tags($_POST['enquiry']);
+            $html_msg['CONTACT_US_OFFICE_FROM'] = OFFICE_FROM . ' ' . $name . '<br />' . OFFICE_EMAIL . '(' . $email_address . ')';
+            $html_msg['EXTRA_INFO'] = $extra_info['HTML'];
+            // Send message
+            zen_mail($send_to_name, $send_to_email, EMAIL_SUBJECT, $text_message, $name, $email_address, $html_msg, 'contact_us');
         }
-        preg_match('/\<[^>]+\>/', $send_to_array[$_POST['send_to']], $send_email_array);
-      }
-
-      $send_to_email = trim(EMAIL_FROM); // default to EMAIL_FROM 
-      $send_to_name  = trim(STORE_NAME);  // default to store name
-
-      if (!empty($send_email_array)) {
-        $send_to_email = preg_replace ("/>/", "", $send_email_array[0]);
-        $send_to_email = trim(preg_replace("/</", "", $send_to_email));
-        $send_to_name  = trim(preg_replace('/\<[^*]*/', '', $send_to_array[$_POST['send_to']]));
-      }
-
-      // Prepare extra-info details
-      $extra_info = email_collect_extra_info($name, $email_address, $customer_name, $customer_email);
-      // Prepare Text-only portion of message
-      $text_message = OFFICE_FROM . "\t" . $name . "\n" .
-      OFFICE_EMAIL . "\t" . $email_address . "\n\n" .
-      '------------------------------------------------------' . "\n\n" .
-      strip_tags($_POST['enquiry']) .  "\n\n" .
-      '------------------------------------------------------' . "\n\n" .
-      $extra_info['TEXT'];
-      // Prepare HTML-portion of message
-      $html_msg['EMAIL_MESSAGE_HTML'] = strip_tags($_POST['enquiry']);
-      $html_msg['CONTACT_US_OFFICE_FROM'] = OFFICE_FROM . ' ' . $name . '<br />' . OFFICE_EMAIL . '(' . $email_address . ')';
-      $html_msg['EXTRA_INFO'] = $extra_info['HTML'];
-      // Send message
-      zen_mail($send_to_name, $send_to_email, EMAIL_SUBJECT, $text_message, $name, $email_address, $html_msg,'contact_us');
+        zen_redirect(zen_href_link(FILENAME_CONTACT_US, 'action=success', 'SSL'));
+    } else {
+        $error = true;
+        if (empty($name)) {
+            $messageStack->add('contact', ENTRY_EMAIL_NAME_CHECK_ERROR);
+        }
+        if ($zc_validate_email == false) {
+            $messageStack->add('contact', ENTRY_EMAIL_ADDRESS_CHECK_ERROR);
+        }
+        if (empty($enquiry)) {
+            $messageStack->add('contact', ENTRY_EMAIL_CONTENT_CHECK_ERROR);
+        }
     }
-    zen_redirect(zen_href_link(FILENAME_CONTACT_US, 'action=success', 'SSL'));
-  } else {
-    $error = true;
-    if (empty($name)) {
-      $messageStack->add('contact', ENTRY_EMAIL_NAME_CHECK_ERROR);
-    }
-    if ($zc_validate_email == false) {
-      $messageStack->add('contact', ENTRY_EMAIL_ADDRESS_CHECK_ERROR);
-    }
-    if (empty($enquiry)) {
-      $messageStack->add('contact', ENTRY_EMAIL_CONTENT_CHECK_ERROR);
-    }
-  }
 } // end action==send
 
 
 if (ENABLE_SSL == 'true' && $request_type != 'SSL') {
-  zen_redirect(zen_href_link(FILENAME_CONTACT_US, '', 'SSL'));
+    zen_redirect(zen_href_link(FILENAME_CONTACT_US, '', 'SSL'));
 }
 
 $email_address = '';
 $name = '';
 
 // default email and name if customer is logged in
-if(!empty($_SESSION['customer_id'])) {
-  $sql = "SELECT customers_id, customers_firstname, customers_lastname, customers_password, customers_email_address, customers_default_address_id
-          FROM " . TABLE_CUSTOMERS . "
-          WHERE customers_id = :customersID";
+if (!empty($_SESSION['customer_id'])) {
+    $sql = "SELECT customers_id, customers_firstname, customers_lastname, customers_password, customers_email_address, customers_default_address_id
+            FROM " . TABLE_CUSTOMERS . "
+            WHERE customers_id = :customersID";
 
-  $sql = $db->bindVars($sql, ':customersID', $_SESSION['customer_id'], 'integer');
-  $check_customer = $db->Execute($sql);
-  $email_address = $check_customer->fields['customers_email_address'];
-  $name= $check_customer->fields['customers_firstname'] . ' ' . $check_customer->fields['customers_lastname'];
+    $sql = $db->bindVars($sql, ':customersID', $_SESSION['customer_id'], 'integer');
+    $check_customer = $db->Execute($sql);
+    $email_address = $check_customer->fields['customers_email_address'];
+    $name = $check_customer->fields['customers_firstname'] . ' ' . $check_customer->fields['customers_lastname'];
 }
 
 $send_to_array = [];
 if (CONTACT_US_LIST !=''){
-  foreach(explode(",", CONTACT_US_LIST) as $k => $v) {
-    $send_to_array[] = ['id' => $k, 'text' => preg_replace('/\<[^*]*/', '', $v)];
-  }
+    foreach (explode(",", CONTACT_US_LIST) as $k => $v) {
+        $send_to_array[] = ['id' => $k, 'text' => preg_replace('/\<[^*]*/', '', $v)];
+    }
 }
 
 // include template specific file name defines


### PR DESCRIPTION
- Adjusted for PSR-2: four spaces for indenting, line endings UNIX style, one space after commas
  of parameters, spaces before/after assignment or comparison, etc...
- Applied PHP 7.x style array handling changing from `array()` to `[]` in all instances.
- Reworked the generation of `$send_to_email` and `$send_to_name` to remove the dependency on the source email from having the format of: `NAME TO DISPLAY <email@address>` where if the section of `<>` was missing then no email would be sent and a debug log would likely be created.  This modification generally expects that a proper email address has been entered in either `EMAIL_FROM` or `CONTACT_US_LIST`.  There is no change to the presence/absence of a validation check of the email address being properly entered.
- Converted use of logic `and` to `&&`.
- Added a test for the presence of posting the `send_to` field when `CONTACT_US_LIST` is populated for strict handling and to default to `EMAIL_FROM` and `STORE_NAME` when `send_to` is not posted or is not recognized in `CONTACT_US_LIST`.