### PR TITLE
Fix prior refactor of ezpages modules

### DIFF
--- a/includes/modules/ezpages_bar_footer.php
+++ b/includes/modules/ezpages_bar_footer.php
@@ -44,7 +44,7 @@ if (EZPAGES_STATUS_FOOTER == '1' || (EZPAGES_STATUS_FOOTER == '2' && (strstr(EXC
         case ($page_query['alt_url'] != '' && $page_query['page_open_new_window'] == '1'):
         $page_query_list_footer[$rows]['altURL']  = (substr($page_query['alt_url'],0,4) == 'http') ?
         $page_query['alt_url'] :
-        ($page_query['alt_url']=='' ? '' : zen_href_link($page_query['alt_url'], '', ($page_query->fields['page_is_ssl']=='0' ? 'NONSSL' : 'SSL'), true, true, true));
+        ($page_query['alt_url']=='' ? '' : zen_href_link($page_query['alt_url'], '', ($page_query['page_is_ssl']=='0' ? 'NONSSL' : 'SSL'), true, true, true));
         break;
         // internal link same window
         case ($page_query['alt_url'] != '' && $page_query['page_open_new_window'] == '0'):
@@ -56,7 +56,7 @@ if (EZPAGES_STATUS_FOOTER == '1' || (EZPAGES_STATUS_FOOTER == '2' && (strstr(EXC
 
       // if altURL is specified, use it; otherwise, use EZPage ID to create link
       $page_query_list_footer[$rows]['link'] = ($page_query_list_footer[$rows]['altURL'] =='') ?
-      zen_href_link(FILENAME_EZPAGES, 'id=' . $page_query['pages_id'] . ($page_query['toc_chapter'] > 0 ? '&chapter=' . $page_query['toc_chapter'] : ''), ($page_query->fields['page_is_ssl']=='0' ? 'NONSSL' : 'SSL')) :
+      zen_href_link(FILENAME_EZPAGES, 'id=' . $page_query['pages_id'] . ($page_query['toc_chapter'] > 0 ? '&chapter=' . $page_query['toc_chapter'] : ''), ($page_query['page_is_ssl']=='0' ? 'NONSSL' : 'SSL')) :
       $page_query_list_footer[$rows]['altURL'];
       $page_query_list_footer[$rows]['link'] .= ($page_query['page_open_new_window'] == '1' ? '" rel="noreferrer noopener" target="_blank' : '');
     }
@@ -66,4 +66,3 @@ if (EZPAGES_STATUS_FOOTER == '1' || (EZPAGES_STATUS_FOOTER == '2' && (strstr(EXC
 } // test for display
 
 $zco_notifier->notify('NOTIFY_END_EZPAGES_FOOTERBAR');
-?>

--- a/includes/modules/ezpages_bar_header.php
+++ b/includes/modules/ezpages_bar_header.php
@@ -56,7 +56,7 @@ if (EZPAGES_STATUS_HEADER == '1' || (EZPAGES_STATUS_HEADER == '2' && (strstr(EXC
 
       // if altURL is specified, use it; otherwise, use EZPage ID to create link
       $page_query_list_header[$rows]['link'] = ($page_query_list_header[$rows]['altURL'] =='') ?
-      zen_href_link(FILENAME_EZPAGES, 'id=' . $page_query['pages_id'] . ($page_query['toc_chapter'] > 0 ? '&chapter=' . $page_query['toc_chapter'] : ''), ($page_query->fields['page_is_ssl']=='0' ? 'NONSSL' : 'SSL')) :
+      zen_href_link(FILENAME_EZPAGES, 'id=' . $page_query['pages_id'] . ($page_query['toc_chapter'] > 0 ? '&chapter=' . $page_query['toc_chapter'] : ''), ($page_query['page_is_ssl']=='0' ? 'NONSSL' : 'SSL')) :
       $page_query_list_header[$rows]['altURL'];
       $page_query_list_header[$rows]['link'] .= ($page_query['page_open_new_window'] == '1' ? '" rel="noreferrer noopener" target="_blank' : '');
     }
@@ -66,4 +66,3 @@ if (EZPAGES_STATUS_HEADER == '1' || (EZPAGES_STATUS_HEADER == '2' && (strstr(EXC
 } // display
 
 $zco_notifier->notify('NOTIFY_END_EZPAGES_HEADERBAR');
-?>

--- a/includes/modules/sideboxes/ezpages.php
+++ b/includes/modules/sideboxes/ezpages.php
@@ -39,8 +39,8 @@
           $page_query_list_sidebox[$rows]['altURL']  = $page_query['alt_url_external'];
           break;
           // internal link new window
-          case ($page_query->fields['alt_url'] != '' && $page_query['page_open_new_window'] == '1'):
-          $page_query_list_sidebox[$rows]['altURL']  = (substr($page_query->fields['alt_url'],0,4) == 'http') ?
+          case ($page_query['alt_url'] != '' && $page_query['page_open_new_window'] == '1'):
+          $page_query_list_sidebox[$rows]['altURL']  = (substr($page_query['alt_url'],0,4) == 'http') ?
           $page_query['alt_url'] :
           ($page_query['alt_url']=='' ? '' : zen_href_link($page_query['alt_url'], '', ($page_query['page_is_ssl']=='0' ? 'NONSSL' : 'SSL'), true, true, true));
           break;
@@ -71,4 +71,3 @@
   } // test for display
 
   $zco_notifier->notify('NOTIFY_END_EZPAGES_SIDEBOX');
-?>


### PR DESCRIPTION
Some of the prior refactoring of while-not-eof code to foreach evidently was incomplete, leaving some `->fields` references behind.