### PR TITLE
Remove extra margin on buttons

### DIFF
--- a/admin/includes/stylesheet.css
+++ b/admin/includes/stylesheet.css
@@ -663,9 +663,11 @@ img[src*="button_cancel"], img[src*="button_reset"]{
   z-index: 100;
 }
 
+/*
 .btn {
   margin: 2px;
 }
+*/
 
 .edit i.base {
   color: #008000;
@@ -780,6 +782,7 @@ input.faint {
     font-size: 0.9em;
 }
 /* End of css buttons */
+
 
 /* Print-specific styles */
 @media print {


### PR DESCRIPTION
This margin in interfering with the look of button-groups, like on the orders page

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zencart/zencart/1877)
<!-- Reviewable:end -->
