### PR TITLE
Product types does not show a default right hand side window

### DIFF
--- a/admin/product_types.php
+++ b/admin/product_types.php
@@ -11,7 +11,6 @@ require('includes/application_top.php');
 $action = (isset($_GET['action']) ? $_GET['action'] : '');
 if (!isset($_GET['cID'])) $_GET['cID'] = '';
 if (!isset($_GET['gID'])) $_GET['gID'] = '';
-if (!isset($_GET['ptID'])) $_GET['ptID'] = '';
 
 if (zen_not_null($action)) {
   switch ($action) {


### PR DESCRIPTION
Logic depends on having `$_GET['ptID']` unset; initializing it introduced problems. 