### PR TITLE
zc156: Square jQuery no-load

### DIFF
--- a/includes/modules/pages/checkout_payment/jscript_square.php
+++ b/includes/modules/pages/checkout_payment/jscript_square.php
@@ -10,7 +10,7 @@
 if (!defined('MODULE_PAYMENT_SQUARE_STATUS') || MODULE_PAYMENT_SQUARE_STATUS != 'True' || (!defined('MODULE_PAYMENT_SQUARE_APPLICATION_ID') || MODULE_PAYMENT_SQUARE_ACCESS_TOKEN == '')) {
     return false;
 }
-if ($payment_modules->in_special_checkout()) {
+if ($payment_modules->in_special_checkout() || empty($square) || !$square->enabled) {
     return false;
 }
 ?>


### PR DESCRIPTION
If the Square payment method is enabled, but not loaded (e.g. the 'freecharger' payment method is active) or if Square has zone restrictions (and the current billing zone is outside of the restrictions), don't load the payment method's jQuery processing, since it will "pollute" the jQuery pool.