### PR TITLE
Embedded break tag not needed

### DIFF
--- a/admin/includes/languages/english.php
+++ b/admin/includes/languages/english.php
@@ -603,7 +603,7 @@ define('TEXT_LEGEND', 'LEGEND: ');
 define('TEXT_LEGEND_STATUS_OFF', 'Status OFF ');
 define('TEXT_LEGEND_STATUS_ON', 'Status ON ');
 
-define('TEXT_INFO_MASTER_CATEGORIES_ID', '<strong>NOTE: Master Category is used for pricing purposes where the<br />product category affects the pricing on linked products, example: Sales</strong>');
+define('TEXT_INFO_MASTER_CATEGORIES_ID', '<strong>NOTE: Master Category is used for pricing purposes where the product category affects the pricing on linked products, example: Sales</strong>');
 define('TEXT_YES', 'Yes');
 define('TEXT_NO', 'No');
 define('TEXT_CANCEL', 'Cancel');


### PR DESCRIPTION
Embedded carriage return means message is not properly formatted on mobile.  Carriage return not required; works fine without it. 