### PR TITLE
check length of attention field before inserting into db

### DIFF
--- a/admin/includes/classes/class.admin.zcObserverLogEventListener.php
+++ b/admin/includes/classes/class.admin.zcObserverLogEventListener.php
@@ -142,7 +142,7 @@ class zcObserverLogEventListener extends base {
         'ip_address'      => substr($_SERVER['REMOTE_ADDR'],0,45),
         'postdata'        => $postdata,
         'flagged'         => $flagged,
-        'attention'       => ($notes === false ? '' : $notes),
+        'attention'       => ($notes === false ? '' : substr($notes,0,zen_field_length(TABLE_ADMIN_ACTIVITY_LOG, 'attention')),
         'severity'        => strtolower($levels[$severity]),  // converts int to corresponding string
     );
 


### PR DESCRIPTION
I have seen this fail when the string was too long.  