### PR TITLE
v156 post before get on cPath assignment

### DIFF
--- a/admin/includes/init_includes/init_category_path.php
+++ b/admin/includes/init_includes/init_category_path.php
@@ -10,10 +10,10 @@ if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
 }
 // calculate category path
-  if (isset($_GET['cPath'])) {
-    $cPath = $_GET['cPath'];
-  } else if (isset($_POST['cPath'])) {
+  if (isset($_POST['cPath'])) {
     $cPath = $_POST['cPath'];
+  } elseif (isset($_GET['cPath'])) {
+    $cPath = $_GET['cPath'];
   } else {
     $cPath = '';
   }


### PR DESCRIPTION
Generally speaking, it seems that when given the opportunity to read
something from the uri and from the posted page data, that the information
to keep/capture should come and normally comes from the posted page data.

As such, this commit modifies the sequence of testing to assign the `$cPath`
on page load such that a modification to the page's uri would not affect
the cPath.