### PR TITLE
These files have the original incorrect ordering of headers

### DIFF
--- a/admin/product.php
+++ b/admin/product.php
@@ -8,6 +8,8 @@
  */
 
   require('includes/application_top.php');
+  require_once('includes/template/common/tplHtmlHead.php');
+  require_once('includes/template/common/tplHtmlHeadLegacy.php');
 
   require(DIR_WS_MODULES . 'prod_cat_header_code.php');
 
@@ -93,8 +95,6 @@
   } else {
     $messageStack->add(ERROR_CATALOG_IMAGE_DIRECTORY_DOES_NOT_EXIST, 'error');
   }
-require_once('includes/template/common/tplHtmlHeadLegacy.php');
-require_once('includes/template/common/tplHtmlHead.php');
 ?>
 <?php if ($action != 'new_product_meta_tags' && $editor_handler != '') include ($editor_handler); ?>
 </head>

--- a/admin/stats_sales_report_graphs.php
+++ b/admin/stats_sales_report_graphs.php
@@ -8,6 +8,9 @@
  */
 
 require('includes/application_top.php');
+require_once('includes/template/common/tplHtmlHead.php');
+require_once('includes/template/common/tplHtmlHeadLegacy.php');
+
 $currencies = new currencies();
 
 if (!defined('SALES_REPORT_GRAPHS_FILTER_DEFAULT')) define('SALES_REPORT_GRAPHS_FILTER_DEFAULT', '00000000110000000000');
@@ -158,10 +161,6 @@ if (strlen($sales_report_filter) == 0) {
      chart.draw(data, options);
    }
 </script>
-<?php
-require_once('includes/template/common/tplHtmlHeadLegacy.php');
-require_once('includes/template/common/tplHtmlHead.php');
-?>
 </head>
 <body onload="init()">
 <!-- header //-->


### PR DESCRIPTION
Without the fixes in this PR, scripts appear above the opening <head> tag. 
Thanks to @Zen4All for reporting this bug.
