### PR TITLE
Avoid errors when restoring cart while cart has product with attibute…

### DIFF
--- a/includes/classes/shopping_cart.php
+++ b/includes/classes/shopping_cart.php
@@ -125,7 +125,7 @@ class shoppingCart extends base {
             foreach($this->contents[$products_id]['attributes'] as $option => $value) {
 
               //clr 031714 udate query to include attribute value. This is needed for text attributes.
-              $attr_value = $this->contents[$products_id]['attributes_values'][$option];
+              $attr_value = isset($this->contents[$products_id]['attributes_values'][$option]) ? $this->contents[$products_id]['attributes_values'][$option] : '';
               //                zen_db_query("insert into " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . " (customers_id, products_id, products_options_id, products_options_value_id, products_options_value_text) values ('" . (int)$customer_id . "', '" . zen_db_input($products_id) . "', '" . (int)$option . "', '" . (int)$value . "', '" . zen_db_input($attr_value) . "')");
               $products_options_sort_order= zen_get_attributes_options_sort_order(zen_get_prid($products_id), $option, $value);
               if ($attr_value) {


### PR DESCRIPTION
…s without a text attribute.

Issue is repeatable if the existing cart has a product with attributes but
one or more of the attributes do not involve a text attribute to then
login to the store of a customer that has cart product already stored.