### PR TITLE
prevent strict notification when zen_get_categories_image called for …

### DIFF
--- a/includes/functions/functions_lookups.php
+++ b/includes/functions/functions_lookups.php
@@ -382,7 +382,7 @@
     $the_categories_image_query= "select categories_image from " . TABLE_CATEGORIES . " where categories_id= '" . $what_am_i . "'";
     $the_products_category = $db->Execute($the_categories_image_query);
 
-    return $the_products_category->fields['categories_image'];
+    return isset($the_products_category->fields['categories_image']) ? $the_products_category->fields['categories_image'] : '';
   }
 
 /*

--- a/includes/functions/functions_lookups.php
+++ b/includes/functions/functions_lookups.php
@@ -379,10 +379,12 @@
   function zen_get_categories_image($what_am_i) {
     global $db;
 
-    $the_categories_image_query= "select categories_image from " . TABLE_CATEGORIES . " where categories_id= '" . $what_am_i . "'";
-    $the_products_category = $db->Execute($the_categories_image_query);
+    $the_categories_image_query= "select categories_image from " . TABLE_CATEGORIES . " where categories_id= '" . (int)$what_am_i . "'";
+    $result = $db->Execute($the_categories_image_query);
 
-    return isset($the_products_category->fields['categories_image']) ? $the_products_category->fields['categories_image'] : '';
+    if ($result->EOF) return '';
+    
+    return $result->fields['categories_image'];
   }
 
 /*

--- a/includes/functions/functions_lookups.php
+++ b/includes/functions/functions_lookups.php
@@ -393,9 +393,11 @@
  */
   function zen_get_categories_name($who_am_i) {
     global $db;
-    $the_categories_name_query= "select categories_name from " . TABLE_CATEGORIES_DESCRIPTION . " where categories_id= '" . $who_am_i . "' and language_id= '" . $_SESSION['languages_id'] . "'";
+    $the_categories_name_query= "select categories_name from " . TABLE_CATEGORIES_DESCRIPTION . " where categories_id= '" . (int)$who_am_i . "' and language_id= '" . (int)$_SESSION['languages_id'] . "'";
 
     $the_categories_name = $db->Execute($the_categories_name_query);
+    
+    if ($the_categories_name->EOF) return '';
 
     return $the_categories_name->fields['categories_name'];
   }
@@ -432,7 +434,7 @@
                       and p.manufacturers_id = m.manufacturers_id";
 
     $product =$db->Execute($product_query);
-
+    if ($product->EOF) return '';
     return $product->fields['manufacturers_image'];
   }
 


### PR DESCRIPTION
…category without image

This returns an empty string if when calling a category that does not return a
categories_image.

Would recommend that the function(s) receiving such an empty string would
handle the result so that the resulting html code would not fail
validation.