### PR TITLE
Missing EMAIL_TEXT_TELEPHONE in order email

### DIFF
--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -1021,6 +1021,7 @@ class order extends base {
     $html_msg['INTRO_URL_VALUE']       = zen_href_link(FILENAME_ACCOUNT_HISTORY_INFO, 'order_id=' . $zf_insert_id, 'SSL', false);
     $html_msg['EMAIL_CUSTOMER_PHONE']  = $this->customer['telephone'];
     $html_msg['EMAIL_ORDER_DATE']      = date(ORDER_EMAIL_DATE_FORMAT);
+    $html_msg['EMAIL_TEXT_TELEPHONE']  = EMAIL_TEXT_TELEPHONE;
 
     $invoiceInfo=EMAIL_TEXT_INVOICE_URL . ' ' . zen_href_link(FILENAME_ACCOUNT_HISTORY_INFO, 'order_id=' . $zf_insert_id, 'SSL', false) . "\n\n";
     $htmlInvoiceURL=EMAIL_TEXT_INVOICE_URL_CLICK;


### PR DESCRIPTION
EMAIL_TEXT_TELEPHONE doesn't get populated to email template.

This change fixes it.