### PR TITLE
V156 zc install - add parser for left join queries

### DIFF
--- a/zc_install/includes/classes/class.zcDatabaseInstaller.php
+++ b/zc_install/includes/classes/class.zcDatabaseInstaller.php
@@ -139,6 +139,7 @@ class zcDatabaseInstaller
   private function parseLineContent()
   {
     $this->lineSplit = explode(" ",(substr($this->line,-1)==';') ? substr($this->line,0,strlen($this->line)-1) : $this->line);
+    if (!isset($this->lineSplit[3])) $this->lineSplit[3] = "";
     if (!isset($this->lineSplit[4])) $this->lineSplit[4] = "";
     if (!isset($this->lineSplit[5])) $this->lineSplit[5] = "";
     foreach ($this->basicParseStrings as $parseString)
@@ -177,7 +178,7 @@ class zcDatabaseInstaller
       $this->writeUpgradeExceptions($this->line, $result, $this->fileName);
       $this->ignoreLine = true;
     } else {
-      if (!(empty($this->lineSplit[2]) && empty($this->lineSplit[3])) || strtoupper($this->lineSplit[2].' '.$this->lineSplit[3]) != 'IF EXISTS')
+      if (strtoupper($this->lineSplit[2].' '.$this->lineSplit[3]) != 'IF EXISTS')
       {
         $this->line = 'DROP TABLE ' . $this->dbPrefix . substr($this->line, 11);
       } else {

--- a/zc_install/includes/classes/class.zcDatabaseInstaller.php
+++ b/zc_install/includes/classes/class.zcDatabaseInstaller.php
@@ -193,7 +193,7 @@ class zcDatabaseInstaller
       $this->ignoreLine = TRUE;
       if (strtoupper($this->lineSplit[2].' '.$this->lineSplit[3].' '.$this->lineSplit[4]) != 'IF NOT EXISTS')
       {
-        $this->writeUpgradeExceptions($this->line, sprintf(REASON_TABLE_ALREADY_EXISTS, $table), $this->filename);
+        $this->writeUpgradeExceptions($this->line, sprintf(REASON_TABLE_ALREADY_EXISTS, $table), $this->fileName);
       }
     } else
     {
@@ -295,7 +295,7 @@ class zcDatabaseInstaller
   public function parserAlterTable() {
     if(!$this->tableExists($this->lineSplit[2])) {
       $result = sprintf(REASON_TABLE_NOT_FOUND, $this->lineSplit[2]).' CHECK PREFIXES!';
-      $this->writeUpgradeExceptions($this->line, $result, $this->filename);
+      $this->writeUpgradeExceptions($this->line, $result, $this->fileName);
     }
     else {
       $this->line = 'ALTER TABLE ' . $this->dbPrefix . substr($this->line, 12);

--- a/zc_install/includes/classes/class.zcDatabaseInstaller.php
+++ b/zc_install/includes/classes/class.zcDatabaseInstaller.php
@@ -177,7 +177,7 @@ class zcDatabaseInstaller
       $this->writeUpgradeExceptions($this->line, $result, $this->fileName);
       $this->ignoreLine = true;
     } else {
-      if (strtoupper($this->lineSplit[2].' '.$this->lineSplit[3]) != 'IF EXISTS')
+      if (!(empty($this->lineSplit[2]) && empty($this->lineSplit[3])) || strtoupper($this->lineSplit[2].' '.$this->lineSplit[3]) != 'IF EXISTS')
       {
         $this->line = 'DROP TABLE ' . $this->dbPrefix . substr($this->line, 11);
       } else {

--- a/zc_install/includes/classes/class.zcDatabaseInstaller.php
+++ b/zc_install/includes/classes/class.zcDatabaseInstaller.php
@@ -366,6 +366,17 @@ class zcDatabaseInstaller
       }
     }
   }
+  public function parserLeftJoin()
+  {
+    if (!$this->tableExists($this->lineSplit[2]))
+    {
+      if (!isset($result)) $result = sprintf(REASON_TABLE_NOT_FOUND, $this->lineSplit[2]).' CHECK PREFIXES!';
+      $this->writeUpgradeExceptions($this->line, $result, $this->fileName);
+      error_log($result . "\n" . $this->line . "\n---------------\n\n");
+    } else {
+      $this->line = 'LEFT JOIN ' . $this->dbPrefix . substr($this->line, 10);
+    }
+  }
   public function writeUpgradeExceptions($line, $message, $sqlFile = '')
   {
     logDetails($line . '  ' . $message . '  ' . $sqlFile, 'upgradeException');

--- a/zc_install/includes/classes/class.zcDatabaseInstaller.php
+++ b/zc_install/includes/classes/class.zcDatabaseInstaller.php
@@ -352,13 +352,13 @@ class zcDatabaseInstaller
   {
     if (!$this->tableExists($this->lineSplit[2]))
     {
-      if (!isset($result)) $result = sprintf(REASON_TABLE_NOT_FOUND, $table).' CHECK PREFIXES!';
+      if (!isset($result)) $result = sprintf(REASON_TABLE_NOT_FOUND, $this->lineSplit[2]).' CHECK PREFIXES!';
       $this->writeUpgradeExceptions($this->line, $result, $this->fileName);
       $this->ignoreLine = true;
     } else {
       if ($this->tableExists($this->lineSplit[4]))
       {
-        if (!isset($result)) $result = sprintf(REASON_TABLE_ALREADY_EXISTS, $table);
+        if (!isset($result)) $result = sprintf(REASON_TABLE_ALREADY_EXISTS, $this->lineSplit[4]);
         $this->writeUpgradeExceptions($this->line, $result, $this->fileName);
         $this->ignoreLine = true;
       } else {

--- a/zc_install/sql/updates/mysql_upgrade_zencart_156.sql
+++ b/zc_install/sql/updates/mysql_upgrade_zencart_156.sql
@@ -163,6 +163,7 @@ DELETE FROM admin_pages WHERE page_key = 'linkpointReview';
 ALTER TABLE customers_basket DROP final_price;
 
 ## add support for multi lingual ezpages
+#NEXT_X_ROWS_AS_ONE_COMMAND:8
 CREATE TABLE IF NOT EXISTS ezpages_content (
   pages_id int(11) NOT NULL DEFAULT '0',
   languages_id int(11) NOT NULL DEFAULT '1',
@@ -172,6 +173,7 @@ CREATE TABLE IF NOT EXISTS ezpages_content (
   KEY idx_lang_id_zen (languages_id)
 ) ENGINE=MyISAM;
 
+#NEXT_X_ROWS_AS_ONE_COMMAND:4
 INSERT IGNORE INTO ezpages_content (pages_id, languages_id, pages_title, pages_html_text)
 SELECT e.pages_id, l.languages_id, e.pages_title, e.pages_html_text
 FROM ezpages e
@@ -195,6 +197,7 @@ ALTER TABLE media_manager ADD KEY idx_media_name_zen (media_name(191));
 ALTER TABLE whos_online MODIFY session_id varchar(191) NOT NULL default '';
 # recreating sessions table since its storage engine is changing to InnoDB:
 DROP TABLE IF EXISTS sessions;
+#NEXT_X_ROWS_AS_ONE_COMMAND:6
 CREATE TABLE sessions (
   sesskey varchar(191) NOT NULL default '',
   expiry int(11) unsigned NOT NULL default 0,
@@ -204,6 +207,7 @@ CREATE TABLE sessions (
 
 
 ## add support for admin notification
+#NEXT_X_ROWS_AS_ONE_COMMAND:6
 CREATE TABLE IF NOT EXISTS admin_notifications (
   notification_key varchar(40) NOT NULL,
   admin_id int(11),


### PR DESCRIPTION
There have recently been multiple posts to the ZC forum about the upgrade process not completing successfully even though the screen message alludes to everything being done.  While some of the issues appear to be related to date or datetime fields having '0000-00-00' stored in them (beyond the date_modified field already addressed) also identified a few items as captured in the comments for each commit of this pull request.  One of the issues was that the sql statement to left join a table did not account for the `DB_PREFIX`.

EDIT: Recommend a method to evaluate the table data stored to see if the table's field definition is date or datetime and then if it could support a value of `0000-00-00` and if not then to modify the value either to `null` (if supported) or `0001-01-01`, though also depends on what caused it and what can be done to handle the reset value.  At the very least, suggest offering more/some information about the issue on the zc_install screen..