### PR TITLE
Add scroll-to-top on ajax confirmation page

### DIFF
--- a/includes/templates/responsive_classic/templates/tpl_ajax_checkout_confirmation_default.php
+++ b/includes/templates/responsive_classic/templates/tpl_ajax_checkout_confirmation_default.php
@@ -217,3 +217,9 @@ if (isset ($_SESSION['shipping']['extras']) && is_array ($_SESSION['shipping']['
 <div class="buttonRow back"><?php echo TITLE_CONTINUE_CHECKOUT_PROCEDURE . '<br />' . TEXT_CONTINUE_CHECKOUT_PROCEDURE; ?></div>
 
 </div>
+<script>
+    $(document).ready(function () {
+        // $(window).scrollTop(0);
+        $("html, body").animate({ scrollTop: 0 }, "fast");
+    });
+</script>


### PR DESCRIPTION
For payment methods which invoke the ajax in-page confirmation HTML swap, the normal "reload the page and position to the top" doesn't occur, thus leaving the customer looking at a lower (possibly suddenly blank) section of the page (where they were entering card details and clicking a submit button).

This update causes it to scroll to the top after the page content is updated.