### PR TITLE
Propose Update on admin css tables borders +others

### DIFF
--- a/admin/includes/stylesheet.css
+++ b/admin/includes/stylesheet.css
@@ -23,10 +23,7 @@ a {
 a, body, html, table {
     font: normal normal 11px Verdana, sans-serif;
 }
-body table {
-  padding: 1px 3px;
-  border-collapse: initial;
-}
+
 body {padding: 0 4px;}
 
 td,th {padding: 1px;}
@@ -303,22 +300,18 @@ tr.attributeBoxContent {
 
 .dataTableHeadingContent {
     color: #333333;
-    font-weight: bold;
 }
 
 .dataTableHeadingContentWhois {
     color: #333333;
-    font-weight: bold;
 }
 
 .dataTableHeadingContentWhois a:link, .dataTableHeadingContentWhois a:visited {
     color: #0000ff;
-    font-weight: bold;
 }
 
 .dataTableHeadingContentWhois a:hover {
     color: #ffffff;
-    font-weight: bold;
 }
 
 .dataTableHeadingRow {


### PR DESCRIPTION
Bootstrap collapses the tables borders, however they are reset on zencart css
In my opinion, they look better with collapsed borders. 

+others :
**TH** elements already are set to bold, so font-weight bold for dataheadings could be removed from the css file. 

The **H1** is set to be 16px by zencart css, however **H2** is set to 30px by bootstrap. Visually is not pretty. Example: the H4 on side box are 14px ... 2px less than H1.
Of course none of this is actually urgent but, I guess with time it could be altered. 
Or not.