### PR TITLE
Fixes #1991 - cPath not set when categories page first drawn

### DIFF
--- a/includes/functions/functions_categories.php
+++ b/includes/functions/functions_categories.php
@@ -53,7 +53,7 @@ function zen_get_path($current_category_id = '')
         if (!empty($cPath_array)) {
             $cPath_new = implode('_', $cPath_array);
         } else {
-            $cPath_new = '';
+            $cPath_new = $current_category_id; 
         }
     }
 


### PR DESCRIPTION
Because of this, it's impossible to descend into subcategories. 