### PR TITLE
Fixes #1997 - pages with red/green icons broken

### DIFF
--- a/admin/banner_manager.php
+++ b/admin/banner_manager.php
@@ -8,8 +8,6 @@
  */
 
   require('includes/application_top.php');
-  require_once('includes/template/common/tplHtmlHeadLegacy.php');
-  require_once('includes/template/common/tplHtmlHead.php');
   require('includes/functions/functions_graphs.php');
 
   $action = (isset($_GET['action']) ? $_GET['action'] : '');
@@ -178,6 +176,8 @@
         break;
     }
   }
+  require_once('includes/template/common/tplHtmlHeadLegacy.php');
+  require_once('includes/template/common/tplHtmlHead.php');
 
 ?>
 <link rel="stylesheet" type="text/css" href="includes/banner_tools.css" />

--- a/admin/coupon_admin.php
+++ b/admin/coupon_admin.php
@@ -8,8 +8,6 @@
  */
 
   require('includes/application_top.php');
-  require_once('includes/template/common/tplHtmlHeadLegacy.php');
-  require_once('includes/template/common/tplHtmlHead.php');
   $currencies = new currencies();
 
   if (isset($_GET['search']) && zen_not_null($_GET['search'])) {
@@ -453,6 +451,10 @@
       }
       zen_redirect(zen_admin_href_link(FILENAME_COUPON_ADMIN, 'cid=' . $_GET['cid'] . (isset($_GET['status']) ? '&status=' . $_GET['status'] : '') . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '')));
   }
+?>
+<?php
+  require_once('includes/template/common/tplHtmlHeadLegacy.php');
+  require_once('includes/template/common/tplHtmlHead.php');
 ?>
 <script type="text/javascript">
 var form = "";

--- a/admin/coupon_restrict.php
+++ b/admin/coupon_restrict.php
@@ -8,8 +8,6 @@
  */
   //define('MAX_DISPLAY_RESTRICT_ENTRIES', 10);
   require('includes/application_top.php');
-  require_once('includes/template/common/tplHtmlHeadLegacy.php');
-  require_once('includes/template/common/tplHtmlHead.php');
   $restrict_array = array();
   $restrict_array[] = array('id'=>'Deny', 'text'=>TEXT_PULLDOWN_DENY);
   $restrict_array[] = array('id'=>'Allow', 'text'=>TEXT_PULLDOWN_ALLOW);
@@ -141,6 +139,10 @@
       $db->Execute("delete from " . TABLE_COUPON_RESTRICT . " where restrict_id = '" . $_GET['info'] . "'");
     }
   }
+?>
+<?php
+  require_once('includes/template/common/tplHtmlHeadLegacy.php');
+  require_once('includes/template/common/tplHtmlHead.php');
 ?>
 </head>
 <body marginwidth="0" marginheight="0" topmargin="0" bottommargin="0" leftmargin="0" rightmargin="0" bgcolor="#FFFFFF">

--- a/admin/customers.php
+++ b/admin/customers.php
@@ -8,8 +8,6 @@
  */
 
   require('includes/application_top.php');
-  require_once('includes/template/common/tplHtmlHeadLegacy.php');
-  require_once('includes/template/common/tplHtmlHead.php');
 
   if (!defined('ENTRY_EMAIL_NEVER_SEND_EMAILS')) define('ENTRY_EMAIL_NEVER_SEND_EMAILS', 'Never (Note: this will prevent ALL emails, including important order-confirmation messages!)');
 
@@ -306,6 +304,10 @@
         $cInfo = new objectInfo($customers->fields);
     }
   }
+?>
+<?php
+  require_once('includes/template/common/tplHtmlHeadLegacy.php');
+  require_once('includes/template/common/tplHtmlHead.php');
 ?>
 <?php
   if ($action == 'edit' || $action == 'update') {

--- a/admin/ezpages.php
+++ b/admin/ezpages.php
@@ -25,8 +25,6 @@
 
 
   require('includes/application_top.php');
-  require_once('includes/template/common/tplHtmlHeadLegacy.php');
-  require_once('includes/template/common/tplHtmlHead.php');
 
   if (!isset($_SESSION['ez_sort_order'])) {
     $_SESSION['ez_sort_order'] = 0;
@@ -180,6 +178,10 @@
         break;
     }
   }
+?>
+<?php
+  require_once('includes/template/common/tplHtmlHeadLegacy.php');
+  require_once('includes/template/common/tplHtmlHead.php');
 ?>
 <?php if ($editor_handler != '') include ($editor_handler); ?>
 </head>

--- a/admin/featured.php
+++ b/admin/featured.php
@@ -8,8 +8,6 @@
  */
 
   require('includes/application_top.php');
-  require_once('includes/template/common/tplHtmlHeadLegacy.php');
-  require_once('includes/template/common/tplHtmlHead.php');
 
   $currencies = new currencies();
 
@@ -134,6 +132,10 @@
 
     }
   }
+?>
+<?php
+  require_once('includes/template/common/tplHtmlHeadLegacy.php');
+  require_once('includes/template/common/tplHtmlHead.php');
 ?>
 </head>
 <body>

--- a/admin/reviews.php
+++ b/admin/reviews.php
@@ -8,8 +8,6 @@
  */
 
   require('includes/application_top.php');
-  require_once('includes/template/common/tplHtmlHeadLegacy.php');
-  require_once('includes/template/common/tplHtmlHead.php');
 
   $action = (isset($_GET['action']) ? $_GET['action'] : '');
   $status_filter = (isset($_GET['status']) ? $_GET['status'] : '');
@@ -60,6 +58,8 @@
         break;
     }
   }
+  require_once('includes/template/common/tplHtmlHeadLegacy.php');
+  require_once('includes/template/common/tplHtmlHead.php');
 ?>
 <?php if ($editor_handler != '') include ($editor_handler); ?>
 </head>

--- a/admin/salemaker.php
+++ b/admin/salemaker.php
@@ -10,8 +10,6 @@
   define('AUTOCHECK', 'False');
 
   require('includes/application_top.php');
-  require_once('includes/template/common/tplHtmlHeadLegacy.php');
-  require_once('includes/template/common/tplHtmlHead.php');
 
   $currencies = new currencies();
 
@@ -151,7 +149,12 @@
         break;
     }
   }
-
+?>
+<?php
+  require_once('includes/template/common/tplHtmlHeadLegacy.php');
+  require_once('includes/template/common/tplHtmlHead.php');
+?>
+<?php 
   if ( ($action == 'new') || ($action == 'edit') ) {
 ?>
 <script type="text/javascript">

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -8,8 +8,6 @@
  */
 
   require('includes/application_top.php');
-  require_once('includes/template/common/tplHtmlHeadLegacy.php');
-  require_once('includes/template/common/tplHtmlHead.php');
 
   $currencies = new currencies();
 
@@ -447,6 +445,10 @@
         break;
     }
   }
+?>
+<?php
+  require_once('includes/template/common/tplHtmlHeadLegacy.php');
+  require_once('includes/template/common/tplHtmlHead.php');
 ?>
 </head>
 <body>


### PR DESCRIPTION
These pages do a redirect early on in their action processing, which means they can't have headers built prior to this.    Fixed. 