### PR TITLE
Admin define TEXT_IMAGE_NONEXISTENT missing in product.php

### DIFF
--- a/admin/includes/languages/english/product.php
+++ b/admin/includes/languages/english/product.php
@@ -33,6 +33,7 @@ define('TEXT_PRODUCTS_DESCRIPTION', 'Products Description:');
 define('TEXT_PRODUCTS_QUANTITY', 'Products Quantity:');
 define('TEXT_PRODUCTS_MODEL', 'Products Model:');
 define('TEXT_PRODUCTS_IMAGE', 'Products Image:');
+define('TEXT_IMAGE_NONEXISTENT', 'Image does not exist');
 define('TEXT_PRODUCTS_IMAGE_DIR', 'Upload to directory:');
 define('TEXT_PRODUCTS_URL', 'Products URL:');
 define('TEXT_PRODUCTS_URL_WITHOUT_HTTP', '<small>(without http://)</small>');


### PR DESCRIPTION
The products page in Admin->Catalog->Categories products needs this
define.