### PR TITLE
Correct field type in zc_install check, allowing upgrade to complete

### DIFF
--- a/zc_install/includes/systemChecks.yml
+++ b/zc_install/includes/systemChecks.yml
@@ -271,7 +271,7 @@ systemChecks:
             tableName: orders_products
             fieldName: products_virtual
             fieldCheck: Type
-            expectedResult: 'tinyint(1)'
+            expectedResult: 'TINYINT(1)'
           - checkType: fieldSchema
             tableName: ezpages_content
             fieldName: pages_html_text


### PR DESCRIPTION
Without this fix, the 1.5.6->2.0 upgrade does not work; thinks it is still needing 1.5.5->1.5.6. 

Upgrade to version 1.5.6 completed.
Could not update to version 1.6.0. We detect that you currently have v1.5.5, and must perform the updates to get to version 1.5.6 first.