### PR TITLE
v156 admin/includes/modules/update_product.php non-posted master_cate…

### DIFF
--- a/admin/includes/modules/update_product.php
+++ b/admin/includes/modules/update_product.php
@@ -78,7 +78,7 @@ if (isset($_POST['edit_x']) || isset($_POST['edit_y'])) {
     ///////////////////////////////////////////////////////
   } elseif ($action == 'update_product') {
     $sql_data_array['products_last_modified'] = 'now()';
-    $sql_data_array['master_categories_id'] = ((int)$_POST['master_category'] > 0 ? (int)$_POST['master_category'] : (int)$_POST['master_categories_id']);
+    $sql_data_array['master_categories_id'] = (!empty($_POST['master_category']) && (int)$_POST['master_category'] > 0 ? (int)$_POST['master_category'] : (int)$_POST['master_categories_id']);
 
     zen_db_perform(TABLE_PRODUCTS, $sql_data_array, 'update', "products_id = " . (int)$products_id);
 


### PR DESCRIPTION
…gory

For a product that is not linked, it will not have a master_category
to post to the preview_info page and therefore will not have
a master_category field to post to update_product.php.  When that
field is not posted and strict processing is active, trying to
cast that to an integer will cause a PHP notice.  This detects
the presence of the posted value and then in abscence of it
expects that the master_categories_id will be posted (even if 0)
and will perform the type conversion on that expected posted value.