### PR TITLE
Renaming some tabled/models for configuration settings

### DIFF
--- a/app/Model/ConfigurationSettings.php
+++ b/app/Model/ConfigurationSettings.php
@@ -12,10 +12,10 @@ use Illuminate\Database\Eloquent\Model as Eloquent;
  * Class Admin
  * @package ZenCart\Model
  */
-class DashboardWidgetsSettingsToWidget extends Eloquent
+class ConfigurationSettings extends Eloquent
 {
-    protected $table = TABLE_DASHBOARD_WIDGETS_SETTINGS_TO_WIDGET;
-    protected $primaryKey = 'widget_key';
+    protected $table = TABLE_CONFIGURATION_SETTINGS;
+    protected $primaryKey = 'setting_key';
     public $incrementing = false;
 
 }

--- a/app/Model/ConfigurationSettingsToWidget.php
+++ b/app/Model/ConfigurationSettingsToWidget.php
@@ -12,10 +12,10 @@ use Illuminate\Database\Eloquent\Model as Eloquent;
  * Class Admin
  * @package ZenCart\Model
  */
-class DashboardWidgetsSettings extends Eloquent
+class ConfigurationSettingsToWidget extends Eloquent
 {
-    protected $table = TABLE_DASHBOARD_WIDGETS_SETTINGS;
-    protected $primaryKey = 'setting_key';
+    protected $table = TABLE_CONFIGURATION_SETTINGS_TO_WIDGET;
+    protected $primaryKey = 'widget_key';
     public $incrementing = false;
 
 }

--- a/app/Model/DashboardWidgets.php
+++ b/app/Model/DashboardWidgets.php
@@ -21,7 +21,7 @@ class DashboardWidgets extends Eloquent
 
     public function dashboardWidgetSettings()
     {
-        return $this->hasMany('App\Model\DashboardWidgetsSettingsToWidget', 'widget_key', 'widget_key');
+        return $this->hasMany('App\Model\ConfigurationSettingsToWidget', 'widget_key', 'widget_key');
     }
 
 }

--- a/app/Model/DashboardWidgetsToUsers.php
+++ b/app/Model/DashboardWidgetsToUsers.php
@@ -28,7 +28,7 @@ class DashboardWidgetsToUsers extends Eloquent
 
     public function DashboardWidgetSettings()
     {
-        return $this->hasMany('App\Model\DashboardWidgetsSettingsToWidget', 'widget_key', 'widget_key');
+        return $this->hasMany('App\Model\ConfigurationSettingsToWidget', 'widget_key', 'widget_key');
     }
 
     public function getWidgetInfoForUser($adminId)

--- a/app/library/zencart/DashboardWidget/src/WidgetManager.php
+++ b/app/library/zencart/DashboardWidget/src/WidgetManager.php
@@ -259,7 +259,7 @@ class WidgetManager
         $widget['title'] = $this->getWidgetTitle($widget['widget_name']);
         $settingKeys = array_column($widget['dashboard_widget_settings'], 'setting_key');
         $dwt = $this->mapToNewKey($widget['dashboard_widget_settings'], 'setting_key');
-        $model = $this->modelFactory->make('DashboardWidgetsSettings');
+        $model = $this->modelFactory->make('ConfigurationSettings');
         $settings = $model->whereIn('setting_key', $settingKeys)->get()->toArray();
         $settingsList = [];
         foreach ($settings as $setting) {

--- a/includes/database_tables.php
+++ b/includes/database_tables.php
@@ -28,6 +28,8 @@ define('TABLE_CATEGORIES', DB_PREFIX . 'categories');
 define('TABLE_CATEGORIES_DESCRIPTION', DB_PREFIX . 'categories_description');
 define('TABLE_CONFIGURATION', DB_PREFIX . 'configuration');
 define('TABLE_CONFIGURATION_GROUP', DB_PREFIX . 'configuration_group');
+define('TABLE_CONFIGURATION_SETTINGS', DB_PREFIX . 'configuration_settings');
+define('TABLE_CONFIGURATION_SETTINGS_TO_WIDGET', DB_PREFIX . 'configuration_settings_to_widget');
 define('TABLE_COUNTER', DB_PREFIX . 'counter');
 define('TABLE_COUNTER_HISTORY', DB_PREFIX . 'counter_history');
 define('TABLE_COUNTRIES', DB_PREFIX . 'countries');
@@ -50,9 +52,7 @@ define('TABLE_DASHBOARD_WIDGETS_GROUPS', DB_PREFIX . 'dashboard_widgets_groups')
 define('TABLE_DASHBOARD_WIDGETS_DESCRIPTION', DB_PREFIX . 'dashboard_widgets_description');
 define('TABLE_DASHBOARD_WIDGETS_TO_PROFILES', DB_PREFIX . 'dashboard_widgets_to_profiles');
 define('TABLE_DASHBOARD_WIDGETS_TO_USERS', DB_PREFIX . 'dashboard_widgets_to_users');
-define('TABLE_DASHBOARD_WIDGETS_SETTINGS', DB_PREFIX . 'dashboard_widgets_settings');
 define('TABLE_DASHBOARD_WIDGETS_SETTINGS_TO_USER', DB_PREFIX . 'dashboard_widgets_settings_to_user');
-define('TABLE_DASHBOARD_WIDGETS_SETTINGS_TO_WIDGET', DB_PREFIX . 'dashboard_widgets_settings_to_widget');
 define('TABLE_EMAIL_ARCHIVE', DB_PREFIX . 'email_archive');
 define('TABLE_EZPAGES', DB_PREFIX . 'ezpages');
 define('TABLE_EZPAGES_CONTENT', DB_PREFIX . 'ezpages_content');

--- a/zc_install/sql/install/mysql_zencart.sql
+++ b/zc_install/sql/install/mysql_zencart.sql
@@ -728,11 +728,11 @@ CREATE TABLE IF NOT EXISTS dashboard_widgets_to_users (
 # --------------------------------------------------------
 
 #
-# Table structure for table 'dashboard_widgets_settings'
+# Table structure for table 'configuration_settings'
 #
 
-DROP TABLE IF EXISTS dashboard_widgets_settings;
-CREATE TABLE dashboard_widgets_settings (
+DROP TABLE IF EXISTS configuration_settings;
+CREATE TABLE configuration_settings (
   setting_key varchar(64) NOT NULL,
   setting_name varchar(255) NOT NULL,
   setting_definition longtext NOT NULL,
@@ -743,11 +743,11 @@ CREATE TABLE dashboard_widgets_settings (
 # --------------------------------------------------------
 
 #
-# Table structure for table 'dashboard_widgets_settings_to_widget'
+# Table structure for table 'configuration_settings_to_widget'
 #
 
-DROP TABLE IF EXISTS dashboard_widgets_settings_to_widget;
-CREATE TABLE dashboard_widgets_settings_to_widget (
+DROP TABLE IF EXISTS configuration_settings_to_widget;
+CREATE TABLE configuration_settings_to_widget (
   setting_key varchar(64) NOT NULL,
   widget_key varchar(64) NOT NULL,
   initial_value longtext,
@@ -3307,20 +3307,20 @@ INSERT INTO dashboard_widgets_to_users (widget_key, admin_id, widget_row, widget
 
 # @todo testing settings - remove for release
 
-INSERT INTO dashboard_widgets_settings (setting_key, setting_name, setting_definition, setting_type) VALUES ('some-text', 'INPUT_LABEL_SOME_TEXT', '{}', 'text');
-INSERT INTO dashboard_widgets_settings (setting_key, setting_name, setting_definition, setting_type) VALUES ('date-from', 'INPUT_LABEL_DATE_FROM', '', 'simpleDate');
+INSERT INTO configuration_settings (setting_key, setting_name, setting_definition, setting_type) VALUES ('some-text', 'INPUT_LABEL_SOME_TEXT', '{}', 'text');
+INSERT INTO configuration_settings (setting_key, setting_name, setting_definition, setting_type) VALUES ('date-from', 'INPUT_LABEL_DATE_FROM', '', 'simpleDate');
 
 # Banner Statistics dashboard widget settings
 
-INSERT INTO dashboard_widgets_settings (setting_key, setting_name, setting_definition, setting_type) VALUES ('banner-id', 'INPUT_LABEL_BANNER_ID', '{"model": "banner", "id": "banners_id", "text": "banners_title"}', 'selectFromModel');
-INSERT INTO dashboard_widgets_settings (setting_key, setting_name, setting_definition, setting_type) VALUES ('banner-date-range', 'INPUT_LABEL_BANNER_DATE_RANGE', '{"options":[{"id":"yearly","text":"OPTIONS_DATERANGE_YEARLY"},{"id":"monthly","text":"OPTIONS_DATERANGE_MONTHLY"},{"id":"daily","text":"OPTIONS_DATERANGE_DAILY"},{"id":"recent","text":"OPTIONS_DATERANGE_RECENT"}]}', 'selectFromArray');
-INSERT INTO dashboard_widgets_settings (setting_key, setting_name, setting_definition, setting_type) VALUES ('banner-show-lines', 'INPUT_LABEL_BANNER_SHOW_LINES', '{}', 'boolean');
+INSERT INTO configuration_settings (setting_key, setting_name, setting_definition, setting_type) VALUES ('banner-id', 'INPUT_LABEL_BANNER_ID', '{"model": "banner", "id": "banners_id", "text": "banners_title"}', 'selectFromModel');
+INSERT INTO configuration_settings (setting_key, setting_name, setting_definition, setting_type) VALUES ('banner-date-range', 'INPUT_LABEL_BANNER_DATE_RANGE', '{"options":[{"id":"yearly","text":"OPTIONS_DATERANGE_YEARLY"},{"id":"monthly","text":"OPTIONS_DATERANGE_MONTHLY"},{"id":"daily","text":"OPTIONS_DATERANGE_DAILY"},{"id":"recent","text":"OPTIONS_DATERANGE_RECENT"}]}', 'selectFromArray');
+INSERT INTO configuration_settings (setting_key, setting_name, setting_definition, setting_type) VALUES ('banner-show-lines', 'INPUT_LABEL_BANNER_SHOW_LINES', '{}', 'boolean');
 
-INSERT INTO dashboard_widgets_settings_to_widget (setting_key, widget_key, initial_value) VALUES ('banner-id', 'banner-statistics', 'monthly');
-INSERT INTO dashboard_widgets_settings_to_widget (setting_key, widget_key, initial_value) VALUES ('banner-date-range', 'banner-statistics', 'monthly');
-INSERT INTO dashboard_widgets_settings_to_widget (setting_key, widget_key, initial_value) VALUES ('banner-show-lines', 'banner-statistics', 'on');
-INSERT INTO dashboard_widgets_settings_to_widget (setting_key, widget_key, initial_value) VALUES ('some-text', 'banner-statistics', '');
-INSERT INTO dashboard_widgets_settings_to_widget (setting_key, widget_key, initial_value) VALUES ('date-from', 'banner-statistics', '');
+INSERT INTO configuration_settings_to_widget (setting_key, widget_key, initial_value) VALUES ('banner-id', 'banner-statistics', 'monthly');
+INSERT INTO configuration_settings_to_widget (setting_key, widget_key, initial_value) VALUES ('banner-date-range', 'banner-statistics', 'monthly');
+INSERT INTO configuration_settings_to_widget (setting_key, widget_key, initial_value) VALUES ('banner-show-lines', 'banner-statistics', 'on');
+INSERT INTO configuration_settings_to_widget (setting_key, widget_key, initial_value) VALUES ('some-text', 'banner-statistics', '');
+INSERT INTO configuration_settings_to_widget (setting_key, widget_key, initial_value) VALUES ('date-from', 'banner-statistics', '');
 
 
 INSERT INTO listingbox_locations (location_key, location_name) VALUES

--- a/zc_install/sql/updates/mysql_upgrade_zencart_160.sql
+++ b/zc_install/sql/updates/mysql_upgrade_zencart_160.sql
@@ -252,11 +252,11 @@ CREATE TABLE IF NOT EXISTS dashboard_widgets_to_users (
 # --------------------------------------------------------
 
 #
-# Table structure for table 'dashboard_widgets_settings'
+# Table structure for table 'configuration_settings'
 #
 
-DROP TABLE IF EXISTS dashboard_widgets_settings;
-CREATE TABLE dashboard_widgets_settings (
+DROP TABLE IF EXISTS configuration_settings;
+CREATE TABLE configuration_settings (
   setting_key varchar(64) NOT NULL,
   setting_name varchar(255) NOT NULL,
   setting_definition longtext NOT NULL,
@@ -267,11 +267,11 @@ CREATE TABLE dashboard_widgets_settings (
 # --------------------------------------------------------
 
 #
-# Table structure for table 'dashboard_widgets_settings_to_widget'
+# Table structure for table 'configuration_settings_to_widget'
 #
 
-DROP TABLE IF EXISTS dashboard_widgets_settings_to_widget;
-CREATE TABLE dashboard_widgets_settings_to_widget (
+DROP TABLE IF EXISTS configuration_settings_to_widget;
+CREATE TABLE configuration_settings_to_widget (
   setting_key varchar(64) NOT NULL,
   widget_key varchar(64) NOT NULL,
   initial_value longtext,
@@ -342,20 +342,20 @@ INSERT INTO dashboard_widgets_to_users (widget_key, admin_id, widget_row, widget
 
 # @todo testing settings - remove for release
 
-INSERT INTO dashboard_widgets_settings (setting_key, setting_name, setting_definition, setting_type) VALUES ('some-text', 'INPUT_LABEL_SOME_TEXT', '{}', 'text');
-INSERT INTO dashboard_widgets_settings (setting_key, setting_name, setting_definition, setting_type) VALUES ('date-from', 'INPUT_LABEL_DATE_FROM', '', 'simpleDate');
+INSERT INTO configuration_settings (setting_key, setting_name, setting_definition, setting_type) VALUES ('some-text', 'INPUT_LABEL_SOME_TEXT', '{}', 'text');
+INSERT INTO configuration_settings (setting_key, setting_name, setting_definition, setting_type) VALUES ('date-from', 'INPUT_LABEL_DATE_FROM', '', 'simpleDate');
 
 # Banner Statistics dashboard widget settings
 
-INSERT INTO dashboard_widgets_settings (setting_key, setting_name, setting_definition, setting_type) VALUES ('banner-id', 'INPUT_LABEL_BANNER_ID', '{"model": "banner", "id": "banners_id", "text": "banners_title"}', 'selectFromModel');
-INSERT INTO dashboard_widgets_settings (setting_key, setting_name, setting_definition, setting_type) VALUES ('banner-date-range', 'INPUT_LABEL_BANNER_DATE_RANGE', '{"options":[{"id":"yearly","text":"OPTIONS_DATERANGE_YEARLY"},{"id":"monthly","text":"OPTIONS_DATERANGE_MONTHLY"},{"id":"daily","text":"OPTIONS_DATERANGE_DAILY"},{"id":"recent","text":"OPTIONS_DATERANGE_RECENT"}]}', 'selectFromArray');
-INSERT INTO dashboard_widgets_settings (setting_key, setting_name, setting_definition, setting_type) VALUES ('banner-show-lines', 'INPUT_LABEL_BANNER_SHOW_LINES', '{}', 'boolean');
+INSERT INTO configuration_settings (setting_key, setting_name, setting_definition, setting_type) VALUES ('banner-id', 'INPUT_LABEL_BANNER_ID', '{"model": "banner", "id": "banners_id", "text": "banners_title"}', 'selectFromModel');
+INSERT INTO configuration_settings (setting_key, setting_name, setting_definition, setting_type) VALUES ('banner-date-range', 'INPUT_LABEL_BANNER_DATE_RANGE', '{"options":[{"id":"yearly","text":"OPTIONS_DATERANGE_YEARLY"},{"id":"monthly","text":"OPTIONS_DATERANGE_MONTHLY"},{"id":"daily","text":"OPTIONS_DATERANGE_DAILY"},{"id":"recent","text":"OPTIONS_DATERANGE_RECENT"}]}', 'selectFromArray');
+INSERT INTO configuration_settings (setting_key, setting_name, setting_definition, setting_type) VALUES ('banner-show-lines', 'INPUT_LABEL_BANNER_SHOW_LINES', '{}', 'boolean');
 
-INSERT INTO dashboard_widgets_settings_to_widget (setting_key, widget_key, initial_value) VALUES ('banner-id', 'banner-statistics', 'monthly');
-INSERT INTO dashboard_widgets_settings_to_widget (setting_key, widget_key, initial_value) VALUES ('banner-date-range', 'banner-statistics', 'monthly');
-INSERT INTO dashboard_widgets_settings_to_widget (setting_key, widget_key, initial_value) VALUES ('banner-show-lines', 'banner-statistics', 'on');
-INSERT INTO dashboard_widgets_settings_to_widget (setting_key, widget_key, initial_value) VALUES ('some-text', 'banner-statistics', '');
-INSERT INTO dashboard_widgets_settings_to_widget (setting_key, widget_key, initial_value) VALUES ('date-from', 'banner-statistics', '');
+INSERT INTO configuration_settings_to_widget (setting_key, widget_key, initial_value) VALUES ('banner-id', 'banner-statistics', 'monthly');
+INSERT INTO configuration_settings_to_widget (setting_key, widget_key, initial_value) VALUES ('banner-date-range', 'banner-statistics', 'monthly');
+INSERT INTO configuration_settings_to_widget (setting_key, widget_key, initial_value) VALUES ('banner-show-lines', 'banner-statistics', 'on');
+INSERT INTO configuration_settings_to_widget (setting_key, widget_key, initial_value) VALUES ('some-text', 'banner-statistics', '');
+INSERT INTO configuration_settings_to_widget (setting_key, widget_key, initial_value) VALUES ('date-from', 'banner-statistics', '');
 
 
 


### PR DESCRIPTION
The intention is that in the future we can re-use the configuration
settings table as part of the overall configuration system, and not just
for dashboard widgets.