### PR TITLE
Refactored zen_get_categories_name_from_product.

### DIFF
--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -2920,9 +2920,19 @@ function zen_limit_image_filename($filename, $table_name, $field_name, $extensio
   function zen_get_categories_name_from_product($product_id) {
     global $db;
 
-//    $check_products_category= $db->Execute("select products_id, categories_id from " . TABLE_PRODUCTS_TO_CATEGORIES . " where products_id='" . $product_id . "' limit 1");
-    $check_products_category = $db->Execute("select products_id, master_categories_id from " . TABLE_PRODUCTS . " where products_id = '" . (int)$product_id . "'");
-    $the_categories_name= $db->Execute("select categories_name from " . TABLE_CATEGORIES_DESCRIPTION . " where categories_id= '" . $check_products_category->fields['master_categories_id'] . "' and language_id= '" . (int)$_SESSION['languages_id'] . "'");
+//    $check_products_category= $db->Execute("SELECT products_id, categories_id FROM " . TABLE_PRODUCTS_TO_CATEGORIES . " WHERE products_id = " . (int)$product_id . " LIMIT 1");
+    $check_products_category = $db->Execute("
+                                             SELECT products_id, master_categories_id
+                                             FROM " . TABLE_PRODUCTS . "
+                                             WHERE products_id = " . (int)$product_id
+                                           );
+    if ($check_products_category->EOF) return '';
+    $the_categories_name= $db->Execute("
+                                        SELECT categories_name
+                                        FROM " . TABLE_CATEGORIES_DESCRIPTION . " 
+                                        WHERE categories_id= " . (int)$check_products_category->fields['master_categories_id'] . "
+                                        AND language_id= " . (int)$_SESSION['languages_id']
+                                      );
     if ($the_categories_name->EOF) return '';
     return $the_categories_name->fields['categories_name'];
   }

--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -2921,14 +2921,12 @@ function zen_limit_image_filename($filename, $table_name, $field_name, $extensio
     global $db;
 
 //    $check_products_category= $db->Execute("SELECT products_id, categories_id FROM " . TABLE_PRODUCTS_TO_CATEGORIES . " WHERE products_id = " . (int)$product_id . " LIMIT 1");
-    $check_products_category = $db->Execute("
-                                             SELECT products_id, master_categories_id
+    $check_products_category = $db->Execute("SELECT products_id, master_categories_id
                                              FROM " . TABLE_PRODUCTS . "
                                              WHERE products_id = " . (int)$product_id
                                            );
     if ($check_products_category->EOF) return '';
-    $the_categories_name= $db->Execute("
-                                        SELECT categories_name
+    $the_categories_name= $db->Execute("SELECT categories_name
                                         FROM " . TABLE_CATEGORIES_DESCRIPTION . " 
                                         WHERE categories_id= " . (int)$check_products_category->fields['master_categories_id'] . "
                                         AND language_id= " . (int)$_SESSION['languages_id']


### PR DESCRIPTION
Identified by a self-implemented coding error that attempting to
access this function with a non-existent products_id caused a
mydebug notice (in strict mode) to be logged for
`$check_products_category->fields['master_categories_id']`
not existing.  Execution continued apparently, but it seems that
it could be improved.  Also removed the text casting quotes around
the values and ensured each were cast as an integer.