### PR TITLE
Admin - initialize error variable in ezpages manager

### DIFF
--- a/admin/ezpages.php
+++ b/admin/ezpages.php
@@ -92,11 +92,11 @@ if (zen_not_null($action)) {
       $status_toc = ($pages_toc_sort_order == 0 ? 0 : (int)$_POST['status_toc']);
 
       $pages_html_url_flag = false;
+      $page_error = false;
       for ($i = 0, $n = sizeof($languages); $i < $n; $i++) {
         if ($_POST['pages_html_text'][$languages[$i]['id']] != '' && strlen(trim($_POST['pages_html_text'][$languages[$i]['id']])) > 6) {
           $pages_html_url_flag = true;
         }
-        $page_error = false;
         if (empty($_POST['pages_title'][$languages[$i]['id']])) {
           $messageStack->add(ERROR_PAGE_TITLE_REQUIRED . ' (' . $languages[$i]['name'] . ')', 'error');
           $page_error = true;


### PR DESCRIPTION
It is possible that $page_error could be set to true but then
set to false while looping through the languages. This removes the
$page_error variable being set to false to outside of the loop.