### PR TITLE
Prevent "Admin Admin" from being in a page title

### DIFF
--- a/admin/includes/init_includes/init_templates.php
+++ b/admin/includes/init_includes/init_templates.php
@@ -43,5 +43,9 @@ $pagename = ucwords($pagename);
 if ($pagename == '') {
   $pagename = STORE_NAME;
 }
-$title = TEXT_ADMIN_TAB_PREFIX . ' ' . $pagename;
+if (strncmp(TEXT_ADMIN_TAB_PREFIX, $pagename, strlen(TEXT_ADMIN_TAB_PREFIX)) == 0) {
+   $title = $pagename;
+} else {
+   $title = TEXT_ADMIN_TAB_PREFIX . ' ' . $pagename;
+}
 define('TITLE', $title);


### PR DESCRIPTION
Check for the string "Admin" at the start of the name before adding it as a prefix. 