### PR TITLE
Cast the year in zen_date_short to int

### DIFF
--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -196,7 +196,7 @@
   function zen_date_short($raw_date) {
     if ( ($raw_date == '0001-01-01 00:00:00') || ($raw_date == '') ) return false;
 
-    $year = substr($raw_date, 0, 4);
+    $year = (int)substr($raw_date, 0, 4);
     $month = (int)substr($raw_date, 5, 2);
     $day = (int)substr($raw_date, 8, 2);
     $hour = (int)substr($raw_date, 11, 2);


### PR DESCRIPTION
Recently a forum member identified a problem with ZC 1.5.6 where an error was thrown I think on line 208 indicating that parameter 6 was expected to be an integer; however, a string was provided.  Now that I have had a look at the software on a larger screen, it appears that the issue stems from `$year` not being cast as an integer.