### PR TITLE
Return false from date functions evaluated to 0000-00-00 00:00:00

### DIFF
--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -176,7 +176,7 @@
   }
 
   function zen_date_long($raw_date) {
-    if ( ($raw_date == '0001-01-01 00:00:00') || ($raw_date == '') ) return false;
+    if (empty($raw_date) || $raw_date <= '0001-01-01 00:00:00') return false;
 
     $year = (int)substr($raw_date, 0, 4);
     $month = (int)substr($raw_date, 5, 2);
@@ -184,8 +184,6 @@
     $hour = (int)substr($raw_date, 11, 2);
     $minute = (int)substr($raw_date, 14, 2);
     $second = (int)substr($raw_date, 17, 2);
-    
-    if (empty($year) && empty($month) && empty($day) && empty($hour) && empty($minute) && empty($second)) return false;
 
     return strftime(DATE_FORMAT_LONG, mktime($hour, $minute, $second, $month, $day, $year));
   }
@@ -196,7 +194,7 @@
 // $raw_date needs to be in this format: YYYY-MM-DD HH:MM:SS
 // NOTE: Includes a workaround for dates before 01/01/1970 that fail on windows servers
   function zen_date_short($raw_date) {
-    if ( ($raw_date == '0001-01-01 00:00:00') || ($raw_date == '') ) return false;
+    if (empty($raw_date) || $raw_date <= '0001-01-01 00:00:00') return false;
 
     $year = substr($raw_date, 0, 4);
     $month = (int)substr($raw_date, 5, 2);
@@ -204,8 +202,6 @@
     $hour = (int)substr($raw_date, 11, 2);
     $minute = (int)substr($raw_date, 14, 2);
     $second = (int)substr($raw_date, 17, 2);
-
-    if (empty($year) && empty($month) && empty($day) && empty($hour) && empty($minute) && empty($second)) return false;
 
 // error on 1969 only allows for leap year
     if ($year != 1969 && @date('Y', mktime($hour, $minute, $second, $month, $day, $year)) == $year) {
@@ -218,7 +214,7 @@
 
 
   function zen_datetime_short($raw_datetime) {
-    if ( ($raw_datetime == '0001-01-01 00:00:00') || ($raw_datetime == '') ) return false;
+    if (empty($raw_datetime) || $raw_datetime <= '0001-01-01 00:00:00') return false;
 
     $year = (int)substr($raw_datetime, 0, 4);
     $month = (int)substr($raw_datetime, 5, 2);
@@ -226,8 +222,6 @@
     $hour = (int)substr($raw_datetime, 11, 2);
     $minute = (int)substr($raw_datetime, 14, 2);
     $second = (int)substr($raw_datetime, 17, 2);
-
-    if (empty($year) && empty($month) && empty($day) && empty($hour) && empty($minute) && empty($second)) return false;
 
     return strftime(DATE_TIME_FORMAT, mktime($hour, $minute, $second, $month, $day, $year));
   }

--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -184,6 +184,8 @@
     $hour = (int)substr($raw_date, 11, 2);
     $minute = (int)substr($raw_date, 14, 2);
     $second = (int)substr($raw_date, 17, 2);
+    
+    if (empty($year) && empty($month) && empty($day) && empty($hour) && empty($minute) && empty($second)) return false;
 
     return strftime(DATE_FORMAT_LONG, mktime($hour, $minute, $second, $month, $day, $year));
   }
@@ -202,6 +204,8 @@
     $hour = (int)substr($raw_date, 11, 2);
     $minute = (int)substr($raw_date, 14, 2);
     $second = (int)substr($raw_date, 17, 2);
+
+    if (empty($year) && empty($month) && empty($day) && empty($hour) && empty($minute) && empty($second)) return false;
 
 // error on 1969 only allows for leap year
     if ($year != 1969 && @date('Y', mktime($hour, $minute, $second, $month, $day, $year)) == $year) {
@@ -222,6 +226,8 @@
     $hour = (int)substr($raw_datetime, 11, 2);
     $minute = (int)substr($raw_datetime, 14, 2);
     $second = (int)substr($raw_datetime, 17, 2);
+
+    if (empty($year) && empty($month) && empty($day) && empty($hour) && empty($minute) && empty($second)) return false;
 
     return strftime(DATE_TIME_FORMAT, mktime($hour, $minute, $second, $month, $day, $year));
   }


### PR DESCRIPTION
I have been trying to track down how a `date` field in a plugin ended up being stored with `0000-00-00` and at least the last place where assignment was made, a Zen Cart date function was used in a similar manner as other `date`/`datetime` functions.  Looking into the associated admin date functions, it appears that if the `datetime` of `0001-01-01 00:00:00` or an empty string (possibly by loose comparison) was fed into the functions then false is returned; however, there is no similar review/response if the result were `0000-00-00 00:00:00` which at least currently for `date` and `datetime` fields is considered to not be acceptable.

Perhaps a similar review should be done for a year of 1, month of 1, day of 1 and empty for the other three fields. Reason? A `date` field may have `0001-01-01` but will not include the time portion and therefore will evaluate back in the `DATE_TIME_FORMAT` as equivalent to `0001-01-01 00:00:00`... Just some thoughts.

I would not be disappointed if the reason this is not incorporated is that perhaps there is a non-database reason to actually return `0000-00-00 00:00:00` and therefore not be incorporated/included.