### PR TITLE
Change keepalive loginURL to camefrom v index on timeout

### DIFF
--- a/admin/includes/keepalive_module.php
+++ b/admin/includes/keepalive_module.php
@@ -17,6 +17,7 @@ if (!defined('TEXT_TIMEOUT_TIMED_OUT_MESSAGE')) define('TEXT_TIMEOUT_TIMED_OUT_M
 // Read default timeout value from the site's configuration:
 $timeoutAfter = ini_get('session.gc_maxlifetime');
 if ((int)$timeoutAfter < 30) $timeoutAfter = 1440;
+$camefrom = basename($PHP_SELF) . (empty($params = zen_get_all_get_params()) ? '' : '?' . trim($params, '&'));
 ?>
 
 <link rel="stylesheet" type="text/css" href="includes/css/jAlert.css">
@@ -33,7 +34,7 @@ $(function(){
     'mouseDebounce': 120, //How many seconds between extending the session when the mouse is moved (instead of extending a billion times within 5 seconds)
     'extendUrl': 'keepalive.php', //URL to request in order to extend the session.
     'logoutUrl': 'logoff.php', //URL to request in order to force a logout after the timeout.
-    'loginUrl': 'index.php', //URL to send a customer to when they want to log back in
+    'loginUrl': '<?= $camefrom; ?>', //URL to send a customer to when they want to log back in
     'secondsPrior': <?= (int)$timeoutAfter/3; ?>, //how many seconds before timing out to run the next callback (onPriorCallback)
     'onPriorCallback': function(timeout, seconds){
         $.jAlert({


### PR DESCRIPTION
i have tested and verified this works...  it creates the camefrom url with 1 `?` and then uses the `&` for seperating parameters.  it also trims the last `&`.

as @Zen4All previously commented on, the `<?=` directive is NOT affected by the short tag being turned on or off since php 5.4.  so i opted to not change all of that code and leave it as is....  which seems clean to me.

in addition, i did move the `'` for the camefrom var to outside of the `$camefrom` as suggested by @drbyte and being consistent with the existing code.