### PR TITLE
addresses error when shipping module comes back w empty response

### DIFF
--- a/includes/classes/shipping.php
+++ b/includes/classes/shipping.php
@@ -183,6 +183,9 @@ class shipping extends base {
         $class = substr($value, 0, strrpos($value, '.'));
         if (isset($GLOBALS[$class]) && is_object($GLOBALS[$class]) && $GLOBALS[$class]->enabled) {
           $quotes = $GLOBALS[$class]->quotes;
+          if (empty($quotes['methods'])) {
+            return;
+          }
           $size = sizeof($quotes['methods']);
           for ($i=0; $i<$size; $i++) {
             if (isset($quotes['methods'][$i]['cost'])){


### PR DESCRIPTION
testing `empty()` v `!is_array()`.  empty seemed to work fine.

i would love to get all files into unix line feeds as opposed to windows....  but it seems so easy for me to screw things up in git.  so apologies about the line change on the time stamp.  i blame my IDE!