### PR TITLE
Do not show home address as delivery address for pickup orders

### DIFF
--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -162,7 +162,7 @@ class order extends base {
                             'format_id' => $order->fields['delivery_address_format_id']);
 
     if (($order->fields['shipping_module_code'] == 'storepickup') || 
-        empty($this->delivery['name']) && empty($this->delivery['street_address'])) {
+        (empty($this->delivery['name']) && empty($this->delivery['street_address']))) {
       $this->delivery = false;
     }
 

--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -161,7 +161,8 @@ class order extends base {
                             'country' => $order->fields['delivery_country'],
                             'format_id' => $order->fields['delivery_address_format_id']);
 
-    if (empty($this->delivery['name']) && empty($this->delivery['street_address'])) {
+    if (($order->fields['shipping_module_code'] == 'storepickup') || 
+        empty($this->delivery['name']) && empty($this->delivery['street_address'])) {
       $this->delivery = false;
     }
 
@@ -1061,11 +1062,16 @@ class order extends base {
     //addresses area: Delivery
     $html_msg['HEADING_ADDRESS_INFORMATION']= HEADING_ADDRESS_INFORMATION;
     $html_msg['ADDRESS_DELIVERY_TITLE']     = EMAIL_TEXT_DELIVERY_ADDRESS;
-    $html_msg['ADDRESS_DELIVERY_DETAIL']    = ($this->content_type != 'virtual') ? zen_address_label($_SESSION['customer_id'], $_SESSION['sendto'], true, '', "<br />") : 'n/a';
+
+    if ($this->content_type != 'virtual' && $this->info['shipping_module_code'] != "storepickup") {
+      $html_msg['ADDRESS_DELIVERY_DETAIL']    = zen_address_label($_SESSION['customer_id'], $_SESSION['sendto'], true, '', "<br />");
+    } else {
+       $html_msg['ADDRESS_DELIVERY_DETAIL']    = 'n/a'; 
+    }
     $html_msg['SHIPPING_METHOD_TITLE']      = HEADING_SHIPPING_METHOD;
     $html_msg['SHIPPING_METHOD_DETAIL']     = (zen_not_null($this->info['shipping_method'])) ? $this->info['shipping_method'] : 'n/a';
 
-    if ($this->content_type != 'virtual') {
+    if ($this->content_type != 'virtual' && $this->info['shipping_module_code'] != "storepickup") {
       $email_order .= "\n" . EMAIL_TEXT_DELIVERY_ADDRESS . "\n" .
       EMAIL_SEPARATOR . "\n" .
       zen_address_label($_SESSION['customer_id'], $_SESSION['sendto'], 0, '', "\n") . "\n";

--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -1063,7 +1063,8 @@ class order extends base {
     $html_msg['HEADING_ADDRESS_INFORMATION']= HEADING_ADDRESS_INFORMATION;
     $html_msg['ADDRESS_DELIVERY_TITLE']     = EMAIL_TEXT_DELIVERY_ADDRESS;
 
-    if ($this->content_type != 'virtual' && $this->info['shipping_module_code'] != "storepickup") {
+    $storepickup = (strpos($this->info['shipping_module_code'], "storepickup") !== false); 
+    if ($this->content_type != 'virtual' && !$storepickup) {
       $html_msg['ADDRESS_DELIVERY_DETAIL']    = zen_address_label($_SESSION['customer_id'], $_SESSION['sendto'], true, '', "<br />");
     } else {
        $html_msg['ADDRESS_DELIVERY_DETAIL']    = 'n/a'; 
@@ -1071,7 +1072,7 @@ class order extends base {
     $html_msg['SHIPPING_METHOD_TITLE']      = HEADING_SHIPPING_METHOD;
     $html_msg['SHIPPING_METHOD_DETAIL']     = (zen_not_null($this->info['shipping_method'])) ? $this->info['shipping_method'] : 'n/a';
 
-    if ($this->content_type != 'virtual' && $this->info['shipping_module_code'] != "storepickup") {
+    if ($this->content_type != 'virtual' && !$storepickup) {
       $email_order .= "\n" . EMAIL_TEXT_DELIVERY_ADDRESS . "\n" .
       EMAIL_SEPARATOR . "\n" .
       zen_address_label($_SESSION['customer_id'], $_SESSION['sendto'], 0, '', "\n") . "\n";


### PR DESCRIPTION
Currently, the address shown as the delivery address for an order to be shipped using Store Pickup is the customer's default address.  This is misleading. 