### PR TITLE
Fix PHP strict error in developers toolkit search

### DIFF
--- a/admin/developers_tool_kit.php
+++ b/admin/developers_tool_kit.php
@@ -10,6 +10,10 @@ require('includes/application_top.php');
 
 $default_context_lines = 0;
 
+if (!empty($_POST) && !isset($_POST['context_lines'])) {
+  $_POST['context_lines'] = abs((int)$default_context_lines);
+}
+
 if (isset($_GET['configuration_key_lookup']) && $_GET['configuration_key_lookup'] != '') {
   $_POST['configuration_key'] = strtoupper($_GET['configuration_key_lookup']);
   $_POST['zv_files'] = 1;


### PR DESCRIPTION
Address other strict notifications when searching not using the last row of search options.

A convenient debugging tool had been added that allowed the
display of lines above and below the line that contains the
result; however, if any other search tool option is chosen
from the screen, then no default set of values is identified and
in strict php processing a notification is made.  This at least
supports defaulting to a sanitized value of the $default_context_lines
when the context_lines are not otherwise provided.