### PR TITLE
Correct for strict notifications when preview_info page URI entered

### DIFF
--- a/admin/includes/modules/document_general/preview_info.php
+++ b/admin/includes/modules/document_general/preview_info.php
@@ -32,6 +32,9 @@ if (zen_not_null($_POST)) {
 
   $pInfo = new objectInfo($product->fields);
   $products_image_name = $pInfo->products_image;
+  $products_name = $pInfo->products_name;
+  $products_description = $pInfo->products_description;
+  $products_url = $pInfo->products_url;
 }
 
 $form_action = (isset($_GET['pID'])) ? 'update_product' : 'insert_product';
@@ -61,11 +64,11 @@ $form_action = (isset($_GET['pID'])) ? 'update_product' : 'insert_product';
     <div class="row">
         <?php
 //auto replace with defined missing image
-        if ($_POST['products_image_manual'] != '') {
+        if (isset($_POST['products_image_manual']) && $_POST['products_image_manual'] != '') {
           $products_image_name = $_POST['img_dir'] . $_POST['products_image_manual'];
           $pInfo->products_name = $products_image_name;
         }
-        if ($_POST['image_delete'] == 1 || $products_image_name == '' && PRODUCTS_IMAGE_NO_IMAGE_STATUS == '1') {
+        if (isset($_POST['image_delete']) && $_POST['image_delete'] == 1 || $products_image_name == '' && PRODUCTS_IMAGE_NO_IMAGE_STATUS == '1') {
           echo zen_image(DIR_WS_CATALOG_IMAGES . PRODUCTS_IMAGE_NO_IMAGE, $pInfo->products_name, SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT, 'align="right" hspace="5" vspace="5"') . $pInfo->products_description;
         } else {
           echo zen_image(DIR_WS_CATALOG_IMAGES . $products_image_name, $pInfo->products_name, SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT, 'align="right" hspace="5" vspace="5"') . $pInfo->products_description;

--- a/admin/includes/modules/document_product/preview_info.php
+++ b/admin/includes/modules/document_product/preview_info.php
@@ -32,6 +32,9 @@ if (zen_not_null($_POST)) {
 
   $pInfo = new objectInfo($product->fields);
   $products_image_name = $pInfo->products_image;
+  $products_name = $pInfo->products_name;
+  $products_description = $pInfo->products_description;
+  $products_url = $pInfo->products_url;
 }
 
 $form_action = (isset($_GET['pID'])) ? 'update_product' : 'insert_product';
@@ -75,11 +78,11 @@ $form_action = (isset($_GET['pID'])) ? 'update_product' : 'insert_product';
     <div class="row">
         <?php
 //auto replace with defined missing image
-        if ($_POST['products_image_manual'] != '') {
+        if (isset($_POST['products_image_manual']) && $_POST['products_image_manual'] != '') {
           $products_image_name = $_POST['img_dir'] . $_POST['products_image_manual'];
           $pInfo->products_name = $products_image_name;
         }
-        if ($_POST['image_delete'] == 1 || $products_image_name == '' && PRODUCTS_IMAGE_NO_IMAGE_STATUS == '1') {
+        if (isset($_POST['image_delete']) && $_POST['image_delete'] == 1 || $products_image_name == '' && PRODUCTS_IMAGE_NO_IMAGE_STATUS == '1') {
           echo zen_image(DIR_WS_CATALOG_IMAGES . PRODUCTS_IMAGE_NO_IMAGE, $pInfo->products_name, SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT, 'align="right" hspace="5" vspace="5"') . $pInfo->products_description;
         } else {
           echo zen_image(DIR_WS_CATALOG_IMAGES . $products_image_name, $pInfo->products_name, SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT, 'align="right" hspace="5" vspace="5"') . $pInfo->products_description;

--- a/admin/includes/modules/product/preview_info.php
+++ b/admin/includes/modules/product/preview_info.php
@@ -32,6 +32,9 @@ if (zen_not_null($_POST)) {
 
   $pInfo = new objectInfo($product->fields);
   $products_image_name = $pInfo->products_image;
+  $products_name = $pInfo->products_name;
+  $products_description = $pInfo->products_description;
+  $products_url = $pInfo->products_url;
 }
 
 $form_action = (isset($_GET['pID'])) ? 'update_product' : 'insert_product';
@@ -76,11 +79,11 @@ $form_action = (isset($_GET['pID'])) ? 'update_product' : 'insert_product';
     <div class="row">
         <?php
 //auto replace with defined missing image
-        if ($_POST['products_image_manual'] != '') {
+        if (isset($_POST['products_image_manual']) && $_POST['products_image_manual'] != '') {
           $products_image_name = $_POST['img_dir'] . $_POST['products_image_manual'];
           $pInfo->products_name = $products_image_name;
         }
-        if ($_POST['image_delete'] == 1 || $products_image_name == '' && PRODUCTS_IMAGE_NO_IMAGE_STATUS == '1') {
+        if (isset($_POST['image_delete']) && $_POST['image_delete'] == 1 || $products_image_name == '' && PRODUCTS_IMAGE_NO_IMAGE_STATUS == '1') {
           echo zen_image(DIR_WS_CATALOG_IMAGES . PRODUCTS_IMAGE_NO_IMAGE, $pInfo->products_name, SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT, 'align="right" hspace="5" vspace="5"') . $pInfo->products_description;
         } else {
           echo zen_image(DIR_WS_CATALOG_IMAGES . $products_image_name, $pInfo->products_name, SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT, 'align="right" hspace="5" vspace="5"') . $pInfo->products_description;

--- a/admin/includes/modules/product_free_shipping/preview_info.php
+++ b/admin/includes/modules/product_free_shipping/preview_info.php
@@ -32,6 +32,9 @@ if (zen_not_null($_POST)) {
 
   $pInfo = new objectInfo($product->fields);
   $products_image_name = $pInfo->products_image;
+  $products_name = $pInfo->products_name;
+  $products_description = $pInfo->products_description;
+  $products_url = $pInfo->products_url;
 }
 
 $form_action = (isset($_GET['pID'])) ? 'update_product' : 'insert_product';
@@ -76,11 +79,11 @@ $form_action = (isset($_GET['pID'])) ? 'update_product' : 'insert_product';
     <div class="row">
         <?php
 //auto replace with defined missing image
-        if ($_POST['products_image_manual'] != '') {
+        if (isset($_POST['products_image_manual']) && $_POST['products_image_manual'] != '') {
           $products_image_name = $_POST['img_dir'] . $_POST['products_image_manual'];
           $pInfo->products_name = $products_image_name;
         }
-        if ($_POST['image_delete'] == 1 || $products_image_name == '' && PRODUCTS_IMAGE_NO_IMAGE_STATUS == '1') {
+        if (isset($_POST['image_delete']) && $_POST['image_delete'] == 1 || $products_image_name == '' && PRODUCTS_IMAGE_NO_IMAGE_STATUS == '1') {
           echo zen_image(DIR_WS_CATALOG_IMAGES . PRODUCTS_IMAGE_NO_IMAGE, $pInfo->products_name, SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT, 'align="right" hspace="5" vspace="5"') . $pInfo->products_description;
         } else {
           echo zen_image(DIR_WS_CATALOG_IMAGES . $products_image_name, $pInfo->products_name, SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT, 'align="right" hspace="5" vspace="5"') . $pInfo->products_description;

--- a/admin/includes/modules/product_music/preview_info.php
+++ b/admin/includes/modules/product_music/preview_info.php
@@ -32,6 +32,9 @@ if (zen_not_null($_POST)) {
 
   $pInfo = new objectInfo($product->fields);
   $products_image_name = $pInfo->products_image;
+  $products_name = $pInfo->products_name;
+  $products_description = $pInfo->products_description;
+  $products_url = $pInfo->products_url;
 }
 
 $form_action = (isset($_GET['pID'])) ? 'update_product' : 'insert_product';
@@ -75,11 +78,11 @@ $form_action = (isset($_GET['pID'])) ? 'update_product' : 'insert_product';
     <div class="row">
         <?php
 //auto replace with defined missing image
-        if ($_POST['products_image_manual'] != '') {
+        if (isset($_POST['products_image_manual']) && $_POST['products_image_manual'] != '') {
           $products_image_name = $_POST['img_dir'] . $_POST['products_image_manual'];
           $pInfo->products_name = $products_image_name;
         }
-        if ($_POST['image_delete'] == 1 || $products_image_name == '' && PRODUCTS_IMAGE_NO_IMAGE_STATUS == '1') {
+        if (isset($_POST['image_delete']) && $_POST['image_delete'] == 1 || $products_image_name == '' && PRODUCTS_IMAGE_NO_IMAGE_STATUS == '1') {
           echo zen_image(DIR_WS_CATALOG_IMAGES . PRODUCTS_IMAGE_NO_IMAGE, $pInfo->products_name, SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT, 'align="right" hspace="5" vspace="5"') . $pInfo->products_description;
         } else {
           echo zen_image(DIR_WS_CATALOG_IMAGES . $products_image_name, $pInfo->products_name, SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT, 'align="right" hspace="5" vspace="5"') . $pInfo->products_description;


### PR DESCRIPTION
If a preview_info page url was provided by itself, there is no
data posted and variables beyond it are accessed, but not set.

This sets those variables and provides control to prevent
notifications while in strict PHP mode.