### PR TITLE
Correct upload warning when no file uploaded

### DIFF
--- a/includes/classes/upload.php
+++ b/includes/classes/upload.php
@@ -79,7 +79,7 @@ class upload extends base
                 'name'     => (isset($GLOBALS[$this->file . '_name']) ? $GLOBALS[$this->file . '_name'] : ''),
                 'type'     => (isset($GLOBALS[$this->file . '_type']) ? $GLOBALS[$this->file . '_type'] : ''),
                 'size'     => (isset($GLOBALS[$this->file . '_size']) ? $GLOBALS[$this->file . '_size'] : ''),
-                'tmp_name' => (isset($GLOBALS[$this->file]) ? $GLOBALS[$this->file] : ''),
+                'tmp_name' => (isset($GLOBALS[$this->file]) && isset($GLOBALS[$this->file]->filename) && zen_not_null($GLOBALS[$this->file]->filename) ? $GLOBALS[$this->file]->filename : ''),
             );
         }
         if (!zen_not_null($file['tmp_name'])) return false;

--- a/includes/classes/upload.php
+++ b/includes/classes/upload.php
@@ -58,30 +58,25 @@ class upload extends base
      */
     function parse($key = '')
     {
-        if (isset($_FILES[$this->file])) {
-            if (zen_not_null($key)) {
-                $file = array(
-                    'name'     => $_FILES[$this->file]['name'][$key],
-                    'type'     => $_FILES[$this->file]['type'][$key],
-                    'size'     => $_FILES[$this->file]['size'][$key],
-                    'tmp_name' => $_FILES[$this->file]['tmp_name'][$key],
-                );
-            } else {
-                $file = array(
-                    'name'     => $_FILES[$this->file]['name'],
-                    'type'     => $_FILES[$this->file]['type'],
-                    'size'     => $_FILES[$this->file]['size'],
-                    'tmp_name' => $_FILES[$this->file]['tmp_name'],
-                );
-            }
+        if (empty($_FILES[$this->file])) {
+            return false;
+        }
+        if (zen_not_null($key)) {
+            $file = array(
+                'name'     => $_FILES[$this->file]['name'][$key],
+                'type'     => $_FILES[$this->file]['type'][$key],
+                'size'     => $_FILES[$this->file]['size'][$key],
+                'tmp_name' => $_FILES[$this->file]['tmp_name'][$key],
+            );
         } else {
             $file = array(
-                'name'     => (isset($GLOBALS[$this->file . '_name']) ? $GLOBALS[$this->file . '_name'] : ''),
-                'type'     => (isset($GLOBALS[$this->file . '_type']) ? $GLOBALS[$this->file . '_type'] : ''),
-                'size'     => (isset($GLOBALS[$this->file . '_size']) ? $GLOBALS[$this->file . '_size'] : ''),
-                'tmp_name' => (isset($GLOBALS[$this->file]) && isset($GLOBALS[$this->file]->filename) && zen_not_null($GLOBALS[$this->file]->filename) ? $GLOBALS[$this->file]->filename : ''),
+                'name'     => $_FILES[$this->file]['name'],
+                'type'     => $_FILES[$this->file]['type'],
+                'size'     => $_FILES[$this->file]['size'],
+                'tmp_name' => $_FILES[$this->file]['tmp_name'],
             );
         }
+
         if (!zen_not_null($file['tmp_name'])) return false;
         //if ($file['tmp_name'] == 'none') return false;
         //if (!is_uploaded_file($file['tmp_name'])) return false;


### PR DESCRIPTION
Found a log being generated if attempt to access a page that would
normally be the one just after an upload, but where it was
landed at without posting data.  As a result, this patch
appears to resolve the logged messages and would assign a
value if one existed.

Example to reproduce would be something like accessing:
admin/product.php?cPath=4&pID=1&action=new_product_preview