### PR TITLE
Cheapest method of shipping class should move to next method when method has no quotes

### DIFF
--- a/includes/classes/shipping.php
+++ b/includes/classes/shipping.php
@@ -184,7 +184,7 @@ class shipping extends base {
         if (isset($GLOBALS[$class]) && is_object($GLOBALS[$class]) && $GLOBALS[$class]->enabled) {
           $quotes = $GLOBALS[$class]->quotes;
           if (empty($quotes['methods'])) {
-            break;
+            continue;
           }
           $size = sizeof($quotes['methods']);
           for ($i=0; $i<$size; $i++) {


### PR DESCRIPTION
In #2078 and then in #2104, an evaluation was added to prevent further processing of the current shipping method if that method did not provide quotes when determining method offering the cheapest rate.  The initial solution exited the `cheapest` method without allowing the class method to evaluate any valid collected data. 

I then, without recognizing that the action response of leaving the `foreach` by *any* method would prevent further shipping module processing, suggested a `break` so that at least the remaining code would be processed.  Considering that the goal of the `cheapest` method is to provide a result based on all available methods and with a lot of additional work outside of the method the result could be obtained, operating the method in this way is sub-optimal.

This commit, in light of seeing the cleanup of the pulls and potentially in preparation of another sub-release is being offered to try to implement the intended fix of continuing to process the remaining methods if the current method has no quotes.