### PR TITLE
v156 Build language dependent variables when preview_info URI entered

### DIFF
--- a/admin/includes/modules/document_general/preview_info.php
+++ b/admin/includes/modules/document_general/preview_info.php
@@ -32,9 +32,12 @@ if (zen_not_null($_POST)) {
 
   $pInfo = new objectInfo($product->fields);
   $products_image_name = $pInfo->products_image;
-  $products_name = $pInfo->products_name;
-  $products_description = $pInfo->products_description;
-  $products_url = $pInfo->products_url;
+
+  foreach($product as $prod) {
+    $products_name[$prod['language_id']] = $prod['products_name'];
+    $products_description[$prod['language_id']] = $prod['products_description'];
+    $products_url[$prod['language_id']] = $prod['products_url'];
+  }
 }
 
 $form_action = (isset($_GET['pID'])) ? 'update_product' : 'insert_product';

--- a/admin/includes/modules/document_product/preview_info.php
+++ b/admin/includes/modules/document_product/preview_info.php
@@ -32,9 +32,12 @@ if (zen_not_null($_POST)) {
 
   $pInfo = new objectInfo($product->fields);
   $products_image_name = $pInfo->products_image;
-  $products_name = $pInfo->products_name;
-  $products_description = $pInfo->products_description;
-  $products_url = $pInfo->products_url;
+
+  foreach($product as $prod) {
+    $products_name[$prod['language_id']] = $prod['products_name'];
+    $products_description[$prod['language_id']] = $prod['products_description'];
+    $products_url[$prod['language_id']] = $prod['products_url'];
+  }
 }
 
 $form_action = (isset($_GET['pID'])) ? 'update_product' : 'insert_product';

--- a/admin/includes/modules/product/preview_info.php
+++ b/admin/includes/modules/product/preview_info.php
@@ -32,9 +32,12 @@ if (zen_not_null($_POST)) {
 
   $pInfo = new objectInfo($product->fields);
   $products_image_name = $pInfo->products_image;
-  $products_name = $pInfo->products_name;
-  $products_description = $pInfo->products_description;
-  $products_url = $pInfo->products_url;
+
+  foreach($product as $prod) {
+    $products_name[$prod['language_id']] = $prod['products_name'];
+    $products_description[$prod['language_id']] = $prod['products_description'];
+    $products_url[$prod['language_id']] = $prod['products_url'];
+  }
 }
 
 $form_action = (isset($_GET['pID'])) ? 'update_product' : 'insert_product';

--- a/admin/includes/modules/product_free_shipping/preview_info.php
+++ b/admin/includes/modules/product_free_shipping/preview_info.php
@@ -32,9 +32,12 @@ if (zen_not_null($_POST)) {
 
   $pInfo = new objectInfo($product->fields);
   $products_image_name = $pInfo->products_image;
-  $products_name = $pInfo->products_name;
-  $products_description = $pInfo->products_description;
-  $products_url = $pInfo->products_url;
+
+  foreach($product as $prod) {
+    $products_name[$prod['language_id']] = $prod['products_name'];
+    $products_description[$prod['language_id']] = $prod['products_description'];
+    $products_url[$prod['language_id']] = $prod['products_url'];
+  }
 }
 
 $form_action = (isset($_GET['pID'])) ? 'update_product' : 'insert_product';

--- a/admin/includes/modules/product_music/preview_info.php
+++ b/admin/includes/modules/product_music/preview_info.php
@@ -32,9 +32,12 @@ if (zen_not_null($_POST)) {
 
   $pInfo = new objectInfo($product->fields);
   $products_image_name = $pInfo->products_image;
-  $products_name = $pInfo->products_name;
-  $products_description = $pInfo->products_description;
-  $products_url = $pInfo->products_url;
+
+  foreach($product as $prod) {
+    $products_name[$prod['language_id']] = $prod['products_name'];
+    $products_description[$prod['language_id']] = $prod['products_description'];
+    $products_url[$prod['language_id']] = $prod['products_url'];
+  }
 }
 
 $form_action = (isset($_GET['pID'])) ? 'update_product' : 'insert_product';


### PR DESCRIPTION
Previous correction applied initiated the concept of building the expected language dependent variables; however, did not incorporate the `language_id` into the variable and therefore an array was not created.  This provides the array needed to continue processing and show the information that existed about the product when it was accessed directly.