### PR TITLE
Support deleting customer_basket related info with attributes.

### DIFF
--- a/zc_install/sql/updates/mysql_upgrade_zencart_156.sql
+++ b/zc_install/sql/updates/mysql_upgrade_zencart_156.sql
@@ -114,11 +114,11 @@ ALTER TABLE orders_status_history ADD updated_by varchar(45) NOT NULL default ''
 
 # Clean up expired prids from baskets
 #NEXT_X_ROWS_AS_ONE_COMMAND:3
-DELETE FROM customers_basket WHERE CAST(products_id AS unsigned) NOT IN (
+DELETE FROM customers_basket WHERE CAST(SUBSTRING_INDEX(products_id, ":", 1) AS unsigned) NOT IN (
 SELECT products_id
 FROM products WHERE products_status > 0);
 #NEXT_X_ROWS_AS_ONE_COMMAND:3
-DELETE FROM customers_basket_attributes WHERE CAST(products_id AS unsigned) NOT IN (
+DELETE FROM customers_basket_attributes WHERE CAST(SUBSTRING_INDEX(products_id, ":", 1) AS unsigned) NOT IN (
 SELECT products_id
 FROM products WHERE products_status > 0);
 


### PR DESCRIPTION
Identified by PanZC2020 at: https://www.zen-cart.com/showthread.php?224986-Update-SQL-error-on-customers_basket-table&p=1354071#post1354071

Inhibits update from completing because casting a string that
starts with a number appears to throw an error as described
in the referenced thread.

This supports pulling the number of the products_id if it is
stored with a colon (:) in it by retrieving everything to the left
of the colon or the entire string if a colon is not present.