### PR TITLE
Return the company name to address layouts

### DIFF
--- a/includes/functions/functions_customers.php
+++ b/includes/functions/functions_customers.php
@@ -83,8 +83,8 @@ function zen_address_format($address_format_id = 1, $incoming = array(), $html =
     // do the substitutions
     $address_out = str_replace(array_keys($address), array_values($address), $fmt);
 
-    if (ACCOUNT_COMPANY == 'true' && !empty($address['company']) && false === strpos($fmt, '$company')) {
-        $address_out = $address['company'] . $address['cr'] . $address_out;
+    if (ACCOUNT_COMPANY == 'true' && !empty($address['$company']) && false === strpos($fmt, '$company')) {
+        $address_out = $address['$company'] . $address['$cr'] . $address_out;
     }
 
     // -----


### PR DESCRIPTION
Identified in https://www.zen-cart.com/showthread.php?224980-Customer-company-name-not-showing-up-on-Edit-Invoice-or-Packing-Slip-pages
the company name was not appearing wherever zen_address_format
was used.  This fixes that issue.