### PR TITLE
Direct Details button to product's category product listing

### DIFF
--- a/admin/products_to_categories.php
+++ b/admin/products_to_categories.php
@@ -755,7 +755,7 @@ $products_list = $db->Execute("SELECT products_id, categories_id
                       $contents[] = array('align' => 'center', 'text' =>
                         '<a href="' . zen_href_link(FILENAME_ATTRIBUTES_CONTROLLER, 'products_filter=' . $products_filter . '&current_category_id=' . $current_category_id) . '" class="btn btn-info" role="button">' . IMAGE_EDIT_ATTRIBUTES . '</a>&nbsp;&nbsp;' .
                         '<a href="' . zen_href_link(FILENAME_PRODUCTS_PRICE_MANAGER, '&products_filter=' . $products_filter . '&current_category_id=' . $current_category_id) . '" class="btn btn-info" role="button">' . IMAGE_PRODUCTS_PRICE_MANAGER . '</a><br /><br />' .
-                        '<a href="' . zen_href_link(FILENAME_PRODUCT, 'cPath=' . zen_get_parent_category_id($products_filter) . '&pID=' . $products_filter . '&product_type=' . zen_get_products_type($products_filter)) . '" class="btn btn-info" role="button">' . IMAGE_DETAILS . '</a>&nbsp;&nbsp;' .
+                        '<a href="' . zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING, 'cPath=' . zen_get_parent_category_id($products_filter) . '&pID=' . $products_filter) . '" class="btn btn-info" role="button">' . IMAGE_DETAILS . '</a>&nbsp;&nbsp;' .
                         '<a href="' . zen_href_link(FILENAME_PRODUCT, 'action=new_product' . '&cPath=' . zen_get_parent_category_id($products_filter) . '&pID=' . $products_filter . '&product_type=' . zen_get_products_type($products_filter)) . '" class="btn btn-info" role="button">' . IMAGE_EDIT_PRODUCT . '</a>'
                       );
                       break;


### PR DESCRIPTION
Correct one mistake made in #1604 of the 7,700 additions and 10,077 removals.

Returns the admin user to the category list showing the product in question.  If the product is in the first page then the entire category is displayed with the product in the list, if the product is in a subsequent page, then just the product is displayed. (Separate issue?)