### PR TITLE
v156 Remove action=save from uri after saved

### DIFF
--- a/admin/template_select.php
+++ b/admin/template_select.php
@@ -55,6 +55,7 @@ if (zen_not_null($action)) {
       $sql = $db->bindVars($sql, ':tpl:', $_POST['ln'], 'string');
       $sql = $db->bindVars($sql, ':id:', $_GET['tID'], 'integer');
       $db->Execute($sql);
+      zen_redirect(zen_href_link(FILENAME_TEMPLATE_SELECT, zen_get_all_get_params(array('action'))));
       break;
     case 'deleteconfirm':
       $check_query = $db->Execute("SELECT template_language


### PR DESCRIPTION
Discussed in issue #2118.  This removes the action from the URI once the database has been updated to prevent restoring from a timeout where the parameter `action=save` was on the uri for `template_select.php`.