### PR TITLE
156: Add missing double quote at the end of a class

### DIFF
--- a/admin/banner_manager.php
+++ b/admin/banner_manager.php
@@ -364,7 +364,7 @@ if (zen_not_null($action)) {
           <div class="form-group">
               <?php echo zen_draw_label(TEXT_BANNERS_IMAGE_TARGET, 'banners_image_target', 'class="col-sm-3 control-label"'); ?>
             <div class="col-sm-9 col-md-6">
-                <?php echo zen_draw_input_field('banners_image_target', '', 'class="form-control'); ?>
+                <?php echo zen_draw_input_field('banners_image_target', '', 'class="form-control"'); ?>
               <span class="help-block"><?php echo DIR_FS_CATALOG_IMAGES; ?></span>
               <div>
                   <?php echo TEXT_BANNER_IMAGE_TARGET_INFO; ?>


### PR DESCRIPTION
As reported in the forum https://www.zen-cart.com/showthread.php?225007-156a-admin-banner-manager-missing-quote-in-parameter&p=1354230#post1354230

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zencart/zencart/2123)
<!-- Reviewable:end -->
