### PR TITLE
v156: Fix missing reviews parameter in $cInfo object

### DIFF
--- a/admin/customers.php
+++ b/admin/customers.php
@@ -428,7 +428,12 @@ if (zen_not_null($action)) {
                                  WHERE a.customers_id = c.customers_id
                                  AND c.customers_id = " . (int)$customers_id);
 
-      $cInfo = new objectInfo($customers->fields);
+      $reviews = $db->Execute("SELECT COUNT(*) AS number_of_reviews
+                               FROM " . TABLE_REVIEWS . "
+                               WHERE customers_id = " . (int)$customers_id);
+
+      $cInfo_array = array_merge($customers->fields, $reviews->fields);
+      $cInfo = new objectInfo($cInfo_array);
   }
 }
 ?>

--- a/zc_install/sql/demo/mysql_demo.sql
+++ b/zc_install/sql/demo/mysql_demo.sql
@@ -1501,7 +1501,7 @@ INSERT INTO record_company_info (record_company_id, languages_id, record_company
 # Dumping data for table `reviews`
 #
 
-INSERT INTO reviews (reviews_id, products_id, customers_id, customers_name, reviews_rating, date_added, last_modified, reviews_read, status) VALUES (1, 19, 0, 'Bill Smith', 5, '2003-12-23 03:18:19', '0001-01-01 00:00:00', 11, 1);
+INSERT INTO reviews (reviews_id, products_id, customers_id, customers_name, reviews_rating, date_added, last_modified, reviews_read, status) VALUES (1, 19, 1, 'Bill Smith', 5, '2003-12-23 03:18:19', '0001-01-01 00:00:00', 11, 1);
 
 #
 # Dumping data for table `reviews_description`


### PR DESCRIPTION
As mentioned in forum thread https://www.zen-cart.com/showthread.php?225009-v156a-Customers-function-trouble-and-mysql_demo-sql-has-wrong-data&p=1354237#post1354237

I am not sure if we should add an updates sql for updates of zen cart, as this might add more problems then it fixes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zencart/zencart/2124)
<!-- Reviewable:end -->
