### PR TITLE
Correct logic mistake of PR 2093

### DIFF
--- a/admin/products_price_manager.php
+++ b/admin/products_price_manager.php
@@ -107,13 +107,13 @@ if (zen_not_null($action)) {
         $master_categories_id = $_POST['master_categories_id'];
       }
 
-      $products_date_available = ((zen_db_prepare_input($_POST['product_start']) == '') ? '0001-01-01' : zen_date_raw($_POST['product_start']));
+      $products_date_available = ((!isset($_POST['product_start']) || zen_db_prepare_input($_POST['product_start']) == '') ? '0001-01-01' : zen_date_raw($_POST['product_start']));
 
-      $specials_date_available = ((zen_db_prepare_input($_POST['special_start']) == '') ? '0001-01-01' : zen_date_raw($_POST['special_start']));
-      $specials_expires_date = ((zen_db_prepare_input($_POST['special_end']) == '') ? '0001-01-01' : zen_date_raw($_POST['special_end']));
+      $specials_date_available = ((!isset($_POST['special_start']) || zen_db_prepare_input($_POST['special_start']) == '') ? '0001-01-01' : zen_date_raw($_POST['special_start']));
+      $specials_expires_date = ((!isset($_POST['special_end']) || zen_db_prepare_input($_POST['special_end']) == '') ? '0001-01-01' : zen_date_raw($_POST['special_end']));
 
-      $featured_date_available = ((isset($_POST['featured_start']) && zen_db_prepare_input($_POST['featured_start']) == '') ? '0001-01-01' : zen_date_raw($_POST['featured_start']));
-      $featured_expires_date = ((isset($_POST['featured_end']) && zen_db_prepare_input($_POST['featured_end']) == '') ? '0001-01-01' : zen_date_raw($_POST['featured_end']));
+      $featured_date_available = ((!isset($_POST['featured_start']) || zen_db_prepare_input($_POST['featured_start']) == '') ? '0001-01-01' : zen_date_raw($_POST['featured_start']));
+      $featured_expires_date = ((!isset($_POST['featured_end']) || zen_db_prepare_input($_POST['featured_end']) == '') ? '0001-01-01' : zen_date_raw($_POST['featured_end']));
 
       $tmp_value = (isset($_POST['products_price_sorter']) ? zen_db_prepare_input($_POST['products_price_sorter']) : '');
       $products_price_sorter = (!zen_not_null($tmp_value) || $tmp_value == '' || $tmp_value == 0) ? 0 : $tmp_value;


### PR DESCRIPTION
In PR #2093, an `isset` was added to attempt to address strict notifications; however, the logic used in this area seems to be reversed in comparison to some other date related comparisons.  As a result, the added logic works in reverse as desired.  This pull sets the date to `'0001-01-01'` if the data is not posted or if it is posted and has no value in it.  If there is something of value posted, then that date will be processed.