### PR TITLE
v156 Search header sidebox strict notice

### DIFF
--- a/includes/modules/sideboxes/search_header.php
+++ b/includes/modules/sideboxes/search_header.php
@@ -1,27 +1,26 @@
 <?php
 /**
  * search_header ("sidebox") - this is a search field that appears in the navigation header
- * (it's not really a "sidebox" per se.
+ * (it's not really a "sidebox" per se).
  *
  * @package templateSystem
- * @copyright Copyright 2003-2005 Zen Cart Development Team
+ * @copyright Copyright 2003-2019 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: search_header.php 2834 2006-01-11 22:16:37Z birdbrain $
+ * @version $Id: search_header.php 2834 2019-01-28 22:16:37Z modified v1.5.6b $
  */
 
-  $search_header_status = $db->Execute("select layout_box_name from " . TABLE_LAYOUT_BOXES . " where (layout_box_status=1 or layout_box_status_single=1) and layout_template ='" . $template_dir . "' and layout_box_name='search_header.php'");
+$search_header_status = $db->Execute("SELECT layout_box_name FROM " . TABLE_LAYOUT_BOXES . " WHERE (layout_box_status=1 OR layout_box_status_single=1) AND layout_template ='" . $template_dir . "' AND layout_box_name='search_header.php'");
 
-  if ($search_header_status->RecordCount() != 0) {
+if ($search_header_status->RecordCount() != 0) {
     $show_search_header= true;
-  }
+}
 
-  if ($show_search_header == true) {
+if (!empty($show_search_header)) {
 
-    require($template->get_template_dir('tpl_search_header.php',DIR_WS_TEMPLATE, $current_page_base,'sideboxes'). '/tpl_search_header.php');
+    require $template->get_template_dir('tpl_search_header.php', DIR_WS_TEMPLATE, $current_page_base, 'sideboxes'). '/tpl_search_header.php';
 
     $title = '<label>' . BOX_HEADING_SEARCH . '</label>';
     $title_link = false;
-    require($template->get_template_dir('tpl_box_header.php',DIR_WS_TEMPLATE, $current_page_base,'common'). '/tpl_box_header.php');
-  }
-?>
+    require $template->get_template_dir('tpl_box_header.php', DIR_WS_TEMPLATE, $current_page_base, 'common') . '/tpl_box_header.php';
+}


### PR DESCRIPTION
Removes the strict notification associated with loading the sidebox and $show_search_header not being set (yet). Replaced a loose verification against equaling `true` with `!empty`.

Also refactored the file while I was here:
- Removed the closing php tag.
- Removed the parentheses around require.
- Separated parameters in the calling functions so that one space was after a comma with no space before the comma.
- Changed the capitalization of the SQL text to capitalize SQL commands/key words.