### PR TITLE
initialize some vars in preview_info pages

### DIFF
--- a/admin/includes/modules/document_general/preview_info.php
+++ b/admin/includes/modules/document_general/preview_info.php
@@ -10,6 +10,10 @@ if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
 }
 $languages = zen_get_languages();
+if (empty($products_description)) $products_description = [];
+if (empty($products_name)) $products_name = [];
+if (empty($products_url)) $products_url = [];
+
 if (zen_not_null($_POST)) {
   $pInfo = new objectInfo($_POST);
   $products_name = $_POST['products_name'];

--- a/admin/includes/modules/document_product/preview_info.php
+++ b/admin/includes/modules/document_product/preview_info.php
@@ -10,6 +10,10 @@ if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
 }
 $languages = zen_get_languages();
+if (empty($products_description)) $products_description = [];
+if (empty($products_name)) $products_name = [];
+if (empty($products_url)) $products_url = [];
+
 if (zen_not_null($_POST)) {
   $pInfo = new objectInfo($_POST);
   $products_name = $_POST['products_name'];

--- a/admin/includes/modules/product/preview_info.php
+++ b/admin/includes/modules/product/preview_info.php
@@ -10,6 +10,10 @@ if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
 }
 $languages = zen_get_languages();
+if (empty($products_description)) $products_description = [];
+if (empty($products_name)) $products_name = [];
+if (empty($products_url)) $products_url = [];
+
 if (zen_not_null($_POST)) {
   $pInfo = new objectInfo($_POST);
   $products_name = $_POST['products_name'];

--- a/admin/includes/modules/product_free_shipping/preview_info.php
+++ b/admin/includes/modules/product_free_shipping/preview_info.php
@@ -10,6 +10,10 @@ if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
 }
 $languages = zen_get_languages();
+if (empty($products_description)) $products_description = [];
+if (empty($products_name)) $products_name = [];
+if (empty($products_url)) $products_url = [];
+
 if (zen_not_null($_POST)) {
   $pInfo = new objectInfo($_POST);
   $products_name = $_POST['products_name'];

--- a/admin/includes/modules/product_music/preview_info.php
+++ b/admin/includes/modules/product_music/preview_info.php
@@ -10,6 +10,10 @@ if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
 }
 $languages = zen_get_languages();
+if (empty($products_description)) $products_description = [];
+if (empty($products_name)) $products_name = [];
+if (empty($products_url)) $products_url = [];
+
 if (zen_not_null($_POST)) {
   $pInfo = new objectInfo($_POST);
   $products_name = $_POST['products_name'];


### PR DESCRIPTION
If the page is loaded without posting information, notifications
may get thrown for attempting to assign an array to an undefined
value, this pre-sets the items allowing the values to have
some pre-existing value to carry through if present otherwise
to assign to an empty array.