### PR TITLE
Fix a strict php notice in zc_install

### DIFF
--- a/zc_install/includes/template/templates/index_default.php
+++ b/zc_install/includes/template/templates/index_default.php
@@ -74,6 +74,7 @@ $adjustWarnIssues = false;
 </div>
 <?php } ?>
 <?php if ($hasWarnErrors) { ?>
+    <?php if (empty($errorHeadingFlag)) $errorHeadingFlag = false; ?>
     <?php foreach ($listWarnErrors as $error) { ?>
         <?php if (strpos($error['mainErrorText'], 'PRO TIP:') === false) { ?>
             <?php $errorHeadingFlag = true; ?>


### PR DESCRIPTION
This was identified by PanZC2020 at the following forum thread:
https://www.zen-cart.com/showthread.php?225023-Undefined-variable-errorHeadingFlag&p=1354326#post1354326

This commit incorporates my interpretation of how to address the
issue.