### PR TITLE
156: Admin specials - Using pre add results in error

### DIFF
--- a/admin/specials.php
+++ b/admin/specials.php
@@ -165,7 +165,7 @@ if (zen_not_null($action)) {
       $expires_date = ((zen_db_prepare_input($_POST['end']) == '') ? '0001-01-01' : zen_date_raw($_POST['end']));
 
       $products_id = zen_db_prepare_input($_POST['pre_add_products_id']);
-      $db->Execute("INSERT INTO " . TABLE_SPECIALS . " (products_id specials_date_added, expires_date, status, specials_date_available)
+      $db->Execute("INSERT INTO " . TABLE_SPECIALS . " (products_id, specials_date_added, expires_date, status, specials_date_available)
                     VALUES ('" . (int)$products_id . "',
                             now(),
                             '" . zen_db_input($expires_date) . "',

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -165,9 +165,8 @@ if (zen_not_null($action)) {
       $expires_date = ((zen_db_prepare_input($_POST['end']) == '') ? '0001-01-01' : zen_date_raw($_POST['end']));
 
       $products_id = zen_db_prepare_input($_POST['pre_add_products_id']);
-      $db->Execute("INSERT INTO " . TABLE_SPECIALS . " (products_id, specials_new_products_price, specials_date_added, expires_date, status, specials_date_available)
+      $db->Execute("INSERT INTO " . TABLE_SPECIALS . " (products_id specials_date_added, expires_date, status, specials_date_available)
                     VALUES ('" . (int)$products_id . "',
-                            '" . zen_db_input($specials_price) . "',
                             now(),
                             '" . zen_db_input($expires_date) . "',
                             '1',


### PR DESCRIPTION
Funny this never was reported, but when using the pre add feature, the $specials_price variable is never set. This results in a database error because $specials_price is not a proper decimal.
Removing the variable will result in sql using the default value for the field (0.0000)., and thus continuing to the next page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zencart/zencart/2159)
<!-- Reviewable:end -->
