### PR TITLE
Accidental assignment in a condition $new_price =

### DIFF
--- a/includes/modules/pages/product_free_shipping_info/main_template_vars.php
+++ b/includes/modules/pages/product_free_shipping_info/main_template_vars.php
@@ -61,7 +61,7 @@
 
     $manufacturers_name= zen_get_products_manufacturers_name((int)$_GET['products_id']);
 
-    if ($new_price = zen_get_products_special_price($product_info->fields['products_id'])) {
+    if ($new_price == zen_get_products_special_price($product_info->fields['products_id'])) {
 
       $specials_price = $currencies->display_price($new_price,
                         zen_get_tax_rate($product_info->fields['products_tax_class_id']));


### PR DESCRIPTION
Most of the main_template_vars.php files are like this. I believe it's a mistake ?
