### PR TITLE
Substitute a constant for hard code in dealing with dates.

### DIFF
--- a/admin/index_dashboard.php
+++ b/admin/index_dashboard.php
@@ -412,8 +412,8 @@ foreach ($whos_online as $session) {
 
         $ds = $dsc = $ys = $ysc = $msc = 0;
 
-        $now = date("d/m/Y");
-        $yesterday = date("d/m/Y", strtotime('-1 days'));
+        $now = date(DATE_FORMAT);
+        $yesterday = date(DATE_FORMAT, strtotime('-1 days'));
 
         foreach ($orders as $order) {
 


### PR DESCRIPTION
Can't seem to find the thread; however, there was a report that
when dates were modified to support a different "location" this
caused data to be incorrectly displayed on the index_dashboard.

This modification ensures alignment between the dates used to
compare and determine what to display.