### PR TITLE
Strict error with coupon lookup

### DIFF
--- a/includes/functions/functions_gvcoupons.php
+++ b/includes/functions/functions_gvcoupons.php
@@ -110,7 +110,7 @@
     $result = $db->Execute($sql);
 
     // check whether coupon has been flagged for not valid with sales
-    if ($result->fields['coupon_is_valid_for_sales']) {
+    if (!empty($result->fields['coupon_is_valid_for_sales'])) {
       return true;
     }
 


### PR DESCRIPTION
If no data is in the table then it is possible that no field
answer is provided which throws a notice.