### PR TITLE
Correct PHP notices, extra orders email to

### DIFF
--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -1132,8 +1132,10 @@ class order extends base {
       $html_msg['EXTRA_INFO'] = $extra_info['HTML'];
 
       // include authcode and transaction id in admin-copy of email
-      if ($GLOBALS[$_SESSION['payment']]->auth_code || $GLOBALS[$_SESSION['payment']]->transaction_id) {
-        $pmt_details = ($GLOBALS[$_SESSION['payment']]->auth_code != '' ? 'AuthCode: ' . $GLOBALS[$_SESSION['payment']]->auth_code . '  ' : '') . ($GLOBALS[$_SESSION['payment']]->transaction_id != '' ?  'TransID: ' . $GLOBALS[$_SESSION['payment']]->transaction_id : '') . "\n\n";
+      $payment_auth_code = !empty($GLOBALS[$_SESSION['payment']]->auth_code) ? $GLOBALS[$_SESSION['payment']]->auth_code : '';
+      $payment_transaction_id = !empty($GLOBALS[$_SESSION['payment']]->transaction_id) ? $GLOBALS[$_SESSION['payment']]->transaction_id : '';
+      if ($payment_auth_code !== '' || $payment_transaction_id !== '') {
+        $pmt_details = ($payment_auth_code != '' ? 'AuthCode: ' . $payment_auth_code . '  ' : '') . ($payment_transaction_id != '' ?  'TransID: ' . $payment_transaction_id : '') . "\n\n";
         $email_order = $pmt_details . $email_order;
         $html_msg['EMAIL_TEXT_HEADER'] = nl2br($pmt_details) . $html_msg['EMAIL_TEXT_HEADER'];
       }


### PR DESCRIPTION
When the order's payment method doesn't supply an auto_code and/or transaction_id, PHP notices are logged when generating the order's "extra orders email" block:

```
--> PHP Notice: Undefined property: moneyorder::$auth_code in C:\xampp\htdocs\zc156posm\includes\classes\order.php on line 1135.
--> PHP Notice: Undefined property: moneyorder::$transaction_id in C:\xampp\htdocs\zc156posm\includes\classes\order.php on line 1135.
```