### PR TITLE
Correct order_total::credit_class notices

### DIFF
--- a/includes/classes/order_total.php
+++ b/includes/classes/order_total.php
@@ -207,7 +207,7 @@ class order_total extends base {
     if (MODULE_ORDER_TOTAL_INSTALLED) {
       foreach($this->modules as $value) {
         $class = substr($value, 0, strrpos($value, '.'));
-        if ( $GLOBALS[$class]->credit_class && method_exists($GLOBALS[$class], 'clear_posts')) {
+        if (!empty($GLOBALS[$class]->credit_class) && method_exists($GLOBALS[$class], 'clear_posts')) {
           $GLOBALS[$class]->clear_posts();
         }
       }

--- a/includes/modules/checkout_process.php
+++ b/includes/modules/checkout_process.php
@@ -107,7 +107,7 @@ if (isset($_SESSION['payment_attempt'])) unset($_SESSION['payment_attempt']);
   $ototal = $order_subtotal = $credits_applied = 0;
   for ($i=0, $n=sizeof($order_totals); $i<$n; $i++) {
     if ($order_totals[$i]['code'] == 'ot_subtotal') $order_subtotal = $order_totals[$i]['value'];
-    if (${$order_totals[$i]['code']}->credit_class == true) $credits_applied += $order_totals[$i]['value'];
+    if (!empty(${$order_totals[$i]['code']}->credit_class)) $credits_applied += $order_totals[$i]['value'];
     if ($order_totals[$i]['code'] == 'ot_total') $ototal = $order_totals[$i]['value'];
     if ($order_totals[$i]['code'] == 'ot_tax') $otax = $order_totals[$i]['value'];
     if ($order_totals[$i]['code'] == 'ot_shipping') $oshipping = $order_totals[$i]['value'];


### PR DESCRIPTION
During `checkout_process`, PHP notices are thrown for order-total modules that don't include a `credit_class` property:

```
--> PHP Notice: Undefined property: ot_subtotal::$credit_class in C:\xampp\htdocs\zc156posm\includes\modules\checkout_process.php on line 110.
--> PHP Notice: Undefined property: ot_subtotal::$credit_class in C:\xampp\htdocs\zc156posm\includes\classes\order_total.php on line 210.
```