### PR TITLE
Correct PHP Notice account-history-info (virtual)

### DIFF
--- a/includes/templates/template_default/templates/tpl_account_history_info_default.php
+++ b/includes/templates/template_default/templates/tpl_account_history_info_default.php
@@ -122,7 +122,7 @@ if (sizeof($statusArray)) {
 <hr />
 <div id="myAccountShipInfo" class="floatingBox back">
 <?php
-  if ($order->delivery != false) {
+  if (!empty($order->delivery['format_id'])) {
 ?>
 <h3><?php echo HEADING_DELIVERY_ADDRESS; ?></h3>
 <address><?php echo zen_address_format($order->delivery['format_id'], $order->delivery, 1, ' ', '<br />'); ?></address>


### PR DESCRIPTION
When a virtual order is displayed in the `account_history_info` page, the "Delivery Address" block is empty (except for the heading) and the following PHP Notice is logged:

```
#1  zen_address_format() called at [C:\xampp\htdocs\zc156posm\includes\templates\template_default\templates\tpl_account_history_info_default.php:128]
#2  require(C:\xampp\htdocs\zc156posm\includes\templates\template_default\templates\tpl_account_history_info_default.php) called at [C:\xampp\htdocs\zc156posm\includes\templates\vinos_rc\common\tpl_main_page.php:171]
#3  require(C:\xampp\htdocs\zc156posm\includes\templates\vinos_rc\common\tpl_main_page.php) called at [C:\xampp\htdocs\zc156posm\index.php:97]
--> PHP Notice: Undefined index: format in C:\xampp\htdocs\zc156posm\includes\functions\functions_customers.php on line 72.
```