### PR TITLE
ot_shipping::__construct, PHP Notice when shipping is free_free

### DIFF
--- a/includes/modules/order_total/ot_shipping.php
+++ b/includes/modules/order_total/ot_shipping.php
@@ -56,7 +56,7 @@
             $shipping_tax_description
         );
         
-        if ($external_shipping_tax_handler === true || $GLOBALS[$module]->tax_class > 0) {
+        if ($external_shipping_tax_handler === true || ($module !== 'free' && $GLOBALS[$module]->tax_class > 0)) {
           if ($external_shipping_tax_handler !== true) {
             if (!isset($GLOBALS[$module]->tax_basis)) {
               $shipping_tax_basis = STORE_SHIPPING_TAX_BASIS;


### PR DESCRIPTION
If the order's shipping is free (e.g. the order is virtual) there are a couple of PHP Notices logged since the **free** shipping-module has no instance:

```
--> PHP Notice: Undefined index: free in C:\xampp\htdocs\zc156posm\includes\modules\order_total\ot_shipping.php on line 59.
--> PHP Notice: Trying to get property of non-object in C:\xampp\htdocs\zc156posm\includes\modules\order_total\ot_shipping.php on line 59.
```