### PR TITLE
Correct checkout_new_address notices

### DIFF
--- a/includes/modules/checkout_new_address.php
+++ b/includes/modules/checkout_new_address.php
@@ -27,7 +27,7 @@ if (!defined('IS_ADMIN_FLAG')) {
 
 if (isset($_POST['action']) && ($_POST['action'] == 'submit')) {
   // process a new address
-  if (zen_not_null($_POST['firstname']) && zen_not_null($_POST['lastname']) && zen_not_null($_POST['street_address'])) {
+  if (!empty($_POST['firstname']) && !empty($_POST['lastname']) && !empty($_POST['street_address'])) {
     $process = true;
     if (ACCOUNT_GENDER == 'true') $gender = zen_db_prepare_input($_POST['gender']);
     if (ACCOUNT_COMPANY == 'true') $company = zen_db_prepare_input($_POST['company']);


### PR DESCRIPTION
If, during the checkout process, a customer chooses to change their shipping or billing address, selecting one of the addresses currently in their address book, a PHP Notice is generated since the new-address form has not been filled out:

```
[18-Mar-2019 08:14:05 America/New_York] PHP Notice:  Undefined index: firstname in C:\xampp\htdocs\zc156posm\includes\modules\checkout_new_address.php on line 30
```