### PR TITLE
paypalwpp: Allow address-creation to be bypassed

### DIFF
--- a/includes/modules/payment/paypalwpp.php
+++ b/includes/modules/payment/paypalwpp.php
@@ -2028,9 +2028,18 @@ if (false) { // disabled until clarification is received about coupons in PayPal
 
       // set the session value for express checkout temp
       $_SESSION['paypal_ec_temp'] = false;
+      
+      // -----
+      // Allow an observer to override the default address-creation processing.
+      //
+      $bypass_address_creation = false;
+      $this->notify('NOTIFY_PAYPALEXPRESS_BYPASS_ADDRESS_CREATION', $paypal_ec_payer_info, $bypass_address_creation);
+      if ($bypass_address_creation) {
+          $this->zcLog('ec_step2_finish - 2a, address-creation bypassed based on observer setting.');
+      }
 
-      // if no address required for shipping, leave shipping portion alone
-      if (strtoupper($_SESSION['paypal_ec_payer_info']['ship_address_status']) != 'NONE' && $_SESSION['paypal_ec_payer_info']['ship_street_1'] != '') {
+      // if no address required for shipping (or overriden by above), leave shipping portion alone
+      if (!$bypass_address_creation && strtoupper($_SESSION['paypal_ec_payer_info']['ship_address_status']) != 'NONE' && $_SESSION['paypal_ec_payer_info']['ship_street_1'] != '') {
         // set the session info for the sendto
         $_SESSION['sendto'] = $_SESSION['customer_default_address_id'];
 

--- a/includes/modules/payment/paypalwpp.php
+++ b/includes/modules/payment/paypalwpp.php
@@ -2035,7 +2035,7 @@ if (false) { // disabled until clarification is received about coupons in PayPal
       $bypass_address_creation = false;
       $this->notify('NOTIFY_PAYPALEXPRESS_BYPASS_ADDRESS_CREATION', $paypal_ec_payer_info, $bypass_address_creation);
       if ($bypass_address_creation) {
-          $this->zcLog('ec_step2_finish - 2a, address-creation bypassed based on observer setting.');
+          $this->zcLog('ec_step2_finish - 2a', 'address-creation bypassed based on observer setting.');
       }
 
       // if no address required for shipping (or overridden by above), leave shipping portion alone

--- a/includes/modules/payment/paypalwpp.php
+++ b/includes/modules/payment/paypalwpp.php
@@ -2038,7 +2038,7 @@ if (false) { // disabled until clarification is received about coupons in PayPal
           $this->zcLog('ec_step2_finish - 2a, address-creation bypassed based on observer setting.');
       }
 
-      // if no address required for shipping (or overriden by above), leave shipping portion alone
+      // if no address required for shipping (or overridden by above), leave shipping portion alone
       if (!$bypass_address_creation && strtoupper($_SESSION['paypal_ec_payer_info']['ship_address_status']) != 'NONE' && $_SESSION['paypal_ec_payer_info']['ship_street_1'] != '') {
         // set the session info for the sendto
         $_SESSION['sendto'] = $_SESSION['customer_default_address_id'];


### PR DESCRIPTION
The processing currently forces a creation of the shipping address returned from PayPal.  Add a notification to allow a plugin (e.g. One-Page Checkout) to bypass this processing.

This will allow interoperation with OPC when a customer has chosen to use a "temporary" address for their order's ship-to address.