### PR TITLE
Correct ot_shipping PHP notice

### DIFF
--- a/includes/modules/order_total/ot_shipping.php
+++ b/includes/modules/order_total/ot_shipping.php
@@ -23,6 +23,7 @@
       unset($_SESSION['shipping_tax_description']);
       $this->output = array();
       if (MODULE_ORDER_TOTAL_SHIPPING_FREE_SHIPPING == 'true') {
+        $pass = false;
         switch (MODULE_ORDER_TOTAL_SHIPPING_DESTINATION) {
           case 'national':
             if ($order->delivery['country_id'] == STORE_COUNTRY) $pass = true; break;


### PR DESCRIPTION
When a store has configured `ot_shipping` to provide free shipping on amounts over a certain value, a PHP Notice is thrown if neither of the 'national' or 'international' checks are found to be (bool)true.

```
PHP Notice:  Undefined variable: pass in C:\xampp\htdocs\zc156posm\includes\modules\order_total\ot_shipping.php on line 37
```
The correction is to initialize the value of `$pass` prior to the switch.