### PR TITLE
Fix PHP Warning in 7.2 with use of PAYPAL_DEV_MODE

### DIFF
--- a/includes/modules/payment/paypal/paypal_curl.php
+++ b/includes/modules/payment/paypal/paypal_curl.php
@@ -11,6 +11,7 @@
 /**
  * PayPal NVP (v124.0) and Payflow Pro (v4 HTTP API) implementation via cURL.
  */
+if (!defined('PAYPAL_DEV_MODE')) define('PAYPAL_DEV_MODE', 'false'); 
 class paypal_curl extends base {
 
   /**


### PR DESCRIPTION
--> PHP Warning: Use of undefined constant PAYPAL_DEV_MODE - assumed 'PAYPAL_DEV_MODE' (this will throw an Error in a future version of PHP) in /includes/modules/payment/paypal/paypal_curl.php on line 409.
