### PR TITLE
ZC 1.5.6 bug fix: Change to fix warning when $var_linklist is empty

### DIFF
--- a/includes/templates/responsive_classic/templates/tpl_modules_mobile_menu.php
+++ b/includes/templates/responsive_classic/templates/tpl_modules_mobile_menu.php
@@ -126,7 +126,7 @@ echo $menulist;
       <ul>
 <?php
   include(DIR_WS_MODULES . zen_get_module_directory('ezpages_bar_header.php'));
-  if (sizeof($var_linksList) >= 1) {
+  if (!empty($var_linksList)) {
     for ($i=1, $n=sizeof($var_linksList); $i<=$n; $i++) {
       echo '<li><a href="' . $var_linksList[$i]['link'] . '">' . $var_linksList[$i]['name'] . '</a></li>' . "\n";
     }


### PR DESCRIPTION
as reported on the forum
https://www.zen-cart.com/showthread.php?225343-myDEBUG-file-created-from-responsive-classic-template-(stock)&p=1356969#post1356969

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zencart/zencart/2285)
<!-- Reviewable:end -->
