### PR TITLE
v156 Shipping Estimator retain ship-to selection after cart edit

### DIFF
--- a/includes/modules/shipping_estimator.php
+++ b/includes/modules/shipping_estimator.php
@@ -55,6 +55,9 @@ if ($_SESSION['cart']->count_contents() > 0) {
     if (isset($_POST['address_id'])){
       // user changed address
       $sendto = $_POST['address_id'];
+    } else if (!empty($_SESSION['sendto'])) {
+      // user has previously selected a destination address
+      $sendto = $_SESSION['sendto'];
     }elseif (!empty($_SESSION['cart_address_id'])){
       // user once changed address
       $sendto = $_SESSION['cart_address_id'];
@@ -89,12 +92,12 @@ if ($_SESSION['cart']->count_contents() > 0) {
       //add state zone_id
       $_SESSION['cart_zone'] = $state_zone_id;
       $_SESSION['cart_zip_code'] = $zip_code;
-    } elseif (!empty($_SESSION['cart_country_id']) && !empty($_SESSION['cart_zip_code'])){
+    } elseif (!empty($_SESSION['cart_country_id'])){
       // session is available
       $_SESSION['country_info'] = zen_get_countries($_SESSION['cart_country_id'],true);
       $country_info = $_SESSION['country_info'];
       // fix here - check for error on $cart_country_id
-      $order->delivery = array('postcode' => $_SESSION['cart_zip_code'],
+      $order->delivery = array('postcode' => $zip_code,
                                'country' => array('id' => $_SESSION['cart_country_id'], 'title' => $country_info['countries_name'], 'iso_code_2' => $country_info['countries_iso_code_2'], 'iso_code_3' =>  $country_info['countries_iso_code_3']),
                                'country_id' => $_SESSION['cart_country_id'],
                                'zone_id' => $state_zone_id,


### PR DESCRIPTION
As identified in issue #2234, if:
- a user is logged in, 
- has gone beyond the `shopping_cart` page, 
- has changed the destination (`sendto`) address,
- has returned to the `shopping_cart` page, and
- the store is setup to display the potential shipping charges on the `shopping_cart` page.

Then when they arrive back at the shopping cart page, the selection determined to be active is the customer's default address that is then carried through the remainder of the checkout process until the customer again changes the selection.  This commit chooses the selection that was previously made/available.

Also, for a customer that is not logged in and because of PR #1952, if the shipping estimator is presented on the shopping cart page, the zip code is not provided and a country has been selected, then upon refresh of the page, the country selection is restored back to the store's default address.  This commit moves the strict notification handling specifically to the zip code within this section of code using the variable `$zip_code` that is set earlier in processing to be set to the posted zip code if provided, otherwise the existing session's zip code and if that is not present to set it to an empty string (`''`). This area is expected to be executed after the shopping_cart has been visited, but before logging in for ordering allowing the posted zip code to take the place of the existing session zip code if it exists.
Fixes #2234.