### PR TITLE
unmatched end tag

### DIFF
--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -564,17 +564,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
       <?php } ?>
       <div class="row"><?php echo zen_draw_separator('pixel_black.gif', '100%', '1px'); ?></div>
       <div class="row">
-          <?php
-          if ($action != '') {
-            ?>
-          <div class="col-xs-12 col-sm-12 col-md-9 col-lg-9 configurationColumnLeft">
-              <?php
-            } else {
-              ?>
-            <div>
-                <?php
-              }
-              ?>
+        <div class="<?php echo (empty($action)) ? '' : 'col-xs-12 col-sm-12 col-md-9 col-lg-9 configurationColumnLeft'; ?>">
             <table class="table table-striped table-hover">
               <thead>
                 <tr>
@@ -1246,8 +1236,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
           <?php
         }
         ?>
-      </div>
-    <!--</div>-->
+    </div>
     <!-- footer //-->
     <?php require(DIR_WS_INCLUDES . 'footer.php'); ?>
     <!-- footer_eof //-->

--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -1247,7 +1247,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
         }
         ?>
       </div>
-    </div>
+    <!--</div>-->
     <!-- footer //-->
     <?php require(DIR_WS_INCLUDES . 'footer.php'); ?>
     <!-- footer_eof //-->


### PR DESCRIPTION
in a default install of ZC 1.5.6a+ on this page.

I navigate to other admin pages and do not have an unclosed tag
(meaning I don't appear to have an extra tag somewhere above the
main body code).

I was asked to "prove" it, though don't know exactly how I can
do that other than possibly show the source code possibly with
my private information obscured.

 I have again installed the code to a new site location and applied demo products.  When looking at this page using Firefox Developer, I receive the following message: Source map error: request failed with status 404
Resource URL: https://template7.mc12345678.com/v156/sWeet-jmg-atTic/includes/css/bootstrap.min.css
Source Map URL: bootstrap.min.css.map'

On Microsoft Edge I receive an unexpected end tag for the </div> at "line" 1363.  I've repeated this on multiple computers and browsers, but it remains an issue.  I've even reloaded with the changes incorporated today.  Some browsers "brush it off" and ignore it, while others will point out that there is in fact an extra </div> at the end of the code.  I was previously asked in #2262 to "prove" it. I can provide the entirety of the source page code that could then be compared/evaluated by an html validator if that will work for those enquiring.  I had started to sit down and manually parse the tags of the source code to identify what closed out what but then after a few hundred lines realized that it would only prove to me that there was an issue, not to anyone else.

So I still stand by the removal of the flagged </div> tag, though it also looks like the code needs to be refactored so that tags line up better.