### PR TITLE
admin/newsletters.php, remove unused code causing error

### DIFF
--- a/admin/newsletters.php
+++ b/admin/newsletters.php
@@ -77,10 +77,6 @@ if (zen_not_null($action)) {
       break;
   }
 }
-
-if ($_GET['mail_sent_to']) {
-  $messageStack->add(sprintf(NOTICE_EMAIL_SENT_TO, $_GET['mail_sent_to']), 'success');
-}
 ?>
 <!doctype html>
 <html <?php echo HTML_PARAMS; ?>>


### PR DESCRIPTION
It appears that the variable `$_GET['mail_sent_to']` is never set by the newsletters' processing and results in a PHP Notice:

```
--> PHP Notice: Undefined index: mail_sent_to in C:\xampp\htdocs\zc156posm\gRoan-Dsw-Habit\newsletters.php on line 81.
```