### PR TITLE
Cleanup json_encode calls in VersionServer.php

### DIFF
--- a/admin/includes/classes/VersionServer.php
+++ b/admin/includes/classes/VersionServer.php
@@ -98,9 +98,9 @@ class VersionServer
 
     protected function buildCurrentInfo()
     {
-        $systemInfo = json_encode(zen_get_system_information(true), true);
+        $systemInfo = json_encode(zen_get_system_information(true));
 
-        $moduleInfo = json_encode($this->getModuleInfo(), true);
+        $moduleInfo = json_encode($this->getModuleInfo());
 
         $country_iso = $this->getCountryIso();
 


### PR DESCRIPTION
In VersionServer.php there are two calls to json_encode that pass a boolean value of true as the options parameter. The documentation for json_encode on php.net specify that the options parameter is of type integer that specifies a bitmask. It's not clear to me the effects, if any, of passing a boolean value.

Removing the options parameter from these two calls provides compatibility with PHP 5.2 since this parameter was added in PHP 5.3. I found this necessary when upgrading Zen Cart from 1.3.9h (modified to run on PHP 5.2) to 1.5.5f.