### PR TITLE
Standardizes zen_is_logged_in usage

### DIFF
--- a/includes/classes/ajax/zcAjaxPayment.php
+++ b/includes/classes/ajax/zcAjaxPayment.php
@@ -39,7 +39,7 @@ class zcAjaxPayment extends base
     if ($_SESSION['cart']->count_contents ()<=0) {
       zen_redirect (zen_href_link (FILENAME_TIME_OUT));
     }
-    if (!$_SESSION['customer_id']) {
+    if (!zen_is_logged_in()) {
       $_SESSION['navigation']->set_snapshot (array(
           'mode' => 'SSL',
           'page' => FILENAME_CHECKOUT_PAYMENT

--- a/includes/modules/pages/account/header_php.php
+++ b/includes/modules/pages/account/header_php.php
@@ -13,7 +13,7 @@ $zco_notifier->notify('NOTIFY_HEADER_START_ACCOUNT');
 $customer_has_gv_balance = false;
 $customer_gv_balance = false;
 
-if (!$_SESSION['customer_id']) {
+if (!zen_is_logged_in()) {
   $_SESSION['navigation']->set_snapshot();
   zen_redirect(zen_href_link(FILENAME_LOGIN, '', 'SSL'));
 }

--- a/includes/modules/pages/account_edit/header_php.php
+++ b/includes/modules/pages/account_edit/header_php.php
@@ -11,7 +11,7 @@
 // This should be first line of the script:
 $zco_notifier->notify('NOTIFY_HEADER_START_ACCOUNT_EDIT');
 
-if (!$_SESSION['customer_id']) {
+if (!zen_is_logged_in()) {
   $_SESSION['navigation']->set_snapshot();
   zen_redirect(zen_href_link(FILENAME_LOGIN, '', 'SSL'));
 }

--- a/includes/modules/pages/account_history/header_php.php
+++ b/includes/modules/pages/account_history/header_php.php
@@ -12,7 +12,7 @@
 $zco_notifier->notify('NOTIFY_HEADER_START_ACCOUNT_HISTORY');
 
 
-if (!$_SESSION['customer_id']) {
+if (!zen_is_logged_in()) {
   $_SESSION['navigation']->set_snapshot();
   zen_redirect(zen_href_link(FILENAME_LOGIN, '', 'SSL'));
 }

--- a/includes/modules/pages/account_history_info/header_php.php
+++ b/includes/modules/pages/account_history_info/header_php.php
@@ -11,7 +11,7 @@
 // This should be first line of the script:
 $zco_notifier->notify('NOTIFY_HEADER_START_ACCOUNT_HISTORY_INFO');
 
-if (!$_SESSION['customer_id']) {
+if (!zen_is_logged_in()) {
   $_SESSION['navigation']->set_snapshot();
   zen_redirect(zen_href_link(FILENAME_LOGIN, '', 'SSL'));
 }

--- a/includes/modules/pages/account_newsletters/header_php.php
+++ b/includes/modules/pages/account_newsletters/header_php.php
@@ -11,7 +11,7 @@
 // This should be first line of the script:
 $zco_notifier->notify('NOTIFY_HEADER_START_ACCOUNT_NEWSLETTERS');
 
-if (!$_SESSION['customer_id']) {
+if (!zen_is_logged_in()) {
   $_SESSION['navigation']->set_snapshot();
   zen_redirect(zen_href_link(FILENAME_LOGIN, '', 'SSL'));
 }

--- a/includes/modules/pages/account_notifications/header_php.php
+++ b/includes/modules/pages/account_notifications/header_php.php
@@ -11,7 +11,7 @@
 // This should be first line of the script:
 $zco_notifier->notify('NOTIFY_HEADER_START_ACCOUNT_NOTIFICATION');
 
-if (!$_SESSION['customer_id']) {
+if (!zen_is_logged_in()) {
   $_SESSION['navigation']->set_snapshot();
   zen_redirect(zen_href_link(FILENAME_LOGIN, '', 'SSL'));
 }

--- a/includes/modules/pages/account_password/header_php.php
+++ b/includes/modules/pages/account_password/header_php.php
@@ -11,7 +11,7 @@
 // This should be first line of the script:
 $zco_notifier->notify('NOTIFY_HEADER_START_ACCOUNT_PASSWORD');
 
-if (!$_SESSION['customer_id']) {
+if (!zen_is_logged_in()) {
   $_SESSION['navigation']->set_snapshot();
   zen_redirect(zen_href_link(FILENAME_LOGIN, '', 'SSL'));
 }

--- a/includes/modules/pages/address_book/header_php.php
+++ b/includes/modules/pages/address_book/header_php.php
@@ -11,7 +11,7 @@
 // This should be first line of the script:
 $zco_notifier->notify('NOTIFY_HEADER_START_ADDRESS_BOOK');
 
-if (!$_SESSION['customer_id']) {
+if (!zen_is_logged_in()) {
   $_SESSION['navigation']->set_snapshot();
   zen_redirect(zen_href_link(FILENAME_LOGIN, '', 'SSL'));
 }

--- a/includes/modules/pages/address_book_process/header_php.php
+++ b/includes/modules/pages/address_book_process/header_php.php
@@ -11,7 +11,7 @@
 // This should be first line of the script:
 $zco_notifier->notify('NOTIFY_HEADER_START_ADDRESS_BOOK_PROCESS');
 
-if (!$_SESSION['customer_id']) {
+if (!zen_is_logged_in()) {
   $_SESSION['navigation']->set_snapshot();
   zen_redirect(zen_href_link(FILENAME_LOGIN, '', 'SSL'));
 }

--- a/includes/modules/pages/advanced_search_result/header_php.php
+++ b/includes/modules/pages/advanced_search_result/header_php.php
@@ -231,7 +231,7 @@ $from_str = "FROM (" . TABLE_PRODUCTS . " p
 $from_str = $db->bindVars($from_str, ':languagesID', $_SESSION['languages_id'], 'integer');
 
 if ((DISPLAY_PRICE_WITH_TAX == 'true') && ((isset($_GET['pfrom']) && zen_not_null($_GET['pfrom'])) || (isset($_GET['pto']) && zen_not_null($_GET['pto'])))) {
-  if (!$_SESSION['customer_country_id']) {
+  if (empty($_SESSION['customer_country_id'])) {
     $_SESSION['customer_country_id'] = STORE_COUNTRY;
     $_SESSION['customer_zone_id'] = STORE_ZONE;
   }

--- a/includes/modules/pages/checkout_confirmation/header_php.php
+++ b/includes/modules/pages/checkout_confirmation/header_php.php
@@ -18,7 +18,7 @@ if ($_SESSION['cart']->count_contents() <= 0) {
 }
 
 // if the customer is not logged on, redirect them to the login page
-  if (!$_SESSION['customer_id']) {
+  if (!zen_is_logged_in()) {
     $_SESSION['navigation']->set_snapshot(array('mode' => 'SSL', 'page' => FILENAME_CHECKOUT_PAYMENT));
     zen_redirect(zen_href_link(FILENAME_LOGIN, '', 'SSL'));
   } else {

--- a/includes/modules/pages/checkout_payment/header_php.php
+++ b/includes/modules/pages/checkout_payment/header_php.php
@@ -22,7 +22,7 @@ if ($_SESSION['cart']->count_contents() <= 0) {
 }
 
 // if the customer is not logged on, redirect them to the login page
-  if (!$_SESSION['customer_id']) {
+  if (!zen_is_logged_in()) {
     $_SESSION['navigation']->set_snapshot();
     zen_redirect(zen_href_link(FILENAME_LOGIN, '', 'SSL'));
   } else {

--- a/includes/modules/pages/checkout_payment_address/header_php.php
+++ b/includes/modules/pages/checkout_payment_address/header_php.php
@@ -18,7 +18,7 @@ if ($_SESSION['cart']->count_contents() <= 0) {
 }
 
 // if the customer is not logged on, redirect them to the login page
-  if (!$_SESSION['customer_id']) {
+  if (!zen_is_logged_in()) {
     $_SESSION['navigation']->set_snapshot();
     zen_redirect(zen_href_link(FILENAME_LOGIN, '', 'SSL'));
   } else {

--- a/includes/modules/pages/checkout_shipping/header_php.php
+++ b/includes/modules/pages/checkout_shipping/header_php.php
@@ -18,7 +18,7 @@
   }
 
 // if the customer is not logged on, redirect them to the login page
-  if (!isset($_SESSION['customer_id']) || !$_SESSION['customer_id']) {
+  if (!zen_is_logged_in()) {
     $_SESSION['navigation']->set_snapshot();
     zen_redirect(zen_href_link(FILENAME_LOGIN, '', 'SSL'));
   } else {

--- a/includes/modules/pages/checkout_shipping_address/header_php.php
+++ b/includes/modules/pages/checkout_shipping_address/header_php.php
@@ -18,7 +18,7 @@ if ($_SESSION['cart']->count_contents() <= 0) {
 }
 
 // if the customer is not logged on, redirect them to the login page
-  if (!isset($_SESSION['customer_id'])) {
+  if (!zen_is_logged_in()) {
     $_SESSION['navigation']->set_snapshot();
     zen_redirect(zen_href_link(FILENAME_LOGIN, '', 'SSL'));
   } else {

--- a/includes/modules/pages/checkout_success/header_php.php
+++ b/includes/modules/pages/checkout_success/header_php.php
@@ -13,7 +13,7 @@
 $zco_notifier->notify('NOTIFY_HEADER_START_CHECKOUT_SUCCESS');
 
 // if the customer is not logged on, redirect them to the shopping cart page
-if (!$_SESSION['customer_id']) {
+if (!zen_is_logged_in()) {
   zen_redirect(zen_href_link(FILENAME_TIME_OUT));
 }
 

--- a/includes/modules/pages/contact_us/header_php.php
+++ b/includes/modules/pages/contact_us/header_php.php
@@ -111,7 +111,7 @@ $email_address = '';
 $name = '';
 
 // default email and name if customer is logged in
-if (!empty($_SESSION['customer_id'])) {
+if (zen_is_logged_in()) {
     $sql = "SELECT customers_id, customers_firstname, customers_lastname, customers_password, customers_email_address, customers_default_address_id
             FROM " . TABLE_CUSTOMERS . "
             WHERE customers_id = :customersID";

--- a/includes/modules/pages/create_account_success/header_php.php
+++ b/includes/modules/pages/create_account_success/header_php.php
@@ -19,7 +19,7 @@ $breadcrumb->add(NAVBAR_TITLE_2);
 //-BOF-lat9
 // Remove this page from the navigation history and if the customer returns to this page after time-out, redirect them to the time_out page
 $_SESSION['navigation']->remove_current_page();
-if (!$_SESSION['customer_id']) {
+if (!zen_is_logged_in()) {
   zen_redirect(zen_href_link(FILENAME_TIME_OUT, '', 'NONSSL'));
 }
 //-EOF-lat9

--- a/includes/modules/pages/download/header_php.php
+++ b/includes/modules/pages/download/header_php.php
@@ -18,7 +18,7 @@ $zco_notifier->notify('NOTIFY_HEADER_START_DOWNLOAD');
 require(DIR_WS_MODULES . zen_get_module_directory('require_languages.php'));
 
 // if the customer is not logged on and no email_address set (i.e. guest checkout), redirect the customer to the time out page
-if (empty($_SESSION['customer_id']) && empty($_SESSION['email_address'])) {
+if (!zen_is_logged_in() && empty($_SESSION['email_address'])) {
     zen_redirect(zen_href_link(FILENAME_TIME_OUT, '', 'SSL'));
 }
 

--- a/includes/modules/pages/gv_redeem/header_php.php
+++ b/includes/modules/pages/gv_redeem/header_php.php
@@ -14,7 +14,7 @@ require(DIR_WS_MODULES . zen_get_module_directory('require_languages.php'));
 $_GET['gv_no'] = zen_sanitize_string(trim($_GET['gv_no']));
 
 // if the customer is not logged on, redirect them to the login page
-if (!$_SESSION['customer_id']) {
+if (!zen_is_logged_in()) {
   $_SESSION['navigation']->set_snapshot();
   $messageStack->add_session('login', ERROR_GV_CREATE_ACCOUNT, 'error');
   zen_redirect(zen_href_link(FILENAME_LOGIN, (isset($_GET['gv_no']) ? 'gv_no=' . preg_replace('/[^0-9.,%]/', '', $_GET['gv_no']) : '' ), 'SSL'));

--- a/includes/modules/pages/gv_send/header_php.php
+++ b/includes/modules/pages/gv_send/header_php.php
@@ -19,12 +19,12 @@ if (isset($_POST['message'])) $_POST['message'] = zen_output_string_protected($_
 require_once('includes/classes/http_client.php');
 
 // verify no timeout has occurred on the send or process
-if (!$_SESSION['customer_id'] and ($_GET['action'] == 'send' or $_GET['action'] == 'process')) {
+if (!zen_is_logged_in() && isset($_GET['action']) && ($_GET['action'] == 'send' or $_GET['action'] == 'process')) {
   zen_redirect(zen_href_link(FILENAME_TIME_OUT));
 }
 
 // if the customer is not logged on, redirect them to the login page
-if (!$_SESSION['customer_id']) {
+if (!zen_is_logged_in()) {
   $_SESSION['navigation']->set_snapshot();
   zen_redirect(zen_href_link(FILENAME_LOGIN, '', 'SSL'));
 }

--- a/includes/modules/pages/logoff/header_php.php
+++ b/includes/modules/pages/logoff/header_php.php
@@ -25,7 +25,7 @@ $breadcrumb->add(NAVBAR_TITLE);
   * If so, kill the session, and redirect back to the logoff page
   * This will cause the header logic to see that the customer_id is gone, and thus not display another logoff link
   */
-if (!empty($_SESSION['customer_id']) || !empty($_SESSION['customer_guest_id'])) {
+if (zen_is_logged_in() || !empty($_SESSION['customer_guest_id'])) {
   zen_session_destroy();
   zen_redirect(zen_href_link(FILENAME_LOGOFF, $logoff_lang));
 }

--- a/includes/modules/pages/payer_auth_verifier/header_php.php
+++ b/includes/modules/pages/payer_auth_verifier/header_php.php
@@ -46,7 +46,7 @@
  */
 
 // if the customer is not logged on, redirect them to the login page
-  if (!$_SESSION['customer_id']) {
+  if (!zen_is_logged_in()) {
     die(WARNING_SESSION_TIMEOUT);
   }
 

--- a/includes/modules/pages/product_info/header_php.php
+++ b/includes/modules/pages/product_info/header_php.php
@@ -31,7 +31,7 @@
   }
 
   // ensure navigation snapshot in case must-be-logged-in-for-price is enabled
-  if (empty($_SESSION['customer_id'])) {
+  if (!zen_is_logged_in()) {
     $_SESSION['navigation']->set_snapshot();
   }
 

--- a/includes/templates/responsive_classic/templates/tpl_modules_mobile_menu.php
+++ b/includes/templates/responsive_classic/templates/tpl_modules_mobile_menu.php
@@ -17,7 +17,7 @@
     <li><a href="<?php echo zen_href_link(FILENAME_CONTACT_US, '', 'SSL'); ?>"><?php echo BOX_INFORMATION_CONTACT; ?></a></li>
 <?php  } ?>
 
-<?php if (!empty($_SESSION['customer_id'])) { ?>
+<?php if (zen_is_logged_in()) { ?>
     <li><a href="<?php echo zen_href_link(FILENAME_LOGOFF, '', 'SSL'); ?>"><?php echo HEADER_TITLE_LOGOFF; ?></a></li>
     <li><a href="<?php echo zen_href_link(FILENAME_ACCOUNT, '', 'SSL'); ?>"><?php echo HEADER_TITLE_MY_ACCOUNT; ?></a></li>
 <?php

--- a/includes/templates/template_default/templates/tpl_modules_shipping_estimator.php
+++ b/includes/templates/template_default/templates/tpl_modules_shipping_estimator.php
@@ -15,7 +15,7 @@
 <?php echo zen_draw_hidden_field('action', 'submit'); ?>
 <?php
   if($_SESSION['cart']->count_contents()) {
-    if (!empty($_SESSION['customer_id'])) {
+    if (zen_is_logged_in()) {
 ?>
 <h2><?php echo CART_SHIPPING_OPTIONS; ?></h2>
 
@@ -85,7 +85,7 @@
     }else{
 ?>
 <table id="seQuoteResults">
-<?php if (empty($_SESSION['customer_id'])){ ?>
+<?php if (!zen_is_logged_in()){ ?>
     <tr>
       <td colspan="2" class="seDisplayedAddressLabel">
         <?php echo CART_SHIPPING_QUOTE_CRITERIA; ?><br />

--- a/includes/templates/template_default/templates/tpl_time_out_default.php
+++ b/includes/templates/template_default/templates/tpl_time_out_default.php
@@ -11,7 +11,7 @@
 ?>
 <div class="centerColumn" id="timeoutDefault">
 <?php
-    if (!empty($_SESSION['customer_id'])) {
+    if (zen_is_logged_in()) {
 ?>
 <h1 id="timeoutDefaultHeading"><?php echo HEADING_TITLE_LOGGED_IN; ?></h1>
 <div id="timeoutDefaultContent" class="content"><?php echo TEXT_INFORMATION_LOGGED_IN; ?></div>


### PR DESCRIPTION
Newer PHP versions will throw an error if a variable is referenced
that does not exist.  A user that is not logged in results in
`$_SESSION['customer_id']` not being defined.  The path forward
is to use the function zen_is_logged_in to determine if a user
is logged in.  This function supports a notifier and on a per
page basis it is possible to determine the page accessed when
the notifier fires.  This standardizes other modifications that
have been made to prevent error notification by changing
`!$_SESSION['customer_id']` and `empty($_SESSION['customer_id'])` to
just use `zen_is_logged_in`.