### PR TITLE
Strict error fix in messageToStack

### DIFF
--- a/includes/classes/message_stack.php
+++ b/includes/classes/message_stack.php
@@ -59,7 +59,7 @@ class messageStack extends base {
 
   function add_session($class, $message, $type = 'error') {
 
-    if (!$_SESSION['messageToStack']) {
+    if (empty($_SESSION['messageToStack'])) {
       $messageToStack = array();
     } else {
       $messageToStack = $_SESSION['messageToStack'];


### PR DESCRIPTION
Ensures accessing the session messageToStack by way of a non-error creating function of empty instead of !.