### PR TITLE
Strict fix by using empty()

### DIFF
--- a/includes/init_includes/init_sessions.php
+++ b/includes/init_includes/init_sessions.php
@@ -117,7 +117,7 @@ if (!isset($_SESSION['customers_host_address'])) {
  */
 if ( ($request_type == 'SSL') && (SESSION_CHECK_SSL_SESSION_ID == 'True') && (ENABLE_SSL == 'true') && ($session_started == true) ) {
   $ssl_session_id = $_SERVER['SSL_SESSION_ID'];
-  if (!$_SESSION['SSL_SESSION_ID']) {
+  if (empty($_SESSION['SSL_SESSION_ID'])) {
     $_SESSION['SSL_SESSION_ID'] = $ssl_session_id;
   }
   if ($_SESSION['SSL_SESSION_ID'] != $ssl_session_id) {
@@ -130,7 +130,7 @@ if ( ($request_type == 'SSL') && (SESSION_CHECK_SSL_SESSION_ID == 'True') && (EN
  */
 if (SESSION_CHECK_USER_AGENT == 'True') {
   $http_user_agent = $_SERVER['HTTP_USER_AGENT'];
-  if (!$_SESSION['SESSION_USER_AGENT']) {
+  if (empty($_SESSION['SESSION_USER_AGENT'])) {
     $_SESSION['SESSION_USER_AGENT'] = $http_user_agent;
   }
   if ($_SESSION['SESSION_USER_AGENT'] != $http_user_agent) {
@@ -143,7 +143,7 @@ if (SESSION_CHECK_USER_AGENT == 'True') {
  */
 if (SESSION_CHECK_IP_ADDRESS == 'True') {
   $ip_address = zen_get_ip_address();
-  if (!$_SESSION['SESSION_IP_ADDRESS']) {
+  if (empty($_SESSION['SESSION_IP_ADDRESS'])) {
     $_SESSION['SESSION_IP_ADDRESS'] = $ip_address;
   }
   if ($_SESSION['SESSION_IP_ADDRESS'] != $ip_address) {


### PR DESCRIPTION
Ensures accessing the session SSL_SESSION_ID by way of a non-error creating function of empty instead of !.