### PR TITLE
Strict fix by using empty()

### DIFF
--- a/includes/modules/pages/checkout_payment_address/header_php.php
+++ b/includes/modules/pages/checkout_payment_address/header_php.php
@@ -33,7 +33,7 @@ require(DIR_WS_MODULES . zen_get_module_directory('require_languages.php'));
 $addressType = "billto";
 require(DIR_WS_MODULES . zen_get_module_directory('checkout_new_address'));
 // if no billing destination address was selected, use their own address as default
-if (!$_SESSION['billto']) {
+if (empty($_SESSION['billto'])) {
   $_SESSION['billto'] = $_SESSION['customer_default_address_id'];
 }
 

--- a/includes/modules/pages/checkout_shipping_address/header_php.php
+++ b/includes/modules/pages/checkout_shipping_address/header_php.php
@@ -46,7 +46,7 @@ $addressType = "shipto";
 require(DIR_WS_MODULES . zen_get_module_directory('checkout_new_address'));
 
 // if no shipping destination address was selected, use their own address as default
-if (!$_SESSION['sendto']) {
+if (empty($_SESSION['sendto'])) {
   $_SESSION['sendto'] = $_SESSION['customer_default_address_id'];
 }
 


### PR DESCRIPTION
Ensures accessing the session keys billto and sendto by way of a non-error creating function of empty instead of !.