### PR TITLE
Strict fix by using empty()

### DIFF
--- a/admin/define_pages_editor.php
+++ b/admin/define_pages_editor.php
@@ -86,7 +86,7 @@ switch ($_GET['action']) {
     break;
 }
 
-if (!$_SESSION['language']) {
+if (empty($_SESSION['language'])) {
   $_SESSION['language'] = $language;
 }
 


### PR DESCRIPTION
Ensures accessing the session language by way of a non-error creating function of empty instead of !.