### PR TITLE
Change continue to break in foreach loop for countries processing

### DIFF
--- a/includes/functions/html_output.php
+++ b/includes/functions/html_output.php
@@ -740,7 +740,7 @@ function zen_catalog_href_link($page = '', $parameters = '', $connection = 'NONS
         {
           // If you don't want to exclude entries already at the top of the list, comment out this next line:
           $alreadyInList = TRUE;
-          continue;
+          break; // found the duplicate, no further need to process this loop
         }
       }
       if (!$alreadyInList) $countries_array[] = array('id' => $countries[$i]['countries_id'], 'text' => $countries[$i]['countries_name']);


### PR DESCRIPTION
Identified that in outputting html that when processing the countries
when the desired state of an if statement was met that the loop
was directed to continue processing instead of leaving the
loop where no further processing was necessary.

This breaks the loop instead of continuing.

No known specific error, is only a code improvement.