### PR TITLE
Update products_to_categories.php issue #2311

### DIFF
--- a/admin/products_to_categories.php
+++ b/admin/products_to_categories.php
@@ -393,21 +393,15 @@ if (zen_not_null($action)) {
       break;
 
     case 'update_product':
-      $zv_check_master_categories_id = true;
+      $zv_check_master_categories_id = ('' !== $_POST['current_master_categories_id']);
       $new_categories_sort_array[] = $_POST['current_master_categories_id'];
       $current_master_categories_id = $_POST['current_master_categories_id'];
       if (!isset($_POST['categories_add'])) $_POST['categories_add'] = array();
 
       // set the linked products master_categories_id product(s)
       for ($i = 0, $n = sizeof($_POST['categories_add']); $i < $n; $i++) {
-        // is current master_categories_id in the list?
-        if ($zv_check_master_categories_id == true && $_POST['categories_add'][$i] == $current_master_categories_id) {
-          $zv_check_master_categories_id = true;
-          // array is set above to master category
-        } else {
-          $zv_check_master_categories_id = false;
-          $new_categories_sort_array[] = (int)$_POST['categories_add'][$i];
-        }
+        // Populate the list of remaining categories in the selection list.
+        $new_categories_sort_array[] = (int)$_POST['categories_add'][$i];
       }
 
       // remove existing products_to_categories for current product
@@ -444,6 +438,12 @@ if (zen_not_null($action)) {
                       WHERE products_id = " . $products_filter);
       } else {
         // reset master_categories_id to current_category_id because it was unselected
+        if ($reset_master_categories_id == '') {
+          $reset_master_categories_id = $current_category_id;
+          // Ensure that product is reachable by product/category relationship.
+          $db->Execute("INSERT INTO " . TABLE_PRODUCTS_TO_CATEGORIES . " (products_id, categories_id)
+                        VALUES (" . $products_filter . ", " . (int)$reset_master_categories_id . ")");
+        }
         $db->Execute("UPDATE " . TABLE_PRODUCTS . "
                       SET master_categories_id = " . (int)$reset_master_categories_id . "
                       WHERE products_id = " . $products_filter);


### PR DESCRIPTION
Because of a change in presenting the products_to_categories page where the master category can not be deselected and the design consideration that if a store has one or more categories that a product is not to be in a category that has categories (specifically not in the root category of the store), this commit fixes #2311 and ensures that a product has both a `master_categories_id` and is listed in the table `products_to_categories` if for some reason the products_to_categories page is reached for the product and the product initially did not have a `master_categories_id` set to something other than ''.

Of course, this file can not be accessed if product is in place with a master_categories_id of 0 and it is desired to link the product to other categories and possibly remove it from the master_category of the root of the store, that in other words the master_categories_id must be modified at the product's page not from this admin area and only after the product has been assigned to multiple categories.