### PR TITLE
Admin Customers DOB not displayed on edit

### DIFF
--- a/admin/customers.php
+++ b/admin/customers.php
@@ -667,7 +667,7 @@ if (zen_not_null($action)) {
                       echo $cInfo->customers_dob . ((empty($customers_dob) || $customers_dob <= '0001-01-01' || $customers_dob == '0001-01-01 00:00:00') ? 'N/A' : zen_draw_hidden_field('customers_dob'));
                     }
                   } else {
-                    echo zen_draw_input_field('customers_dob', ((empty($customers_dob) || $customers_dob <= '0001-01-01' || $customers_dob == '0001-01-01 00:00:00') ? '' : zen_date_short($cInfo->customers_dob)), 'maxlength="10" class="form-control"', true);
+                    echo zen_draw_input_field('customers_dob', ((empty($cInfo->customers_dob) || $cInfo->customers_dob <= '0001-01-01' || $cInfo->customers_dob == '0001-01-01 00:00:00') ? '' : zen_date_short($cInfo->customers_dob)), 'maxlength="10" class="form-control"', true);
                   }
                   ?>
               </div>


### PR DESCRIPTION
When displaying a customer's record, the DOB if set to be displayed/used does not get displayed when editing the record.  This corrects that. For some reason the variable `$customers_dob` was being used which would be appropriate on update as it is set in the `update` action, but not on edit where the variable is not set.