### PR TITLE
v156 account_edit recognize ISO-8601 DOB

### DIFF
--- a/includes/languages/english.php
+++ b/includes/languages/english.php
@@ -189,8 +189,8 @@
   define('ENTRY_LAST_NAME_ERROR', 'Is your last name correct? Our system requires a minimum of ' . ENTRY_LAST_NAME_MIN_LENGTH . ' characters. Please try again.');
   define('ENTRY_LAST_NAME_TEXT', '*');
   define('ENTRY_DATE_OF_BIRTH', 'Date of Birth:');
-  define('ENTRY_DATE_OF_BIRTH_ERROR', 'Is your birth date correct? Our system requires the date in this format: MM/DD/YYYY (eg 05/21/1970)');
-  define('ENTRY_DATE_OF_BIRTH_TEXT', '* (eg. 05/21/1970)');
+  define('ENTRY_DATE_OF_BIRTH_ERROR', 'Is your birth date correct? Our system requires the date in this format: MM/DD/YYYY (eg 05/21/1970) or this format: YYYY-MM-DD (eg 1970-05-21)');
+  define('ENTRY_DATE_OF_BIRTH_TEXT', '* (eg. 05/21/1970 or 1970-05-21)');
   define('ENTRY_EMAIL_ADDRESS', 'Email Address:');
   define('ENTRY_EMAIL_ADDRESS_ERROR', 'Is your email address correct? It should contain at least ' . ENTRY_EMAIL_ADDRESS_MIN_LENGTH . ' characters. Please try again.');
   define('ENTRY_EMAIL_ADDRESS_CHECK_ERROR', 'Sorry, my system does not understand your email address. Please try again.');

--- a/includes/modules/pages/account_edit/header_php.php
+++ b/includes/modules/pages/account_edit/header_php.php
@@ -176,6 +176,15 @@ if (ACCOUNT_GENDER == 'true') {
   $female = !$male;
 }
 
+if (!(isset($_POST['action']) && ($_POST['action'] == 'process'))) {
+  // Posted page content is not requested to be processed, populate dob with customer's database entry.
+  // Using ISO-8601 format of date display to support javascript/jQuery driven date picker data handling.
+  $dob = zen_date_raw(zen_date_short($account->fields['customers_dob']));
+  $dob = substr($dob, 0, 4) . '-' . substr($dob, 4, 2) . '-' . substr($dob, 6, 2);
+  if ($dob <= '0001-01-01') {
+    $dob = '0001-01-01 00:00:00';
+  }
+}
 // if DOB field has database default setting, show blank:
 $dob = ($dob == '0001-01-01 00:00:00') ? '' : $dob;
 

--- a/includes/modules/pages/account_edit/header_php.php
+++ b/includes/modules/pages/account_edit/header_php.php
@@ -51,6 +51,10 @@ if (isset($_POST['action']) && ($_POST['action'] == 'process')) {
 
   if (ACCOUNT_DOB == 'true') {
     if (ENTRY_DOB_MIN_LENGTH > 0 or !empty($_POST['dob'])) {
+      // Support ISO-8601 style date
+      if (preg_match('/^([0-9]{4})(|-|\/)([0-9]{2})\2([0-9]{2})$/', $dob)) {
+        $_POST['dob'] = $dob = date(DATE_FORMAT, strtotime($dob));
+      }
       if (substr_count($dob,'/') > 2 || checkdate((int)substr(zen_date_raw($dob), 4, 2), (int)substr(zen_date_raw($dob), 6, 2), (int)substr(zen_date_raw($dob), 0, 4)) == false) {
         $error = true;
         $messageStack->add('account_edit', ENTRY_DATE_OF_BIRTH_ERROR);


### PR DESCRIPTION
Similar to #1518, but for account edit.  If using a mobile device, the date is presented with a date selector (though still haven't been able to get the date selector to populate with the known/existing date) that stores the date locally/internally using ISO-8601 format which in the previous format would prevent updating the record.  This at least allows updating the record, though it seems that the user would have to re-enter the birthdate.

It appears that in jscript_responsive_framework.php the line associated with the dob:
`$('input#dob').clone().attr('type','date').insertAfter('input#dob').prev().remove();`

causes the attribute of `value` to get cleared once the type is modified to date. In briefly trying to address this in light of upcoming distribution, I haven't come up with a "one-liner" to resolve this.  May require more than one line in that file. That though is basically a separate issue. :/