### PR TITLE
Correct over-sanitization of DTK search string

### DIFF
--- a/admin/includes/init_includes/init_sanitize.php
+++ b/admin/includes/init_includes/init_sanitize.php
@@ -248,4 +248,7 @@ $sanitizer->addComplexSanitization($group);
 $group = array('query_string' => array('sanitizerType' => 'NULL_ACTION', 'method' => 'post', 'pages' => array('sqlpatch')));
 $sanitizer->addComplexSanitization($group);
 
+$group = array('configuration_key' => array('sanitizerType' => 'NULL_ACTION', 'method' => 'post', 'pages' => array('developers_tool_kit')));
+$sanitizer->addComplexSanitization($group);
+
 $sanitizer->runSanitizers();


### PR DESCRIPTION
As reported on the forums, if the DTK's search string contains "special" HTML characters, those characters will be sanitized into their HTML entities, resulting in "no results found" when, if fact, there should be.  Add an opt-out in the admin's init_sanitizer to correct this.