### PR TITLE
v156 strict notice: check that vert_links key exists

### DIFF
--- a/includes/modules/pages/page/header_php.php
+++ b/includes/modules/pages/page/header_php.php
@@ -97,7 +97,7 @@ foreach($vert_links as $key => $value) {
       $previous_v = $vert_links[$key - 1];
     }
     $next_vssl = '0';
-    if ($vert_links[$key + 1]) {
+    if (!empty($vert_links[$key + 1])) {
       $next_item_v = $vert_links[$key + 1];
     } else {
       $next_item_v = $vert_links[0];


### PR DESCRIPTION
if `$vert_links[]` is assigned it is given a non-zero value.  This commit prevents the notice provided in strict operation of testing for a non-existing array key by use of `[$key+1]`.