### PR TITLE
Correct PHP Notice on coupon-valid check

### DIFF
--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -3824,9 +3824,13 @@ function get_logs_data($maxToList = 'count') {
     global $db;
     $sql = "SELECT coupon_id, coupon_is_valid_for_sales
             FROM " . TABLE_COUPONS . "
-            WHERE coupon_id = " . (int)$coupon_id;
+            WHERE coupon_id = " . (int)$coupon_id . "
+            LIMIT 1";
 
     $result = $db->Execute($sql);
+    if ($result->EOF) {
+        return false;
+    }
 
     // check whether coupon has been flagged for valid with sales
     if ($result->fields['coupon_is_valid_for_sales']) {


### PR DESCRIPTION
If the `is_coupon_valid_for_sales` function is called with an invalid coupon-id, then a PHP Notice is thrown because no data is returned on from the db's SELECT clause.