### PR TITLE
Coupon admin:  Can't add Free Shipping only coupon

### DIFF
--- a/admin/coupon_admin.php
+++ b/admin/coupon_admin.php
@@ -400,6 +400,10 @@
       if ( (!empty($_POST['back_x'])) || (!empty($_POST['back_y'])) ) {
         $_GET['action'] = 'new';
       } else {
+        if (empty($_POST['coupon_amount'])) {
+            $_POST['coupon_amount'] = '0';
+        }
+        
         $coupon_type = 'F'; // amount off
         if ($_POST['coupon_free_ship']) $coupon_type = 'S'; // free shipping
         if (substr($_POST['coupon_amount'], -1) == '%') $coupon_type = 'P'; // percentage off


### PR DESCRIPTION
When you want to create a coupon that's only valid for free shipping, you enter the coupon amount as 0 (or 0.00).  Somewhere in the process, that value gets changed to an empty string ('') which is an invalid numeric value and results in a MySQL error when the coupon is being recorded in the database.

This PR forces the amount value to be a valid numeric when that value is 'empty' (e.g. either 0, 0.00 or an empty string).