### PR TITLE
Free shipping coupon w/ taxed shipping

### DIFF
--- a/includes/modules/order_total/ot_coupon.php
+++ b/includes/modules/order_total/ot_coupon.php
@@ -577,7 +577,6 @@ class ot_coupon {
               {
                 $od_amount['tax_groups'][$key] = zen_round($orderTotalDetails['orderTaxGroups'][$key] * $ratio, $currencyDecimalPlaces);
                 $od_amount['tax'] += $od_amount['tax_groups'][$key];
-                if ($od_amount['tax_groups'][$key] == 0) unset($od_amount['tax_groups'][$key]);
               }
               if (DISPLAY_PRICE_WITH_TAX == 'true' && $coupon->fields['coupon_type'] == 'F') $od_amount['total'] = $od_amount['total'] + $od_amount['tax'];
               break;
@@ -593,7 +592,6 @@ class ot_coupon {
         }
       }
     }
-
 //    print_r($order->info);
 //    print_r($orderTotalDetails);echo "<br><br>";
 //    echo 'RATIo = '. $ratio;
@@ -636,7 +634,6 @@ class ot_coupon {
       $orderTotal -= $order->info['shipping_cost'];
       if (isset($_SESSION['shipping_tax_description']) && $_SESSION['shipping_tax_description'] != '')
       {
-         $orderTaxGroups[$_SESSION['shipping_tax_description']] -= $order->info['shipping_tax'];
          $orderTotalTax -= $order->info['shipping_tax'];
       }
     }


### PR DESCRIPTION
Fixes #2353
There are two changes in this update:

1. `ot_coupon::get_order_total`: The shipping tax shouldn't be subtracted from the overall value, as that value represents the amount of tax to be **removed** from each tax-group.
2. `ot_coupon::calculate_deductions`: Don't `unset` a tax-group with a 0-value; results in PHP Notice if shipping tax class is unique and the coupon gives free shipping.