### PR TITLE
Don't specify countries_id on INSERT

### DIFF
--- a/zc_install/sql/updates/mysql_upgrade_zencart_153.sql
+++ b/zc_install/sql/updates/mysql_upgrade_zencart_153.sql
@@ -43,7 +43,7 @@ UPDATE configuration set configuration_group_id = 6 where configuration_key in (
 #ISO Updates:
 UPDATE countries SET countries_name = 'Libya' WHERE countries_iso_code_3 = 'LBY';
 UPDATE countries SET countries_name = 'Palestine, State of' WHERE countries_iso_code_3 = 'PSE';
-INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (246,'South Sudan','SS','SSD','1');
+INSERT INTO countries (countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES ('South Sudan','SS','SSD','1');
 
 
 ALTER TABLE admin MODIFY COLUMN pwd_last_change_date datetime NOT NULL default '0001-01-01 00:00:00', MODIFY COLUMN last_modified datetime NOT NULL default '0001-01-01 00:00:00', MODIFY COLUMN last_login_date datetime NOT NULL default '0001-01-01 00:00:00', MODIFY COLUMN last_failed_attempt datetime NOT NULL default '0001-01-01 00:00:00';

--- a/zc_install/sql/updates/mysql_upgrade_zencart_155.sql
+++ b/zc_install/sql/updates/mysql_upgrade_zencart_155.sql
@@ -47,8 +47,8 @@ UPDATE countries set countries_name = 'Åland Islands' where countries_iso_code_
 UPDATE countries set countries_name = 'Réunion' where countries_iso_code_3 = 'REU';
 UPDATE countries set countries_name = "Côte d'Ivoire" where countries_iso_code_3 = 'CIV';
 UPDATE countries set countries_name = 'Bonaire, Sint Eustatius and Saba', countries_iso_code_2 = 'BQ', countries_iso_code_3 = 'BES' WHERE countries_iso_code_3 = 'ANT';
-INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (247,'Curaçao','CW','CUW','1');
-INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (248,'Sint Maarten (Dutch part)','SX','SXM','1');
+INSERT INTO countries (countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES ('Curaçao','CW','CUW','1');
+INSERT INTO countries (countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES ('Sint Maarten (Dutch part)','SX','SXM','1');
 
 UPDATE configuration SET configuration_title='Credit Card Enable Status - Debit', configuration_key = 'CC_ENABLED_DEBIT', configuration_value ='0', configuration_description='Accept Debit Cards 0= off 1= on<br>NOTE: This is not deeply integrated at this time, and this setting may be redundant if your payment modules do not yet specifically have code to honour this switch.', date_added=now() WHERE configuration_key='CC_ENABLED_SWITCH';
 


### PR DESCRIPTION
This guy's point is well taken: 
https://www.zen-cart.com/showthread.php?224820-Database-upgrade-fails-when-upgrading-my-1-5-3-to-1-5-6&p=1355473#post1355473

Suggest merging this into 156 (in case there's a 156c patch) as well as 1.5.7. 
