### PR TITLE
zc156b: address_book_process, HTML validation

### DIFF
--- a/docs/changed_files-v1-5-6.html
+++ b/docs/changed_files-v1-5-6.html
@@ -198,6 +198,7 @@
                 <li>/includes/classes/shipping.php</li>
                 <li>/includes/classes/shopping_cart.php</li>
                 <li>/includes/classes/upload.php</li>
+                <li>/includes/classes/vendors/PHPMailer  (whole directory)</li>
                 <li>/includes/extra_configures/not_for_release.php</li>
                 <li>/includes/filenames.php</li>
                 <li>/includes/functions/audience.php</li>

--- a/docs/changed_files-v1-5-6.html
+++ b/docs/changed_files-v1-5-6.html
@@ -229,6 +229,7 @@
                 <li>/includes/languages/english/popup_coupon_help.php</li>
                 <li>/includes/languages/english/shopping_cart.php</li>
                 <li>/includes/modules/attributes.php</li>
+                <li>/includes/modules/category_row.php</li>
                 <li>/includes/modules/checkout_address_book.php</li>
                 <li>/includes/modules/checkout_new_address.php</li>
                 <li>/includes/modules/checkout_process.php</li>

--- a/includes/templates/template_default/templates/tpl_modules_address_book_details.php
+++ b/includes/templates/template_default/templates/tpl_modules_address_book_details.php
@@ -98,7 +98,7 @@
 <br class="clearBoth" />
 
 <label class="inputLabel" for="country"><?php echo ENTRY_COUNTRY; ?></label>
-<?php echo zen_get_country_list('zone_country_id', $entry->fields['entry_country_id'], 'id="country" placeholder="' . ENTRY_COUNTRY_TEXT . '"' . ($flag_show_pulldown_states == true ? 'onchange="update_zone(this.form);"' : '')); ?>
+<?php echo zen_get_country_list('zone_country_id', $entry->fields['entry_country_id'], 'id="country" placeholder="' . ENTRY_COUNTRY_TEXT . '"' . ($flag_show_pulldown_states == true ? ' onchange="update_zone(this.form);"' : '')); ?>
 <br class="clearBoth" />
 
 <?php

--- a/includes/templates/template_default/templates/tpl_modules_checkout_new_address.php
+++ b/includes/templates/template_default/templates/tpl_modules_checkout_new_address.php
@@ -95,7 +95,7 @@
 <br class="clearBoth" />
 
 <label class="inputLabel" for="country"><?php echo ENTRY_COUNTRY; ?></label>
-<?php echo zen_get_country_list('zone_country_id', $selected_country, 'id="country" placeholder="' . ENTRY_COUNTRY_TEXT . '"' . ($flag_show_pulldown_states == true ? 'onchange="update_zone(this.form);"' : '')); ?>
+<?php echo zen_get_country_list('zone_country_id', $selected_country, 'id="country" placeholder="' . ENTRY_COUNTRY_TEXT . '"' . ($flag_show_pulldown_states == true ? ' onchange="update_zone(this.form);"' : '')); ?>
 <br class="clearBoth" />
 </fieldset>
 </div>


### PR DESCRIPTION
On the subject page, when using 'pulldown states', there's a space missing between HTML attributes, causing validation issues:
```
<select name="zone_country_id" id="country" placeholder="*"onchange="update_zone(this.form);">
```
This issue has been around for a while!