### PR TITLE
V156 download redirect

### DIFF
--- a/docs/changed_files-v1-5-6.html
+++ b/docs/changed_files-v1-5-6.html
@@ -198,6 +198,7 @@
                 <li>/includes/classes/shipping.php</li>
                 <li>/includes/classes/shopping_cart.php</li>
                 <li>/includes/classes/upload.php</li>
+                <li>/includes/classes/vendors/PHPMailer  (whole directory)</li>
                 <li>/includes/extra_configures/not_for_release.php</li>
                 <li>/includes/filenames.php</li>
                 <li>/includes/functions/audience.php</li>

--- a/docs/changed_files-v1-5-6.html
+++ b/docs/changed_files-v1-5-6.html
@@ -229,6 +229,7 @@
                 <li>/includes/languages/english/popup_coupon_help.php</li>
                 <li>/includes/languages/english/shopping_cart.php</li>
                 <li>/includes/modules/attributes.php</li>
+                <li>/includes/modules/category_row.php</li>
                 <li>/includes/modules/checkout_address_book.php</li>
                 <li>/includes/modules/checkout_new_address.php</li>
                 <li>/includes/modules/checkout_process.php</li>

--- a/includes/classes/observers/auto.downloads_via_redirect.php
+++ b/includes/classes/observers/auto.downloads_via_redirect.php
@@ -44,7 +44,30 @@ class zcObserverDownloadsViaRedirect extends base {
     if (DOWNLOAD_BY_REDIRECT != 'true') return false;
 
     $this->pubFolder = DIR_FS_DOWNLOAD_PUBLIC;
-    $this->wsPubFolder = HTTP_SERVER . DIR_WS_DOWNLOAD_PUBLIC;
+
+    $server_path = HTTP_SERVER;
+
+    // Remove the protocol from the path if present.
+    if (strpos($server_path, '//') !== false) {
+      $server_path = substr($server_path, strpos($server_path, '//') + 2);
+    }
+
+    // Remove the domain name from the path, if present.
+    // if HTTP_SERVER does not contain a sub-directory then no change needed.
+    // else remove the domain name and prefix the path to begin at the domain name.
+    if (strpos($server_path, '/') === false) {
+      $server_path = '';
+    } else {
+      // Remove the domain name from the path if present.
+      $server_path = substr($server_path, strpos($server_path, '/') + 1);
+
+      // Prefix the path to ensure starting at the base of the domain name.
+      if (substr($server_path, 0, 1) !== '/') {
+        $server_path = '/' . $server_path;
+      }
+    }
+
+    $this->wsPubFolder = $server_path . DIR_WS_DOWNLOAD_PUBLIC;
 
     // attach listener
     $this->attach($this, array('NOTIFY_DOWNLOAD_READY_TO_REDIRECT'));

--- a/includes/classes/observers/auto.downloads_via_redirect.php
+++ b/includes/classes/observers/auto.downloads_via_redirect.php
@@ -44,7 +44,7 @@ class zcObserverDownloadsViaRedirect extends base {
     if (DOWNLOAD_BY_REDIRECT != 'true') return false;
 
     $this->pubFolder = DIR_FS_DOWNLOAD_PUBLIC;
-    $this->wsPubFolder = DIR_WS_DOWNLOAD_PUBLIC;
+    $this->wsPubFolder = HTTP_SERVER . DIR_WS_DOWNLOAD_PUBLIC;
 
     // attach listener
     $this->attach($this, array('NOTIFY_DOWNLOAD_READY_TO_REDIRECT'));


### PR DESCRIPTION
v156 Download by redirect if `HTTP_SERVER` has sub-directory.
(May also apply backwards to Zen Cart v1.5.5) and definitely to Zen Cart 1.5.7.
    
    In the following Zen Cart Forum thread:
    https://www.zen-cart.com/showthread.php?225481-Doc-Product-Type-Download-by-redirect-redirects-to-wrong-pub-folder
    
    it was identified (indirectly) that if `HTTP_SERVER` contained
    a sub-directory (such as for a shared server account where the
    store were reached using domain/~user, domain/user, etc...)
    that when continuing on with processing, the attempted browser
    path would exclude the sub-directory contained in `HTTP_SERVER`.
    
    Unfortunately, the same would be true if the download was
    expected for `HTTPS_SERVER`; however, the redirect code already
    accounts for that if the provided path is based off of the
    `HTTP_SERVER` prefix.
    
    The other "unfortunate" part of this is that the web browser
    path provided is assigned to a class variable which is
    accessible within the attached listener for
    `'NOTIFY_DOWNLOAD_READY_TO_REDIRECT'`.  The reason this is
    unfortunate is that to whatever the variable is set, it is
    ideal if the observer can "readily" identify what may need to be
    stripped or detected if working from that direction instead of
    simply building what is needed/desired to operate on the
    `wsPubFolder` property.
    
    As a result, I have created two different commits that make
    up this branch, each providing the same end result of supporting
    a download via redirect for a site that has one or more
    sub-directories in `HTTP_SERVER`.  I am not familiar with the
    other uses and/or applications that anticipate using the
    above notifier and therefore welcome comment/discussion about
    the best way forwards.  This first commit is the easiest and
    one that seems to make the most sense for supporting further
    processing and alignment to an outside storage location. E.g.
    with the path built from `HTTP_SERVER` and `DIR_WS_DOWNLOAD_PUBLIC`
    it is possible to just remove the beginning of the string where
    `HTTP_SERVER` is used resulting in a path that begins with:
    `/pub`.  A site that is stored in a sub-directory but does not
    have a sub-directory in `HTTP_SERVER` will, however, begin with
    the sub-directory defined by `DIR_WS_CATALOG` which would also
    be known and technically could be removed from the full path as
    well in the deconstruction of the `downloadsViaRedirect` class'
    property `wsPubFolder`.

v156 Second of two solutions for download via redirect <- Current final commit of branch.
    
    This solution determines the sub-folder information from
    `HTTP_SERVER` and prepends it to `DIR_WS_DOWNLOAD_PUBLIC`.
    While it maintains a "server-less" characteristic allowing
    the `zen_redirect` function to operate off of the domain name,
    it is not easy to reverse engineer and actually requires a bit
    of work to recreate even if a variable name were made available.
    
    Recommendation (if it supports the proposed integration with other
    code) is to use the first commit of this branch.