### PR TITLE
Always unset temp variable in whos_online

### DIFF
--- a/admin/whos_online.php
+++ b/admin/whos_online.php
@@ -528,8 +528,8 @@ $listingURL = FILENAME_WHOS_ONLINE . '.php?' . zen_get_all_get_params(['q', 't',
                 $backup = $_SESSION;
                 if (false === session_decode($session_data_field[$key])) {
                     $_SESSION = $backup;
-                    unset ($backup);
                 }
+                unset($backup);
               }
 
               if (isset($_SESSION['cart']) && is_object($_SESSION['cart'])) {


### PR DESCRIPTION
If the unsetting location was on purpose (to provide a downstream
indicator about the success of decoding the session data), then
please ignore this commit (and please leave comment for
historical sake :)). Otherwise, it seems like the variable
`$backup` is not needed elsewhere after this assignment and
should be removed at each assignment.