### PR TITLE
Remove old-style javascript comments

### DIFF
--- a/admin/admin_account.php
+++ b/admin/admin_account.php
@@ -88,10 +88,9 @@ $userDetails = $userList[0];
 <link rel="stylesheet" type="text/css" href="includes/stylesheet.css">
 <link rel="stylesheet" type="text/css" href="includes/cssjsmenuhover.css" media="all" id="hoverJS">
 <link rel="stylesheet" type="text/css" href="includes/admin_access.css" />
-<script language="javascript" src="includes/menu.js"></script>
-<script language="javascript" src="includes/general.js"></script>
+<script type="text/javascript" src="includes/menu.js"></script>
+<script type="text/javascript" src="includes/general.js"></script>
 <script type="text/javascript">
-  <!--
   function init()
   {
     cssjsmenu('navbar');
@@ -101,7 +100,6 @@ $userDetails = $userList[0];
       kill.disabled = true;
     }
   }
-  // -->
 </script>
 </head>
 <body onload="init()">

--- a/admin/coupon_admin.php
+++ b/admin/coupon_admin.php
@@ -470,10 +470,9 @@
 <title><?php echo TITLE; ?></title>
 <link rel="stylesheet" type="text/css" href="includes/stylesheet.css">
 <link rel="stylesheet" type="text/css" href="includes/cssjsmenuhover.css" media="all" id="hoverJS">
-<script language="javascript" src="includes/menu.js"></script>
-<script language="javascript" src="includes/general.js"></script>
+<script type="text/javascript" src="includes/menu.js"></script>
+<script type="text/javascript" src="includes/general.js"></script>
 <script type="text/javascript">
-  <!--
   function init()
   {
     cssjsmenu('navbar');
@@ -483,9 +482,8 @@
       kill.disabled = true;
     }
   }
-  // -->
 </script>
-<script language="javascript" type="text/javascript"><!--
+<script language="javascript" type="text/javascript">
 var form = "";
 var submitted = false;
 var error = false;
@@ -543,8 +541,7 @@ function check_form(form_name) {
     submitted = true;
     return true;
   }
-}
-//--></script>
+}</script>
 <?php if ($editor_handler != '') include ($editor_handler); ?>
 </head>
 <body onLoad="init()">

--- a/admin/coupon_admin_export.php
+++ b/admin/coupon_admin_export.php
@@ -307,9 +307,8 @@ if ($action != '')
 <title><?php echo TITLE; ?></title>
 <link rel="stylesheet" type="text/css" href="includes/stylesheet.css">
 <link rel="stylesheet" type="text/css" href="includes/cssjsmenuhover.css" media="all" id="hoverJS">
-<script language="javascript" src="includes/menu.js"></script>
+<script type="text/javascript" src="includes/menu.js"></script>
 <script type="text/javascript">
-  <!--
   function init()
   {
     cssjsmenu('navbar');
@@ -319,7 +318,6 @@ if ($action != '')
       kill.disabled = true;
     }
   }
-  // -->
 </script>
 </head>
 <body onload="init()">

--- a/admin/coupon_restrict.php
+++ b/admin/coupon_restrict.php
@@ -147,9 +147,8 @@
 <title><?php echo TITLE; ?></title>
 <link rel="stylesheet" type="text/css" href="includes/stylesheet.css">
 <link rel="stylesheet" type="text/css" href="includes/cssjsmenuhover.css" media="all" id="hoverJS">
-<script language="javascript" src="includes/menu.js"></script>
+<script type="text/javascript" src="includes/menu.js"></script>
 <script type="text/javascript">
-  <!--
   function init()
   {
     cssjsmenu('navbar');
@@ -159,7 +158,6 @@
       kill.disabled = true;
     }
   }
-  // -->
 </script>
 </head>
 <body onload="init()" marginwidth="0" marginheight="0" topmargin="0" bottommargin="0" leftmargin="0" rightmargin="0" bgcolor="#FFFFFF">

--- a/admin/denied.php
+++ b/admin/denied.php
@@ -18,10 +18,9 @@ require('includes/application_top.php');
 <link rel="stylesheet" type="text/css" href="includes/stylesheet.css">
 <link rel="stylesheet" type="text/css" href="includes/cssjsmenuhover.css" media="all" id="hoverJS">
 <link rel="stylesheet" type="text/css" href="includes/admin_access.css" />
-<script language="javascript" src="includes/menu.js"></script>
-<script language="javascript" src="includes/general.js"></script>
+<script type="text/javascript" src="includes/menu.js"></script>
+<script type="text/javascript" src="includes/general.js"></script>
 <script type="text/javascript">
-  <!--
   function init()
   {
     cssjsmenu('navbar');
@@ -31,7 +30,6 @@ require('includes/application_top.php');
       kill.disabled = true;
     }
   }
-  // -->
 </script>
 </head>
 <body onload="init()">

--- a/admin/gv_mail.php
+++ b/admin/gv_mail.php
@@ -166,9 +166,8 @@
 <title><?php echo TITLE; ?></title>
 <link rel="stylesheet" type="text/css" href="includes/stylesheet.css">
 <link rel="stylesheet" type="text/css" href="includes/cssjsmenuhover.css" media="all" id="hoverJS">
-<script language="javascript" src="includes/menu.js"></script>
+<script type="text/javascript" src="includes/menu.js"></script>
 <script type="text/javascript">
-  <!--
   function init()
   {
     cssjsmenu('navbar');
@@ -178,9 +177,8 @@
       kill.disabled = true;
     }
   }
-  // -->
 </script>
-<script language="javascript" type="text/javascript"><!--
+<script language="javascript" type="text/javascript">
 var form = "";
 var submitted = false;
 var error = false;
@@ -251,7 +249,7 @@ function check_form(form_name) {
     return true;
   }
 }
-//--></script>
+</script>
 <?php if ($editor_handler != '') include ($editor_handler); ?>
 </head>
 <body onLoad="init()">

--- a/admin/gv_queue.php
+++ b/admin/gv_queue.php
@@ -115,9 +115,8 @@
 <title><?php echo TITLE; ?></title>
 <link rel="stylesheet" type="text/css" href="includes/stylesheet.css">
 <link rel="stylesheet" type="text/css" href="includes/cssjsmenuhover.css" media="all" id="hoverJS">
-<script language="javascript" src="includes/menu.js"></script>
+<script type="text/javascript" src="includes/menu.js"></script>
 <script type="text/javascript">
-  <!--
   function init()
   {
     cssjsmenu('navbar');
@@ -127,7 +126,6 @@
       kill.disabled = true;
     }
   }
-  // -->
 </script>
 </head>
 <body onload="init()">

--- a/admin/gv_sent.php
+++ b/admin/gv_sent.php
@@ -19,9 +19,8 @@
 <title><?php echo TITLE; ?></title>
 <link rel="stylesheet" type="text/css" href="includes/stylesheet.css">
 <link rel="stylesheet" type="text/css" href="includes/cssjsmenuhover.css" media="all" id="hoverJS">
-<script language="javascript" src="includes/menu.js"></script>
+<script type="text/javascript" src="includes/menu.js"></script>
 <script type="text/javascript">
-  <!--
   function init()
   {
     cssjsmenu('navbar');
@@ -31,7 +30,6 @@
       kill.disabled = true;
     }
   }
-  // -->
 </script>
 </head>
 <body onload="init()">

--- a/admin/media_manager.php
+++ b/admin/media_manager.php
@@ -136,10 +136,9 @@
 <title><?php echo TITLE; ?></title>
 <link rel="stylesheet" type="text/css" href="includes/stylesheet.css">
 <link rel="stylesheet" type="text/css" href="includes/cssjsmenuhover.css" media="all" id="hoverJS">
-<script language="javascript" src="includes/menu.js"></script>
-<script language="javascript" src="includes/general.js"></script>
+<script type="text/javascript" src="includes/menu.js"></script>
+<script type="text/javascript" src="includes/general.js"></script>
 <script type="text/javascript">
-  <!--
   function init()
   {
     cssjsmenu('navbar');
@@ -149,7 +148,6 @@
       kill.disabled = true;
     }
   }
-  // -->
 </script>
 </head>
 <body onLoad="init()">

--- a/admin/paypal.php
+++ b/admin/paypal.php
@@ -70,10 +70,9 @@
 <title><?php echo TITLE; ?></title>
 <link rel="stylesheet" type="text/css" href="includes/stylesheet.css">
 <link rel="stylesheet" type="text/css" href="includes/cssjsmenuhover.css" media="all" id="hoverJS">
-<script language="javascript" src="includes/menu.js"></script>
-<script language="javascript" src="includes/general.js"></script>
+<script src="includes/menu.js"></script>
+<script src="includes/general.js"></script>
 <script type="text/javascript">
-  <!--
   function init()
   {
     cssjsmenu('navbar');
@@ -83,7 +82,6 @@
       kill.disabled = true;
     }
   }
-  // -->
 </script>
 </head>
 <body marginwidth="0" marginheight="0" topmargin="0" bottommargin="0" leftmargin="0" rightmargin="0" bgcolor="#FFFFFF" onLoad="SetFocus(), init();">

--- a/admin/server_info.php
+++ b/admin/server_info.php
@@ -48,9 +48,8 @@
 <title><?php echo TITLE; ?></title>
 <link rel="stylesheet" type="text/css" href="includes/stylesheet.css">
 <link rel="stylesheet" type="text/css" href="includes/cssjsmenuhover.css" media="all" id="hoverJS">
-<script language="javascript" src="includes/menu.js"></script>
+<script type="text/javascript" src="includes/menu.js"></script>
 <script type="text/javascript">
-  <!--
   function init()
   {
     cssjsmenu('navbar');
@@ -60,7 +59,6 @@
       kill.disabled = true;
     }
   }
-  // -->
 </script>
 <style>
 .pageHeading {font-size: 2em;}

--- a/admin/store_manager.php
+++ b/admin/store_manager.php
@@ -214,10 +214,9 @@
 <title><?php echo TITLE; ?></title>
 <link rel="stylesheet" type="text/css" href="includes/stylesheet.css">
 <link rel="stylesheet" type="text/css" href="includes/cssjsmenuhover.css" media="all" id="hoverJS">
-<script language="javascript" src="includes/menu.js"></script>
-<script language="javascript" src="includes/general.js"></script>
+<script type="text/javascript" src="includes/menu.js"></script>
+<script type="text/javascript" src="includes/general.js"></script>
 <script type="text/javascript">
-  <!--
   function init()
   {
     cssjsmenu('navbar');
@@ -227,7 +226,6 @@
       kill.disabled = true;
     }
   }
-  // -->
 </script>
 <?php if ($processing_message != '' && $processing_action_url != '') echo '<meta http-equiv="refresh" content="2;URL=' . $processing_action_url . '">'; ?>
 

--- a/includes/classes/payment.php
+++ b/includes/classes/payment.php
@@ -120,7 +120,7 @@ class payment extends base {
   function javascript_validation() {
     $js = '';
     if (is_array($this->modules) && sizeof($this->selection()) > 0) {
-      $js = '<script type="text/javascript"><!-- ' . "\n" .
+      $js = '<script type="text/javascript">' . "\n" .
       'function check_form() {' . "\n" .
       '  var error = 0;' . "\n" .
       '  var error_message = "' . JS_ERROR . '";' . "\n" .
@@ -160,7 +160,7 @@ class payment extends base {
        }
        $js =  $js .' if (result == false) doCollectsCardDataOnsite();' . "\n";
        $js =  $js .'    return result;' . "\n";
-       $js =  $js .'  }' . "\n" . '}' . "\n" . '//--></script>' . "\n";
+       $js =  $js .'  }' . "\n" . '}' . "\n" . '</script>' . "\n";
     }
     return $js;
   }

--- a/includes/form_check.js.php
+++ b/includes/form_check.js.php
@@ -9,7 +9,7 @@
  * @version $Id: Author: DrByte  Wed Jan 6 12:47:43 2016 -0500 Modified in v1.5.5 $
  */
 ?>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 var selected;
 
 function check_form_optional(form_name) {
@@ -175,4 +175,4 @@ function check_form(form_name) {
     return true;
   }
 }
-//--></script>
+</script>

--- a/includes/modules/additional_images.php
+++ b/includes/modules/additional_images.php
@@ -158,7 +158,7 @@ if ($num_images > 0) {
             $link_parameters
         );
         if ($script_link === false) {
-            $script_link = '<script type="text/javascript"><!--' . "\n" . 'document.write(\'' . ($flag_display_large ? '<a href="javascript:popupWindow(\\\'' . str_replace($products_image_large, urlencode(addslashes($products_image_large)), $large_link) . '\\\')">' . $thumb_slashes . '<br />' . TEXT_CLICK_TO_ENLARGE . '</a>' : $thumb_slashes) . '\');' . "\n" . '//--></script>';
+            $script_link = '<script type="text/javascript">' . "\n" . 'document.write(\'' . ($flag_display_large ? '<a href="javascript:popupWindow(\\\'' . str_replace($products_image_large, urlencode(addslashes($products_image_large)), $large_link) . '\\\')">' . $thumb_slashes . '<br />' . TEXT_CLICK_TO_ENLARGE . '</a>' : $thumb_slashes) . '\');' . "\n" . '</script>';
         }
 
         $noscript_link = '<noscript>' . ($flag_display_large ? '<a href="' . zen_href_link(FILENAME_POPUP_IMAGE_ADDITIONAL, 'pID=' . $_GET['products_id'] . '&pic=' . $i . '&products_image_large_additional=' . $products_image_large) . '" target="_blank">' . $thumb_regular . '<br /><span class="imgLinkAdditional">' . TEXT_CLICK_TO_ENLARGE . '</span></a>' : $thumb_regular ) . '</noscript>';

--- a/includes/modules/pages/account/jscript_main.php
+++ b/includes/modules/pages/account/jscript_main.php
@@ -4,9 +4,9 @@
 // |zen-cart Open Source E-commerce                                       |
 // +----------------------------------------------------------------------+
 // | Copyright (c) 2003 The zen-cart developers                           |
-// |                                                                      |   
-// | http://www.zen-cart.com/index.php                                    |   
-// |                                                                      |   
+// |                                                                      |
+// | http://www.zen-cart.com/index.php                                    |
+// |                                                                      |
 // | Portions Copyright (c) 2003 osCommerce                               |
 // +----------------------------------------------------------------------+
 // | This source file is subject to version 2.0 of the GPL license,       |
@@ -20,7 +20,7 @@
 // $Id: jscript_main.php 1105 2005-04-04 22:05:35Z birdbrain $
 //
 ?>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 function rowOverEffect(object) {
   if (object.className == 'moduleRow') object.className = 'moduleRowOver';
 }
@@ -28,4 +28,4 @@ function rowOverEffect(object) {
 function rowOutEffect(object) {
   if (object.className == 'moduleRowOver') object.className = 'moduleRow';
 }
-//--></script> 
+</script> 

--- a/includes/modules/pages/account_edit/jscript_form_check.php
+++ b/includes/modules/pages/account_edit/jscript_form_check.php
@@ -9,7 +9,7 @@
  * @version $Id: dakanji Thu Jun 14 20:55:08 2018 +0300 Modified in v1.5.6 $
  */
 ?>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 var selected;
 
 function check_form_optional(form_name) {
@@ -175,4 +175,4 @@ function check_form(form_name) {
     return true;
   }
 }
-//--></script>
+</script>

--- a/includes/modules/pages/account_history_info/jscript_main.php
+++ b/includes/modules/pages/account_history_info/jscript_main.php
@@ -9,10 +9,10 @@
  * @version $Id: Author: DrByte  Wed Jan 6 12:47:43 2016 -0500 Modified in v1.5.5 $
  */
 ?>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 
 function couponpopupWindow(url) {
   window.open(url,'couponpopupWindow','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no,width=450,height=320,screenX=150,screenY=150,top=150,left=150')
 }
 
-//--></script>
+</script>

--- a/includes/modules/pages/account_newsletters/jscript_main.php
+++ b/includes/modules/pages/account_newsletters/jscript_main.php
@@ -9,8 +9,8 @@
  * @version $Id: Author: DrByte  Wed Jan 6 12:47:43 2016 -0500 Modified in v1.5.5 $
  */
 ?>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 function checkBox(object) {
   document.account_newsletter.elements[object].checked = !document.account_newsletter.elements[object].checked;
 }
-//--></script>
+</script>

--- a/includes/modules/pages/account_password/jscript_form_check.php
+++ b/includes/modules/pages/account_password/jscript_form_check.php
@@ -9,7 +9,7 @@
  * @version $Id: dakanji Thu Jun 14 20:55:08 2018 +0300 Modified in v1.5.6 $
  */
 ?>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 var selected;
 
 function check_form_optional(form_name) {
@@ -175,4 +175,4 @@ function check_form(form_name) {
     return true;
   }
 }
-//--></script>
+</script>

--- a/includes/modules/pages/address_book/jscript_main.php
+++ b/includes/modules/pages/address_book/jscript_main.php
@@ -4,9 +4,9 @@
 // |zen-cart Open Source E-commerce                                       |
 // +----------------------------------------------------------------------+
 // | Copyright (c) 2003 The zen-cart developers                           |
-// |                                                                      |   
-// | http://www.zen-cart.com/index.php                                    |   
-// |                                                                      |   
+// |                                                                      |
+// | http://www.zen-cart.com/index.php                                    |
+// |                                                                      |
 // | Portions Copyright (c) 2003 osCommerce                               |
 // +----------------------------------------------------------------------+
 // | This source file is subject to version 2.0 of the GPL license,       |
@@ -20,7 +20,7 @@
 // $Id: jscript_main.php 1105 2005-04-04 22:05:35Z birdbrain $
 //
 ?>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 function rowOverEffect(object) {
   if (object.className == 'moduleRow') object.className = 'moduleRowOver';
 }
@@ -28,4 +28,4 @@ function rowOverEffect(object) {
 function rowOutEffect(object) {
   if (object.className == 'moduleRowOver') object.className = 'moduleRow';
 }
-//--></script>
+</script>

--- a/includes/modules/pages/address_book_process/jscript_addr_pulldowns.php
+++ b/includes/modules/pages/address_book_process/jscript_addr_pulldowns.php
@@ -11,7 +11,7 @@
  * @version $Id: Scott C Wilson Sat Oct 27 01:31:20 2018 -0400 Modified in v1.5.6 $
  */
 ?>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 
 function update_zone(theForm) {
   // if there is no zone_id field to update, or if it is hidden from display, then exit performing no updates
@@ -62,4 +62,4 @@ function update_zone(theForm) {
     document.getElementById("stBreak").className = 'clearBoth visibleField';
     document.getElementById("stBreak").setAttribute('className', 'clearBoth visibleField');
   }
-//--></script>
+</script>

--- a/includes/modules/pages/address_book_process/jscript_main.php
+++ b/includes/modules/pages/address_book_process/jscript_main.php
@@ -9,7 +9,7 @@
  * @version $Id: dakanji Thu Jun 14 20:55:08 2018 +0300 Modified in v1.5.6 $
  */
 ?>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 var selected;
 
 function check_form_optional(form_name) {
@@ -175,4 +175,4 @@ function check_form(form_name) {
     return true;
   }
 }
-//--></script>
+</script>

--- a/includes/modules/pages/advanced_search/jscript_main.php
+++ b/includes/modules/pages/advanced_search/jscript_main.php
@@ -21,7 +21,7 @@
 //
 ?>
 <script src="includes/general.js" type="text/javascript"></script>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 function check_form() {
   var error_message = "<?php echo JS_ERROR; ?>";
   var error_found = false;
@@ -108,4 +108,4 @@ function check_form() {
 function popupWindow(url) {
   window.open(url,'popupWindow','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no,width=450,height=280,screenX=150,screenY=150,top=150,left=150')
 }
-//--></script>
+</script>

--- a/includes/modules/pages/checkout_confirmation/jscript_main.php
+++ b/includes/modules/pages/checkout_confirmation/jscript_main.php
@@ -9,7 +9,7 @@
  * @version $Id: DrByte 2019 May 25 Modified in v1.5.6b $
  */
 ?>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 var submitter = null;
 function popupWindow(url) {
   window.open(url,'popupWindow','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no,width=450,height=320,screenX=150,screenY=150,top=150,left=150')
@@ -39,4 +39,4 @@ function button_timeout() {
   button.disabled = true;
 }
 
-//--></script>
+</script>

--- a/includes/modules/pages/checkout_payment/jscript_main.php
+++ b/includes/modules/pages/checkout_payment/jscript_main.php
@@ -9,7 +9,7 @@
  * @version $Id: Fri Jul 15 2016  Modified in v1.5.5 $
  */
 ?>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 var selected;
 var submitter = null;
 
@@ -74,4 +74,4 @@ function doCollectsCardDataOnsite()
       });
     });
 
-//--></script>
+</script>

--- a/includes/modules/pages/checkout_payment/jscript_payeezy.php
+++ b/includes/modules/pages/checkout_payment/jscript_payeezy.php
@@ -14,7 +14,7 @@ if ($payment_modules->in_special_checkout() || empty($payeezyjszc) || !$payeezyj
     return false;
 }
 ?>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 
 var Payeezy = function() {
     function e(e) {
@@ -204,4 +204,4 @@ jQuery(function($) {
     });
 });
 
---></script>
+</script>

--- a/includes/modules/pages/checkout_payment_address/jscript_addr_pulldowns.php
+++ b/includes/modules/pages/checkout_payment_address/jscript_addr_pulldowns.php
@@ -11,7 +11,7 @@
  * @version $Id: Scott C Wilson Sat Oct 27 01:31:20 2018 -0400 Modified in v1.5.6 $
  */
 ?>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 
 function update_zone(theForm) {
   // if there is no zone_id field to update, or if it is hidden from display, then exit performing no updates
@@ -62,4 +62,4 @@ function update_zone(theForm) {
     document.getElementById("stBreak").className = 'clearBoth visibleField';
     document.getElementById("stBreak").setAttribute('className', 'clearBoth visibleField');
   }
-//--></script>
+</script>

--- a/includes/modules/pages/checkout_payment_address/jscript_main.php
+++ b/includes/modules/pages/checkout_payment_address/jscript_main.php
@@ -9,7 +9,7 @@
  * @version $Id: dakanji Thu Jun 14 20:55:08 2018 +0300 Modified in v1.5.6 $
  */
 ?>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 var selected;
 
 function check_form_optional(form_name) {
@@ -175,5 +175,5 @@ function check_form(form_name) {
     return true;
   }
 }
-//--></script>
+</script>
 

--- a/includes/modules/pages/checkout_shipping_address/jscript_addr_pulldowns.php
+++ b/includes/modules/pages/checkout_shipping_address/jscript_addr_pulldowns.php
@@ -11,7 +11,7 @@
  * @version $Id: Scott C Wilson Sat Oct 27 01:31:20 2018 -0400 Modified in v1.5.6 $
  */
 ?>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 
 function update_zone(theForm) {
   // if there is no zone_id field to update, or if it is hidden from display, then exit performing no updates
@@ -62,4 +62,4 @@ function update_zone(theForm) {
     document.getElementById("stBreak").className = 'clearBoth visibleField';
     document.getElementById("stBreak").setAttribute('className', 'clearBoth visibleField');
   }
-//--></script>
+</script>

--- a/includes/modules/pages/checkout_shipping_address/jscript_main.php
+++ b/includes/modules/pages/checkout_shipping_address/jscript_main.php
@@ -9,7 +9,7 @@
  * @version $Id: dakanji Thu Jun 14 20:55:08 2018 +0300 Modified in v1.5.6 $
  */
 ?>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 var selected;
 
 function check_form_optional(form_name) {
@@ -175,4 +175,4 @@ function check_form(form_name) {
     return true;
   }
 }
-//--></script>
+</script>

--- a/includes/modules/pages/checkout_success/header_php.php
+++ b/includes/modules/pages/checkout_success/header_php.php
@@ -132,7 +132,6 @@ $define_page = zen_get_file_directory(DIR_WS_LANGUAGES . $_SESSION['language'] .
 } else {
   echo '<html><head>';
   echo '<script type="text/javascript">
-<!--
 theTimer = 0;
 timeOut = 12;
 
@@ -156,7 +155,6 @@ function continueClick()
 }
 
 submit_form();
-//-->
 </script>' . "\n" . '</head>';
   echo '<body style="text-align: center; min-width: 600px;">' . "\n" . '<div style="text-align: center;  width: 600px;  margin-left: auto;  margin-right: auto; margin-top:20%;"><p>This page will automatically redirect you back to ' . STORE_NAME . ' for your order confirmation details.<br />If you are not redirected within 5 seconds, please click the button below to continue.</p>';
   echo "\n" . '<form action="' . zen_href_link(FILENAME_CHECKOUT_SUCCESS, zen_get_all_get_params(array('action')), 'SSL', false) . '" method="post" name="formpost" />' . "\n";

--- a/includes/modules/pages/create_account/jscript_addr_pulldowns.php
+++ b/includes/modules/pages/create_account/jscript_addr_pulldowns.php
@@ -11,7 +11,7 @@
  * @version $Id: Scott C Wilson Sat Oct 27 01:31:20 2018 -0400 Modified in v1.5.6 $
  */
 ?>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 
 function update_zone(theForm) {
   // if there is no zone_id field to update, or if it is hidden from display, then exit performing no updates
@@ -61,4 +61,4 @@ function update_zone(theForm) {
     document.getElementById("stBreak").className = 'clearBoth visibleField';
     document.getElementById("stBreak").setAttribute('className', 'clearBoth visibleField');
   }
-//--></script>
+</script>

--- a/includes/modules/pages/document_general_info/jscript_main.php
+++ b/includes/modules/pages/document_general_info/jscript_main.php
@@ -20,11 +20,11 @@
 // $Id: jscript_main.php 5444 2006-12-29 06:45:56Z drbyte $
 //
 ?>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 function popupWindow(url) {
   window.open(url,'popupWindow','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=no,resizable=yes,copyhistory=no,width=100,height=100,screenX=150,screenY=150,top=150,left=150')
 }
 function popupWindowPrice(url) {
   window.open(url,'popupWindow','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no,width=600,height=400,screenX=150,screenY=150,top=150,left=150')
 }
-//--></script>
+</script>

--- a/includes/modules/pages/document_product_info/jscript_main.php
+++ b/includes/modules/pages/document_product_info/jscript_main.php
@@ -20,11 +20,11 @@
 // $Id: jscript_main.php 5444 2006-12-29 06:45:56Z drbyte $
 //
 ?>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 function popupWindow(url) {
   window.open(url,'popupWindow','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=no,resizable=yes,copyhistory=no,width=100,height=100,screenX=150,screenY=150,top=150,left=150')
 }
 function popupWindowPrice(url) {
   window.open(url,'popupWindow','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no,width=600,height=400,screenX=150,screenY=150,top=150,left=150')
 }
-//--></script>
+</script>

--- a/includes/modules/pages/login/jscript_addr_pulldowns.php
+++ b/includes/modules/pages/login/jscript_addr_pulldowns.php
@@ -11,7 +11,7 @@
  * @version $Id: Author: DrByte  Wed Jan 6 12:47:43 2016 -0500 Modified in v1.5.5 $
  */
 ?>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 
 function update_zone(theForm) {
   // if there is no zone_id field to update, or if it is hidden from display, then exit performing no updates
@@ -59,4 +59,4 @@ function update_zone(theForm) {
     document.getElementById("stBreak").className = 'clearBoth visibleField';
     document.getElementById("stBreak").setAttribute('className', 'clearBoth visibleField');
   }
-//--></script>
+</script>

--- a/includes/modules/pages/login/jscript_form_check.php
+++ b/includes/modules/pages/login/jscript_form_check.php
@@ -9,7 +9,7 @@
  * @version $Id: dakanji Thu Jun 14 20:55:08 2018 +0300 Modified in v1.5.6 $
  */
 ?>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 var selected;
 
 function check_form_optional(form_name) {
@@ -175,4 +175,4 @@ function check_form(form_name) {
     return true;
   }
 }
-//--></script>
+</script>

--- a/includes/modules/pages/login/jscript_main.php
+++ b/includes/modules/pages/login/jscript_main.php
@@ -4,9 +4,9 @@
 // |zen-cart Open Source E-commerce                                       |
 // +----------------------------------------------------------------------+
 // | Copyright (c) 2003 The zen-cart developers                           |
-// |                                                                      |   
-// | http://www.zen-cart.com/index.php                                    |   
-// |                                                                      |   
+// |                                                                      |
+// | http://www.zen-cart.com/index.php                                    |
+// |                                                                      |
 // | Portions Copyright (c) 2003 osCommerce                               |
 // +----------------------------------------------------------------------+
 // | This source file is subject to version 2.0 of the GPL license,       |
@@ -20,8 +20,8 @@
 // $Id: jscript_main.php 1969 2005-09-13 06:57:21Z drbyte $
 //
 ?>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 function session_win() {
   window.open("<?php echo zen_href_link(FILENAME_INFO_SHOPPING_CART); ?>","info_shopping_cart","height=460,width=430,toolbar=no,statusbar=no,scrollbars=yes").focus();
 }
-//--></script>
+</script>

--- a/includes/modules/pages/popup_coupon_help/jscript_main.php
+++ b/includes/modules/pages/popup_coupon_help/jscript_main.php
@@ -20,7 +20,7 @@
 // $Id: jscript_main.php 1969 2005-09-13 06:57:21Z drbyte $
 //
 ?>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 var i=0;
 function resize() {
   if (navigator.appName == 'Netscape') i=10;
@@ -36,4 +36,4 @@ function resize() {
   }
   self.focus();
 }
-//--></script>
+</script>

--- a/includes/modules/pages/popup_cvv_help/jscript_main.php
+++ b/includes/modules/pages/popup_cvv_help/jscript_main.php
@@ -4,9 +4,9 @@
 // |zen-cart Open Source E-commerce                                       |
 // +----------------------------------------------------------------------+
 // | Copyright (c) 2003 The zen-cart developers                           |
-// |                                                                      |   
-// | http://www.zen-cart.com/index.php                                    |   
-// |                                                                      |   
+// |                                                                      |
+// | http://www.zen-cart.com/index.php                                    |
+// |                                                                      |
 // | Portions Copyright (c) 2003 osCommerce                               |
 // +----------------------------------------------------------------------+
 // | This source file is subject to version 2.0 of the GPL license,       |
@@ -20,11 +20,11 @@
 // $Id: jscript_main.php 1969 2005-09-13 06:57:21Z drbyte $
 //
 ?>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 var i=0;
 function resize() {
   if (navigator.appName == 'Netscape') i=40;
   if (document.images[0]) window.resizeTo(document.images[0].width +30, document.images[0].height+60-i);
   self.focus();
 }
-//--></script>
+</script>

--- a/includes/modules/pages/popup_image/jscript_main.php
+++ b/includes/modules/pages/popup_image/jscript_main.php
@@ -9,7 +9,7 @@
  * @version $Id: Author: DrByte  Wed Jan 6 12:47:43 2016 -0500 Modified in v1.5.5 $
  */
 ?>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 var i=0;
 function resize() {
   i=0;
@@ -51,4 +51,4 @@ function resize() {
   }
   self.focus();
 }
-//--></script>
+</script>

--- a/includes/modules/pages/popup_image_additional/jscript_main.php
+++ b/includes/modules/pages/popup_image_additional/jscript_main.php
@@ -9,7 +9,7 @@
  * @version $Id: Author: DrByte  Wed Jan 6 12:47:43 2016 -0500 Modified in v1.5.5 $
  */
 ?>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 var i=0;
 function resize() {
   i=0;
@@ -51,4 +51,4 @@ function resize() {
   }
   self.focus();
 }
-//--></script>
+</script>

--- a/includes/modules/pages/popup_search_help/jscript_main.php
+++ b/includes/modules/pages/popup_search_help/jscript_main.php
@@ -4,9 +4,9 @@
 // |zen-cart Open Source E-commerce                                       |
 // +----------------------------------------------------------------------+
 // | Copyright (c) 2003 The zen-cart developers                           |
-// |                                                                      |   
-// | http://www.zen-cart.com/index.php                                    |   
-// |                                                                      |   
+// |                                                                      |
+// | http://www.zen-cart.com/index.php                                    |
+// |                                                                      |
 // | Portions Copyright (c) 2003 osCommerce                               |
 // +----------------------------------------------------------------------+
 // | This source file is subject to version 2.0 of the GPL license,       |
@@ -20,11 +20,11 @@
 // $Id: jscript_main.php 1969 2005-09-13 06:57:21Z drbyte $
 //
 ?>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 var i=0;
 function resize() {
   if (navigator.appName == 'Netscape') i=40;
   if (document.images[0]) window.resizeTo(document.images[0].width +30, document.images[0].height+60-i);
   self.focus();
 }
-//--></script>
+</script>

--- a/includes/modules/pages/popup_shipping_estimator/jscript_addr_pulldowns.php
+++ b/includes/modules/pages/popup_shipping_estimator/jscript_addr_pulldowns.php
@@ -11,7 +11,7 @@
  * @version $Id: Author: DrByte  Wed Jan 6 12:47:43 2016 -0500 Modified in v1.5.5 $
  */
 ?>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 
 function update_zone(theForm) {
   // if there is no zone_id field to update, or if it is hidden from display, then exit performing no updates
@@ -55,4 +55,4 @@ function update_zone(theForm) {
     document.getElementById("stBreak").className = 'clearBoth visibleField';
     document.getElementById("stBreak").setAttribute('className', 'clearBoth visibleField');
   }
-//--></script>
+</script>

--- a/includes/modules/pages/product_free_shipping_info/jscript_main.php
+++ b/includes/modules/pages/product_free_shipping_info/jscript_main.php
@@ -20,11 +20,11 @@
 // $Id: jscript_main.php 5444 2006-12-29 06:45:56Z drbyte $
 //
 ?>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 function popupWindow(url) {
   window.open(url,'popupWindow','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=no,resizable=yes,copyhistory=no,width=100,height=100,screenX=150,screenY=150,top=150,left=150')
 }
 function popupWindowPrice(url) {
   window.open(url,'popupWindow','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no,width=600,height=400,screenX=150,screenY=150,top=150,left=150')
 }
-//--></script>
+</script>

--- a/includes/modules/pages/product_info/jscript_main.php
+++ b/includes/modules/pages/product_info/jscript_main.php
@@ -20,11 +20,11 @@
 // $Id: jscript_main.php 5444 2006-12-29 06:45:56Z drbyte $
 //
 ?>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 function popupWindow(url) {
   window.open(url,'popupWindow','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=no,resizable=yes,copyhistory=no,width=100,height=100,screenX=150,screenY=150,top=150,left=150')
 }
 function popupWindowPrice(url) {
   window.open(url,'popupWindow','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no,width=600,height=400,screenX=150,screenY=150,top=150,left=150')
 }
-//--></script>
+</script>

--- a/includes/modules/pages/product_music_info/jscript_main.php
+++ b/includes/modules/pages/product_music_info/jscript_main.php
@@ -20,11 +20,11 @@
 // $Id: jscript_main.php 5444 2006-12-29 06:45:56Z drbyte $
 //
 ?>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 function popupWindow(url) {
   window.open(url,'popupWindow','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=no,resizable=yes,copyhistory=no,width=100,height=100,screenX=150,screenY=150,top=150,left=150')
 }
 function popupWindowPrice(url) {
   window.open(url,'popupWindow','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no,width=600,height=400,screenX=150,screenY=150,top=150,left=150')
 }
-//--></script>
+</script>

--- a/includes/modules/pages/product_reviews/jscript_main.php
+++ b/includes/modules/pages/product_reviews/jscript_main.php
@@ -4,9 +4,9 @@
 // |zen-cart Open Source E-commerce                                       |
 // +----------------------------------------------------------------------+
 // | Copyright (c) 2003 The zen-cart developers                           |
-// |                                                                      |   
-// | http://www.zen-cart.com/index.php                                    |   
-// |                                                                      |   
+// |                                                                      |
+// | http://www.zen-cart.com/index.php                                    |
+// |                                                                      |
 // | Portions Copyright (c) 2003 osCommerce                               |
 // +----------------------------------------------------------------------+
 // | This source file is subject to version 2.0 of the GPL license,       |
@@ -20,8 +20,8 @@
 // $Id: jscript_main.php 1105 2005-04-04 22:05:35Z birdbrain $
 //
 ?>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 function popupWindow(url) {
   window.open(url,'popupWindow','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=no,resizable=yes,copyhistory=no,width=100,height=100,screenX=150,screenY=150,top=150,left=150')
 }
-//--></script> 
+</script> 

--- a/includes/modules/pages/product_reviews_info/jscript_main.php
+++ b/includes/modules/pages/product_reviews_info/jscript_main.php
@@ -4,9 +4,9 @@
 // |zen-cart Open Source E-commerce                                       |
 // +----------------------------------------------------------------------+
 // | Copyright (c) 2003 The zen-cart developers                           |
-// |                                                                      |   
-// | http://www.zen-cart.com/index.php                                    |   
-// |                                                                      |   
+// |                                                                      |
+// | http://www.zen-cart.com/index.php                                    |
+// |                                                                      |
 // | Portions Copyright (c) 2003 osCommerce                               |
 // +----------------------------------------------------------------------+
 // | This source file is subject to version 2.0 of the GPL license,       |

--- a/includes/modules/pages/product_reviews_write/jscript_main.php
+++ b/includes/modules/pages/product_reviews_write/jscript_main.php
@@ -20,7 +20,7 @@
 // $Id: jscript_main.php 1105 2005-04-04 22:05:35Z birdbrain $
 //
 ?>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 var form = "";
 var submitted = false;
 var error = false;
@@ -86,4 +86,4 @@ function checkForm(form_name) {
 function popupWindow(url) {
   window.open(url,'popupWindow','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=no,resizable=yes,copyhistory=no,width=100,height=100,screenX=150,screenY=150,top=150,left=150')
 }
-//--></script>
+</script>

--- a/includes/modules/pages/shopping_cart/jscript_main.php
+++ b/includes/modules/pages/shopping_cart/jscript_main.php
@@ -21,11 +21,11 @@
 //
 ?>
 <script src="includes/general.js" type="text/javascript"></script>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 function popupWindow(url) {
   window.open(url,'popupWindow','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no,width=550,height=550,screenX=150,screenY=100,top=100,left=150')
 }
 function session_win() {
   window.open("<?php echo zen_href_link(FILENAME_INFO_SHOPPING_CART); ?>","info_shopping_cart","height=460,width=430,toolbar=no,statusbar=no,scrollbars=yes").focus();
 }
-//--></script>
+</script>

--- a/includes/templates/responsive_classic/jscript/jscript_responsive_framework.php
+++ b/includes/templates/responsive_classic/jscript/jscript_responsive_framework.php
@@ -7,7 +7,7 @@
  */
 ?>
 
-<script type="text/javascript"><!--//
+<script type="text/javascript">
 
 (function($) {
 $(document).ready(function() {
@@ -142,4 +142,4 @@ $('.no-fouc').removeClass('no-fouc');
 
 }) (jQuery);
 
-//--></script>
+</script>

--- a/includes/templates/template_default/templates/tpl_modules_main_product_image.php
+++ b/includes/templates/template_default/templates/tpl_modules_main_product_image.php
@@ -11,9 +11,9 @@
 ?>
 <?php require(DIR_WS_MODULES . zen_get_module_directory(FILENAME_MAIN_PRODUCT_IMAGE)); ?>
 <div id="productMainImage" class="centeredContent back">
-<script type="text/javascript"><!--
+<script type="text/javascript">
 document.write('<?php echo '<a href="javascript:popupWindow(\\\'' . zen_href_link(FILENAME_POPUP_IMAGE, 'pID=' . $_GET['products_id']) . '\\\')">' . zen_image(addslashes($products_image_medium), addslashes($products_name), MEDIUM_IMAGE_WIDTH, MEDIUM_IMAGE_HEIGHT) . '<br /><span class="imgLink">' . TEXT_CLICK_TO_ENLARGE . '</span></a>'; ?>');
-//--></script>
+</script>
 <noscript>
 <?php
   echo '<a href="' . zen_href_link(FILENAME_POPUP_IMAGE, 'pID=' . $_GET['products_id']) . '" target="_blank">' . zen_image($products_image_medium, $products_name, MEDIUM_IMAGE_WIDTH, MEDIUM_IMAGE_HEIGHT) . '<br /><span class="imgLink">' . TEXT_CLICK_TO_ENLARGE . '</span></a>';


### PR DESCRIPTION
Most javascripts contained very old style comments to hide javascript from ancient browsers like ie6, because they could not handle javascript.
Modern browsers all know how to handle javascript. This will also make coding and debugging easier using an IDE.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zencart/zencart/2401)
<!-- Reviewable:end -->
