### PR TITLE
Fix typo in doctype

### DIFF
--- a/admin/tax_classes.php
+++ b/admin/tax_classes.php
@@ -65,7 +65,7 @@ if (zen_not_null($action)) {
   }
 }
 ?>
-<!doctype html public>
+<!doctype html>
 <html <?php echo HTML_PARAMS; ?>>
   <head>
     <meta charset="<?php echo CHARSET; ?>">


### PR DESCRIPTION
The doctype contained "public", which should not be there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zencart/zencart/2404)
<!-- Reviewable:end -->
