### PR TITLE
Supports required file uploads.

### DIFF
--- a/admin/attributes_controller.php
+++ b/admin/attributes_controller.php
@@ -1222,7 +1222,14 @@ function zen_js_option_values_list($selectedName, $fieldName) {
 
                 $products_name_only = zen_get_products_name($attributes_value['products_id']);
                 $options_name = zen_options_name($attributes_value['options_id']);
-                $values_name = zen_values_name($attributes_value['options_values_id']);
+
+                $sql = "SELECT products_options_type FROM " . TABLE_PRODUCTS_OPTIONS . " WHERE products_options_id = " . (int)$attributes_value['options_id'];
+                $sql_result = $db->Execute($sql);
+
+                if (empty($attributes_value['options_values_id'])) {
+                  $value_type = translate_type_to_name($sql_result->fields['products_options_type']);
+                }
+                $values_name = (!empty($attributes_value['options_values_id']) ? zen_values_name($attributes_value['options_values_id']) : $value_type);
                 $rows++;
 
 // delete all option name values

--- a/admin/includes/languages/english/attributes_controller.php
+++ b/admin/includes/languages/english/attributes_controller.php
@@ -92,7 +92,7 @@ define('TABLE_TEXT_MAX_COUNT_SHORT', 'Max:');
   define('TEXT_ATTRIBUTES_DEFAULT', 'Default Attribute<br />to be Marked Selected:');
   define('TEXT_ATTRIBUTE_IS_DISCOUNTED', 'Apply Discounts Used<br />by Product Special/Sale:');
   define('TEXT_ATTRIBUTE_PRICE_BASE_INCLUDED','Include in Base Price<br />When Priced by Attributes');
-  define('TEXT_ATTRIBUTES_REQUIRED','Attribute Required<br />for Text:');
+  define('TEXT_ATTRIBUTES_REQUIRED','Attribute Required<br />for Text<br />or File:');
 
   define('LEGEND_BOX','Legend:');
   define('LEGEND_KEYS','OFF/ON');


### PR DESCRIPTION
As identified in the Zen Cart forum:
https://www.zen-cart.com/showthread.php?225489-Setting-up-a-product-with-a-single-required-file-upload-attribute
This offers a way to honor marking an File attribute as required.

<strike>This does not yet address the option name being identified as
Text when it is a file attribute.</strike> <- Addressed by this [commit](https://github.com/zencart/zencart/pull/2408/commits/0bc618a3a2a34de95545f03a9c71200e5413bcf1).

Note, if two or more files are marked as required that this
will "upload" all files identified; however, if any required
file is not uploaded, then none of the uploaded files get
attached to a store product and would need to be uploaded again.
Not sure yet if/how to address this, but maybe another will be
able to help or "accept" that issue.

Partially fixes #2407 