### PR TITLE
Admin: removal of constants already defined in main language file

### DIFF
--- a/admin/includes/languages/english/attributes_controller.php
+++ b/admin/includes/languages/english/attributes_controller.php
@@ -148,7 +148,6 @@ define('TABLE_TEXT_MAX_COUNT_SHORT', 'Max:');
   define('TEXT_PRODUCT_OPTIONS', '<strong>Please Choose:</strong>');
 
   define('TEXT_ATTRIBUTES_INSERT_INFO', '<strong>Define the Attribute Settings then press Insert to apply</strong>');
-  define('TEXT_PRICED_BY_ATTRIBUTES', 'Priced by Attributes');
   define('TEXT_PRODUCTS_PRICE', 'Products Price: ');
   define('TEXT_SPECIAL_PRICE', 'Special Price: ');
   define('TEXT_SALE_PRICE', 'Sale Price: ');
@@ -156,7 +155,6 @@ define('TABLE_TEXT_MAX_COUNT_SHORT', 'Max:');
   define('TEXT_CALL_FOR_PRICE', 'Call for Price');
   define('TEXT_SAVE_CHANGES','UPDATE AND SAVE CHANGES:');
 
-  define('TEXT_INFO_ID', 'ID#');
   define('TEXT_INFO_ALLOW_ADD_TO_CART_NO', 'No adding to cart');
 
   define('TEXT_DELETE_ATTRIBUTES_OPTION_NAME_VALUES', 'Confirm deletion of ALL of the Product Option Values for Option Name ...');

--- a/admin/includes/languages/english/extra_definitions/stats_sales_report_graphs.php
+++ b/admin/includes/languages/english/extra_definitions/stats_sales_report_graphs.php
@@ -8,4 +8,4 @@
  */
 
 define('BOX_REPORTS_SALES_REPORT_GRAPHS', 'Sales Report with Graphs');
-define('MONTH_TO_DATE', 'Month to Date');
+

--- a/admin/includes/languages/english/options_name_manager.php
+++ b/admin/includes/languages/english/options_name_manager.php
@@ -66,9 +66,6 @@ define('TABLE_TEXT_MAX_COUNT_SHORT', 'Max:');
   define('TABLE_HEADING_OPT_SORT_ORDER','Sort Order');
   define('TABLE_HEADING_OPT_DEFAULT','Default');
 
-  define('TABLE_HEADING_YES','Yes');
-  define('TABLE_HEADING_NO','No');
-
   define('TABLE_HEADING_OPT_TYPE', 'Option Type'); //CLR 031203 add option type column
   define('TABLE_HEADING_OPTION_VALUE_SIZE','Size');
   define('TABLE_HEADING_OPTION_VALUE_MAX','Max');

--- a/admin/includes/languages/english/options_values_manager.php
+++ b/admin/includes/languages/english/options_values_manager.php
@@ -53,9 +53,6 @@ define('TABLE_TEXT_MAX_COUNT_SHORT', 'Max:');
   define('TABLE_HEADING_OPT_SORT_ORDER','Sort Order');
   define('TABLE_HEADING_OPT_DEFAULT','Default');
 
-  define('TABLE_HEADING_YES','Yes');
-  define('TABLE_HEADING_NO','No');
-
   define('TABLE_HEADING_OPT_TYPE', 'Option Type'); //CLR 031203 add option type column
   define('TABLE_HEADING_OPTION_VALUE_SIZE','Size');
   define('TABLE_HEADING_OPTION_VALUE_MAX','Max');

--- a/admin/includes/languages/english/products_price_manager.php
+++ b/admin/includes/languages/english/products_price_manager.php
@@ -86,7 +86,6 @@ define('TEXT_INFO_HEADING_DELETE_FEATURED', 'Delete Featured');
 define('TEXT_INFO_DELETE_INTRO', 'Are you sure you want to delete the featured product?');
 
   define('TEXT_ATTRIBUTES_INSERT_INFO', '<strong>Define the Attribute Settings then press Insert to apply</strong>');
-  define('TEXT_PRICED_BY_ATTRIBUTES', 'Priced by Attributes');
   define('TEXT_PRODUCTS_PRICE', 'Products Price: ');
   define('TEXT_SPECIAL_PRICE', 'Special Price: ');
   define('TEXT_SALE_PRICE', 'Sale Price: ');

--- a/admin/includes/languages/english/users.php
+++ b/admin/includes/languages/english/users.php
@@ -13,7 +13,6 @@ define('IMAGE_ADD_USER', 'Add User');
 
 define('TEXT_ID', 'ID');
 define('TEXT_NAME', 'Name');
-define('TEXT_EMAIL', 'Email');
 define('TEXT_PROFILE', 'Profile');
 define('TEXT_CHOOSE_PROFILE', 'Choose Profile');
 define('TEXT_PASSWORD', 'Password');


### PR DESCRIPTION
These all get spat out by Report All Errors.

These are the only ones not fixed.

TEXT_GV_REDEEM
If this is removed from gv_name, then 
admin->Discounts->Mail Gift Certificate gives an error as it is undefined.
admin->Discounts->Gift Certificates sent gives an error as it is undefined.

On the Admin-Payment modules page, there are 100 duplicated paypal constants errors!

The Catalog side needs a lot of TLC in this respect that someone else will need to do!
