### PR TITLE
Don't use result of void function

### DIFF
--- a/zc_install/includes/modules/pages/completion/header_php.php
+++ b/zc_install/includes/modules/pages/completion/header_php.php
@@ -37,7 +37,7 @@
     $dbInstaller = new zcDatabaseInstaller($options);
     $result = $dbInstaller->getConnection();
     $extendedOptions = array();
-    $error = $dbInstaller->doCompletion($options);
+    $dbInstaller->doCompletion($options);
   }
 
   // Update Nginx Conf Template


### PR DESCRIPTION
doCompletion() returns no result, so result shouldn't be saved. 