### PR TITLE
Correct ot_shipping PHP notice

### DIFF
--- a/includes/modules/order_total/ot_shipping.php
+++ b/includes/modules/order_total/ot_shipping.php
@@ -86,6 +86,9 @@
           $shipping_tax_amount = zen_calculate_tax($order->info['shipping_cost'], $shipping_tax);
           $order->info['shipping_tax'] += $shipping_tax_amount;
           $order->info['tax'] += $shipping_tax_amount;
+          if (!isset($order->info['tax_groups'][$shipping_tax_description])) {
+              $order->info['tax_groups'][$shipping_tax_description] = 0;
+          }
           $order->info['tax_groups']["$shipping_tax_description"] += zen_calculate_tax($order->info['shipping_cost'], $shipping_tax);
           $order->info['total'] += zen_calculate_tax($order->info['shipping_cost'], $shipping_tax);
           $_SESSION['shipping_tax_description'] =  $shipping_tax_description;


### PR DESCRIPTION
If a store has configured a shipping tax-class **different from** the product-related tax classes, that tax-group isn't added to the order's `tax_groups` array until such time as the ot_shipping module is instantiated.

That results in a PHP Notice being thrown during the `checkout_payment` page's header processing:

```
[18-Jun-2019 12:49:00 America/New_York] Request URI: /zc156ms/index.php?main_page=checkout_payment, IP address: ::1
#1  ot_shipping->__construct() called at [C:\xampp\htdocs\zc156ms\includes\classes\order_total.php:51]
#2  order_total->__construct() called at [C:\xampp\htdocs\zc156ms\includes\modules\pages\checkout_payment\header_php.php:99]
#3  require(C:\xampp\htdocs\zc156ms\includes\modules\pages\checkout_payment\header_php.php) called at [C:\xampp\htdocs\zc156ms\index.php:36]
--> PHP Notice: Undefined index: NC Shipping Tax (5%) in C:\xampp\htdocs\zc156ms\includes\modules\order_total\ot_shipping.php on line 89.
```

This update initializes that entry in the order's `tax_groups` to a value of 0, if not already set.