### PR TITLE
v157 PHP 7.3 notice of non-variable passed by reference

### DIFF
--- a/includes/modules/pages/account_edit/header_php.php
+++ b/includes/modules/pages/account_edit/header_php.php
@@ -104,10 +104,8 @@ if (isset($_POST['action']) && ($_POST['action'] == 'process')) {
   $zco_notifier->notify('NOTIFY_HEADER_ACCOUNT_EDIT_VERIFY_COMPLETE');
 
   if ($error == false) {
-    //update external bb system with new email address
-    $new_email_address = $db->prepareInput($email_address);
-    $zco_notifier->notify('NOTIFY_NICK_UPDATE_EMAIL_ADDRESS', $nick, $new_email_address);
-    unset($new_email_address);
+    //update external bb system with submitted email address
+    $zco_notifier->notify('NOTIFY_NICK_UPDATE_EMAIL_ADDRESS', $nick, $email_address);
 
     // build array of data to store the requested changes
     $sql_data_array = array(array('fieldName'=>'customers_firstname', 'value'=>$firstname, 'type'=>'stringIgnoreNull'),

--- a/includes/modules/pages/account_edit/header_php.php
+++ b/includes/modules/pages/account_edit/header_php.php
@@ -105,7 +105,9 @@ if (isset($_POST['action']) && ($_POST['action'] == 'process')) {
 
   if ($error == false) {
     //update external bb system with new email address
-    $zco_notifier->notify('NOTIFY_NICK_UPDATE_EMAIL_ADDRESS', $nick, $db->prepareInput($email_address));
+    $new_email_address = $db->prepareInput($email_address);
+    $zco_notifier->notify('NOTIFY_NICK_UPDATE_EMAIL_ADDRESS', $nick, $new_email_address);
+    unset($new_email_address);
 
     // build array of data to store the requested changes
     $sql_data_array = array(array('fieldName'=>'customers_firstname', 'value'=>$firstname, 'type'=>'stringIgnoreNull'),


### PR DESCRIPTION
Fixed #2464.

Created a variable specifically to pass the sanitized information to the observer and then deleted the variable.  This maintains the notifier as previously provided while still providing sanitized information to the second parameter (editable by design of the observer class beginning in Zen Cart 1.5.3) but is then unset to not affect the subsequent storage of the original provided `$email_address`.