### PR TITLE
v157 paypalwpp.php zen_get_file_directory support template override

### DIFF
--- a/includes/modules/payment/paypalwpp.php
+++ b/includes/modules/payment/paypalwpp.php
@@ -2196,7 +2196,7 @@ if (false) { // disabled until clarification is received about coupons in PayPal
         // send Welcome Email if appropriate
         if ($this->new_acct_notify == 'Yes') {
           // require the language file
-          require(zen_get_file_directory(DIR_FS_CATALOG . DIR_WS_LANGUAGES . $_SESSION['language'], 'create_account.php', 'false'));
+          require(zen_get_file_directory(DIR_FS_CATALOG . DIR_WS_LANGUAGES . $_SESSION['language'] . DIRECTORY_SEPARATOR, 'create_account.php', 'false'));
           // set the mail text
           $email_text = sprintf(EMAIL_GREET_NONE, $paypal_ec_payer_info['payer_firstname']) . EMAIL_WELCOME . "\n\n" . EMAIL_TEXT;
           $email_text .= "\n\n" . EMAIL_EC_ACCOUNT_INFORMATION . "\nUsername: " . $paypal_ec_payer_info['payer_email'] . "\nPassword: " . $password . "\n\n";


### PR DESCRIPTION
The first parameter to the function `zen_get_file_directory()` is expecting a path that ends with a slash to support joining the data presented.  If it is not provided there and it is not provided as the filename prefix, then the returned value may not be a valid filename, at the least it will not be the file expected/desired as the filename will be joined to the language.

Proposals have been made to v156 that while restoring some version of operation, does not support using the template override version of the `create_account.php` file. At some point in the merge of files (possibly by another future PR) the issue may get resolved.

I don't care how/when/by whom, just that this issue is resolved back to the way it operated before.