### PR TITLE
v156b-c/v157 Ensure $detect is set when html_header.php overridden

### DIFF
--- a/includes/templates/responsive_classic/common/main_template_vars.php
+++ b/includes/templates/responsive_classic/common/main_template_vars.php
@@ -29,7 +29,14 @@
   if (!isset($flag_disable_right)) {
     $flag_disable_right = false;
   }
-  $display_as_mobile = ($detect->isMobile() && !$detect->isTablet() || $_SESSION['layoutType'] == 'mobile' or  $detect->isTablet() || $_SESSION['layoutType'] == 'tablet'); 
+
+  if (!class_exists('Mobile_Detect')) {
+    include_once(DIR_WS_CLASSES . 'Mobile_Detect.php');
+  }
+  if (!isset($detect)) $detect = new Mobile_Detect;
+  if (!isset($_SESSION['layoutType'])) $_SESSION['layoutType'] = 'legacy';
+
+  $display_as_mobile = ($detect->isMobile() || $detect->isTablet() || $_SESSION['layoutType'] == 'mobile' || $_SESSION['layoutType'] == 'tablet'); 
 
 /**
  * load page-specific main_template_vars if present, or jump directly to template file


### PR DESCRIPTION
The majority of variables such as `$template` and `$template_dir` are set in the early loading process of Zen Cart; however, `$detect` is provided for responsive template use and is loaded in the common/html_header.php file.  Unfortunately, in processing of `index.php`, the template directory is searched using the `$current_page_base` for an override folder to possibly override `html_header.php`.  If that file is overridden, then execution of the `common/main_template_vars.php` file will fail at the use of `$detect` if that override does not set it to a class that supports the methods `isMobile()` and `isTablet()`.  

The current version of the file "assigns" `$layoutType` to `'legacy'` basically if the `common/html_header.php` file is overridden without defining `$layoutType` and then further ignores the variables of `$isMobile` and `$isTablet` in potential assignment of `$paginateAsUL`.

The `$display_as_mobile` is rewritten for a little clarity.  Initial thought was to simply change `or` to `||`; however, upon further inspection and testing of all combinations of results, `$display_as_mobile` was found to be true for all cases except where: `$detect->isMobile()` is false, `$detect->isTablet()` is false *AND* `$_SESSION['layoutType']` is not equal to `mobile` nor `tablet`.  Whether that variable is truly used elsewhere or not is questionable, but this commit appears to address the problem of `$detect` not being defined and ensuring that `$_SESSION['layoutType']` is set.

I could see a number of other ways to address these assignments within this file; however, not sure yet how far spread overrides are that prevent loading one or the other file but still maintain the broad spectrum of operation.

Additionally, I recognize that this does not ensure setting of either `$isMobile` or `$isTablet`. Why? I wasn't so sure that these needed to be set in order to support further/downstream code seeing as much of it relies on the `$detect` variable.

Unfortunately though, if both `common/html_header.php` and `common/main_template_vars.php` are overridden, then some other method of setting/establishing `$detect` would still be needed if this is to remain a conditional variable to be set for only when a responsive template is in use. 

*EDIT:* Ohh, also, this was noticed/identified in the Zen Cart forum thread with a similar solution posted: https://www.zen-cart.com/showthread.php?225541-1-56-6B-Change-Sitemap-XML-Result-File-404-error