### PR TITLE
Prevent `Parameter must be an array` error on checkout confirmation page

### DIFF
--- a/includes/classes/payment.php
+++ b/includes/classes/payment.php
@@ -219,7 +219,7 @@ class payment extends base {
       if (is_object($GLOBALS[$this->selected_module]) && ($GLOBALS[$this->selected_module]->enabled) ) {
         $confirmation = $GLOBALS[$this->selected_module]->confirmation();
         if (!is_array($confirmation)) $confirmation = array('title' => '', 'fields' => array());
-        if (!(isset($confirmation['fields']) && is_array($confirmation['fields']))) $confirmation['fields'] = array();
+        if (!isset($confirmation['fields']) || !is_array($confirmation['fields'])) $confirmation['fields'] = array();
         if (!isset($confirmation['title'])) $confirmation['title'] = '';
       }
     }

--- a/includes/classes/payment.php
+++ b/includes/classes/payment.php
@@ -214,15 +214,16 @@ class payment extends base {
   }
 
   function confirmation() {
+    $confirmation = array('title' => '', 'fields' => array());
     if (is_array($this->modules)) {
       if (is_object($GLOBALS[$this->selected_module]) && ($GLOBALS[$this->selected_module]->enabled) ) {
         $confirmation = $GLOBALS[$this->selected_module]->confirmation();
-        if (!is_array($confirmation)) $confirmation = array('title' => '');
+        if (!is_array($confirmation)) $confirmation = array('title' => '', 'fields' => array());
         if (!(isset($confirmation['fields']) && is_array($confirmation['fields']))) $confirmation['fields'] = array();
         if (!isset($confirmation['title'])) $confirmation['title'] = '';
-        return $confirmation;
       }
     }
+    return $confirmation;
   }
 
   function process_button_ajax() {


### PR DESCRIPTION
Fixes #2364 