### PR TITLE
Improve upgrade message

### DIFF
--- a/zc_install/ajaxLoadUpdatesSql.php
+++ b/zc_install/ajaxLoadUpdatesSql.php
@@ -44,11 +44,8 @@ $versionInfo = $updateList[$updateVersion];
 if ($versionInfo['required'] != $dbVersion)
 {
   $error = TRUE;
-  if (!empty($versionInfo['required'])) {
-    $errorList[] = sprintf(TEXT_COULD_NOT_UPDATE_BECAUSE_ANOTHER_VERSION_REQUIRED, $updateVersion, $dbVersion, $versionInfo['required']);
-  } else {
-    $errorList[] = TEXT_COULD_NOT_UPDATE_BECAUSE_PATH_NOT_DEFINED;
-  }
+  if (empty($versionInfo['required'])) $versionInfo['required'] = '[ ERROR: NOT READY FOR UPGRADES YET. NOTIFY DEV TEAM!] ';
+  $errorList[] = sprintf(TEXT_COULD_NOT_UPDATE_BECAUSE_ANOTHER_VERSION_REQUIRED, $updateVersion, $dbVersion, $versionInfo['required']);
 }
 if (!$error)
 {

--- a/zc_install/ajaxLoadUpdatesSql.php
+++ b/zc_install/ajaxLoadUpdatesSql.php
@@ -44,7 +44,11 @@ $versionInfo = $updateList[$updateVersion];
 if ($versionInfo['required'] != $dbVersion)
 {
   $error = TRUE;
-  $errorList[] = sprintf(TEXT_COULD_NOT_UPDATE_BECAUSE_ANOTHER_VERSION_REQUIRED, $updateVersion, $dbVersion, $versionInfo['required']);
+  if (!empty($versionInfo['required'])) {
+    $errorList[] = sprintf(TEXT_COULD_NOT_UPDATE_BECAUSE_ANOTHER_VERSION_REQUIRED, $updateVersion, $dbVersion, $versionInfo['required']);
+  } else {
+    $errorList[] = TEXT_COULD_NOT_UPDATE_BECAUSE_PATH_NOT_DEFINED;
+  }
 }
 if (!$error)
 {

--- a/zc_install/includes/languages/lngEnglish.php
+++ b/zc_install/includes/languages/lngEnglish.php
@@ -75,7 +75,6 @@ define('TEXT_LOADING_DEMO_DATA', 'Loading Demo Data');
 define('TEXT_LOADING_PLUGIN_DATA', 'Loading SQL for Pre-installed Plugins');
 
 define('TEXT_COULD_NOT_UPDATE_BECAUSE_ANOTHER_VERSION_REQUIRED', 'Could not update to version %s. We detect that you currently have v%s, and must perform the updates to get to version %s first.');
-define('TEXT_COULD_NOT_UPDATE_BECAUSE_PATH_NOT_DEFINED', 'Could not update - path to new version not defined in $updateList.');
 
 define('TEXT_PAGE_HEADING_ADMIN_SETUP', 'Admin Setup');
 define('TEXT_ADMIN_SETUP_USER_SETTINGS', 'Admin User Settings');

--- a/zc_install/includes/languages/lngEnglish.php
+++ b/zc_install/includes/languages/lngEnglish.php
@@ -75,6 +75,7 @@ define('TEXT_LOADING_DEMO_DATA', 'Loading Demo Data');
 define('TEXT_LOADING_PLUGIN_DATA', 'Loading SQL for Pre-installed Plugins');
 
 define('TEXT_COULD_NOT_UPDATE_BECAUSE_ANOTHER_VERSION_REQUIRED', 'Could not update to version %s. We detect that you currently have v%s, and must perform the updates to get to version %s first.');
+define('TEXT_COULD_NOT_UPDATE_BECAUSE_PATH_NOT_DEFINED', 'Could not update - path to new version not defined in $updateList.');
 
 define('TEXT_PAGE_HEADING_ADMIN_SETUP', 'Admin Setup');
 define('TEXT_ADMIN_SETUP_USER_SETTINGS', 'Admin User Settings');


### PR DESCRIPTION
When I went to test the upgrade, the new version had not yet been defined in the `$updateList`, so the message was confusing (since one of the strings which were embedded in the error message were blank). 

Instead of saying:
[we] must perform the updates to get to version 1.5.6 first.
it said, 
[we] must perform the updates to get to version first.
