### PR TITLE
Fix PHP Notice when no db checks defined yet in zc_install

### DIFF
--- a/zc_install/includes/classes/class.systemChecker.php
+++ b/zc_install/includes/classes/class.systemChecker.php
@@ -160,6 +160,7 @@ class systemChecker
       if ($systemCheck['runLevel'] == 'dbVersion')
       {
         $resultCombined = TRUE;
+        if (!isset($systemCheck['methods'])) $systemCheck['methods'] = array(); 
         foreach ($systemCheck['methods'] as $methodName => $methodDetail)
         {
           if (isset($methodDetail['method'])) $methodName = $methodDetail['method'];


### PR DESCRIPTION
Resolves 

[07-Jul-2019 03:33:16 America/New_York] PHP Notice:  Undefined index: methods in /Users/scott/Sites/gh_demo_157/zc_install/includes/classes/class.systemChecker.php on line 163