### PR TITLE
Set value to an number instead of empty quotes if no value.

### DIFF
--- a/admin/products_to_categories.php
+++ b/admin/products_to_categories.php
@@ -8,7 +8,7 @@
  */
 require('includes/application_top.php');
 
-$_GET['products_filter'] = $products_filter = ((isset($_GET['products_filter']) && $_GET['products_filter'] > 0) ? (int)$_GET['products_filter'] : (isset($_POST['products_filter'])  ? (int)$_POST['products_filter'] : ''));
+$_GET['products_filter'] = $products_filter = ((isset($_GET['products_filter']) && $_GET['products_filter'] > 0) ? (int)$_GET['products_filter'] : (isset($_POST['products_filter'])  ? (int)$_POST['products_filter'] : 0));
 $_GET['current_category_id'] = $current_category_id = (isset($_GET['current_category_id']) ? (int)$_GET['current_category_id'] : (int)$current_category_id);
 
 // verify at least one product exists


### PR DESCRIPTION
All results for `$_GET['products_filter']` and `$products_filter`
are set to an `integer` `(int)`, thus seems the default not found
value should also be set to an integer which in this case is `0`.