### PR TITLE
Provide consistent use of added `zen_get_file_directory` calls

### DIFF
--- a/admin/includes/languages/english.php
+++ b/admin/includes/languages/english.php
@@ -780,6 +780,6 @@ define('WARNING_PRIMARY_SERVER_FAILED', 'Warning: The primary exchange rate serv
 
 ///////////////////////////////////////////////////////////
 // include additional files:
-  require(DIR_WS_LANGUAGES . $_SESSION['language'] . '/' . FILENAME_EMAIL_EXTRAS);
+  require(DIR_WS_LANGUAGES . $_SESSION['language'] . "/" . FILENAME_EMAIL_EXTRAS);
   include(zen_get_file_directory(DIR_FS_CATALOG_LANGUAGES . $_SESSION['language'] . '/', FILENAME_OTHER_IMAGES_NAMES, 'false'));
 

--- a/includes/functions/audience.php
+++ b/includes/functions/audience.php
@@ -18,7 +18,7 @@
   // ie: mail, gv_main, coupon_admin... and eventually newsletters too.
   // gets info from query_builder table
 
-  include_once(zen_get_file_directory(DIR_FS_CATALOG . DIR_WS_LANGUAGES . $_SESSION['language'] . DIRECTORY_SEPARATOR, 'audience.php', 'false'));
+  include_once(zen_get_file_directory(DIR_FS_CATALOG . DIR_WS_LANGUAGES . $_SESSION['language'] . "/", 'audience.php', 'false'));
 
   global $db;
   $count_array = array();

--- a/includes/languages/english.php
+++ b/includes/languages/english.php
@@ -632,7 +632,7 @@
   $file_list = array(FILENAME_EMAIL_EXTRAS, FILENAME_HEADER, FILENAME_BUTTON_NAMES, FILENAME_ICON_NAMES, FILENAME_OTHER_IMAGES_NAMES, FILENAME_CREDIT_CARDS, FILENAME_WHOS_ONLINE, FILENAME_META_TAGS); 
   foreach ($file_list as $file) { 
     $file = str_replace(".php","",$file); 
-    require_once(zen_get_file_directory(DIR_FS_CATALOG . DIR_WS_LANGUAGES . $_SESSION['language'] . '/', $file . '.php', 'false'));
+    require_once(zen_get_file_directory(DIR_FS_CATALOG . DIR_WS_LANGUAGES . $_SESSION['language'] . "/", $file . '.php', 'false'));
   }
 
 // END OF EXTERNAL LANGUAGE LINKS


### PR DESCRIPTION
Recent additions of adding a closing slash have been accepted
with double quotes (`""`) instead of single quotes (`''`)
or `DIRECTORY_SEPARATOR`. This makes the usage consistent and
easier to locate if a search is necessary other than a
regex that looks for either type of quotes.