### PR TITLE
Eliminate PHP Warning: preg_xxxxx JIT compilation failed:

### DIFF
--- a/admin/includes/application_top.php
+++ b/admin/includes/application_top.php
@@ -33,6 +33,7 @@ if (!isset($PHP_SELF)) $PHP_SELF = $_SERVER['SCRIPT_NAME'];
 $PHP_SELF = htmlspecialchars($PHP_SELF);
 // Suppress html from error messages
 @ini_set("html_errors","0");
+@ini_set("pcre.jit", "0");
 /*
  * Get time zone info from PHP config
 */

--- a/includes/application_top.php
+++ b/includes/application_top.php
@@ -62,6 +62,7 @@ define('PAGE_PARSE_START_TIME', microtime());
 //  define('DISPLAY_PAGE_PARSE_TIME', 'true');
 @ini_set("arg_separator.output","&");
 @ini_set("html_errors","0");
+@ini_set("pcre.jit", "0");
 /**
  * Set the local configuration parameters - mainly for developers
  */


### PR DESCRIPTION
no more memory in filename....

Seen occurring in PHP 7.3.6.