### PR TITLE
Respect overrides in includes/modules/sideboxes

### DIFF
--- a/includes/functions/functions_general.php
+++ b/includes/functions/functions_general.php
@@ -1322,7 +1322,7 @@
     }
   }
 
-  function zen_get_module_sidebox_directory($check_file, $dir_only = 'false') {
+  function zen_get_module_sidebox_directory($check_file) { 
     global $template_dir;
 
     $zv_filename = $check_file;
@@ -1334,11 +1334,7 @@
       $template_dir_select = 'sideboxes/';
     }
 
-    if ($dir_only == 'true') {
-      return $template_dir_select;
-    } else {
-      return $template_dir_select . $zv_filename;
-    }
+    return $template_dir_select . $zv_filename;
   }
 
 

--- a/includes/functions/functions_general.php
+++ b/includes/functions/functions_general.php
@@ -1322,6 +1322,25 @@
     }
   }
 
+  function zen_get_module_sidebox_directory($check_file, $dir_only = 'false') {
+    global $template_dir;
+
+    $zv_filename = $check_file;
+    if (!strstr($zv_filename, '.php')) $zv_filename .= '.php';
+
+    if (file_exists(DIR_WS_MODULES . 'sideboxes/' . $template_dir . '/' . $zv_filename)) {
+      $template_dir_select = 'sideboxes/' . $template_dir . '/';
+    } else {
+      $template_dir_select = 'sideboxes/';
+    }
+
+    if ($dir_only == 'true') {
+      return $template_dir_select;
+    } else {
+      return $template_dir_select . $zv_filename;
+    }
+  }
+
 
 ////
 // find template or default file

--- a/includes/templates/responsive_classic/common/tpl_header.php
+++ b/includes/templates/responsive_classic/common/tpl_header.php
@@ -85,7 +85,9 @@ echo '<div class="header Fixed"><a href="#menu" title="Menu"><i class="fa fa-bar
     <li class="last"><a class="blue" href="<?php echo zen_href_link(FILENAME_CHECKOUT_SHIPPING, '', 'SSL'); ?>"><i class="fa fa-check-square" title="Checkout"></i></a></li>
 <?php }?>
   </ul>
-<div id="navMainSearch" class="forward"><?php require(DIR_WS_MODULES . 'sideboxes/search_header.php'); ?></div>
+<div id="navMainSearch" class="forward">
+     <?php require(DIR_WS_MODULES . zen_get_module_sidebox_directory('search_header.php')); ?>
+</div>
 </div>
 </div>
 
@@ -198,9 +200,13 @@ echo '<div class="header Fixed"><a href="#menu" title="Menu"><i class="fa fa-bar
 <!--eof header logo and navigation display-->
 
 <?php if ( $detect->isMobile() && !$detect->isTablet() || $_SESSION['layoutType'] == 'mobile' ) { ?>
-  <div id="navMainSearch1" class="forward"><?php require(DIR_WS_MODULES . 'sideboxes/search_header.php'); ?></div>
+  <div id="navMainSearch1" class="forward">
+     <?php require(DIR_WS_MODULES . zen_get_module_sidebox_directory('search_header.php')); ?>
+  </div>
 <?php  } else if ( $detect->isTablet() || $_SESSION['layoutType'] == 'tablet' ) { ?>
-  <div id="navMainSearch1" class="forward"><?php require(DIR_WS_MODULES . 'sideboxes/search_header.php'); ?></div>
+  <div id="navMainSearch1" class="forward">
+     <?php require(DIR_WS_MODULES . zen_get_module_sidebox_directory('search_header.php')); ?>
+  </div>
 <?php  } else if ( $_SESSION['layoutType'] == 'full' ) {
   } else {
 //

--- a/includes/templates/responsive_classic/common/tpl_header.php
+++ b/includes/templates/responsive_classic/common/tpl_header.php
@@ -86,7 +86,7 @@ echo '<div class="header Fixed"><a href="#menu" title="Menu"><i class="fa fa-bar
 <?php }?>
   </ul>
 <div id="navMainSearch" class="forward">
-     <?php require(DIR_WS_MODULES . zen_get_module_sidebox_directory('search_header.php')); ?>
+  <?php require(DIR_WS_MODULES . zen_get_module_sidebox_directory('search_header.php')); ?>
 </div>
 </div>
 </div>
@@ -126,7 +126,9 @@ echo '<div class="header Fixed"><a href="#menu" title="Menu"><i class="fa fa-bar
     <li class="last"><a class="blue" href="<?php echo zen_href_link(FILENAME_CHECKOUT_SHIPPING, '', 'SSL'); ?>"><?php echo HEADER_TITLE_CHECKOUT; ?></a></li>
 <?php }?>
 </ul>
-<div id="navMainSearch" class="forward"><?php require(DIR_WS_MODULES . 'sideboxes/search_header.php'); ?></div>
+<div id="navMainSearch" class="forward">
+   <?php require(DIR_WS_MODULES . zen_get_module_sidebox_directory('search_header.php')); ?>
+</div>
 </div>
 </div>
 <!--eof navigation display-->
@@ -163,7 +165,9 @@ echo '<div class="header Fixed"><a href="#menu" title="Menu"><i class="fa fa-bar
     <li class="last"><a class="blue" href="<?php echo zen_href_link(FILENAME_CHECKOUT_SHIPPING, '', 'SSL'); ?>"><?php echo HEADER_TITLE_CHECKOUT; ?></a></li>
 <?php }?>
   </ul>
-<div id="navMainSearch" class="forward"><?php require(DIR_WS_MODULES . 'sideboxes/search_header.php'); ?></div>
+<div id="navMainSearch" class="forward">
+     <?php require(DIR_WS_MODULES . zen_get_module_sidebox_directory('search_header.php')); ?>
+</div>
 </div>
 </div>
 <!--eof navigation display-->

--- a/includes/templates/responsive_classic/templates/tpl_modules_mobile_menu.php
+++ b/includes/templates/responsive_classic/templates/tpl_modules_mobile_menu.php
@@ -136,7 +136,9 @@ echo $menulist;
     </li>
 
 
-    <li id="menu-search"><?php require(DIR_WS_MODULES . 'sideboxes/search_header.php'); ?></li>
+    <li id="menu-search">
+      <?php require(DIR_WS_MODULES . zen_get_module_sidebox_directory('search_header.php')); ?>
+    </li>
 
   </ul>
 </nav>

--- a/includes/templates/template_default/common/tpl_header.php
+++ b/includes/templates/template_default/common/tpl_header.php
@@ -61,7 +61,9 @@ if (!isset($flag_disable_header) || !$flag_disable_header) {
 <?php }?>
 </ul>
 </div>
-<div id="navMainSearch"><?php require(DIR_WS_MODULES . 'sideboxes/search_header.php'); ?></div>
+<div id="navMainSearch">
+  <?php require(DIR_WS_MODULES . zen_get_module_sidebox_directory('search_header.php')); ?>
+</div>
 <br class="clearBoth" />
 </div>
 <!--eof-navigation display-->


### PR DESCRIPTION
Using `require(DIR_WS_MODULES . 'sideboxes/search_header.php');` means a sidebox template override will be ignored. 