### PR TITLE
Ensure submitonce() is available on payment page

### DIFF
--- a/includes/modules/pages/checkout_confirmation/jscript_double_submit.php
+++ b/includes/modules/pages/checkout_confirmation/jscript_double_submit.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * jscript_main
+ *
+ * @package page
+ * @copyright Copyright 2003-2019 Zen Cart Development Team
+ * @copyright Portions Copyright 2003 osCommerce
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: DrByte 2019 May 25 Modified in v1.5.6b $
+ */
+?>
+<script type="text/javascript">
+function submitonce()
+{
+  var button = document.getElementById("btn_submit");
+  button.style.cursor="wait";
+  button.disabled = true;
+  setTimeout('button_timeout()', 4000);
+  return false;
+}
+function button_timeout() {
+  var button = document.getElementById("btn_submit");
+  button.style.cursor="wait";
+  button.disabled = true;
+}
+
+</script>

--- a/includes/modules/pages/checkout_confirmation/jscript_main.php
+++ b/includes/modules/pages/checkout_confirmation/jscript_main.php
@@ -25,18 +25,4 @@ function submitFunction($gv,$total) {
    }
 }
 
-function submitonce()
-{
-  var button = document.getElementById("btn_submit");
-  button.style.cursor="wait";
-  button.disabled = true;
-  setTimeout('button_timeout()', 4000);
-  return false;
-}
-function button_timeout() {
-  var button = document.getElementById("btn_submit");
-  button.style.cursor="wait";
-  button.disabled = true;
-}
-
 </script>

--- a/includes/modules/pages/checkout_payment/jscript_double_submit.php
+++ b/includes/modules/pages/checkout_payment/jscript_double_submit.php
@@ -1,4 +1,2 @@
 <?php 
   require(DIR_WS_MODULES . '/pages/checkout_confirmation/jscript_double_submit.php'); 
-?>
-

--- a/includes/modules/pages/checkout_payment/jscript_double_submit.php
+++ b/includes/modules/pages/checkout_payment/jscript_double_submit.php
@@ -1,0 +1,4 @@
+<?php 
+  require(DIR_WS_MODULES . '/pages/checkout_confirmation/jscript_double_submit.php'); 
+?>
+

--- a/includes/modules/pages/checkout_payment/jscript_main.php
+++ b/includes/modules/pages/checkout_payment/jscript_main.php
@@ -75,3 +75,4 @@ function doCollectsCardDataOnsite()
     });
 
 </script>
+<?php require(DIR_WS_MODULES . '/pages/checkout_confirmation/jscript_double_submit.php'); ?>

--- a/includes/modules/pages/checkout_payment/jscript_main.php
+++ b/includes/modules/pages/checkout_payment/jscript_main.php
@@ -75,4 +75,3 @@ function doCollectsCardDataOnsite()
     });
 
 </script>
-<?php require(DIR_WS_MODULES . '/pages/checkout_confirmation/jscript_double_submit.php'); ?>


### PR DESCRIPTION
Fixes #2536 PADSS_AJAX_CHECKOUT means checkout confirmation javascript not loaded so submit once protection is missing. 