### PR TITLE
Provide the option of not going to 404 when product status is 0

### DIFF
--- a/includes/functions/functions_products.php
+++ b/includes/functions/functions_products.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * functions_products.php
+ * Functions related to products
+ * Note: Several product-related lookup functions are located in functions_lookups.php
+ *
+ * @package functions
+ * @copyright Copyright 2019 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: New in v1.5.7 $
+ */
+
+/**
+ * Query product details
+ * @param int $product_id
+ * @param int $language_id (optional)
+ * @return queryFactoryResult
+ */
+function zen_get_product_details($product_id, $language_id = null)
+{
+    global $db;
+
+    if ($language_id === null) $language_id = $_SESSION['languages_id'];
+
+    $sql = "SELECT p.products_status, p.*, pd.*
+            FROM " . TABLE_PRODUCTS . " p, " .
+                     TABLE_PRODUCTS_DESCRIPTION . " pd
+            WHERE    p.products_id = " . (int)$product_id . "
+            AND      pd.products_id = p.products_id
+            AND      pd.language_id = " . (int)$language_id;
+    return $db->Execute($sql);
+}
+
+/**
+ * @param int $product_id
+ * @param null $product_info
+ */
+function zen_product_set_header_response($product_id, $product_info = null)
+{
+    global $zco_notifier, $breadcrumb, $robotsNoIndex;
+
+    // make sure we got a dbResponse
+    if ($product_info === null || !isset($product_info->EOF)) {
+        $product_info = zen_get_product_details($product_id);
+    }
+    // make sure it's for the current product
+    if (!isset($product_info->fields['products_id'], $product_info->fields['products_status']) || $product_info->fields['products_id'] !== $product_id) {
+        $product_info = zen_get_product_details($product_id);
+    }
+
+    $response_code = 200;
+
+    $should_throw_404 = $product_not_found = $product_info->EOF;
+    if ($should_throw_404) {
+        $response_code = 404;
+    }
+
+    global $product_status;
+    $product_status = !$product_info->EOF && $product_info->fields['products_status'] ? (int)$product_info->fields['products_status'] : 0;
+
+    if ($product_status === 0) {
+        $response_code = 410;
+    }
+
+    if (defined('PRODUCT_THROWS_200_WHEN_DISABLED') && PRODUCT_THROWS_200_WHEN_DISABLED === true) {
+        $response_code = 200;
+    }
+
+    if ($product_status === -1) {
+        $response_code = 410;
+    }
+
+    $use_custom_response_code = false;
+    /**
+     * optionally update the $product_status, $should_throw_404, $response_code vars via the observer
+     */
+    $zco_notifier->notify('NOTIFY_PRODUCT_INFO_PRODUCT_STATUS_CHECK', $product_info->fields, $product_status, $should_throw_404, $response_code, $use_custom_response_code);
+
+    if ($use_custom_response_code) {
+        // skip this function's processing and leave all header handling to the observer.
+        // Note: the observer should do all the 404 stuff from below too
+        return;
+    }
+
+    if ($should_throw_404) {
+        // if specified product_id doesn't exist, ensure that metatags and breadcrumbs don't share bad data or inappropriate information
+        unset($_GET['products_id']);
+        unset($breadcrumb->_trail[sizeof($breadcrumb->_trail)-1]['title']);
+        $robotsNoIndex = true;
+        header('HTTP/1.1 404 Not Found');
+        return;
+    }
+
+    if ($response_code === 410) {
+        $robotsNoIndex = true;
+        header('HTTP/1.1 410 Gone');
+        return;
+    }
+
+    if ($response_code === 200) return;
+}

--- a/includes/init_includes/init_general_funcs.php
+++ b/includes/init_includes/init_general_funcs.php
@@ -4,10 +4,10 @@
  * see {@link  http://www.zen-cart.com/wiki/index.php/Developers_API_Tutorials#InitSystem wikitutorials} for more details.
  *
  * @package initSystem
- * @copyright Copyright 2003-2014 Zen Cart Development Team
+ * @copyright Copyright 2003-2019 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version GIT: $Id: Author: DrByte  Tue Apr 1 15:45:22 2014 -0400 Modified in v1.5.3 $
+ * @version GIT: $Id: Author: DrByte  Modified in v1.5.7 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
@@ -16,6 +16,10 @@ if (!defined('IS_ADMIN_FLAG')) {
  * General Functions
  */
 require(DIR_WS_FUNCTIONS . 'functions_general.php');
+/**
+ * Product Functions
+ */
+require(DIR_WS_FUNCTIONS . 'functions_products.php');
 /**
  * html_output functions (href_links, input types etc)
  */

--- a/includes/modules/pages/document_general_info/header_php.php
+++ b/includes/modules/pages/document_general_info/header_php.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * document_general header_php.php 
+ * document_general header_php.php
  *
  * @package page
  * @copyright Copyright 2003-2006 Zen Cart Development Team
@@ -9,11 +9,14 @@
  * @version $Id: header_php.php 2978 2006-02-07 00:52:01Z drbyte $
  */
 
-  // This should be first line of the script:
-  $zco_notifier->notify('NOTIFY_HEADER_START_DOCUMENT_GENERAL_INFO');
+// This should be first line of the script:
+$zco_notifier->notify('NOTIFY_HEADER_START_DOCUMENT_GENERAL_INFO');
 
-  require(DIR_WS_MODULES . zen_get_module_directory('require_languages.php'));
+require(DIR_WS_MODULES . zen_get_module_directory('require_languages.php'));
 
-  // This should be last line of the script:
-  $zco_notifier->notify('NOTIFY_HEADER_END_DOCUMENT_GENERAL_INFO');
-?>
+$product_info = zen_get_product_details($products_id_current = (int)$_GET['products_id']);
+
+zen_product_set_header_response($products_id_current, $product_info);
+
+// This should be last line of the script:
+$zco_notifier->notify('NOTIFY_HEADER_END_DOCUMENT_GENERAL_INFO');

--- a/includes/modules/pages/document_general_info/main_template_vars.php
+++ b/includes/modules/pages/document_general_info/main_template_vars.php
@@ -15,57 +15,34 @@
   // This should be first line of the script:
   $zco_notifier->notify('NOTIFY_MAIN_TEMPLATE_VARS_START_DOCUMENT_GENERAL_INFO');
 
-  $sql = "select count(*) as total
-          from " . TABLE_PRODUCTS . " p, " .
-                   TABLE_PRODUCTS_DESCRIPTION . " pd
-          where    p.products_status = '1'
-          and      p.products_id = '" . (int)$_GET['products_id'] . "'
-          and      pd.products_id = p.products_id
-          and      pd.language_id = '" . (int)$_SESSION['languages_id'] . "'";
+  if (!isset($product_info->EOF, $product_info->fields['products_id'], $product_info->fields['products_status']) || $product_info->fields['products_id'] !== (int)$_GET['products_id']) {
+    $product_info = zen_get_product_details($_GET['products_id']);
+  }
 
+  $product_not_found = $product_info->EOF;
 
-  $res = $db->Execute($sql);
+  if (!defined('PRODUCT_THROWS_200_WHEN_DISABLED') || PRODUCT_THROWS_200_WHEN_DISABLED !== true) {
+    if ($product_info->fields['products_status'] != 1) {
+      $product_not_found = true;
+    }
+  }
 
-  if ( $res->fields['total'] < 1 ) {
-
+  if ($product_not_found) {
     $tpl_page_body = '/tpl_product_info_noproduct.php';
-
   } else {
 
     $tpl_page_body = '/tpl_document_general_info_display.php';
 
     $zco_notifier->notify('NOTIFY_PRODUCT_VIEWS_HIT_INCREMENTOR', (int)$_GET['products_id']);
 
-    $sql = "select p.products_id, pd.products_name,
-                  pd.products_description, p.products_model,
-                  p.products_quantity, p.products_image,
-                  pd.products_url, p.products_price,
-                  p.products_tax_class_id, p.products_date_added,
-                  p.products_date_available, p.manufacturers_id, p.products_quantity,
-                  p.products_weight, p.products_priced_by_attribute, p.product_is_free,
-                  p.products_qty_box_status,
-                  p.products_quantity_order_max,
-                  p.products_discount_type, p.products_discount_type_from, p.products_sort_order, p.products_price_sorter
-           from   " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_DESCRIPTION . " pd
-           where  p.products_status = '1'
-           and    p.products_id = '" . (int)$_GET['products_id'] . "'
-           and    pd.products_id = p.products_id
-           and    pd.language_id = '" . (int)$_SESSION['languages_id'] . "'";
-
-    $product_info = $db->Execute($sql);
-
     $products_price_sorter = $product_info->fields['products_price_sorter'];
 
-    $products_price = $currencies->display_price($product_info->fields['products_price'],
-                      zen_get_tax_rate($product_info->fields['products_tax_class_id']));
+    $products_price = $currencies->display_price($product_info->fields['products_price'], zen_get_tax_rate($product_info->fields['products_tax_class_id']));
 
     $manufacturers_name= zen_get_products_manufacturers_name((int)$_GET['products_id']);
 
     if ($new_price = zen_get_products_special_price($product_info->fields['products_id'])) {
-
-      $specials_price = $currencies->display_price($new_price,
-                        zen_get_tax_rate($product_info->fields['products_tax_class_id']));
-
+      $specials_price = $currencies->display_price($new_price, zen_get_tax_rate($product_info->fields['products_tax_class_id']));
     }
 
 // set flag for attributes module usage:

--- a/includes/modules/pages/document_product_info/header_php.php
+++ b/includes/modules/pages/document_product_info/header_php.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * document_product header_php.php 
+ * document_product header_php.php
  *
  * @package page
  * @copyright Copyright 2003-2006 Zen Cart Development Team
@@ -9,11 +9,19 @@
  * @version $Id: header_php.php 2978 2006-02-07 00:52:01Z drbyte $
  */
 
-  // This should be first line of the script:
-  $zco_notifier->notify('NOTIFY_HEADER_START_DOCUMENT_PRODUCT_INFO');
+// This should be first line of the script:
+$zco_notifier->notify('NOTIFY_HEADER_START_DOCUMENT_PRODUCT_INFO');
 
-  require(DIR_WS_MODULES . zen_get_module_directory('require_languages.php'));
+require(DIR_WS_MODULES . zen_get_module_directory('require_languages.php'));
 
-  // This should be last line of the script:
-  $zco_notifier->notify('NOTIFY_HEADER_END_DOCUMENT_PRODUCT_INFO');
-?>
+$product_info = zen_get_product_details($products_id_current = (int)$_GET['products_id']);
+
+zen_product_set_header_response($products_id_current, $product_info);
+
+// ensure navigation snapshot is set in order to "go back" in case must-be-logged-in-for-price is enabled
+if (!zen_is_logged_in()) {
+    $_SESSION['navigation']->set_snapshot();
+}
+
+// This should be last line of the script:
+$zco_notifier->notify('NOTIFY_HEADER_END_DOCUMENT_PRODUCT_INFO');

--- a/includes/modules/pages/document_product_info/main_template_vars.php
+++ b/includes/modules/pages/document_product_info/main_template_vars.php
@@ -15,18 +15,19 @@
   // This should be first line of the script:
   $zco_notifier->notify('NOTIFY_MAIN_TEMPLATE_VARS_START_DOCUMENT_PRODUCT_INFO');
 
-  $sql = "select count(*) as total
-          from " . TABLE_PRODUCTS . " p, " .
-                   TABLE_PRODUCTS_DESCRIPTION . " pd
-          where    p.products_status = '1'
-          and      p.products_id = '" . (int)$_GET['products_id'] . "'
-          and      pd.products_id = p.products_id
-          and      pd.language_id = '" . (int)$_SESSION['languages_id'] . "'";
+  if (!isset($product_info->EOF, $product_info->fields['products_id'], $product_info->fields['products_status']) || $product_info->fields['products_id'] !== (int)$_GET['products_id']) {
+    $product_info = zen_get_product_details($_GET['products_id']);
+  }
 
+  $product_not_found = $product_info->EOF;
 
-  $res = $db->Execute($sql);
+  if (!defined('PRODUCT_THROWS_200_WHEN_DISABLED') || PRODUCT_THROWS_200_WHEN_DISABLED !== true) {
+    if ($product_info->fields['products_status'] != 1) {
+      $product_not_found = true;
+    }
+  }
 
-  if ( $res->fields['total'] < 1 ) {
+  if ($product_not_found) {
 
     $tpl_page_body = '/tpl_product_info_noproduct.php';
 
@@ -36,36 +37,14 @@
 
     $zco_notifier->notify('NOTIFY_PRODUCT_VIEWS_HIT_INCREMENTOR', (int)$_GET['products_id']);
 
-    $sql = "select p.products_id, pd.products_name,
-                  pd.products_description, p.products_model,
-                  p.products_quantity, p.products_image,
-                  pd.products_url, p.products_price,
-                  p.products_tax_class_id, p.products_date_added,
-                  p.products_date_available, p.manufacturers_id, p.products_quantity,
-                  p.products_weight, p.products_priced_by_attribute, p.product_is_free,
-                  p.products_qty_box_status,
-                  p.products_quantity_order_max,
-                  p.products_discount_type, p.products_discount_type_from, p.products_sort_order, p.products_price_sorter
-           from   " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_DESCRIPTION . " pd
-           where  p.products_status = '1'
-           and    p.products_id = '" . (int)$_GET['products_id'] . "'
-           and    pd.products_id = p.products_id
-           and    pd.language_id = '" . (int)$_SESSION['languages_id'] . "'";
-
-    $product_info = $db->Execute($sql);
-
     $products_price_sorter = $product_info->fields['products_price_sorter'];
 
-    $products_price = $currencies->display_price($product_info->fields['products_price'],
-                      zen_get_tax_rate($product_info->fields['products_tax_class_id']));
+    $products_price = $currencies->display_price($product_info->fields['products_price'], zen_get_tax_rate($product_info->fields['products_tax_class_id']));
 
     $manufacturers_name= zen_get_products_manufacturers_name((int)$_GET['products_id']);
 
     if ($new_price = zen_get_products_special_price($product_info->fields['products_id'])) {
-
-      $specials_price = $currencies->display_price($new_price,
-                        zen_get_tax_rate($product_info->fields['products_tax_class_id']));
-
+      $specials_price = $currencies->display_price($new_price, zen_get_tax_rate($product_info->fields['products_tax_class_id']));
     }
 
 // set flag for attributes module usage:

--- a/includes/modules/pages/product_free_shipping_info/header_php.php
+++ b/includes/modules/pages/product_free_shipping_info/header_php.php
@@ -1,23 +1,27 @@
 <?php
-//
-// +----------------------------------------------------------------------+
-// |zen-cart Open Source E-commerce                                       |
-// +----------------------------------------------------------------------+
-// | Copyright (c) 2004 The zen-cart developers                           |
-// |                                                                      |
-// | http://www.zen-cart.com/index.php                                    |
-// |                                                                      |
-// | Portions Copyright (c) 2003 osCommerce                               |
-// +----------------------------------------------------------------------+
-// | This source file is subject to version 2.0 of the GPL license,       |
-// | that is bundled with this package in the file LICENSE, and is        |
-// | available through the world-wide-web at the following url:           |
-// | http://www.zen-cart.com/license/2_0.txt.                             |
-// | If you did not receive a copy of the zen-cart license and are unable |
-// | to obtain it through the world-wide-web, please send a note to       |
-// | license@zen-cart.com so we can mail you a copy immediately.          |
-// +----------------------------------------------------------------------+
-// $Id: header_php.php 2578 2005-12-15 19:31:34Z drbyte $
-//
-  require(DIR_WS_MODULES . zen_get_module_directory('require_languages.php'));
-?>
+/**
+ * product_free_shipping_info header_php.php
+ *
+ * @package page
+ * @copyright Copyright 2003-2019 Zen Cart Development Team
+ * @copyright Portions Copyright 2003 osCommerce
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: mc12345678 2019 Apr 30 Modified in v1.5.6b $
+ */
+
+// This should be first line of the script:
+$zco_notifier->notify('NOTIFY_HEADER_START_PRODUCT_FREE_SHIPPING_INFO');
+
+require(DIR_WS_MODULES . zen_get_module_directory('require_languages.php'));
+
+$product_info = zen_get_product_details($products_id_current = (int)$_GET['products_id']);
+
+zen_product_set_header_response($products_id_current, $product_info);
+
+// ensure navigation snapshot is set in order to "go back" in case must-be-logged-in-for-price is enabled
+if (!zen_is_logged_in()) {
+    $_SESSION['navigation']->set_snapshot();
+}
+
+// This should be last line of the script:
+$zco_notifier->notify('NOTIFY_HEADER_END_PRODUCT_FREE_SHIPPING_INFO');

--- a/includes/modules/pages/product_free_shipping_info/main_template_vars.php
+++ b/includes/modules/pages/product_free_shipping_info/main_template_vars.php
@@ -15,57 +15,34 @@
   // This should be first line of the script:
   $zco_notifier->notify('NOTIFY_MAIN_TEMPLATE_VARS_START_PRODUCT_FREE_SHIPPING_INFO');
 
-  $sql = "select count(*) as total
-          from " . TABLE_PRODUCTS . " p, " .
-                   TABLE_PRODUCTS_DESCRIPTION . " pd
-          where    p.products_status = '1'
-          and      p.products_id = '" . (int)$_GET['products_id'] . "'
-          and      pd.products_id = p.products_id
-          and      pd.language_id = '" . (int)$_SESSION['languages_id'] . "'";
+  if (!isset($product_info->EOF, $product_info->fields['products_id'], $product_info->fields['products_status']) || $product_info->fields['products_id'] !== (int)$_GET['products_id']) {
+    $product_info = zen_get_product_details($_GET['products_id']);
+  }
 
+  $product_not_found = $product_info->EOF;
 
-  $res = $db->Execute($sql);
+  if (!defined('PRODUCT_THROWS_200_WHEN_DISABLED') || PRODUCT_THROWS_200_WHEN_DISABLED !== true) {
+    if ($product_info->fields['products_status'] != 1) {
+      $product_not_found = true;
+    }
+  }
 
-  if ( $res->fields['total'] < 1 ) {
-
+  if ($product_not_found) {
     $tpl_page_body = '/tpl_product_info_noproduct.php';
-
   } else {
 
     $tpl_page_body = '/tpl_product_free_shipping_info_display.php';
 
     $zco_notifier->notify('NOTIFY_PRODUCT_VIEWS_HIT_INCREMENTOR', (int)$_GET['products_id']);
 
-    $sql = "select p.products_id, pd.products_name,
-                  pd.products_description, p.products_model,
-                  p.products_quantity, p.products_image,
-                  pd.products_url, p.products_price,
-                  p.products_tax_class_id, p.products_date_added,
-                  p.products_date_available, p.manufacturers_id, p.products_quantity,
-                  p.products_weight, p.products_priced_by_attribute, p.product_is_free,
-                  p.products_qty_box_status,
-                  p.products_quantity_order_max,
-                  p.products_discount_type, p.products_discount_type_from, p.products_sort_order, p.products_price_sorter
-           from   " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_DESCRIPTION . " pd
-           where  p.products_status = '1'
-           and    p.products_id = '" . (int)$_GET['products_id'] . "'
-           and    pd.products_id = p.products_id
-           and    pd.language_id = '" . (int)$_SESSION['languages_id'] . "'";
-
-    $product_info = $db->Execute($sql);
-
     $products_price_sorter = $product_info->fields['products_price_sorter'];
 
-    $products_price = $currencies->display_price($product_info->fields['products_price'],
-                      zen_get_tax_rate($product_info->fields['products_tax_class_id']));
+    $products_price = $currencies->display_price($product_info->fields['products_price'], zen_get_tax_rate($product_info->fields['products_tax_class_id']));
 
     $manufacturers_name= zen_get_products_manufacturers_name((int)$_GET['products_id']);
 
     if ($new_price = zen_get_products_special_price($product_info->fields['products_id'])) {
-
-      $specials_price = $currencies->display_price($new_price,
-                        zen_get_tax_rate($product_info->fields['products_tax_class_id']));
-
+      $specials_price = $currencies->display_price($new_price, zen_get_tax_rate($product_info->fields['products_tax_class_id']));
     }
 
 // set flag for attributes module usage:

--- a/includes/modules/pages/product_info/header_php.php
+++ b/includes/modules/pages/product_info/header_php.php
@@ -9,31 +9,19 @@
  * @version $Id: mc12345678 2019 Apr 30 Modified in v1.5.6b $
  */
 
-  // This should be first line of the script:
-  $zco_notifier->notify('NOTIFY_HEADER_START_PRODUCT_INFO');
+// This should be first line of the script:
+$zco_notifier->notify('NOTIFY_HEADER_START_PRODUCT_INFO');
 
-  require(DIR_WS_MODULES . zen_get_module_directory('require_languages.php'));
+require(DIR_WS_MODULES . zen_get_module_directory('require_languages.php'));
 
-  // if specified product_id is disabled or doesn't exist, ensure that metatags and breadcrumbs don't share inappropriate information
-  $sql = "select count(*) as total
-          from " . TABLE_PRODUCTS . " p, " .
-                   TABLE_PRODUCTS_DESCRIPTION . " pd
-          where    p.products_status = '1'
-          and      p.products_id = '" . (int)$_GET['products_id'] . "'
-          and      pd.products_id = p.products_id
-          and      pd.language_id = '" . (int)$_SESSION['languages_id'] . "'";
-  $res = $db->Execute($sql);
-  if ( $res->fields['total'] < 1 ) {
-    unset($_GET['products_id']);
-    unset($breadcrumb->_trail[sizeof($breadcrumb->_trail)-1]['title']);
-    $robotsNoIndex = true;
-    header('HTTP/1.1 404 Not Found');
-  }
+$product_info = zen_get_product_details($products_id_current = (int)$_GET['products_id']);
 
-  // ensure navigation snapshot in case must-be-logged-in-for-price is enabled
-  if (!zen_is_logged_in()) {
+zen_product_set_header_response($products_id_current, $product_info);
+
+// ensure navigation snapshot is set in order to "go back" in case must-be-logged-in-for-price is enabled
+if (!zen_is_logged_in()) {
     $_SESSION['navigation']->set_snapshot();
-  }
+}
 
-  // This should be last line of the script:
-  $zco_notifier->notify('NOTIFY_HEADER_END_PRODUCT_INFO');
+// This should be last line of the script:
+$zco_notifier->notify('NOTIFY_HEADER_END_PRODUCT_INFO');

--- a/includes/modules/pages/product_info/main_template_vars.php
+++ b/includes/modules/pages/product_info/main_template_vars.php
@@ -15,57 +15,34 @@
   // This should be first line of the script:
   $zco_notifier->notify('NOTIFY_MAIN_TEMPLATE_VARS_START_PRODUCT_INFO');
 
-  $sql = "select count(*) as total
-          from " . TABLE_PRODUCTS . " p, " .
-                   TABLE_PRODUCTS_DESCRIPTION . " pd
-          where    p.products_status = '1'
-          and      p.products_id = '" . (int)$_GET['products_id'] . "'
-          and      pd.products_id = p.products_id
-          and      pd.language_id = '" . (int)$_SESSION['languages_id'] . "'";
+  if (!isset($product_info->EOF, $product_info->fields['products_id'], $product_info->fields['products_status']) || $product_info->fields['products_id'] !== (int)$_GET['products_id']) {
+    $product_info = zen_get_product_details($_GET['products_id']);
+  }
 
+  $product_not_found = $product_info->EOF;
 
-  $res = $db->Execute($sql);
+  if (!defined('PRODUCT_THROWS_200_WHEN_DISABLED') || PRODUCT_THROWS_200_WHEN_DISABLED !== true) {
+      if ($product_info->fields['products_status'] != 1) {
+          $product_not_found = true;
+      }
+  }
 
-  if ( $res->fields['total'] < 1 ) {
-
+  if ($product_not_found) {
     $tpl_page_body = '/tpl_product_info_noproduct.php';
-
   } else {
 
     $tpl_page_body = '/tpl_product_info_display.php';
 
     $zco_notifier->notify('NOTIFY_PRODUCT_VIEWS_HIT_INCREMENTOR', (int)$_GET['products_id']);
 
-    $sql = "select p.products_id, pd.products_name,
-                  pd.products_description, p.products_model,
-                  p.products_quantity, p.products_image,
-                  pd.products_url, p.products_price,
-                  p.products_tax_class_id, p.products_date_added,
-                  p.products_date_available, p.manufacturers_id, p.products_quantity,
-                  p.products_weight, p.products_priced_by_attribute, p.product_is_free,
-                  p.products_qty_box_status,
-                  p.products_quantity_order_max,
-                  p.products_discount_type, p.products_discount_type_from, p.products_sort_order, p.products_price_sorter
-           from   " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_DESCRIPTION . " pd
-           where  p.products_status = '1'
-           and    p.products_id = '" . (int)$_GET['products_id'] . "'
-           and    pd.products_id = p.products_id
-           and    pd.language_id = '" . (int)$_SESSION['languages_id'] . "'";
-
-    $product_info = $db->Execute($sql);
-
     $products_price_sorter = $product_info->fields['products_price_sorter'];
 
-    $products_price = $currencies->display_price($product_info->fields['products_price'],
-                      zen_get_tax_rate($product_info->fields['products_tax_class_id']));
+    $products_price = $currencies->display_price($product_info->fields['products_price'], zen_get_tax_rate($product_info->fields['products_tax_class_id']));
 
     $manufacturers_name= zen_get_products_manufacturers_name((int)$_GET['products_id']);
 
     if ($new_price = zen_get_products_special_price($product_info->fields['products_id'])) {
-
-      $specials_price = $currencies->display_price($new_price,
-                        zen_get_tax_rate($product_info->fields['products_tax_class_id']));
-
+      $specials_price = $currencies->display_price($new_price, zen_get_tax_rate($product_info->fields['products_tax_class_id']));
     }
 
 // set flag for attributes module usage:

--- a/includes/modules/pages/product_music_info/header_php.php
+++ b/includes/modules/pages/product_music_info/header_php.php
@@ -1,23 +1,27 @@
 <?php
-//
-// +----------------------------------------------------------------------+
-// |zen-cart Open Source E-commerce                                       |
-// +----------------------------------------------------------------------+
-// | Copyright (c) 2004 The zen-cart developers                           |
-// |                                                                      |
-// | http://www.zen-cart.com/index.php                                    |
-// |                                                                      |
-// | Portions Copyright (c) 2003 osCommerce                               |
-// +----------------------------------------------------------------------+
-// | This source file is subject to version 2.0 of the GPL license,       |
-// | that is bundled with this package in the file LICENSE, and is        |
-// | available through the world-wide-web at the following url:           |
-// | http://www.zen-cart.com/license/2_0.txt.                             |
-// | If you did not receive a copy of the zen-cart license and are unable |
-// | to obtain it through the world-wide-web, please send a note to       |
-// | license@zen-cart.com so we can mail you a copy immediately.          |
-// +----------------------------------------------------------------------+
-// $Id: header_php.php 2578 2005-12-15 19:31:34Z drbyte $
-//
-  require(DIR_WS_MODULES . zen_get_module_directory('require_languages.php'));
-?>
+/**
+ * product_music_info header_php.php
+ *
+ * @package page
+ * @copyright Copyright 2003-2019 Zen Cart Development Team
+ * @copyright Portions Copyright 2003 osCommerce
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: mc12345678 2019 Apr 30 Modified in v1.5.6b $
+ */
+
+// This should be first line of the script:
+$zco_notifier->notify('NOTIFY_HEADER_START_PRODUCT_MUSIC_INFO');
+
+require(DIR_WS_MODULES . zen_get_module_directory('require_languages.php'));
+
+$product_info = zen_get_product_details($products_id_current = (int)$_GET['products_id']);
+
+zen_product_set_header_response($products_id_current, $product_info);
+
+// ensure navigation snapshot is set in order to "go back" in case must-be-logged-in-for-price is enabled
+if (!zen_is_logged_in()) {
+    $_SESSION['navigation']->set_snapshot();
+}
+
+// This should be last line of the script:
+$zco_notifier->notify('NOTIFY_HEADER_END_PRODUCT_MUSIC_INFO');

--- a/includes/modules/pages/product_music_info/main_template_vars.php
+++ b/includes/modules/pages/product_music_info/main_template_vars.php
@@ -15,18 +15,19 @@
   // This should be first line of the script:
   $zco_notifier->notify('NOTIFY_MAIN_TEMPLATE_VARS_START_PRODUCT_MUSIC_INFO');
 
-  $sql = "select count(*) as total
-          from " . TABLE_PRODUCTS . " p, " .
-                   TABLE_PRODUCTS_DESCRIPTION . " pd
-          where    p.products_status = '1'
-          and      p.products_id = '" . (int)$_GET['products_id'] . "'
-          and      pd.products_id = p.products_id
-          and      pd.language_id = '" . (int)$_SESSION['languages_id'] . "'";
+  if (!isset($product_info->EOF, $product_info->fields['products_id'], $product_info->fields['products_status']) || $product_info->fields['products_id'] !== (int)$_GET['products_id']) {
+    $product_info = zen_get_product_details($_GET['products_id']);
+  }
 
+  $product_not_found = $product_info->EOF;
 
-  $res = $db->Execute($sql);
+  if (!defined('PRODUCT_THROWS_200_WHEN_DISABLED') || PRODUCT_THROWS_200_WHEN_DISABLED !== true) {
+    if ($product_info->fields['products_status'] != 1) {
+      $product_not_found = true;
+    }
+  }
 
-  if ( $res->fields['total'] < 1 ) {
+  if ($product_not_found) {
 
     $tpl_page_body = '/tpl_product_info_noproduct.php';
 
@@ -36,36 +37,14 @@
 
     $zco_notifier->notify('NOTIFY_PRODUCT_VIEWS_HIT_INCREMENTOR', (int)$_GET['products_id']);
 
-    $sql = "select p.products_id, pd.products_name,
-                  pd.products_description, p.products_model,
-                  p.products_quantity, p.products_image,
-                  pd.products_url, p.products_price,
-                  p.products_tax_class_id, p.products_date_added,
-                  p.products_date_available, p.manufacturers_id, p.products_quantity,
-                  p.products_weight, p.products_priced_by_attribute, p.product_is_free,
-                  p.products_qty_box_status,
-                  p.products_quantity_order_max,
-                  p.products_discount_type, p.products_discount_type_from, p.products_sort_order, p.products_price_sorter
-           from   " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_DESCRIPTION . " pd
-           where  p.products_status = '1'
-           and    p.products_id = '" . (int)$_GET['products_id'] . "'
-           and    pd.products_id = p.products_id
-           and    pd.language_id = '" . (int)$_SESSION['languages_id'] . "'";
-
-    $product_info = $db->Execute($sql);
-
     $products_price_sorter = $product_info->fields['products_price_sorter'];
 
-    $products_price = $currencies->display_price($product_info->fields['products_price'],
-                      zen_get_tax_rate($product_info->fields['products_tax_class_id']));
+    $products_price = $currencies->display_price($product_info->fields['products_price'], zen_get_tax_rate($product_info->fields['products_tax_class_id']));
 
     $manufacturers_name = zen_get_products_manufacturers_name((int)$_GET['products_id']);
 
     if ($new_price = zen_get_products_special_price($product_info->fields['products_id'])) {
-
-      $specials_price = $currencies->display_price($new_price,
-                        zen_get_tax_rate($product_info->fields['products_tax_class_id']));
-
+      $specials_price = $currencies->display_price($new_price, zen_get_tax_rate($product_info->fields['products_tax_class_id']));
     }
 
 // set flag for attributes module usage:


### PR DESCRIPTION
Split out the code for handling 404 Header responses so it can be intercepted with an Observer if needed.
Added ability to define a constant PRODUCT_THROWS_200_WHEN_DISABLED to boolean `true` without needing an Observer, if a Store wishes to allow a product to display even when disabled.
A 404 will still trigger if the product doesn't actually exist in the db.
A 410 can be triggered by setting `products_status` to `-1` in custom code, without needing an observer for the 410 response.

This change should also reduce queries on product page.

Fixes #1699