### PR TITLE
Extra check for non super user access to banner statistics page

### DIFF
--- a/admin/includes/functions/admin_access.php
+++ b/admin/includes/functions/admin_access.php
@@ -59,6 +59,13 @@ function check_page($page, $params) {
   return $retVal;
 }
 
+function check_related_page($page, $params) {
+   if ($page == FILENAME_BANNER_STATISTICS) {
+      return check_page(FILENAME_BANNER_MANAGER, $params);
+   }
+   return false;
+}
+
 function zen_is_superuser()
 {
   global $db;

--- a/admin/includes/init_includes/init_admin_auth.php
+++ b/admin/includes/init_includes/init_admin_auth.php
@@ -65,7 +65,7 @@ if (basename($_SERVER['SCRIPT_FILENAME']) != FILENAME_ALERT_PAGE . '.php')
     if (!in_array($page, array(FILENAME_DEFAULT,FILENAME_ADMIN_ACCOUNT,FILENAME_LOGOFF,FILENAME_ALERT_PAGE,FILENAME_PASSWORD_FORGOTTEN,FILENAME_DENIED,FILENAME_ALT_NAV)) &&
         !zen_is_superuser())
     {
-      if (check_page($page, $_GET) == FALSE)
+      if ( (check_page($page, $_GET) == FALSE) && (check_related_page($page, $_GET) == FALSE) ) 
       {
         zen_record_admin_activity('Attempted access to unauthorized page [' . $page . ']. Redirected to DENIED page instead.', 'notice');
         zen_redirect(zen_href_link(FILENAME_DENIED, '', 'SSL'));


### PR DESCRIPTION
Non superusers who are allowed to use the Tools->Banner Manager page should also have access to the banners statistics page, but there's no checkbox for this page, so we'll use Banner Manager as a proxy. 