### PR TITLE
Build in basic version of DaveWest's non-captcha spam detection

### DIFF
--- a/includes/classes/observers/auto.non_captcha_observer.php
+++ b/includes/classes/observers/auto.non_captcha_observer.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Designed for v1.5.7
+ *
+ * Observer class used to detect spam input
+ *
+ * @package nonCAPTCHA
+ * @copyright Copyright 2003-2019 Zen Cart Development Team
+ * @copyright Portions Copyright 2017-2019 CowboyGeek.com
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: auto.non_captcha_observer.php $
+ */
+
+class zcObserverNonCaptchaObserver extends base
+{
+    private $chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+    public function __construct()
+    {
+        $this->attach($this, [
+            'NOTIFY_NONCAPTCHA_CHECK',
+            'NOTIFY_CREATE_ACCOUNT_CAPTCHA_CHECK',
+            'NOTIFY_CONTACT_US_CAPTCHA_CHECK',
+            'NOTIFY_REVIEWS_WRITE_CAPTCHA_CHECK',
+        ]);
+
+        if (empty($_SESSION['antispam_fieldname'])) {
+            $_SESSION['antispam_fieldname'] = $this->generate_random_string($this->chars, 10);
+        }
+        $GLOBALS['antiSpamFieldName'] = $_SESSION['antispam_fieldname'];
+    }
+
+    // This update method fires if no updateNotifyxxxxxx function is declared below to match the notifier hooks we're listening to
+    public function update(&$class, $eventID, $paramsArray)
+    {
+        $this->testURLSpam();
+        $this->testAntiSpamFields();
+    }
+
+    public function updateNotifyContactUsCaptchaCheck(&$class, $eventID, $paramsArray)
+    {
+        // sanitize the contact-us name field more aggressively
+        $GLOBALS['name'] = zen_db_prepare_input(zen_sanitize_string($_POST['contactname']));
+
+        // fire default tests
+        $this->update($class, $eventID, $paramsArray);
+    }
+
+    protected function testAntiSpamFields()
+    {
+        if (!empty($_POST[$_SESSION['antispam_fieldname']]) || !empty($_POST['should_be_empty'])) {
+            $GLOBALS['antiSpam'] = 'spam';
+        }
+    }
+
+    protected function generate_random_string($input, $strength = 16)
+    {
+        $function = PHP_VERSION_ID >= 70000 ? 'random_int' : 'mt_rand';
+        $input_length = strlen($input);
+        $random_string = '';
+        for ($i = 0; $i < $strength; $i++) {
+            $random_character = $input[$function(0, $input_length - 1)];
+            $random_string .= $random_character;
+        }
+
+        return $random_string;
+    }
+
+    protected function testURLSpam()
+    {
+        $test_string = '';
+
+        // Simple regex to identify presence of an (unwanted) URL
+        $reg_exUrl = '~(https?|ftps?):/~';
+
+        $fields = array(
+            'firstname',
+            'lastname',
+            'contactname',
+            'company',
+            'street_address',
+            'suburb',
+            'city',
+            'state',
+            'zone_country_id',
+            'nick',
+            'customers_referral',
+            'telephone',
+            'fax',
+            'email_format',
+            'to_name',
+            'subject',
+            'passwordhintA',
+            'review_text', // comment-out if you actually want to allow URLs for this
+            'enquiry',     // comment-out if you actually want to allow URLs for this
+        );
+
+        // prepare for inspection
+        foreach ($fields as $field) {
+            if (!empty($_POST[$field])) {
+                $test_string .= $_POST[$field];
+            }
+        }
+
+        if (empty($test_string)) return;
+
+        // inspect
+        if(preg_match($reg_exUrl, $test_string)) {
+            $GLOBALS['antiSpam'] = 'spam';
+        }
+    }
+
+}
+

--- a/includes/modules/create_account.php
+++ b/includes/modules/create_account.php
@@ -29,12 +29,14 @@ if (!defined('IS_ADMIN_FLAG')) {
   $extra_welcome_text = '';
   $send_welcome_email = true;
 
+  $antiSpamFieldName = isset($_SESSION['antispam_fieldname']) ? $_SESSION['antispam_fieldname'] : 'should_be_empty';
+
 /**
  * Process form contents
  */
 if (isset($_POST['action']) && ($_POST['action'] == 'process')) {
   $process = true;
-  $antiSpam = isset($_POST['should_be_empty']) ? zen_db_prepare_input($_POST['should_be_empty']) : '';
+  $antiSpam = !empty($_POST[$antiSpamFieldName]) ? 'spam' : '';
   if (!empty($_POST['firstname']) && preg_match('~https?://?~', $_POST['firstname'])) $antiSpam = 'spam';
   if (!empty($_POST['lastname']) && preg_match('~https?://?~', $_POST['lastname'])) $antiSpam = 'spam';
 

--- a/includes/modules/pages/contact_us/header_php.php
+++ b/includes/modules/pages/contact_us/header_php.php
@@ -16,12 +16,13 @@ require DIR_WS_MODULES . zen_get_module_directory('require_languages.php');
 
 $error = false;
 $enquiry = '';
+$antiSpamFieldName = isset($_SESSION['antispam_fieldname']) ? $_SESSION['antispam_fieldname'] : 'should_be_empty';
 
 if (isset($_GET['action']) && ($_GET['action'] == 'send')) {
     $name = zen_db_prepare_input($_POST['contactname']);
     $email_address = zen_db_prepare_input($_POST['email']);
     $enquiry = zen_db_prepare_input(strip_tags($_POST['enquiry']));
-    $antiSpam = isset($_POST['should_be_empty']) ? zen_db_prepare_input($_POST['should_be_empty']) : '';
+    $antiSpam = !empty($_POST[$antiSpamFieldName]) ? 'spam' : '';
     if (!empty($_POST['contactname']) && preg_match('~https?://?~', $_POST['contactname'])) $antiSpam = 'spam';
 
     $zco_notifier->notify('NOTIFY_CONTACT_US_CAPTCHA_CHECK', $_POST);

--- a/includes/modules/pages/product_reviews_write/header_php.php
+++ b/includes/modules/pages/product_reviews_write/header_php.php
@@ -15,6 +15,8 @@
 // This should be first line of the script:
 $zco_notifier->notify('NOTIFY_HEADER_START_PRODUCT_REVIEWS_WRITE');
 
+$antiSpamFieldName = isset($_SESSION['antispam_fieldname']) ? $_SESSION['antispam_fieldname'] : 'should_be_empty';
+
 if (!zen_is_logged_in()) {
   $_SESSION['navigation']->set_snapshot();
   zen_redirect(zen_href_link(FILENAME_LOGIN, '', 'SSL'));
@@ -48,7 +50,7 @@ $error = false;
 if (isset($_GET['action']) && ($_GET['action'] == 'process')) {
   $rating = (int)$_POST['rating'];
   $review_text = $_POST['review_text'];
-  $antiSpam = isset($_POST['should_be_empty']) ? zen_db_prepare_input($_POST['should_be_empty']) : '';
+  $antiSpam = !empty($_POST[$antiSpamFieldName]) ? 'spam' : '';
   $zco_notifier->notify('NOTIFY_REVIEWS_WRITE_CAPTCHA_CHECK');
 
   if (strlen($review_text) < REVIEW_TEXT_MIN_LENGTH) {
@@ -86,7 +88,7 @@ if (isset($_GET['action']) && ($_GET['action'] == 'process')) {
       $insert_id = $db->Insert_ID();
 
       $zco_notifier->notify('NOTIFY_REVIEW_INSERTED_DURING_WRITE_REVIEW');
-     
+
       $sql = "INSERT INTO " . TABLE_REVIEWS_DESCRIPTION . " (reviews_id, languages_id, reviews_text)
               VALUES (:insertID, :languagesID, :reviewText)";
 
@@ -97,7 +99,7 @@ if (isset($_GET['action']) && ($_GET['action'] == 'process')) {
 
       $email_text = '';
       $send_admin_email = REVIEWS_APPROVAL == '1' && SEND_EXTRA_REVIEW_NOTIFICATION_EMAILS_TO_STATUS == '1' && defined('SEND_EXTRA_REVIEW_NOTIFICATION_EMAILS_TO') && SEND_EXTRA_REVIEW_NOTIFICATION_EMAILS_TO !='';
-    
+
       $zco_notifier->notify('NOTIFY_SEND_ADMIN_EMAIL_WRITE_REVIEW');
       // send review-notification email to admin
       if ($send_admin_email) {

--- a/includes/templates/responsive_classic/templates/tpl_product_reviews_write_default.php
+++ b/includes/templates/responsive_classic/templates/tpl_product_reviews_write_default.php
@@ -69,7 +69,7 @@
 <label id="textAreaReviews" for="review-text"><?php echo SUB_TITLE_REVIEW; ?></label>
 
 <?php echo zen_draw_textarea_field('review_text', 60, 5, '', 'id="review-text"'); ?>
-<?php echo zen_draw_input_field('should_be_empty', '', ' size="60" id="RAS" style="visibility:hidden; display:none;" autocomplete="off"'); ?>
+<?php echo zen_draw_input_field($antiSpamFieldName, '', ' size="60" id="RAS" style="visibility:hidden; display:none;" autocomplete="off"'); ?>
 
 
 <div class="buttonRow forward"><?php echo zen_image_submit(BUTTON_IMAGE_SUBMIT, BUTTON_SUBMIT_ALT); ?></div>

--- a/includes/templates/template_default/templates/tpl_contact_us_default.php
+++ b/includes/templates/template_default/templates/tpl_contact_us_default.php
@@ -72,7 +72,7 @@
 <label for="enquiry"><?php echo ENTRY_ENQUIRY; ?></label>
 <?php echo zen_draw_textarea_field('enquiry', '30', '7', $enquiry, 'id="enquiry" placeholder="' . ENTRY_REQUIRED_SYMBOL . '" required'); ?>
 
-<?php echo zen_draw_input_field('should_be_empty', '', ' size="40" id="CUAS" style="visibility:hidden; display:none;" autocomplete="off"'); ?>
+<?php echo zen_draw_input_field($antiSpamFieldName, '', ' size="40" id="CUAS" style="visibility:hidden; display:none;" autocomplete="off"'); ?>
 
 </fieldset>
 

--- a/includes/templates/template_default/templates/tpl_modules_create_account.php
+++ b/includes/templates/template_default/templates/tpl_modules_create_account.php
@@ -69,7 +69,7 @@
   <?php echo zen_draw_input_field('street_address', '', zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_street_address', '40') . ' id="street-address" placeholder="' . ENTRY_STREET_ADDRESS_TEXT . '"'. ((int)ENTRY_STREET_ADDRESS_MIN_LENGTH > 0 ? ' required' : '')); ?>
 <br class="clearBoth" />
 
-<?php echo zen_draw_input_field('should_be_empty', '', ' size="40" id="CAAS" style="visibility:hidden; display:none;" autocomplete="off"'); ?>
+<?php echo zen_draw_input_field($antiSpamFieldName, '', ' size="40" id="CAAS" style="visibility:hidden; display:none;" autocomplete="off"'); ?>
 
 <?php
   if (ACCOUNT_SUBURB == 'true') {

--- a/includes/templates/template_default/templates/tpl_product_reviews_write_default.php
+++ b/includes/templates/template_default/templates/tpl_product_reviews_write_default.php
@@ -64,7 +64,7 @@
 
 <label id="textAreaReviews" for="review-text"><?php echo SUB_TITLE_REVIEW; ?></label>
 <?php echo zen_draw_textarea_field('review_text', 60, 5, '', 'id="review-text"'); ?>
-<?php echo zen_draw_input_field('should_be_empty', '', ' size="60" id="RAS" style="visibility:hidden; display:none;" autocomplete="off"'); ?>
+<?php echo zen_draw_input_field($antiSpamFieldName, '', ' size="60" id="RAS" style="visibility:hidden; display:none;" autocomplete="off"'); ?>
 
     <div class="buttonRow forward"><?php echo zen_image_submit(BUTTON_IMAGE_SUBMIT, BUTTON_SUBMIT_ALT); ?></div>
 <br class="clearBoth" />


### PR DESCRIPTION
This is a reduced version of davewest's non-captcha spam trap catcher, which only handles URL detection and dynamic fieldname for honeypot.

It does NOT handle the slider or other human-detection questions. Those can be added by using the Addon to replace core functionality.