### PR TITLE
Remove unused message WARNING_MODULES_MISSING_KEYS

### DIFF
--- a/admin/includes/languages/english/modules.php
+++ b/admin/includes/languages/english/modules.php
@@ -26,4 +26,3 @@ define('TEXT_EMAIL_MESSAGE_ADMIN_MODULE_REMOVED', 'This is an automated email fr
 define('TEXT_DELETE_INTRO', 'Are you sure you want to remove this module?');
 define('TEXT_WARNING_SSL_EDIT', 'ALERT: <a href="http://www.zen-cart.com/content.php?56" target="_blank">For security reasons, Editing of this module is disabled until your Admin is configured for SSL</a>.');
 define('TEXT_WARNING_SSL_INSTALL', 'ALERT: <a href="http://www.zen-cart.com/content.php?56" target="_blank">For security reasons, Installation of this module is disabled until your Admin is configured for SSL</a>.');
-define('WARNING_MODULES_MISSING_KEYS', '<span class="alert">Missing keys - Save (write down), Remove, Install and Reconfigure</span>');


### PR DESCRIPTION
No longer happens due to increased awesomeness in Zen Cart. :) 