### PR TITLE
Enforce PHP 5.6 as a minimum in the installer

### DIFF
--- a/zc_install/includes/languages/lngEnglish.php
+++ b/zc_install/includes/languages/lngEnglish.php
@@ -153,7 +153,7 @@ define('TEXT_ERROR_STORE_CONFIGURE', 'Main /includes/configure.php file either d
 define('TEXT_ERROR_ADMIN_CONFIGURE', 'Admin /admin/includes/configure.php file either does not exist, is not readable or is not writeable');
 define('TEXT_ERROR_PHP_VERSION', str_replace(array("\n", "\r"), '', 'Incorrect PHP Version.
 <p>The PHP version you are using (' . PHP_VERSION . ') is not suitable.</p>
-<p>This version of Zen Cart&reg; is compatible with PHP versions 5.5 to 7.3.x.<br>
+<p>This version of Zen Cart&reg; is compatible with PHP versions 5.6 to 7.3.x, although 7.2.x or higher is recommended.<br>
 Check the <a href="https://www.zen-cart.com">www.zen-cart.com</a> website for the latest version of Zen Cart&reg;.</p>
 '));
 define('TEXT_ERROR_PHP_VERSION_RECOMMENDED', 'For maximum security and compatibility you should be using PHP %s or newer. This installer can proceed, but this is just letting you know that your site will not be PCI Compliant when running out-of-date software.');

--- a/zc_install/includes/systemChecks.yml
+++ b/zc_install/includes/systemChecks.yml
@@ -56,9 +56,9 @@ systemChecks:
       checkPhpVersionMin:
         method: checkPhpVersion
         parameters:
-          version: 5.5.0
+          version: 5.6.0
           versionTest: ge
-          localErrorText: <?php echo sprintf(TEXT_ERROR_PHP_VERSION_MIN, '5.5.0') . PHP_EOL; ?>
+          localErrorText: <?php echo sprintf(TEXT_ERROR_PHP_VERSION_MIN, '5.6.0') . PHP_EOL; ?>
       checkPhpVersionMax:
         method: checkPhpVersion
         parameters:

--- a/zc_install/index.php
+++ b/zc_install/index.php
@@ -7,6 +7,8 @@
  * @version $Id: Drbyte Tue Sep 11 15:53:41 2018 -0400 Modified in v1.5.6 $
  */
 
+  // Actual version check is more strict; this is just to start the program
+  // For true minimum, see includes/systemChecks.yml under checkPhpVersionMin
   if (PHP_VERSION_ID < 50500) {
     die('Sorry, requires minimum PHP 5.5');
   }


### PR DESCRIPTION
First part of fixing #2586 - don't let them get started with less than 5.6. 