### PR TITLE
Properly handle form-input $required parameter on admin side

### DIFF
--- a/admin/includes/functions/html_output.php
+++ b/admin/includes/functions/html_output.php
@@ -206,7 +206,7 @@
 
     $field .= ' />';
 
-    if ($required) {
+    if ($required && !empty(TEXT_FIELD_REQUIRED)) {
       $field .= '&nbsp;<span class="alert">' . TEXT_FIELD_REQUIRED . '</span>';
     }
     return $field;

--- a/admin/includes/functions/html_output.php
+++ b/admin/includes/functions/html_output.php
@@ -206,6 +206,9 @@
 
     $field .= ' />';
 
+    if ($required) {
+      $field .= '&nbsp;<span class="alert">' . TEXT_FIELD_REQUIRED . '</span>';
+    }
     return $field;
   }
 
@@ -222,7 +225,7 @@
   }
 
 ////
-// Output a form filefield
+// Output a form file field
   function zen_draw_file_field($name, $required = false, $parameters = '') {
     $field = zen_draw_input_field($name, '', ' size="50" ' . $parameters, $required, 'file');
 

--- a/admin/includes/languages/english.php
+++ b/admin/includes/languages/english.php
@@ -451,7 +451,7 @@ define('PREVNEXT_BUTTON_LAST', 'LAST&raquo;');
 
 define('TEXT_DEFAULT', 'default');
 define('TEXT_SET_DEFAULT', 'Set as default');
-define('TEXT_FIELD_REQUIRED', '&nbsp;<span class="fieldRequired">* Required</span>');
+define('TEXT_FIELD_REQUIRED', '&nbsp;<span class="fieldRequired">*</span>');
 
 define('ERROR_NO_DEFAULT_CURRENCY_DEFINED', 'Error: There is currently no default currency set. Please set one at: Administration Tools->Localization->Currencies');
 
@@ -706,7 +706,6 @@ define('ENTRY_NOTHING_TO_SEND','You haven\'t entered any content for your messag
   define('TEXT_INFO_OPTION_NAMES_VALUES_COPIER_STATUS', 'All Global Copy, Add and Delete Features Status is currently OFF');
   define('TEXT_SHOW_OPTION_NAMES_VALUES_COPIER_ON', 'Display Global Features - ON');
   define('TEXT_SHOW_OPTION_NAMES_VALUES_COPIER_OFF', 'Display Global Features - OFF');
-
 // moved from categories and all product type language files
   define('ERROR_CANNOT_LINK_TO_SAME_CATEGORY', 'Error: a linked product cannot be created in the same category.');
   define('ERROR_CATALOG_IMAGE_DIRECTORY_NOT_WRITEABLE', 'Error: Catalog images directory is not writeable: ' . DIR_FS_CATALOG_IMAGES);

--- a/admin/includes/stylesheet.css
+++ b/admin/includes/stylesheet.css
@@ -8,6 +8,10 @@
 
 @import url("css/bootstrap.min.css");
 /* @import url("https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css"); */
+.form-control {
+  width: 90%;
+  display: inline-block;
+}
 
 @import url("menu.css");
 

--- a/admin/includes/stylesheet.css
+++ b/admin/includes/stylesheet.css
@@ -8,10 +8,6 @@
 
 @import url("css/bootstrap.min.css");
 /* @import url("https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css"); */
-.form-control {
-  width: 90%;
-  display: inline-block;
-}
 
 @import url("menu.css");
 
@@ -766,3 +762,9 @@ input.faint {
     }
 }
 /* end of print-specific styles */
+
+/* Forms - put this last */ 
+.form-control {
+  width: 90%;
+  display: inline-block;
+}


### PR DESCRIPTION
Parameter ignored in some cases; fixed display of fields so that when used it would appear to the right rather than below the field. 

Part of the fix for #2578 