### PR TITLE
Hide empty div in customer emails

### DIFF
--- a/includes/functions/functions_email.php
+++ b/includes/functions/functions_email.php
@@ -554,7 +554,9 @@ use PHPMailer\PHPMailer\SMTP;
     //strip linebreaks and tabs out of the template
 //  $file_holder = str_replace(array("\r\n", "\n", "\r", "\t"), '', $file_holder);
     $file_holder = str_replace(array("\t"), ' ', $file_holder);
-
+	if (empty($block['EXTRA_INFO']) || empty(trim($block['EXTRA_INFO']))) {
+      $file_holder = preg_replace('/<div class="extra-info">\s?\$EXTRA_INFO\s?<\/div>/', '', $file_holder);
+	}
 
     if (!defined('HTTP_CATALOG_SERVER')) define('HTTP_CATALOG_SERVER', HTTP_SERVER);
     //check for some specifics that need to be included with all messages

--- a/includes/functions/functions_email.php
+++ b/includes/functions/functions_email.php
@@ -554,9 +554,10 @@ use PHPMailer\PHPMailer\SMTP;
     //strip linebreaks and tabs out of the template
 //  $file_holder = str_replace(array("\r\n", "\n", "\r", "\t"), '', $file_holder);
     $file_holder = str_replace(array("\t"), ' ', $file_holder);
-	if (empty($block['EXTRA_INFO']) || empty(trim($block['EXTRA_INFO']))) {
+
+    if (empty($block['EXTRA_INFO']) || empty(trim($block['EXTRA_INFO']))) {
       $file_holder = preg_replace('/<div class="extra-info">\s?\$EXTRA_INFO\s?<\/div>/', '', $file_holder);
-	}
+    }
 
     if (!defined('HTTP_CATALOG_SERVER')) define('HTTP_CATALOG_SERVER', HTTP_SERVER);
     //check for some specifics that need to be included with all messages


### PR DESCRIPTION
For email templates that include the $EXTRA_INFO block, a customer's email displays an empty but styled div, as identified in this thread:

https://www.zen-cart.com/showthread.php?225671-Hide-empty-div-in-emails

Code addition for /includes/functions/functions_email.php by @lat9 is in post [#19](https://www.zen-cart.com/showthread.php?225671-Hide-empty-div-in-emails&p=1359711#post1359711).