### PR TITLE
Sanitize IP addresses via filter_var

### DIFF
--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -3683,12 +3683,16 @@ function zen_get_ip_address() {
   /**
    * sanitize for validity as an IPv4 or IPv6 address
    */
-  $ip = preg_replace('~[^a-fA-F0-9.:%/]~', '', $ip);
+    $original_ip = $ip;
+    $ip = filter_var((string)$ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 | FILTER_FLAG_IPV4);
 
   /**
-   *  if it's still blank, set to a single dot
+   *  If it's an invalid IP, set the value to a single dot and issue a notification.
    */
-  if (trim($ip) == '') $ip = '.';
+  if ($ip === false) {
+      $ip = '.';
+      $GLOBALS['zco_notifier']->notify('NOTIFY_ZEN_ADMIN_INVALID_IP_DETECTED', $original_ip);
+  }
 
   return $ip;
 }

--- a/includes/functions/functions_general.php
+++ b/includes/functions/functions_general.php
@@ -781,12 +781,16 @@
     /**
      * sanitize for validity as an IPv4 or IPv6 address
      */
-    $ip = preg_replace('~[^a-fA-F0-9.:%/,]~', '', $ip);
+    $original_ip = $ip;
+    $ip = filter_var((string)$ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 | FILTER_FLAG_IPV4);
 
     /**
-     *  if it's still blank, set to a single dot
+     *  If it's an invalid IP, set the value to a single dot and issue a notification.
      */
-    if (trim($ip) == '') $ip = '.';
+    if ($ip === false) {
+        $ip = '.';
+        $GLOBALS['zco_notifier']->notify('NOTIFY_ZEN_INVALID_IP_DETECTED', $original_ip);
+    }
 
     return $ip;
   }


### PR DESCRIPTION
As identified in [this](https://www.zen-cart.com/showthread.php?225679-PHP-Fatal-error-1406-Data-too-long-for-column-ip_address-at-row-1&p=1359685#post1359685) Zen Cart forum thread.

Use the built-in PHP `filter_var` function to fully vet the incoming IP address.  The change specifies the IP filter types to make the processing more obvious.

If an invalid IP is found, set (as current) the IP value to a single dot and issue a notification allowing follow-on code to catch and possibly record the invalid access.