### PR TITLE
Handle error string not defined in val_function check

### DIFF
--- a/admin/includes/functions/configuration_checks.php
+++ b/admin/includes/functions/configuration_checks.php
@@ -19,9 +19,12 @@
      global $messageStack; 
      $data = json_decode($check_string, true); 
      // check inputs - error should be a defined constant in the language files
-     if (empty($data['error']) || !defined($data['error'])) return;
-     $error_msg = constant($data['error']); 
-
+     if (empty($data['error'])) return; 
+     if (!defined($data['error'])) {
+        $error_msg = TEXT_DATA_OUT_OF_RANGE; 
+     } else { 
+        $error_msg = constant($data['error']); 
+     }
      if (defined($data['id'])) { 
         $id = constant($data['id']); 
      } else if (is_integer($data['id'])) { 

--- a/admin/includes/languages/english/configuration.php
+++ b/admin/includes/languages/english/configuration.php
@@ -28,3 +28,6 @@ define('TEXT_INFO_EDIT_INTRO', 'Please make any necessary changes');
 define('TEXT_INFO_DATE_ADDED', 'Date Added:');
 define('TEXT_INFO_LAST_MODIFIED', 'Last Modified:');
 define('TEXT_MIN_ADMIN_USER_LENGTH', 'Must be of a length of 4 or more.');
+// Validation defines
+define('TEXT_DATA_OUT_OF_RANGE','Data out of range'); 
+


### PR DESCRIPTION
The database creation specifies a set of error strings for min max checks.  None of the strings (such as TEXT_MAX_ADMIN_ADDRESS_BOOK_ENTRIES_LENGTH) have been defined, so the check just returns successfully even though the test would fail.  Creating a default check will fix this for the time being.  