### PR TITLE
Display product options when enabling disabled category

### DIFF
--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -1028,8 +1028,8 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
                                   '<div class="radio"><label>' . zen_draw_radio_field('set_subcategories_status', 'set_subcategories_status_on', true) . TEXT_SUBCATEGORIES_STATUS_ON . '</label></div>' .
                                   '<div class="radio"><label>' . zen_draw_radio_field('set_subcategories_status', 'set_subcategories_status_nochange') . TEXT_SUBCATEGORIES_STATUS_NOCHANGE . '</label></div>' : '') .
 
-                              //hide products selection if no products
-                              (zen_get_products_to_categories($_GET['cID']) > 0 ? zen_draw_label(TEXT_PRODUCTS_STATUS_INFO, 'set_products_status','class="control-label"') .
+                              //hide products selection if no enabled nor disabled products
+                              (zen_get_products_to_categories($_GET['cID'], true) > 0 ? zen_draw_label(TEXT_PRODUCTS_STATUS_INFO, 'set_products_status','class="control-label"') .
                               '<div class="radio"><label>' . zen_draw_radio_field('set_products_status', 'set_products_status_on', true) . TEXT_PRODUCTS_STATUS_ON . '</label></div>' .
                               '<div class="radio"><label>' . zen_draw_radio_field('set_products_status', 'set_products_status_nochange') . TEXT_PRODUCTS_STATUS_NOCHANGE . '</label></div>' : '')
                       );


### PR DESCRIPTION
See bug report: https://www.zen-cart.com/showthread.php?225704-v156c-cannot-reenable-all-product-when-enabling-category&p=1359899#post1359899

Ref: #2301 