### PR TITLE
Removing old PHP Version checks

### DIFF
--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -907,11 +907,8 @@ function zen_get_uprid($prid, $params)
 
 ////
 // Sets timeout for the current script.
-// Cant be used in safe mode.
   function zen_set_time_limit($limit) {
-    if (!get_cfg_var('safe_mode')) {
-      @set_time_limit($limit);
-    }
+     @set_time_limit($limit);
   }
 
 

--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -909,7 +909,7 @@ function zen_get_uprid($prid, $params)
 // Sets timeout for the current script.
 // Cant be used in safe mode.
   function zen_set_time_limit($limit) {
-    if (version_compare(PHP_VERSION, 5.4, '>=') || !get_cfg_var('safe_mode')) {
+    if (!get_cfg_var('safe_mode')) {
       @set_time_limit($limit);
     }
   }

--- a/admin/includes/header.php
+++ b/admin/includes/header.php
@@ -201,7 +201,7 @@ if (defined('MODULE_ORDER_TOTAL_GV_SHOW_QUEUE_IN_ADMIN') && MODULE_ORDER_TOTAL_G
         echo '&nbsp;' . date("O", time()) . ' GMT';  // time zone
         echo '&nbsp;[' . $_SERVER['REMOTE_ADDR'] . ']'; // current admin user's IP address
         echo '<br />';
-        echo version_compare(PHP_VERSION, '5.3.0', 'lt') ? php_uname('n') : gethostname(); //what server am I working on? // NOTE: gethostbyname only available since PHP 5.3.0
+        echo gethostname(); 
         echo ' - ' . date_default_timezone_get(); //what is the PHP timezone set to?
         $loc = setlocale(LC_TIME, 0);
         if ($loc !== FALSE) echo ' - ' . $loc; //what is the locale in use?

--- a/admin/sqlpatch.php
+++ b/admin/sqlpatch.php
@@ -53,9 +53,7 @@ $linebreak = '
 // NOTE: this line break is intentional!!!!
 
 function executeSql($lines, $database, $table_prefix = '') {
-  if (version_compare(PHP_VERSION, 5.4, '>=') || !get_cfg_var('safe_mode')) {
-    @set_time_limit(1200);
-  }
+  zen_set_time_limit(1200); 
   global $db, $debug, $messageStack;
   $sql_file = 'SQLPATCH';
   $newline = '';


### PR DESCRIPTION
Part 2 of #2586.  

Note that some of the removed checks were actually wrong; they used OR where they should have used AND. 