### PR TITLE
Add observer hooks, and field-data-properties to Attributes module

### DIFF
--- a/includes/templates/template_default/templates/tpl_modules_attributes.php
+++ b/includes/templates/template_default/templates/tpl_modules_attributes.php
@@ -19,6 +19,9 @@
 <?php
     for($i=0, $j=sizeof($options_name); $i<$j; $i++) {
 ?>
+
+<div class="attribBlock">
+
 <?php
   if ($options_comment[$i] != '' and $options_comment_position[$i] == '0') {
 ?>
@@ -49,6 +52,8 @@ if (!empty($options_attributes_image[$i])) {
 }
 ?>
 <br class="clearBoth">
+
+</div>
 <?php
     }
 ?>


### PR DESCRIPTION
Observer hooks can be used to set `data-x="y"` properties on html fields, which can later be leveraged by front-end clients to control display/selection dependencies.