### PR TITLE
Function signatures - init arrays to array instead of string

### DIFF
--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -204,7 +204,7 @@
   }
 
 
-  function zen_get_category_tree($parent_id = '0', $spacing = '', $exclude = '', $category_tree_array = '', $include_itself = false, $category_has_products = false, $limit = false) {
+  function zen_get_category_tree($parent_id = '0', $spacing = '', $exclude = '', $category_tree_array = array(), $include_itself = false, $category_has_products = false, $limit = false) {
     global $db;
 
     if ($limit) {
@@ -1023,7 +1023,7 @@
     return $systemInfo;
 }
 
-  function zen_generate_category_path($id, $from = 'category', $categories_array = '', $index = 0) {
+  function zen_generate_category_path($id, $from = 'category', $categories_array = array(), $index = 0) {
     global $db;
 
     if (!is_array($categories_array)) $categories_array = array();
@@ -2682,7 +2682,7 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
   }
 
 ////
-  function zen_get_categories($categories_array = '', $parent_id = '0', $indent = '') {
+  function zen_get_categories($categories_array = array(), $parent_id = '0', $indent = '') {
     global $db;
 
     if (!is_array($categories_array)) $categories_array = array();

--- a/includes/functions/functions_categories.php
+++ b/includes/functions/functions_categories.php
@@ -112,7 +112,7 @@
   }
 
 ////
-  function zen_get_categories($categories_array = '', $parent_id = '0', $indent = '', $status_setting = '') {
+  function zen_get_categories($categories_array = array(), $parent_id = '0', $indent = '', $status_setting = '') {
     global $db;
 
     if (!is_array($categories_array)) $categories_array = array();
@@ -520,7 +520,7 @@
   }
 
 //// bof: manage master_categories_id vs cPath
-  function zen_generate_category_path($id, $from = 'category', $categories_array = '', $index = 0) {
+  function zen_generate_category_path($id, $from = 'category', $categories_array = array(), $index = 0) {
     global $db;
 
     if (!is_array($categories_array)) $categories_array = array();

--- a/includes/functions/functions_lookups.php
+++ b/includes/functions/functions_lookups.php
@@ -214,7 +214,7 @@
 /*
  * List manufacturers (returned in an array)
  */
-  function zen_get_manufacturers($manufacturers_array = '', $have_products = false) {
+  function zen_get_manufacturers($manufacturers_array = array(), $have_products = false) {
     global $db;
     if (!is_array($manufacturers_array)) $manufacturers_array = array();
 

--- a/includes/functions/functions_taxes.php
+++ b/includes/functions/functions_taxes.php
@@ -139,7 +139,7 @@
     global $db;
     // -----
     // Give an observer the chance to override this function's return.
-    //
+    // It is *intended* to be an empty string; this is not a bug.
     $rates_array = '';
     $GLOBALS['zco_notifier']->notify(
         'NOTIFY_ZEN_GET_MULTIPLE_TAX_RATES_OVERRIDE',


### PR DESCRIPTION
These changes make the code a bit more self documenting with the new stricter handling of strings vs arrays in PHP7. 