### PR TITLE
Consolidate language-defines for Product Model

### DIFF
--- a/admin/includes/languages/english.php
+++ b/admin/includes/languages/english.php
@@ -533,6 +533,9 @@ define('NOT_INSTALLED_TEXT','Not Installed');
 
 // generic model
   define('TEXT_MODEL','Model:');
+  define('TEXT_PRODUCTS_MODEL', 'Products Model:');
+  define('TABLE_HEADING_PRODUCTS_MODEL','Model');
+  define('TABLE_HEADING_MODEL', 'Model');
 
 // column controller
   define('BOX_TOOLS_LAYOUT_CONTROLLER','Layout Boxes Controller');

--- a/admin/includes/languages/english/category_product_listing.php
+++ b/admin/includes/languages/english/category_product_listing.php
@@ -12,7 +12,6 @@ define('HEADING_TITLE_GOTO', 'Go To:');
 
 define('TABLE_HEADING_ID', 'ID');
 define('TABLE_HEADING_CATEGORIES_PRODUCTS', 'Categories / Products');
-define('TABLE_HEADING_MODEL', 'Model');
 
 define('TABLE_HEADING_PRICE', 'Price/Special/Sale');
 define('TABLE_HEADING_QUANTITY', 'Quantity');

--- a/admin/includes/languages/english/coupon_restrict.php
+++ b/admin/includes/languages/english/coupon_restrict.php
@@ -41,7 +41,7 @@ define('TEXT_ALL_MANUFACTURERS_ADD', 'Add All Manufacturer Products');
 define('TEXT_ALL_MANUFACTURERS_REMOVE', 'Remove All Manufacturer Products');
 
 define('HEADER_PRODUCT_STATUS', 'Status');
-define('HEADER_PRODUCT_MODEL', TABLE_HEADING_MODEL);
+define('HEADER_PRODUCT_MODEL', 'Model');
 
 define('ERROR_RESET_CATEGORY_MANUFACTURER', 'Category and Manufacturer filters reset. Use filters individually.');
 

--- a/admin/includes/languages/english/coupon_restrict.php
+++ b/admin/includes/languages/english/coupon_restrict.php
@@ -41,7 +41,7 @@ define('TEXT_ALL_MANUFACTURERS_ADD', 'Add All Manufacturer Products');
 define('TEXT_ALL_MANUFACTURERS_REMOVE', 'Remove All Manufacturer Products');
 
 define('HEADER_PRODUCT_STATUS', 'Status');
-define('HEADER_PRODUCT_MODEL', 'Model');
+define('HEADER_PRODUCT_MODEL', TABLE_HEADING_MODEL);
 
 define('ERROR_RESET_CATEGORY_MANUFACTURER', 'Category and Manufacturer filters reset. Use filters individually.');
 

--- a/admin/includes/languages/english/downloads_manager.php
+++ b/admin/includes/languages/english/downloads_manager.php
@@ -1,30 +1,16 @@
 <?php
-//
-// +----------------------------------------------------------------------+
-// |zen-cart Open Source E-commerce                                       |
-// +----------------------------------------------------------------------+
-// | Copyright (c) 2003 The zen-cart developers                           |
-// |                                                                      |
-// | http://www.zen-cart.com/index.php                                    |
-// |                                                                      |
-// | Portions Copyright (c) 2003 osCommerce                               |
-// +----------------------------------------------------------------------+
-// | This source file is subject to version 2.0 of the GPL license,       |
-// | that is bundled with this package in the file LICENSE, and is        |
-// | available through the world-wide-web at the following url:           |
-// | http://www.zen-cart.com/license/2_0.txt.                             |
-// | If you did not receive a copy of the zen-cart license and are unable |
-// | to obtain it through the world-wide-web, please send a note to       |
-// | license@zen-cart.com so we can mail you a copy immediately.          |
-// +----------------------------------------------------------------------+
-//  $Id: downloads_manager.php 1105 2005-04-04 22:05:35Z birdbrain $
-//
+/**
+ * @package languageDefines
+ * @copyright Copyright 2003-2019 Zen Cart Development Team
+ * @copyright Portions Copyright 2003 osCommerce
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: 
+ */
 
 define('HEADING_TITLE','Downloads Manager');
 define('TABLE_HEADING_ATTRIBUTES_ID', 'Attr ID');
 define('TABLE_HEADING_PRODUCTS_ID', 'Prod ID');
 define('TABLE_HEADING_PRODUCT', 'Product Name');
-define('TABLE_HEADING_MODEL', 'Model');
 define('TABLE_HEADING_OPT_NAME', 'Option Name');
 define('TABLE_HEADING_OPT_VALUE', 'Option Value Name');
 define('TABLE_TEXT_FILENAME', 'Filename');
@@ -36,7 +22,6 @@ define('TABLE_HEADING_OPT_PRICE', 'Price');
 define('TABLE_HEADING_OPT_PRICE_PREFIX', 'Prefix');
 
 define('TEXT_PRODUCTS_NAME', 'Product: ');
-define('TEXT_PRODUCTS_MODEL', 'Model: ');
 
 define('TEXT_INFO_HEADING_EDIT_PRODUCTS_DOWNLOAD', 'EDITING DOWNLOAD INFORMATION');
 define('TEXT_INFO_HEADING_DELETE_PRODUCTS_DOWNLOAD', 'CONFIRM DELETION OF DOWNLOAD');
@@ -49,4 +34,3 @@ define('TEXT_INFO_MAX_COUNT', 'Max Downloads: ');
 
 define('TEXT_INFO_FILENAME_MISSING','&nbsp;Missing filename');
 define('TEXT_INFO_FILENAME_GOOD','&nbsp;Valid filename');
-?>

--- a/admin/includes/languages/english/featured.php
+++ b/admin/includes/languages/english/featured.php
@@ -10,7 +10,6 @@
 define('HEADING_TITLE', 'Featured Products');
 
 define('TABLE_HEADING_PRODUCTS', 'Products');
-define('TABLE_HEADING_PRODUCTS_MODEL','Model');
 define('TABLE_HEADING_PRODUCTS_PRICE', 'Products Price/Special/Sale');
 define('TABLE_HEADING_PRODUCTS_PERCENTAGE','Percentage');
 define('TABLE_HEADING_AVAILABLE_DATE', 'Available');

--- a/admin/includes/languages/english/featured.php
+++ b/admin/includes/languages/english/featured.php
@@ -42,4 +42,3 @@ define('TEXT_INFO_HEADING_PRE_ADD_FEATURED', 'Manually add new Featured by Produ
 define('TEXT_INFO_PRE_ADD_INTRO', 'On large databases, you may Manually Add a Featured by the Product ID<br /><br />This is best used when the page takes too long to render and trying to select a Product from the dropdown becomes difficult due to too many Products from which to choose.');
 define('TEXT_PRE_ADD_PRODUCTS_ID', 'Please enter the Product ID to be Pre-Added: ');
 define('TEXT_INFO_MANUAL', 'Product ID to be Manually Added as a Featured');
-?>

--- a/admin/includes/languages/english/invoice.php
+++ b/admin/includes/languages/english/invoice.php
@@ -1,31 +1,17 @@
 <?php
-//
-// +----------------------------------------------------------------------+
-// |zen-cart Open Source E-commerce                                       |
-// +----------------------------------------------------------------------+
-// | Copyright (c) 2003 The zen-cart developers                           |
-// |                                                                      |
-// | http://www.zen-cart.com/index.php                                    |
-// |                                                                      |
-// | Portions Copyright (c) 2003 osCommerce                               |
-// +----------------------------------------------------------------------+
-// | This source file is subject to version 2.0 of the GPL license,       |
-// | that is bundled with this package in the file LICENSE, and is        |
-// | available through the world-wide-web at the following url:           |
-// | http://www.zen-cart.com/license/2_0.txt.                             |
-// | If you did not receive a copy of the zen-cart license and are unable |
-// | to obtain it through the world-wide-web, please send a note to       |
-// | license@zen-cart.com so we can mail you a copy immediately.          |
-// +----------------------------------------------------------------------+
-//  $Id: invoice.php 5961 2007-03-03 17:17:39Z ajeh $
-//
+/**
+ * @package languageDefines
+ * @copyright Copyright 2003-2019 Zen Cart Development Team
+ * @copyright Portions Copyright 2003 osCommerce
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: 
+ */
 
 define('TABLE_HEADING_COMMENTS', 'Comments');
 define('TABLE_HEADING_CUSTOMER_NOTIFIED', 'Customer Notified');
 define('TABLE_HEADING_DATE_ADDED', 'Date Added');
 define('TABLE_HEADING_STATUS', 'Status');
 
-define('TABLE_HEADING_PRODUCTS_MODEL', 'Model');
 define('TABLE_HEADING_PRODUCTS', 'Products');
 define('TABLE_HEADING_TAX', 'Tax');
 define('TABLE_HEADING_TOTAL', 'Total');
@@ -47,4 +33,3 @@ define('ENTRY_DATE_PURCHASED', 'Date Ordered:');
 
 define('ENTRY_ORDER_ID','Invoice No. ');
 define('TEXT_INFO_ATTRIBUTE_FREE', '&nbsp;-&nbsp;FREE');
-?>

--- a/admin/includes/languages/english/orders.php
+++ b/admin/includes/languages/english/orders.php
@@ -29,7 +29,6 @@ define('TABLE_HEADING_STATUS', 'Status');
 define('TABLE_HEADING_TYPE', 'Order Type');
 define('TABLE_HEADING_ACTION', 'Action');
 define('TABLE_HEADING_QUANTITY', 'Qty.');
-define('TABLE_HEADING_PRODUCTS_MODEL', 'Model');
 define('TABLE_HEADING_PRODUCTS', 'Products');
 define('TABLE_HEADING_TAX', 'Tax');
 define('TABLE_HEADING_TOTAL', 'Total');

--- a/admin/includes/languages/english/packingslip.php
+++ b/admin/includes/languages/english/packingslip.php
@@ -1,31 +1,17 @@
 <?php
-//
-// +----------------------------------------------------------------------+
-// |zen-cart Open Source E-commerce                                       |
-// +----------------------------------------------------------------------+
-// | Copyright (c) 2003 The zen-cart developers                           |
-// |                                                                      |
-// | http://www.zen-cart.com/index.php                                    |
-// |                                                                      |
-// | Portions Copyright (c) 2003 osCommerce                               |
-// +----------------------------------------------------------------------+
-// | This source file is subject to version 2.0 of the GPL license,       |
-// | that is bundled with this package in the file LICENSE, and is        |
-// | available through the world-wide-web at the following url:           |
-// | http://www.zen-cart.com/license/2_0.txt.                             |
-// | If you did not receive a copy of the zen-cart license and are unable |
-// | to obtain it through the world-wide-web, please send a note to       |
-// | license@zen-cart.com so we can mail you a copy immediately.          |
-// +----------------------------------------------------------------------+
-//  $Id: packingslip.php 5961 2007-03-03 17:17:39Z ajeh $
-//
+/**
+ * @package languageDefines
+ * @copyright Copyright 2003-2019 Zen Cart Development Team
+ * @copyright Portions Copyright 2003 osCommerce
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: 
+ */
 
 define('TABLE_HEADING_COMMENTS', 'Comments');
 define('TABLE_HEADING_CUSTOMER_NOTIFIED', 'Customer Notified');
 define('TABLE_HEADING_DATE_ADDED', 'Date Added');
 define('TABLE_HEADING_STATUS', 'Status');
 
-define('TABLE_HEADING_PRODUCTS_MODEL', 'Model');
 define('TABLE_HEADING_PRODUCTS', 'Products');
 
 define('ENTRY_CUSTOMER', 'CUSTOMER:');
@@ -36,4 +22,3 @@ define('ENTRY_PAYMENT_METHOD', 'Payment Method:');
 define('ENTRY_DATE_PURCHASED', 'Date Ordered:');
 
 define('ENTRY_ORDER_ID','Invoice No. ');
-?>

--- a/admin/includes/languages/english/product.php
+++ b/admin/includes/languages/english/product.php
@@ -31,7 +31,6 @@ define('TEXT_PRODUCTS_MANUFACTURER', 'Products Manufacturer:');
 define('TEXT_PRODUCTS_NAME', 'Products Name:');
 define('TEXT_PRODUCTS_DESCRIPTION', 'Products Description:');
 define('TEXT_PRODUCTS_QUANTITY', 'Products Quantity:');
-define('TEXT_PRODUCTS_MODEL', 'Products Model:');
 define('TEXT_PRODUCTS_IMAGE', 'Products Image:');
 define('TEXT_IMAGE_NONEXISTENT', 'Image does not exist');
 define('TEXT_PRODUCTS_IMAGE_DIR', 'Upload to directory:');

--- a/admin/includes/languages/english/products_price_manager.php
+++ b/admin/includes/languages/english/products_price_manager.php
@@ -10,7 +10,6 @@ define('HEADING_TITLE', 'Products Price Manager');
 define('HEADING_TITLE_PRODUCT_SELECT','Please select a Category with Products to display the Pricing Information of ...');
 
 define('TABLE_HEADING_PRODUCTS', 'Products');
-define('TABLE_HEADING_PRODUCTS_MODEL','Model');
 define('TABLE_HEADING_PRODUCTS_PRICE', 'Products Price/Special/Sale');
 define('TABLE_HEADING_PRODUCTS_PERCENTAGE','Percentage');
 define('TABLE_HEADING_AVAILABLE_DATE', 'Available');
@@ -20,7 +19,6 @@ define('TABLE_HEADING_ACTION', 'Action');
 
 define('TEXT_PRODUCT_INFO', 'Product Info:');
 define('TEXT_PRODUCTS_PRICE_INFO', 'Product Price Info:');
-define('TEXT_PRODUCTS_MODEL','Model:');
 define('TEXT_PRICE', 'Price');
 define('TEXT_PRICE_NET', 'Price (Net)');
 define('TEXT_PRICE_GROSS', 'Price (Gross)');

--- a/admin/includes/languages/english/products_to_categories.php
+++ b/admin/includes/languages/english/products_to_categories.php
@@ -14,13 +14,11 @@ define('TEXT_INFO_PRODUCTS_TO_CATEGORIES_AVAILABLE', 'Categories with Products t
 
 define('TABLE_HEADING_PRODUCTS_ID', 'Prod ID');
 define('TABLE_HEADING_PRODUCT', 'Product Name');
-define('TABLE_HEADING_MODEL', 'Model');
 define('TABLE_HEADING_ACTION', 'Action');
 
 define('TEXT_INFO_HEADING_EDIT_PRODUCTS_TO_CATEGORIES', 'Edit Product Links');
 define('TEXT_PRODUCTS_ID', 'Product ID# ');
 define('TEXT_PRODUCTS_NAME', 'Product: ');
-define('TEXT_PRODUCTS_MODEL', 'Model: ');
 define('TEXT_PRODUCTS_PRICE', 'Price: ');
 define('BUTTON_UPDATE_CATEGORY_LINKS', 'Update Category Links');
 define('BUTTON_NEW_PRODUCTS_TO_CATEGORIES', 'Select Another Product by ID#');

--- a/admin/includes/languages/english/reviews.php
+++ b/admin/includes/languages/english/reviews.php
@@ -9,7 +9,6 @@
 
 define('HEADING_TITLE', 'Reviews');
 
-define('TABLE_HEADING_MODEL', 'Model');
 define('TABLE_HEADING_PRODUCT', 'Product');
 define('TABLE_HEADING_CUSTOMER_NAME','Customer Name');
 define('TABLE_HEADING_LANGUAGE', 'Lang');

--- a/admin/includes/languages/english/specials.php
+++ b/admin/includes/languages/english/specials.php
@@ -23,7 +23,6 @@
 define('HEADING_TITLE', 'Specials');
 
 define('TABLE_HEADING_PRODUCTS', 'Products');
-define('TABLE_HEADING_PRODUCTS_MODEL','Model');
 define('TABLE_HEADING_PRODUCTS_PRICE', 'Products Price/Special/Sale');
 define('TABLE_HEADING_PRODUCTS_PERCENTAGE','Percentage');
 define('TABLE_HEADING_AVAILABLE_DATE', 'Available');

--- a/admin/includes/languages/english/stats_products_purchased.php
+++ b/admin/includes/languages/english/stats_products_purchased.php
@@ -1,24 +1,12 @@
 <?php
-//
-// +----------------------------------------------------------------------+
-// |zen-cart Open Source E-commerce                                       |
-// +----------------------------------------------------------------------+
-// | Copyright (c) 2003 The zen-cart developers                           |
-// |                                                                      |
-// | http://www.zen-cart.com/index.php                                    |
-// |                                                                      |
-// | Portions Copyright (c) 2003 osCommerce                               |
-// +----------------------------------------------------------------------+
-// | This source file is subject to version 2.0 of the GPL license,       |
-// | that is bundled with this package in the file LICENSE, and is        |
-// | available through the world-wide-web at the following url:           |
-// | http://www.zen-cart.com/license/2_0.txt.                             |
-// | If you did not receive a copy of the zen-cart license and are unable |
-// | to obtain it through the world-wide-web, please send a note to       |
-// | license@zen-cart.com so we can mail you a copy immediately.          |
-// +----------------------------------------------------------------------+
-//  $Id: stats_products_purchased.php 4735 2006-10-12 22:37:46Z ajeh $
-//
+
+/**
+ * @package languageDefines
+ * @copyright Copyright 2003-2019 Zen Cart Development Team
+ * @copyright Portions Copyright 2003 osCommerce
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: 
+ */
 
 define('HEADING_TITLE', 'Best Products Purchased');
 
@@ -32,5 +20,3 @@ define('TABLE_HEADING_ORDERS_DATE_PURCHASED', 'Date');
 define('TABLE_HEADING_CUSTOMERS_INFO', 'Customer');
 define('TABLE_HEADING_PRODUCTS_QUANTITY', 'QTY');
 define('TABLE_HEADING_PRODUCTS_NAME', 'Product');
-define('TABLE_HEADING_PRODUCTS_MODEL', 'Model');
-?>

--- a/includes/languages/english.php
+++ b/includes/languages/english.php
@@ -445,6 +445,8 @@
   define('PRODUCTS_QUANTITY_ADD_ADDITIONAL_LISTING','Add Additional:');
 
   define('PRODUCTS_QUANTITY_MAX_TEXT_LISTING','Max:');
+  define('TEXT_PRODUCT_MODEL', 'Model: ');
+  define('TABLE_HEADING_MODEL', 'Model');
 
   define('TEXT_PRODUCTS_MIX_OFF','*Mixed OFF');
   define('TEXT_PRODUCTS_MIX_ON','*Mixed ON');

--- a/includes/languages/english/advanced_search.php
+++ b/includes/languages/english/advanced_search.php
@@ -32,7 +32,6 @@ define('ENTRY_DATE_RANGE', 'Search by Date Added');
   define('TEXT_ALL_MANUFACTURERS', 'All Manufacturers');
 
   define('TABLE_HEADING_IMAGE', '');
-  define('TABLE_HEADING_MODEL', 'Model');
   define('TABLE_HEADING_PRODUCTS', 'Product Name');
   define('TABLE_HEADING_MANUFACTURER', 'Manufacturer');
   define('TABLE_HEADING_PRICE', 'Price');
@@ -50,4 +49,3 @@ define('ENTRY_DATE_RANGE', 'Search by Date Added');
   define('ERROR_PRICE_TO_LESS_THAN_PRICE_FROM', 'Price To must be greater than or equal to Price From.');
   define('ERROR_INVALID_KEYWORDS', 'Invalid keywords.');
 
-?>

--- a/includes/languages/english/advanced_search_result.php
+++ b/includes/languages/english/advanced_search_result.php
@@ -1,24 +1,12 @@
 <?php
-//
-// +----------------------------------------------------------------------+
-// |zen-cart Open Source E-commerce                                       |
-// +----------------------------------------------------------------------+
-// | Copyright (c) 2003 The zen-cart developers                           |
-// |                                                                      |   
-// | http://www.zen-cart.com/index.php                                    |   
-// |                                                                      |   
-// | Portions Copyright (c) 2003 osCommerce                               |
-// +----------------------------------------------------------------------+
-// | This source file is subject to version 2.0 of the GPL license,       |
-// | that is bundled with this package in the file LICENSE, and is        |
-// | available through the world-wide-web at the following url:           |
-// | http://www.zen-cart.com/license/2_0.txt.                             |
-// | If you did not receive a copy of the zen-cart license and are unable |
-// | to obtain it through the world-wide-web, please send a note to       |
-// | license@zen-cart.com so we can mail you a copy immediately.          |
-// +----------------------------------------------------------------------+
-// $Id: advanced_search_result.php 1969 2005-09-13 06:57:21Z drbyte $
-//
+
+/**
+ * @package languageDefines
+ * @copyright Copyright 2003-2019 Zen Cart Development Team
+ * @copyright Portions Copyright 2003 osCommerce
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: 
+ */
 
 define('NAVBAR_TITLE_1', 'Advanced Search');
 define('NAVBAR_TITLE_2', 'Search Results');
@@ -47,7 +35,6 @@ define('TEXT_SEARCH_HELP', 'Keywords may be separated by AND and/or OR statement
 define('TEXT_CLOSE_WINDOW', 'Close Window [x]');
 
 define('TABLE_HEADING_IMAGE', '');
-define('TABLE_HEADING_MODEL', 'Model');
 define('TABLE_HEADING_PRODUCTS', 'Product Name');
 define('TABLE_HEADING_MANUFACTURER', 'Manufacturer');
 define('TABLE_HEADING_PRICE', 'Price');
@@ -64,4 +51,3 @@ define('ERROR_PRICE_FROM_MUST_BE_NUM', 'Price From must be a number.');
 define('ERROR_PRICE_TO_MUST_BE_NUM', 'Price To must be a number.');
 define('ERROR_PRICE_TO_LESS_THAN_PRICE_FROM', 'Price To must be greater than or equal to Price From.');
 define('ERROR_INVALID_KEYWORDS', 'Invalid keywords.');
-?>

--- a/includes/languages/english/document_general_info.php
+++ b/includes/languages/english/document_general_info.php
@@ -17,7 +17,6 @@ define('TEXT_PRODUCT_OPTIONS', 'Please Choose: ');
 define('TEXT_PRODUCT_MANUFACTURER', 'Manufactured by: ');
 define('TEXT_PRODUCT_WEIGHT', 'Shipping Weight: ');
 define('TEXT_PRODUCT_QUANTITY', ' Units in Stock');
-define('TEXT_PRODUCT_MODEL', 'Model: ');
 
 
 
@@ -45,4 +44,3 @@ define('ATTRIBUTES_PRICE_DELIMITER_SUFFIX', ' )');
 define('ATTRIBUTES_WEIGHT_DELIMITER_PREFIX', ' (');
 define('ATTRIBUTES_WEIGHT_DELIMITER_SUFFIX', ') ');
 
-?>

--- a/includes/languages/english/document_product_info.php
+++ b/includes/languages/english/document_product_info.php
@@ -17,7 +17,6 @@ define('TEXT_PRODUCT_OPTIONS', 'Please Choose: ');
 define('TEXT_PRODUCT_MANUFACTURER', 'Manufactured by: ');
 define('TEXT_PRODUCT_WEIGHT', 'Shipping Weight: ');
 define('TEXT_PRODUCT_QUANTITY', ' Units in Stock');
-define('TEXT_PRODUCT_MODEL', 'Model: ');
 
 
 
@@ -44,4 +43,3 @@ define('ATTRIBUTES_PRICE_DELIMITER_PREFIX', ' ( ');
 define('ATTRIBUTES_PRICE_DELIMITER_SUFFIX', ' )');
 define('ATTRIBUTES_WEIGHT_DELIMITER_PREFIX', ' (');
 define('ATTRIBUTES_WEIGHT_DELIMITER_SUFFIX', ') ');
-?>

--- a/includes/languages/english/featured_products.php
+++ b/includes/languages/english/featured_products.php
@@ -1,24 +1,11 @@
 <?php
-//
-// +----------------------------------------------------------------------+
-// |zen-cart Open Source E-commerce                                       |
-// +----------------------------------------------------------------------+
-// | Copyright (c) 2003 The zen-cart developers                           |
-// |                                                                      |
-// | http://www.zen-cart.com/index.php                                    |
-// |                                                                      |
-// | Portions Copyright (c) 2003 osCommerce                               |
-// +----------------------------------------------------------------------+
-// | This source file is subject to version 2.0 of the GPL license,       |
-// | that is bundled with this package in the file LICENSE, and is        |
-// | available through the world-wide-web at the following url:           |
-// | http://www.zen-cart.com/license/2_0.txt.                             |
-// | If you did not receive a copy of the zen-cart license and are unable |
-// | to obtain it through the world-wide-web, please send a note to       |
-// | license@zen-cart.com so we can mail you a copy immediately.          |
-// +----------------------------------------------------------------------+
-// $Id: featured_products.php 1969 2005-09-13 06:57:21Z drbyte $
-//
+/**
+ * @package languageDefines
+ * @copyright Copyright 2003-2019 Zen Cart Development Team
+ * @copyright Portions Copyright 2003 osCommerce
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: 
+ */
 
 define('NAVBAR_TITLE', 'Featured Products');
 define('HEADING_TITLE', 'Featured Products');
@@ -27,8 +14,6 @@ define('TEXT_DATE_ADDED', 'Date Added:');
 define('TEXT_MANUFACTURER', 'Manufacturer:');
 define('TEXT_PRICE', 'Price:');
 
-define('TEXT_PRODUCTS_MODEL','Model: ');
 define('TEXT_PRODUCTS_WEIGHT','Weight: ');
 define('TEXT_PRODUCTS_QUANTITY','In Stock: ');
 define('TEXT_OUT_OF_STOCK','Out of Stock');
-?>

--- a/includes/languages/english/index.php
+++ b/includes/languages/english/index.php
@@ -31,7 +31,6 @@ if ( ($category_depth == 'products') || (zen_check_url_get_terms()) ) {
   // This section deals with product-listing page contents
   define('HEADING_TITLE', 'Available Products');
   define('TABLE_HEADING_IMAGE', 'Product Image');
-  define('TABLE_HEADING_MODEL', 'Model');
   define('TABLE_HEADING_PRODUCTS', 'Product Name');
   define('TABLE_HEADING_MANUFACTURER', 'Manufacturer');
   define('TABLE_HEADING_PRICE', 'Price');
@@ -54,4 +53,3 @@ if ( ($category_depth == 'products') || (zen_check_url_get_terms()) ) {
   /*Replace this line with the headline you would like for your shop. For example: 'Welcome to My SHOP!'*/
   define('HEADING_TITLE', 'Congratulations! You have successfully installed your Zen Cart&reg; E-Commerce Solution.'); 
 }
-?>

--- a/includes/languages/english/product_free_shipping_info.php
+++ b/includes/languages/english/product_free_shipping_info.php
@@ -17,7 +17,6 @@ define('TEXT_PRODUCT_OPTIONS', 'Please Choose:');
 define('TEXT_PRODUCT_MANUFACTURER', 'Manufactured by: ');
 define('TEXT_PRODUCT_WEIGHT', 'Shipping Weight: ');
 define('TEXT_PRODUCT_QUANTITY', ' Units in Stock');
-define('TEXT_PRODUCT_MODEL', 'Model: ');
 
 
 
@@ -45,4 +44,3 @@ define('ATTRIBUTES_PRICE_DELIMITER_SUFFIX', ' )');
 define('ATTRIBUTES_WEIGHT_DELIMITER_PREFIX', ' (');
 define('ATTRIBUTES_WEIGHT_DELIMITER_SUFFIX', ') ');
 
-?>

--- a/includes/languages/english/product_info.php
+++ b/includes/languages/english/product_info.php
@@ -17,7 +17,6 @@ define('TEXT_PRODUCT_OPTIONS', 'Please Choose: ');
 define('TEXT_PRODUCT_MANUFACTURER', 'Manufactured by: ');
 define('TEXT_PRODUCT_WEIGHT', 'Shipping Weight: ');
 define('TEXT_PRODUCT_QUANTITY', ' Units in Stock');
-define('TEXT_PRODUCT_MODEL', 'Model: ');
 
 
 
@@ -45,4 +44,3 @@ define('ATTRIBUTES_PRICE_DELIMITER_SUFFIX', ' )');
 define('ATTRIBUTES_WEIGHT_DELIMITER_PREFIX', ' (');
 define('ATTRIBUTES_WEIGHT_DELIMITER_SUFFIX', ') ');
 
-?>

--- a/includes/languages/english/product_music_info.php
+++ b/includes/languages/english/product_music_info.php
@@ -20,7 +20,6 @@ define('TEXT_PRODUCT_ARTIST', 'Artist: ');
 define('TEXT_PRODUCT_MUSIC_GENRE', 'Music Genre: ');
 define('TEXT_PRODUCT_WEIGHT', 'Shipping Weight: ');
 define('TEXT_PRODUCT_QUANTITY', ' Units in Stock');
-define('TEXT_PRODUCT_MODEL', 'Model: ');
 define('TEXT_PRODUCT_COLLECTIONS', 'Media Collection: ');
 
 
@@ -49,4 +48,3 @@ define('ATTRIBUTES_PRICE_DELIMITER_SUFFIX', ' )');
 define('ATTRIBUTES_WEIGHT_DELIMITER_PREFIX', ' (');
 define('ATTRIBUTES_WEIGHT_DELIMITER_SUFFIX', ') ');
 
-?>

--- a/includes/languages/english/products_all.php
+++ b/includes/languages/english/products_all.php
@@ -1,24 +1,11 @@
 <?php
-//
-// +----------------------------------------------------------------------+
-// |zen-cart Open Source E-commerce                                       |
-// +----------------------------------------------------------------------+
-// | Copyright (c) 2004 The zen-cart developers                           |
-// |                                                                      |   
-// | http://www.zen-cart.com/index.php                                    |   
-// |                                                                      |   
-// | Portions Copyright (c) 2003 osCommerce                               |
-// +----------------------------------------------------------------------+
-// | This source file is subject to version 2.0 of the GPL license,       |
-// | that is bundled with this package in the file LICENSE, and is        |
-// | available through the world-wide-web at the following url:           |
-// | http://www.zen-cart.com/license/2_0.txt.                             |
-// | If you did not receive a copy of the zen-cart license and are unable |
-// | to obtain it through the world-wide-web, please send a note to       |
-// | license@zen-cart.com so we can mail you a copy immediately.          |
-// +----------------------------------------------------------------------+
-// $Id: products_all.php 1969 2005-09-13 06:57:21Z drbyte $
-//
+/**
+ * @package languageDefines
+ * @copyright Copyright 2003-2019 Zen Cart Development Team
+ * @copyright Portions Copyright 2003 osCommerce
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: 
+ */
 
 define('NAVBAR_TITLE', 'All Products');
 define('HEADING_TITLE', 'All Products');
@@ -27,8 +14,6 @@ define('TEXT_DATE_ADDED', 'Date Added:');
 define('TEXT_MANUFACTURER', 'Manufacturer:');
 define('TEXT_PRICE', 'Price:');
 
-define('TEXT_PRODUCTS_MODEL','Model: ');
 define('TEXT_PRODUCTS_WEIGHT','Weight: ');
 define('TEXT_PRODUCTS_QUANTITY','In Stock: ');
 define('TEXT_OUT_OF_STOCK','Out of Stock');
-?>

--- a/includes/languages/english/products_new.php
+++ b/includes/languages/english/products_new.php
@@ -1,24 +1,11 @@
 <?php
-//
-// +----------------------------------------------------------------------+
-// |zen-cart Open Source E-commerce                                       |
-// +----------------------------------------------------------------------+
-// | Copyright (c) 2003 The zen-cart developers                           |
-// |                                                                      |
-// | http://www.zen-cart.com/index.php                                    |
-// |                                                                      |
-// | Portions Copyright (c) 2003 osCommerce                               |
-// +----------------------------------------------------------------------+
-// | This source file is subject to version 2.0 of the GPL license,       |
-// | that is bundled with this package in the file LICENSE, and is        |
-// | available through the world-wide-web at the following url:           |
-// | http://www.zen-cart.com/license/2_0.txt.                             |
-// | If you did not receive a copy of the zen-cart license and are unable |
-// | to obtain it through the world-wide-web, please send a note to       |
-// | license@zen-cart.com so we can mail you a copy immediately.          |
-// +----------------------------------------------------------------------+
-// $Id: products_new.php 1969 2005-09-13 06:57:21Z drbyte $
-//
+/**
+ * @package languageDefines
+ * @copyright Copyright 2003-2019 Zen Cart Development Team
+ * @copyright Portions Copyright 2003 osCommerce
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: 
+ */
 
 define('NAVBAR_TITLE', 'New Products');
 define('HEADING_TITLE', 'New Products');
@@ -27,8 +14,6 @@ define('TEXT_DATE_ADDED', 'Date Added:');
 define('TEXT_MANUFACTURER', 'Manufacturer:');
 define('TEXT_PRICE', 'Price:');
 
-define('TEXT_PRODUCTS_MODEL','Model: ');
 define('TEXT_PRODUCTS_WEIGHT','Weight: ');
 define('TEXT_PRODUCTS_QUANTITY','In Stock: ');
 define('TEXT_OUT_OF_STOCK','Out of Stock');
-?>

--- a/includes/languages/english/responsive_classic/index.php
+++ b/includes/languages/english/responsive_classic/index.php
@@ -31,7 +31,6 @@ if ( ($category_depth == 'products') || (zen_check_url_get_terms()) ) {
   // This section deals with product-listing page contents
   define('HEADING_TITLE', 'Available Products');
   define('TABLE_HEADING_IMAGE', '');
-  define('TABLE_HEADING_MODEL', 'Model');
   define('TABLE_HEADING_PRODUCTS', 'Product Name');
   define('TABLE_HEADING_MANUFACTURER', 'Manufacturer');
   define('TABLE_HEADING_PRICE', 'Price');
@@ -54,4 +53,3 @@ if ( ($category_depth == 'products') || (zen_check_url_get_terms()) ) {
   /*Replace this line with the headline you would like for your shop. For example: 'Welcome to My SHOP!'*/
   define('HEADING_TITLE', 'Congratulations! You have successfully installed your Zen Cart&reg; E-Commerce Solution.'); 
 }
-?>

--- a/includes/languages/english/shopping_cart.php
+++ b/includes/languages/english/shopping_cart.php
@@ -13,7 +13,6 @@ define('NAVBAR_TITLE', 'The Shopping Cart');
 define('HEADING_TITLE', 'Your Shopping Cart Contents');
 define('HEADING_TITLE_EMPTY', 'Your Shopping Cart');
 define('TABLE_HEADING_REMOVE', 'Remove');
-define('TABLE_HEADING_MODEL', 'Model');
 define('TABLE_HEADING_PRICE','Unit');
 define('TEXT_CART_EMPTY', 'Your Shopping Cart is empty.');
 define('SUB_TITLE_SUB_TOTAL', 'Sub-Total:');


### PR DESCRIPTION
This is PR #623 from 2.0.  Make it easier to change the string "Product Model", which clients do ask for.  