### PR TITLE
Additional notifiers and valid HTML on previews

### DIFF
--- a/admin/includes/modules/copy_product_confirm.php
+++ b/admin/includes/modules/copy_product_confirm.php
@@ -184,6 +184,8 @@ if (isset($_POST['products_id']) && isset($_POST['categories_id'])) {
         }
 
         zen_record_admin_activity('Product ' . $products_id . ' duplicated as product ' . $dup_products_id . ' via admin console.', 'info');
+        
+        $zco_notifier->notify('NOTIFY_MODULES_COPY_TO_CONFIRM_DUPLICATE', array('products_id' => $products_id, 'dup_products_id' => $dup_products_id));
 
         $products_id = $dup_products_id;//reset for further use in price update and final redirect to new linked product or new duplicated product
     }// EOF duplication

--- a/admin/includes/modules/document_general/collect_info.php
+++ b/admin/includes/modules/document_general/collect_info.php
@@ -235,6 +235,39 @@ for ($i = 0, $n = sizeof($tax_class_array); $i < $n; $i++) {
       ?>
     </div>
   </div>
+  
+<?php
+//-bof-zen_tags-lat9  *** 1 of 1 ***
+    // -----
+    // Give an observer the chance to supply some additional product-related inputs.  Each
+    // entry in the $extra_product_inputs returned contains:
+    //
+    // array(
+    //    'label' => array(
+    //        'text' => 'The label text',   (required)
+    //        'field_name' => 'The name of the field associated with the label', (required)
+    //        'addl_class' => {Any additional class to be applied to the label} (optional)
+    //        'parms' => {Any additional parameters for the label, e.g. 'style="font-weight: 700;"} (optional)
+    //    ),
+    //    'input' => 'The HTML to be inserted' (required)
+    // )
+    $extra_product_inputs = array();
+    $zco_notifier->notify('NOTIFY_ADMIN_DOCUMENT_GENERAL_COLLECT_INFO_EXTRA_INPUTS', $pInfo, $extra_product_inputs);
+    if (!empty($extra_product_inputs)) {
+        foreach ($extra_product_inputs as $extra_input) {
+            $addl_class = (isset($extra_input['label']['addl_class'])) ? (' ' . $extra_input['label']['addl_class']) : '';
+            $parms = (isset($extra_input['label']['parms'])) ? (' ' . $extra_input['label']['parms']) : '';
+?>
+            <div class="form-group">
+                <?php echo zen_draw_label($extra_input['label']['text'], $extra_input['label']['field_name'], 'class="col-sm-3 control-label' . $addl_class . '"' . $parms); ?>
+                <div class="col-sm-9 col-md-6"><?php echo $extra_input['input']; ?></div>
+            </div>
+<?php
+        }
+    }
+//-eof-zen_tags-lat9  *** 1 of 1
+?>
+
   <div class="form-group">
       <?php echo zen_draw_label(TEXT_DOCUMENT_DETAILS, 'products_description', 'class="col-sm-3 control-label"'); ?>
     <div class="col-sm-9 col-md-6">

--- a/admin/includes/modules/document_general/collect_info.php
+++ b/admin/includes/modules/document_general/collect_info.php
@@ -237,7 +237,6 @@ for ($i = 0, $n = sizeof($tax_class_array); $i < $n; $i++) {
   </div>
   
 <?php
-//-bof-zen_tags-lat9  *** 1 of 1 ***
     // -----
     // Give an observer the chance to supply some additional product-related inputs.  Each
     // entry in the $extra_product_inputs returned contains:
@@ -265,7 +264,6 @@ for ($i = 0, $n = sizeof($tax_class_array); $i < $n; $i++) {
 <?php
         }
     }
-//-eof-zen_tags-lat9  *** 1 of 1
 ?>
 
   <div class="form-group">

--- a/admin/includes/modules/document_general/collect_info.php
+++ b/admin/includes/modules/document_general/collect_info.php
@@ -250,8 +250,11 @@ for ($i = 0, $n = sizeof($tax_class_array); $i < $n; $i++) {
     //    ),
     //    'input' => 'The HTML to be inserted' (required)
     // )
+    //
+    // Note: The product's type can be found in the 'product_type' element of the passed $pInfo object.
+    //
     $extra_product_inputs = array();
-    $zco_notifier->notify('NOTIFY_ADMIN_DOCUMENT_GENERAL_COLLECT_INFO_EXTRA_INPUTS', $pInfo, $extra_product_inputs);
+    $zco_notifier->notify('NOTIFY_ADMIN_PRODUCT_COLLECT_INFO_EXTRA_INPUTS', $pInfo, $extra_product_inputs);
     if (!empty($extra_product_inputs)) {
         foreach ($extra_product_inputs as $extra_input) {
             $addl_class = (isset($extra_input['label']['addl_class'])) ? (' ' . $extra_input['label']['addl_class']) : '';

--- a/admin/includes/modules/document_product/collect_info.php
+++ b/admin/includes/modules/document_product/collect_info.php
@@ -275,8 +275,11 @@ for ($i = 0, $n = sizeof($tax_class_array); $i < $n; $i++) {
     //    ),
     //    'input' => 'The HTML to be inserted' (required)
     // )
+    //
+    // Note: The product's type can be found in the 'product_type' element of the passed $pInfo object.
+    //
     $extra_product_inputs = array();
-    $zco_notifier->notify('NOTIFY_ADMIN_DOCUMENT_PRODUCT_COLLECT_INFO_EXTRA_INPUTS', $pInfo, $extra_product_inputs);
+    $zco_notifier->notify('NOTIFY_ADMIN_PRODUCT_COLLECT_INFO_EXTRA_INPUTS', $pInfo, $extra_product_inputs);
     if (!empty($extra_product_inputs)) {
         foreach ($extra_product_inputs as $extra_input) {
             $addl_class = (isset($extra_input['label']['addl_class'])) ? (' ' . $extra_input['label']['addl_class']) : '';

--- a/admin/includes/modules/document_product/collect_info.php
+++ b/admin/includes/modules/document_product/collect_info.php
@@ -260,6 +260,36 @@ for ($i = 0, $n = sizeof($tax_class_array); $i < $n; $i++) {
       ?>
     </div>
   </div>
+  
+<?php
+    // -----
+    // Give an observer the chance to supply some additional product-related inputs.  Each
+    // entry in the $extra_product_inputs returned contains:
+    //
+    // array(
+    //    'label' => array(
+    //        'text' => 'The label text',   (required)
+    //        'field_name' => 'The name of the field associated with the label', (required)
+    //        'addl_class' => {Any additional class to be applied to the label} (optional)
+    //        'parms' => {Any additional parameters for the label, e.g. 'style="font-weight: 700;"} (optional)
+    //    ),
+    //    'input' => 'The HTML to be inserted' (required)
+    // )
+    $extra_product_inputs = array();
+    $zco_notifier->notify('NOTIFY_ADMIN_DOCUMENT_PRODUCT_COLLECT_INFO_EXTRA_INPUTS', $pInfo, $extra_product_inputs);
+    if (!empty($extra_product_inputs)) {
+        foreach ($extra_product_inputs as $extra_input) {
+            $addl_class = (isset($extra_input['label']['addl_class'])) ? (' ' . $extra_input['label']['addl_class']) : '';
+            $parms = (isset($extra_input['label']['parms'])) ? (' ' . $extra_input['label']['parms']) : '';
+?>
+            <div class="form-group">
+                <?php echo zen_draw_label($extra_input['label']['text'], $extra_input['label']['field_name'], 'class="col-sm-3 control-label' . $addl_class . '"' . $parms); ?>
+                <div class="col-sm-9 col-md-6"><?php echo $extra_input['input']; ?></div>
+            </div>
+<?php
+        }
+    }
+?>
   <div class="form-group">
       <?php echo zen_draw_label(TEXT_PRODUCT_IS_FREE, 'product_is_free', 'class="col-sm-3 control-label"'); ?>
     <div class="col-sm-9 col-md-6">

--- a/admin/includes/modules/product/collect_info.php
+++ b/admin/includes/modules/product/collect_info.php
@@ -274,6 +274,9 @@ for ($i = 0, $n = sizeof($tax_class_array); $i < $n; $i++) {
     //    ),
     //    'input' => 'The HTML to be inserted' (required)
     // )
+    //
+    // Note: The product's type can be found in the 'product_type' element of the passed $pInfo object.
+    //
     $extra_product_inputs = array();
     $zco_notifier->notify('NOTIFY_ADMIN_PRODUCT_COLLECT_INFO_EXTRA_INPUTS', $pInfo, $extra_product_inputs);
     if (!empty($extra_product_inputs)) {

--- a/admin/includes/modules/product/collect_info.php
+++ b/admin/includes/modules/product/collect_info.php
@@ -260,6 +260,35 @@ for ($i = 0, $n = sizeof($tax_class_array); $i < $n; $i++) {
       ?>
     </div>
   </div>
+<?php
+    // -----
+    // Give an observer the chance to supply some additional product-related inputs.  Each
+    // entry in the $extra_product_inputs returned contains:
+    //
+    // array(
+    //    'label' => array(
+    //        'text' => 'The label text',   (required)
+    //        'field_name' => 'The name of the field associated with the label', (required)
+    //        'addl_class' => {Any additional class to be applied to the label} (optional)
+    //        'parms' => {Any additional parameters for the label, e.g. 'style="font-weight: 700;"} (optional)
+    //    ),
+    //    'input' => 'The HTML to be inserted' (required)
+    // )
+    $extra_product_inputs = array();
+    $zco_notifier->notify('NOTIFY_ADMIN_PRODUCT_COLLECT_INFO_EXTRA_INPUTS', $pInfo, $extra_product_inputs);
+    if (!empty($extra_product_inputs)) {
+        foreach ($extra_product_inputs as $extra_input) {
+            $addl_class = (isset($extra_input['label']['addl_class'])) ? (' ' . $extra_input['label']['addl_class']) : '';
+            $parms = (isset($extra_input['label']['parms'])) ? (' ' . $extra_input['label']['parms']) : '';
+?>
+            <div class="form-group">
+                <?php echo zen_draw_label($extra_input['label']['text'], $extra_input['label']['field_name'], 'class="col-sm-3 control-label' . $addl_class . '"' . $parms); ?>
+                <div class="col-sm-9 col-md-6"><?php echo $extra_input['input']; ?></div>
+            </div>
+<?php
+        }
+    }
+?>
   <div class="form-group">
       <?php echo zen_draw_label(TEXT_PRODUCT_IS_FREE, 'product_is_free', 'class="col-sm-3 control-label"'); ?>
     <div class="col-sm-9 col-md-6">

--- a/admin/includes/modules/product/preview_info.php
+++ b/admin/includes/modules/product/preview_info.php
@@ -172,12 +172,11 @@ $form_action = (isset($_GET['pID'])) ? 'update_product' : 'insert_product';
       }
       ?>
       <a href="<?php echo zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING, 'cPath=' . $cPath . (isset($_GET['pID']) ? '&pID=' . $_GET['pID'] : '') . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')); ?>" class="btn btn-default" role="button"><?php echo IMAGE_CANCEL; ?></a>
+    </div>
       <?php 
+  }
       if (!(isset($_GET['read']) && ($_GET['read'] === 'only'))) {
         echo '</form>'; 
-      } ?>
-    </div>
-    <?php
   }
   ?>
 </div>

--- a/admin/includes/modules/product/preview_info.php
+++ b/admin/includes/modules/product/preview_info.php
@@ -172,11 +172,12 @@ $form_action = (isset($_GET['pID'])) ? 'update_product' : 'insert_product';
       }
       ?>
       <a href="<?php echo zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING, 'cPath=' . $cPath . (isset($_GET['pID']) ? '&pID=' . $_GET['pID'] : '') . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')); ?>" class="btn btn-default" role="button"><?php echo IMAGE_CANCEL; ?></a>
+      <?php 
+      if (!(isset($_GET['read']) && ($_GET['read'] === 'only'))) {
+        echo '</form>'; 
+      } ?>
     </div>
     <?php
-  }
-  if (!(isset($_GET['read']) && ($_GET['read'] === 'only'))) {
-    echo '</form>';
   }
   ?>
 </div>

--- a/admin/includes/modules/product_free_shipping/collect_info.php
+++ b/admin/includes/modules/product_free_shipping/collect_info.php
@@ -275,8 +275,11 @@ for ($i = 0, $n = sizeof($tax_class_array); $i < $n; $i++) {
     //    ),
     //    'input' => 'The HTML to be inserted' (required)
     // )
+    //
+    // Note: The product's type can be found in the 'product_type' element of the passed $pInfo object.
+    //
     $extra_product_inputs = array();
-    $zco_notifier->notify('NOTIFY_ADMIN_PRODUCT_FREE_SHIPPING_COLLECT_INFO_EXTRA_INPUTS', $pInfo, $extra_product_inputs);
+    $zco_notifier->notify('NOTIFY_ADMIN_PRODUCT_COLLECT_INFO_EXTRA_INPUTS', $pInfo, $extra_product_inputs);
     if (!empty($extra_product_inputs)) {
         foreach ($extra_product_inputs as $extra_input) {
             $addl_class = (isset($extra_input['label']['addl_class'])) ? (' ' . $extra_input['label']['addl_class']) : '';

--- a/admin/includes/modules/product_free_shipping/collect_info.php
+++ b/admin/includes/modules/product_free_shipping/collect_info.php
@@ -260,6 +260,36 @@ for ($i = 0, $n = sizeof($tax_class_array); $i < $n; $i++) {
       ?>
     </div>
   </div>
+  
+<?php
+    // -----
+    // Give an observer the chance to supply some additional product-related inputs.  Each
+    // entry in the $extra_product_inputs returned contains:
+    //
+    // array(
+    //    'label' => array(
+    //        'text' => 'The label text',   (required)
+    //        'field_name' => 'The name of the field associated with the label', (required)
+    //        'addl_class' => {Any additional class to be applied to the label} (optional)
+    //        'parms' => {Any additional parameters for the label, e.g. 'style="font-weight: 700;"} (optional)
+    //    ),
+    //    'input' => 'The HTML to be inserted' (required)
+    // )
+    $extra_product_inputs = array();
+    $zco_notifier->notify('NOTIFY_ADMIN_PRODUCT_FREE_SHIPPING_COLLECT_INFO_EXTRA_INPUTS', $pInfo, $extra_product_inputs);
+    if (!empty($extra_product_inputs)) {
+        foreach ($extra_product_inputs as $extra_input) {
+            $addl_class = (isset($extra_input['label']['addl_class'])) ? (' ' . $extra_input['label']['addl_class']) : '';
+            $parms = (isset($extra_input['label']['parms'])) ? (' ' . $extra_input['label']['parms']) : '';
+?>
+            <div class="form-group">
+                <?php echo zen_draw_label($extra_input['label']['text'], $extra_input['label']['field_name'], 'class="col-sm-3 control-label' . $addl_class . '"' . $parms); ?>
+                <div class="col-sm-9 col-md-6"><?php echo $extra_input['input']; ?></div>
+            </div>
+<?php
+        }
+    }
+?>
   <div class="form-group">
       <?php echo zen_draw_label(TEXT_PRODUCT_IS_FREE, 'product_is_free', 'class="col-sm-3 control-label"'); ?>
     <div class="col-sm-9 col-md-6">

--- a/admin/includes/modules/product_free_shipping/preview_info.php
+++ b/admin/includes/modules/product_free_shipping/preview_info.php
@@ -172,12 +172,11 @@ $form_action = (isset($_GET['pID'])) ? 'update_product' : 'insert_product';
       }
       ?>
       <a href="<?php echo zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING, 'cPath=' . $cPath . (isset($_GET['pID']) ? '&pID=' . $_GET['pID'] : '') . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')); ?>" class="btn btn-default" role="button"><?php echo IMAGE_CANCEL; ?></a>
+    </div>
       <?php 
+  }
       if (!(isset($_GET['read']) && ($_GET['read'] === 'only'))) {
         echo '</form>'; 
-      } ?>
-    </div>
-    <?php
   }
   ?>
 </div>

--- a/admin/includes/modules/product_free_shipping/preview_info.php
+++ b/admin/includes/modules/product_free_shipping/preview_info.php
@@ -172,11 +172,12 @@ $form_action = (isset($_GET['pID'])) ? 'update_product' : 'insert_product';
       }
       ?>
       <a href="<?php echo zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING, 'cPath=' . $cPath . (isset($_GET['pID']) ? '&pID=' . $_GET['pID'] : '') . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')); ?>" class="btn btn-default" role="button"><?php echo IMAGE_CANCEL; ?></a>
+      <?php 
+      if (!(isset($_GET['read']) && ($_GET['read'] === 'only'))) {
+        echo '</form>'; 
+      } ?>
     </div>
     <?php
-  }
-  if (!(isset($_GET['read']) && ($_GET['read'] === 'only'))) {
-    echo '</form>';
   }
   ?>
 </div>

--- a/admin/includes/modules/product_music/collect_info.php
+++ b/admin/includes/modules/product_music/collect_info.php
@@ -310,8 +310,11 @@ for ($i = 0, $n = sizeof($tax_class_array); $i < $n; $i++) {
     //    ),
     //    'input' => 'The HTML to be inserted' (required)
     // )
+    //
+    // Note: The product's type can be found in the 'product_type' element of the passed $pInfo object.
+    //
     $extra_product_inputs = array();
-    $zco_notifier->notify('NOTIFY_ADMIN_PRODUCT_MUSIC_COLLECT_INFO_EXTRA_INPUTS', $pInfo, $extra_product_inputs);
+    $zco_notifier->notify('NOTIFY_ADMIN_PRODUCT_COLLECT_INFO_EXTRA_INPUTS', $pInfo, $extra_product_inputs);
     if (!empty($extra_product_inputs)) {
         foreach ($extra_product_inputs as $extra_input) {
             $addl_class = (isset($extra_input['label']['addl_class'])) ? (' ' . $extra_input['label']['addl_class']) : '';

--- a/admin/includes/modules/product_music/collect_info.php
+++ b/admin/includes/modules/product_music/collect_info.php
@@ -295,6 +295,36 @@ for ($i = 0, $n = sizeof($tax_class_array); $i < $n; $i++) {
       ?>
     </div>
   </div>
+  
+<?php
+    // -----
+    // Give an observer the chance to supply some additional product-related inputs.  Each
+    // entry in the $extra_product_inputs returned contains:
+    //
+    // array(
+    //    'label' => array(
+    //        'text' => 'The label text',   (required)
+    //        'field_name' => 'The name of the field associated with the label', (required)
+    //        'addl_class' => {Any additional class to be applied to the label} (optional)
+    //        'parms' => {Any additional parameters for the label, e.g. 'style="font-weight: 700;"} (optional)
+    //    ),
+    //    'input' => 'The HTML to be inserted' (required)
+    // )
+    $extra_product_inputs = array();
+    $zco_notifier->notify('NOTIFY_ADMIN_PRODUCT_MUSIC_COLLECT_INFO_EXTRA_INPUTS', $pInfo, $extra_product_inputs);
+    if (!empty($extra_product_inputs)) {
+        foreach ($extra_product_inputs as $extra_input) {
+            $addl_class = (isset($extra_input['label']['addl_class'])) ? (' ' . $extra_input['label']['addl_class']) : '';
+            $parms = (isset($extra_input['label']['parms'])) ? (' ' . $extra_input['label']['parms']) : '';
+?>
+            <div class="form-group">
+                <?php echo zen_draw_label($extra_input['label']['text'], $extra_input['label']['field_name'], 'class="col-sm-3 control-label' . $addl_class . '"' . $parms); ?>
+                <div class="col-sm-9 col-md-6"><?php echo $extra_input['input']; ?></div>
+            </div>
+<?php
+        }
+    }
+?>
   <div class="form-group">
       <?php echo zen_draw_label(TEXT_PRODUCT_IS_FREE, 'product_is_free', 'class="col-sm-3 control-label"'); ?>
     <div class="col-sm-9 col-md-6">

--- a/admin/includes/modules/product_music/copy_product_confirm.php
+++ b/admin/includes/modules/product_music/copy_product_confirm.php
@@ -208,6 +208,8 @@ if (isset($_POST['products_id']) && isset($_POST['categories_id'])) {
         }
 
         zen_record_admin_activity('Product ' . $products_id . ' duplicated as product ' . $dup_products_id . ' via admin console.', 'info');
+        
+        $zco_notifier->notify('NOTIFY_PRODUCT_MUSIC_COPY_TO_CONFIRM_DUPLICATE', array('products_id' => $products_id, 'dup_products_id' => $dup_products_id));
 
         $products_id = $dup_products_id;//reset for further use in price update and final redirect to new linked product or new duplicated product
     }// EOF duplication

--- a/admin/includes/modules/product_music/preview_info.php
+++ b/admin/includes/modules/product_music/preview_info.php
@@ -171,11 +171,12 @@ $form_action = (isset($_GET['pID'])) ? 'update_product' : 'insert_product';
       }
       ?>
       <a href="<?php echo zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING, 'cPath=' . $cPath . (isset($_GET['pID']) ? '&pID=' . $_GET['pID'] : '') . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')); ?>" class="btn btn-default" role="button"><?php echo IMAGE_CANCEL; ?></a>
+      <?php 
+      if (!(isset($_GET['read']) && ($_GET['read'] === 'only'))) {
+        echo '</form>'; 
+      } ?>
     </div>
     <?php
-  }
-  if (!(isset($_GET['read']) && ($_GET['read'] === 'only'))) {
-    echo '</form>';
   }
   ?>
 </div>

--- a/admin/includes/modules/product_music/preview_info.php
+++ b/admin/includes/modules/product_music/preview_info.php
@@ -171,12 +171,11 @@ $form_action = (isset($_GET['pID'])) ? 'update_product' : 'insert_product';
       }
       ?>
       <a href="<?php echo zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING, 'cPath=' . $cPath . (isset($_GET['pID']) ? '&pID=' . $_GET['pID'] : '') . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')); ?>" class="btn btn-default" role="button"><?php echo IMAGE_CANCEL; ?></a>
+    </div>
       <?php 
+  }
       if (!(isset($_GET['read']) && ($_GET['read'] === 'only'))) {
         echo '</form>'; 
-      } ?>
-    </div>
-    <?php
   }
   ?>
 </div>

--- a/admin/includes/modules/product_music/update_product.php
+++ b/admin/includes/modules/product_music/update_product.php
@@ -133,6 +133,7 @@ if (isset($_POST['edit']) && $_POST['edit'] == 'edit') {
       zen_db_perform(TABLE_PRODUCTS_DESCRIPTION, $sql_data_array, 'update', "products_id = " . (int)$products_id . " and language_id = " . (int)$language_id);
     }
   }
+  $zco_notifier->notify('NOTIFY_PRODUCT_MUSIC_UPDATE_PRODUCT_END', array('action' => $action, 'products_id' => $products_id));
 
   zen_redirect(zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING, 'cPath=' . $cPath . '&pID=' . $products_id . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . (isset($_POST['search']) ? '&search=' . $_POST['search'] : '')));
 } else {

--- a/admin/includes/modules/update_product.php
+++ b/admin/includes/modules/update_product.php
@@ -117,6 +117,8 @@ if (isset($_POST['edit']) && $_POST['edit'] == 'edit') {
     }
   }
 
+  $zco_notifier->notify('NOTIFY_MODULES_UPDATE_PRODUCT_END', array('action' => $action, 'products_id' => $products_id));
+
   zen_redirect(zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING, 'cPath=' . $cPath . '&pID=' . $products_id . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . (isset($_POST['search']) ? '&search=' . $_POST['search'] : '')));
 } else {
   $messageStack->add_session(ERROR_NO_DATA_TO_SAVE, 'error');


### PR DESCRIPTION
1.  Add notifiers to each product type's `collect_info` enabling observers to seamlessly add more product-related fields.
2.  Add notifiers to the various `copy_to_confirm` and `update_product` modules, to work with the above additions
3.  Update various `preview_info` modules to product valid HTML