### PR TITLE
Add dynamic error messages for val_function validations

### DIFF
--- a/admin/includes/functions/configuration_checks.php
+++ b/admin/includes/functions/configuration_checks.php
@@ -21,26 +21,12 @@
      // check inputs - error should be a defined constant in the language files
      if (empty($data['error'])) return; 
      if (!defined($data['error'])) {
-        $msg_array = explode('_', $data['error']);
-
-        $str_msg = array();
-
-        foreach ($msg_array as $key => $word) {
-          $str_msg[$key] = implode('_', array_slice($msg_array, 0, $key + 1));
-/*          if ($key == 0) {
-            $str_msg[$key] = $word;
-          } else {
-            $str_msg[$key] = $str_msg[$key - 1] . '_' . $word;
-          }*/
-        }
-
-        $str_count = count($str_msg);
 
         switch (true) {
-          case ($str_count >= 3 && $str_msg[2] == 'TEXT_MIN_ADMIN'):
+          case (str_pos($data['error'], 'TEXT_MIN_ADMIN') === 0):
             $error_msg = TEXT_MIN_GENERAL_ADMIN;
             break;
-          case ($str_count >= 3 && $str_msg[2] == 'TEXT_MAX_ADMIN');
+          case (str_pos($data['error'], 'TEXT_MAX_ADMIN') === 0);
             $error_msg = TEXT_MAX_GENERAL_ADMIN;
             break;
           default:

--- a/admin/includes/functions/configuration_checks.php
+++ b/admin/includes/functions/configuration_checks.php
@@ -21,7 +21,31 @@
      // check inputs - error should be a defined constant in the language files
      if (empty($data['error'])) return; 
      if (!defined($data['error'])) {
-        $error_msg = TEXT_DATA_OUT_OF_RANGE; 
+        $msg_array = explode('_', $data['error']);
+
+        $str_msg = array();
+
+        foreach ($msg_array as $key => $word) {
+          $str_msg[$key] = implode('_', array_slice($msg_array, 0, $key + 1));
+/*          if ($key == 0) {
+            $str_msg[$key] = $word;
+          } else {
+            $str_msg[$key] = $str_msg[$key - 1] . '_' . $word;
+          }*/
+        }
+
+        $str_count = count($str_msg);
+
+        switch (true) {
+          case ($str_count >= 3 && $str_msg[2] == 'TEXT_MIN_ADMIN'):
+            $error_msg = TEXT_MIN_GENERAL_ADMIN;
+            break;
+          case ($str_count >= 3 && $str_msg[2] == 'TEXT_MAX_ADMIN');
+            $error_msg = TEXT_MAX_GENERAL_ADMIN;
+            break;
+          default:
+            $error_msg = TEXT_DATA_OUT_OF_RANGE;
+        }
      } else { 
         $error_msg = constant($data['error']); 
      }

--- a/admin/includes/languages/english/configuration.php
+++ b/admin/includes/languages/english/configuration.php
@@ -30,4 +30,5 @@ define('TEXT_INFO_LAST_MODIFIED', 'Last Modified:');
 define('TEXT_MIN_ADMIN_USER_LENGTH', 'Must be of a length of 4 or more.');
 // Validation defines
 define('TEXT_DATA_OUT_OF_RANGE','Data out of range'); 
-
+define('TEXT_MIN_GENERAL_ADMIN', 'The minimum value entered was not a whole number (integer).');
+define('TEXT_MAX_GENERAL_ADMIN', 'The value entered as a maximum was not a whole number (integer).');


### PR DESCRIPTION
This adds a generic message to handle the values that are in the
minimum configuration group and the values that are in the
maximum configuration group if a specific error message is not
already defined.

Two methods of processing are presented, my less preferred is
commented out. Less preferred because it seems to involve more
code though perhaps is easier to "read".

Partially fixes #2632 by at least providing a generic define for each, still think
need to address overrides and developer incorporation.