### PR TITLE
Order-class/low-stock refinements

### DIFF
--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -817,7 +817,10 @@ class order extends base {
           }
           
           $products_status_update = ($stock_left <= 0 && SHOW_PRODUCTS_SOLD_OUT == '0') ? ', products_status = 0' : '';
-          $db->Execute("UPDATE " . TABLE_PRODUCTS . " SET products_quantity = $stock_left$products_status_update WHERE products_id = " . zen_get_prid($this->products[$i]['id']) . " LIMIT 1");
+		
+          $db->Execute("UPDATE " . TABLE_PRODUCTS . " SET products_quantity = " . $stock_left .
+                        $products_status_update . 
+                       " WHERE products_id = " . zen_get_prid($this->products[$i]['id']) . " LIMIT 1");
 
           // for low stock email
           if ( $stock_left <= STOCK_REORDER_LEVEL ) {


### PR DESCRIPTION
1.  When download _is_ enabled, gather **all** the `products` table fields, like when it isn't.
2.  Remove single-quotes from database actions on integer fields.
3.  Use `ExecuteNoCache` instead of all the additional parameters (improves readability)
4.  Combine product's quantity and status update into a single query.
5.  Use `LIMIT 1` for performance for sites with large product definitions.