### PR TITLE
account-history-info: Additional fields

### DIFF
--- a/includes/modules/pages/account_history_info/header_php.php
+++ b/includes/modules/pages/account_history_info/header_php.php
@@ -16,13 +16,14 @@ if (!zen_is_logged_in()) {
   zen_redirect(zen_href_link(FILENAME_LOGIN, '', 'SSL'));
 }
 
-if (!isset($_GET['order_id']) || (isset($_GET['order_id']) && !is_numeric($_GET['order_id']))) {
+if (empty($_GET['order_id']) || !is_numeric($_GET['order_id'])) {
   zen_redirect(zen_href_link(FILENAME_ACCOUNT_HISTORY, '', 'SSL'));
 }
 
 $customer_info_query = "SELECT customers_id
                         FROM   " . TABLE_ORDERS . "
-                        WHERE  orders_id = :ordersID";
+                        WHERE  orders_id = :ordersID
+                        LIMIT 1";
 
 $customer_info_query = $db->bindVars($customer_info_query, ':ordersID', $_GET['order_id'], 'integer');
 $customer_info = $db->Execute($customer_info_query);
@@ -31,7 +32,7 @@ if ($customer_info->fields['customers_id'] != $_SESSION['customer_id']) {
   zen_redirect(zen_href_link(FILENAME_ACCOUNT_HISTORY, '', 'SSL'));
 }
 
-$statuses_query = "SELECT os.orders_status_name, osh.date_added, osh.comments
+$statuses_query = "SELECT os.orders_status_name, osh.*
                    FROM   " . TABLE_ORDERS_STATUS . " os, " . TABLE_ORDERS_STATUS_HISTORY . " osh
                    WHERE      osh.orders_id = :ordersID
                    AND        osh.orders_status_id = os.orders_status_id
@@ -45,11 +46,7 @@ $statuses = $db->Execute($statuses_query);
 $statusArray = array();
 
 while (!$statuses->EOF) {
-  $statusArray[] = array(
-      'date_added'=>$statuses->fields['date_added'],
-      'orders_status_name'=>$statuses->fields['orders_status_name'],
-      'comments'=>$statuses->fields['comments'],
-      );
+  $statusArray[] = $statuses->fields;
   $statuses->MoveNext();
 }
 


### PR DESCRIPTION
1.  Simplify initial order-id sanitization
2.  Limit order-check to a single order (performance for large stores)
3. Gather **all** fields from the `orders_status_history` table; available for template overrides' usage.