### PR TITLE
Add a notifier to zen_requires_attribute_selection to handle addition…

### DIFF
--- a/includes/functions/functions_lookups.php
+++ b/includes/functions/functions_lookups.php
@@ -279,7 +279,7 @@
  *  @return integer
  */
   function zen_requires_attribute_selection($products_id) {
-    global $db;
+    global $db, $zco_notifier;
 
     $noDoubles = array();
     $noDoubles[] = PRODUCTS_OPTIONS_TYPE_RADIO;
@@ -299,6 +299,9 @@
               where pa.products_id = " . (int)$products_id . "
               and po.language_id = " . (int)$_SESSION['languages_id'] . "
               group by products_options_id, options_type";
+
+    $zco_notifier->notify('NOTIFY_FUNCTIONS_LOOKUPS_REQUIRES_ATTRIBUTES_SELECTION', '', $query, $noSingles, $noDoubles);
+
     $result = $db->Execute($query);
 
     // if no attributes found, return false


### PR DESCRIPTION
…al attribute types

Adds a notifier to allow manipulation of the response when
querying if product can be directly added without
further attribute selection.

Relates to PR #2650