### PR TITLE
Enable customer order-confirmation email to be skipped/bypassed

### DIFF
--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -1162,8 +1162,7 @@ class order extends base {
     $html_msg['EXTRA_INFO'] = '';
     
     // -----
-    // Enable an observer to indicate that the customer email should not be sent.
-    //
+    // Send customer confirmation email unless observer overrides it.
     $send_customer_email = true;
     $this->notify('NOTIFY_ORDER_INVOICE_CONTENT_READY_TO_SEND', array('zf_insert_id' => $zf_insert_id, 'text_email' => $email_order, 'html_email' => $html_msg), $email_order, $html_msg, $send_customer_email);
     if ($send_customer_email === true) {

--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -815,9 +815,9 @@ class order extends base {
           } else {
             $stock_left = $stock_values->fields['products_quantity'];
           }
-          
+
           $products_status_update = ($stock_left <= 0 && SHOW_PRODUCTS_SOLD_OUT == '0') ? ', products_status = 0' : '';
-		
+
           $db->Execute("UPDATE " . TABLE_PRODUCTS . " SET products_quantity = " . $stock_left .
                         $products_status_update . 
                        " WHERE products_id = " . zen_get_prid($this->products[$i]['id']) . " LIMIT 1");
@@ -1160,8 +1160,15 @@ class order extends base {
     //  $html_msg['EMAIL_TEXT_HEADER'] = EMAIL_TEXT_HEADER;
 
     $html_msg['EXTRA_INFO'] = '';
-    $this->notify('NOTIFY_ORDER_INVOICE_CONTENT_READY_TO_SEND', array('zf_insert_id' => $zf_insert_id, 'text_email' => $email_order, 'html_email' => $html_msg), $email_order, $html_msg);
-    zen_mail($this->customer['firstname'] . ' ' . $this->customer['lastname'], $this->customer['email_address'], EMAIL_TEXT_SUBJECT . EMAIL_ORDER_NUMBER_SUBJECT . $zf_insert_id, $email_order, STORE_NAME, EMAIL_FROM, $html_msg, 'checkout', $this->attachArray);
+    
+    // -----
+    // Enable an observer to indicate that the customer email should not be sent.
+    //
+    $send_customer_email = true;
+    $this->notify('NOTIFY_ORDER_INVOICE_CONTENT_READY_TO_SEND', array('zf_insert_id' => $zf_insert_id, 'text_email' => $email_order, 'html_email' => $html_msg), $email_order, $html_msg, $send_customer_email);
+    if ($send_customer_email === true) {
+        zen_mail($this->customer['firstname'] . ' ' . $this->customer['lastname'], $this->customer['email_address'], EMAIL_TEXT_SUBJECT . EMAIL_ORDER_NUMBER_SUBJECT . $zf_insert_id, $email_order, STORE_NAME, EMAIL_FROM, $html_msg, 'checkout', $this->attachArray);
+    }
 
     // send additional emails
     if (SEND_EXTRA_ORDER_EMAILS_TO != '') {


### PR DESCRIPTION
This could be desired, for instance, if an admin is placing an order on behalf of a customer.