### PR TITLE
missing parameter large_link expected by colorbox and image handler plugins

### DIFF
--- a/includes/modules/additional_images.php
+++ b/includes/modules/additional_images.php
@@ -152,6 +152,7 @@ if ($num_images > 0) {
                 'products_name' => $products_name,
                 'products_image_large' => $products_image_large,
                 'thumb_slashes' => $thumb_slashes,
+                'large_link' => $large_link,
                 'index' => $i
             ),
             $script_link,


### PR DESCRIPTION
Between this and a Colorbox plugin observer, caused a php notice with this plugin.
Image Handler observer also expects it.