### PR TITLE
Put back the missing columns on product catalog list in admin

### DIFF
--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -353,8 +353,8 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
   <head>
     <meta charset="<?php echo CHARSET; ?>">
     <title><?php echo TITLE; ?></title>
-    <link rel="stylesheet" type="text/css" href="includes/stylesheet.css">
-    <link rel="stylesheet" type="text/css" href="includes/cssjsmenuhover.css" media="all" id="hoverJS">
+    <link rel="stylesheet" href="includes/stylesheet.css">
+    <link rel="stylesheet" href="includes/cssjsmenuhover.css" media="all" id="hoverJS">
     <script src="includes/menu.js"></script>
     <script src="includes/general.js"></script>
     <script>
@@ -557,7 +557,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
       <?php } ?>
       <div class="row"><?php echo zen_draw_separator('pixel_black.gif', '100%', '1px'); ?></div>
       <div class="row">
-        <div class="<?php echo (empty($action)) ? '' : 'col-xs-12 col-sm-12 col-md-9 col-lg-9 configurationColumnLeft'; ?>">
+        <div class="<?php echo (empty($action)) ? 'col-xs-12' : 'col-xs-12 col-sm-12 col-md-9 col-lg-9 configurationColumnLeft'; ?>">
               <?php
               $order_by = " ";
               switch ($_SESSION['categories_products_sort_order']) {
@@ -602,15 +602,15 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
                 <tr>
                   <th class="text-right"><?php echo TABLE_HEADING_ID; ?></th>
                   <th><?php echo TABLE_HEADING_CATEGORIES_PRODUCTS; ?></th>
-                  <th class="hidden-md hidden-sm hidden-xs"><?php if ($show_prod_labels) echo TABLE_HEADING_MODEL; ?></th>
-                  <th class="text-right hidden-md hidden-sm hidden-xs"><?php if ($show_prod_labels) echo TABLE_HEADING_PRICE; ?></th>
-                  <th class="text-right hidden-md hidden-sm hidden-xs">&nbsp;</th>
-                  <th class="text-right hidden-md hidden-sm hidden-xs"><?php echo TABLE_HEADING_QUANTITY; ?></th>
-                  <th class="text-right hidden-md hidden-sm hidden-xs"><?php echo TABLE_HEADING_STATUS; ?></th>
+                  <th class="hidden-sm hidden-xs"><?php if ($show_prod_labels) echo TABLE_HEADING_MODEL; ?></th>
+                  <th class="text-right hidden-sm hidden-xs"><?php if ($show_prod_labels) echo TABLE_HEADING_PRICE; ?></th>
+                  <th class="text-right hidden-sm hidden-xs">&nbsp;</th>
+                  <th class="text-right hidden-sm hidden-xs"><?php echo TABLE_HEADING_QUANTITY; ?></th>
+                  <th class="text-right hidden-sm hidden-xs"><?php echo TABLE_HEADING_STATUS; ?></th>
                   <?php
                   if ($action == '') {
                     ?>
-                    <th class="text-right hidden-md hidden-sm hidden-xs"><?php echo TABLE_HEADING_CATEGORIES_SORT_ORDER; ?></th>
+                    <th class="text-right hidden-sm hidden-xs"><?php echo TABLE_HEADING_CATEGORIES_SORT_ORDER; ?></th>
                     <th class="text-right"><?php echo TABLE_HEADING_ACTION; ?></th>
                     <?php
                   }
@@ -637,10 +637,10 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
                 <tr onclick="document.location.href = '<?php echo zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING, zen_get_path($category['categories_id'])); ?>'" role="button">
                   <td class="text-right"><?php echo $category['categories_id']; ?></td>
                   <td><?php echo zen_image(DIR_WS_ICONS . 'folder.gif', ICON_FOLDER); ?>&nbsp;<strong><?php echo $category['categories_name']; ?></strong></td>
-                  <td class="text-center hidden-md hidden-sm hidden-xs">&nbsp;</td>
-                  <td class="text-right hidden-md hidden-sm hidden-xs"><?php echo zen_get_products_sale_discount('', $category['categories_id'], true); ?></td>
-                  <td class="text-center hidden-md hidden-sm hidden-xs">&nbsp;</td>
-                  <td class="text-right hidden-md hidden-sm hidden-xs">
+                  <td class="text-center hidden-sm hidden-xs">&nbsp;</td>
+                  <td class="text-right hidden-sm hidden-xs"><?php echo zen_get_products_sale_discount('', $category['categories_id'], true); ?></td>
+                  <td class="text-center hidden-sm hidden-xs">&nbsp;</td>
+                  <td class="text-right hidden-sm hidden-xs">
                       <?php
                       if (SHOW_COUNTS_ADMIN == 'false') {
                         // don't show counts
@@ -652,7 +652,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
                       }
                       ?>
                   </td>
-                  <td class="text-right hidden-md hidden-sm hidden-xs">
+                  <td class="text-right hidden-sm hidden-xs">
                       <?php
                       if (SHOW_CATEGORY_PRODUCTS_LINKED_STATUS == 'true' && zen_get_products_to_categories($category['categories_id'], true, 'products_active') == 'true') {
                         echo zen_image(DIR_WS_IMAGES . 'icon_yellow_on.gif', IMAGE_ICON_LINKED, '', '', 'style="margin:2px;"');
@@ -669,7 +669,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
                   <?php
                   if ($action == '') {
                     ?>
-                    <td class="text-right hidden-md hidden-sm hidden-xs"><?php echo $category['sort_order']; ?></td>
+                    <td class="text-right hidden-sm hidden-xs"><?php echo $category['sort_order']; ?></td>
                     <td class="text-right">
                       <a href="<?php echo zen_href_link(FILENAME_CATEGORIES, 'cPath=' . $cPath . '&cID=' . $category['categories_id'] . '&action=edit_category' . ((isset($_GET['search']) && !empty($_GET['search'])) ? '&search=' . $_GET['search'] : '')); ?>" style="text-decoration: none">
                         <div class="fa-stack fa-lg edit">
@@ -842,10 +842,10 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
                 <tr>
                   <td class="text-right"><?php echo $product['products_id']; ?></td>
                   <td><a href="<?php echo zen_catalog_href_link($type_handler . '_info', 'cPath=' . $cPath . '&products_id=' . $product['products_id'] . '&language=' . $_SESSION['languages_code'] . '&product_type=' . $product['products_type']); ?>" target="_blank"><?php echo zen_image(DIR_WS_ICONS . 'preview.gif', ICON_PREVIEW); ?></a>&nbsp;<?php echo $product['products_name']; ?></td>
-                  <td class="hidden-md hidden-sm hidden-xs"><?php echo $product['products_model']; ?></td>
-                  <td colspan="2" class="text-right hidden-md hidden-sm hidden-xs"><?php echo zen_get_products_display_price($product['products_id']); ?></td>
-                  <td class="text-right hidden-md hidden-sm hidden-xs"><?php echo $product['products_quantity']; ?></td>
-                  <td class="text-right hidden-md hidden-sm hidden-xs">
+                  <td class="hidden-sm hidden-xs"><?php echo $product['products_model']; ?></td>
+                  <td colspan="2" class="text-right hidden-sm hidden-xs"><?php echo zen_get_products_display_price($product['products_id']); ?></td>
+                  <td class="text-right hidden-sm hidden-xs"><?php echo $product['products_quantity']; ?></td>
+                  <td class="text-right hidden-sm hidden-xs">
 <?php
                       $additional_icons = '';
                       $zco_notifier->notify('NOTIFY_ADMIN_PROD_LISTING_ADD_ICON', $product, $additional_icons);
@@ -873,7 +873,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
                   <?php
                   if ($action == '') {
                     ?>
-                    <td class="text-right hidden-md hidden-sm hidden-xs"><?php echo $product['products_sort_order']; ?></td>
+                    <td class="text-right hidden-sm hidden-xs"><?php echo $product['products_sort_order']; ?></td>
                     <td class="text-right">
                       <a href="<?php echo zen_href_link(FILENAME_PRODUCT, 'cPath=' . $cPath . '&product_type=' . $product['products_type'] . '&pID=' . $product['products_id'] . '&action=new_product' . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')); ?>" style="text-decoration: none">
                         <div class="fa-stack fa-lg edit">


### PR DESCRIPTION
fixes #2614

- This will remove the too "aggressive" hiding of columns.
- Additionally I removed the obsolete type="text/css"
- adding col-xs-12 to class, to prevent empty class (and easier upgrade to future BS4)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zencart/zencart/2713)
<!-- Reviewable:end -->
