### PR TITLE
Enable additional search-clause

### DIFF
--- a/includes/modules/pages/advanced_search_result/header_php.php
+++ b/includes/modules/pages/advanced_search_result/header_php.php
@@ -33,7 +33,8 @@ $_GET['keyword'] = trim($_GET['keyword']);
 $search_additional_clause = false;
 $zco_notifier->notify('NOTIFY_ADVANCED_SEARCH_RESULTS_ADDL_CLAUSE', array(), $search_additional_clause);
 
-if ( $search_additional_clause === false && (isset($_GET['keyword']) && (empty($_GET['keyword']) || $_GET['keyword']==HEADER_SEARCH_DEFAULT_TEXT || $_GET['keyword'] == KEYWORD_FORMAT_STRING ) ) &&
+if ($search_additional_clause === false && 
+(isset($_GET['keyword']) && (empty($_GET['keyword']) || $_GET['keyword']== HEADER_SEARCH_DEFAULT_TEXT || $_GET['keyword'] == KEYWORD_FORMAT_STRING ) ) &&
 (isset($_GET['dfrom']) && (empty($_GET['dfrom']) || ($_GET['dfrom'] == DOB_FORMAT_STRING))) &&
 (isset($_GET['dto']) && (empty($_GET['dto']) || ($_GET['dto'] == DOB_FORMAT_STRING))) &&
 (isset($_GET['pfrom']) && !is_numeric($_GET['pfrom'])) &&

--- a/includes/modules/pages/advanced_search_result/header_php.php
+++ b/includes/modules/pages/advanced_search_result/header_php.php
@@ -26,7 +26,14 @@ $missing_one_input = false;
 
 $_GET['keyword'] = trim($_GET['keyword']);
 
-if ( (isset($_GET['keyword']) && (empty($_GET['keyword']) || $_GET['keyword']==HEADER_SEARCH_DEFAULT_TEXT || $_GET['keyword'] == KEYWORD_FORMAT_STRING ) ) &&
+// -----
+// Give an observer the chance to indicate that there's another element to the search
+// that **is** provided, enabling the the search to continue.
+//
+$search_additional_clause = false;
+$zco_notifier->notify('NOTIFY_ADVANCED_SEARCH_RESULTS_ADDL_CLAUSE', array(), $search_additional_clause);
+
+if ( $search_additional_clause === false && (isset($_GET['keyword']) && (empty($_GET['keyword']) || $_GET['keyword']==HEADER_SEARCH_DEFAULT_TEXT || $_GET['keyword'] == KEYWORD_FORMAT_STRING ) ) &&
 (isset($_GET['dfrom']) && (empty($_GET['dfrom']) || ($_GET['dfrom'] == DOB_FORMAT_STRING))) &&
 (isset($_GET['dto']) && (empty($_GET['dto']) || ($_GET['dto'] == DOB_FORMAT_STRING))) &&
 (isset($_GET['pfrom']) && !is_numeric($_GET['pfrom'])) &&


### PR DESCRIPTION
If a customization provides additional clauses for the search, this notification enables that customization to override the "is anything selected" check in the `advanced_search_results` page's handling.

Otherwise, if none of the built-in search parameters are set, the customization's additional clause gets ignored.