### PR TITLE
Display order number in heading

### DIFF
--- a/admin/includes/languages/english/orders.php
+++ b/admin/includes/languages/english/orders.php
@@ -8,7 +8,7 @@
  */
 
 define('HEADING_TITLE', 'Orders');
-define('HEADING_TITLE_DETAILS', 'Order Details');
+define('HEADING_TITLE_DETAILS', 'Order Details (#%u)');     //-%u is filled in with the actual order-number
 define('HEADING_TITLE_SEARCH', 'Order ID:');
 define('HEADING_TITLE_STATUS', 'Status:');
 define('HEADING_TITLE_SEARCH_DETAIL_ORDERS_PRODUCTS', 'Product Name or ID:XX or Model');

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -410,7 +410,7 @@ if (zen_not_null($action) && $order_exists == true) {
     <!-- body //-->
     <div class="container-fluid">
       <!-- body_text //-->
-      <h1><?php echo ($action == 'edit' && $order_exists) ? HEADING_TITLE_DETAILS : HEADING_TITLE; ?></h1>
+      <h1><?php echo ($action == 'edit' && $order_exists) ? sprintf(HEADING_TITLE_DETAILS, (int)$oID) : HEADING_TITLE; ?></h1>
 
       <?php $order_list_button = '<a role="button" class="btn btn-default" href="' . zen_href_link(FILENAME_ORDERS) . '"><i class="fa fa-th-list" aria-hidden="true">&nbsp;</i> ' . BUTTON_TO_LIST . '</a>'; ?>
       <?php if ($action == '') { ?>


### PR DESCRIPTION
Currently, when displaying an order in the admin, the order number _is_ present but in relatively small text within the order's details.

Update the order's detailed display to include the order number in the level-1 heading so that it's more obvious to admin staff.