### PR TITLE
Admin - Correctly select default email recipient

### DIFF
--- a/admin/gv_mail.php
+++ b/admin/gv_mail.php
@@ -353,7 +353,7 @@ function check_form(form_name) {
 ?>
               <tr>
                 <td class="main"><?php echo TEXT_CUSTOMER; ?></td>
-                <td><?php echo zen_draw_pull_down_menu('customers_email_address', $customers, (!empty($_GET['customer']) ? (int)$_GET['customer'] : 0));?></td>
+                <td><?php echo zen_draw_pull_down_menu('customers_email_address', $customers, (!empty($_GET['customer']) ? $_GET['customer'] : ''));?></td>
               </tr>
               <tr>
                 <td colspan="2"><?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?></td>


### PR DESCRIPTION
In #2332, an incorrect resolution for strict PHP notices was provided by assigning the default value for dropdown selection to be an `integer`.  At this point in the code, the `customer` is the id associated with individual to be selected when the gv_mail page has een entered. The id is either the e-mail address or the standard name such as `All%20Customers`.  This restores the default selection of email address dropdown.

This also affects ZC 1.5.6b and ZC 1.5.6c.