### PR TITLE
Correct paypalwpp notices

### DIFF
--- a/includes/modules/payment/paypal/paypalwpp_admin_notification.php
+++ b/includes/modules/payment/paypal/paypalwpp_admin_notification.php
@@ -9,17 +9,17 @@
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: Author: DrByte  Mon Dec 7 14:47:12 2015 -0500 Modified in v1.5.5 $
  */
-  if (!defined('TEXT_MAXIMUM_CHARACTERS_ALLOWED')) define('TEXT_MAXIMUM_CHARACTERS_ALLOWED', ' chars allowed');
+if (!defined('TEXT_MAXIMUM_CHARACTERS_ALLOWED')) define('TEXT_MAXIMUM_CHARACTERS_ALLOWED', ' chars allowed');
 
-  $outputStartBlock = '';
-  $outputPayPal = '';
-  $outputPFmain = '';
-  $outputAuth = '';
-  $outputCapt = '';
-  $outputVoid = '';
-  $outputRefund = '';
-  $outputEndBlock = '';
-  $output = '';
+$outputStartBlock = '';
+$outputPayPal = '';
+$outputPFmain = '';
+$outputAuth = '';
+$outputCapt = '';
+$outputVoid = '';
+$outputRefund = '';
+$outputEndBlock = '';
+$output = '';
 
 $outputStartBlock .= '
 <script>
@@ -35,18 +35,18 @@ function characterCount(field, count, maxchars) {
 }
 </script>';
 
-  // strip slashes in case they were added to handle apostrophes:
-  foreach ($ipn->fields as $key=>$value){
+// strip slashes in case they were added to handle apostrophes:
+foreach ($ipn->fields as $key => $value) {
     $ipn->fields[$key] = stripslashes($value);
-  }
+}
 
-    $outputStartBlock .= '<td><table class="noprint">'."\n";
-    $outputStartBlock .= '<tr style="background-color : #cccccc; border-style : dotted;">'."\n";
-    $outputEndBlock .= '</tr>'."\n";
-    $outputEndBlock .='</table></td>'."\n";
+$outputStartBlock .= '<td><table class="noprint">'."\n";
+$outputStartBlock .= '<tr style="background-color : #cccccc; border-style : dotted;">'."\n";
+$outputEndBlock .= '</tr>'."\n";
+$outputEndBlock .='</table></td>'."\n";
 
 
-  if ($response['RESPMSG'] != '') {
+if ($response['RESPMSG'] != '') {
     // these would be payflow transactions
 
     $outputPFmain .= '<td valign="top"><table>'."\n";
@@ -101,51 +101,50 @@ function characterCount(field, count, maxchars) {
     $outputPFmain .= '</td></tr>'."\n";
 
     if ($response['DAYS_TO_SETTLE'] != '' ) {
-      $outputPFmain .= '<tr><td class="main">'."\n";
-      $outputPFmain .= MODULE_PAYMENT_PAYPAL_ENTRY_DAYSTOSETTLE."\n";
-      $outputPFmain .= '</td><td class="main">'."\n";
-      $outputPFmain .= $response['DAYS_TO_SETTLE'] ."\n";
-      $outputPFmain .= '</td></tr>'."\n";
+        $outputPFmain .= '<tr><td class="main">'."\n";
+        $outputPFmain .= MODULE_PAYMENT_PAYPAL_ENTRY_DAYSTOSETTLE."\n";
+        $outputPFmain .= '</td><td class="main">'."\n";
+        $outputPFmain .= $response['DAYS_TO_SETTLE'] ."\n";
+        $outputPFmain .= '</td></tr>'."\n";
     }
     $outputPFmain .= '</table></td>'."\n";
 
     if ($ipn->fields['mc_gross'] > 0) {
-      $outputPFmain .= '<td valign="top"><table>'."\n";
+        $outputPFmain .= '<td valign="top"><table>'."\n";
 
-      $outputPFmain .= '<tr><td class="main">'."\n";
-      $outputPFmain .= MODULE_PAYMENT_PAYPAL_ENTRY_CURRENCY."\n";
-      $outputPFmain .= '</td><td class="main">'."\n";
-      $outputPFmain .= $ipn->fields['mc_currency'] ."\n";
-      $outputPFmain .= '</td></tr>'."\n";
+        $outputPFmain .= '<tr><td class="main">'."\n";
+        $outputPFmain .= MODULE_PAYMENT_PAYPAL_ENTRY_CURRENCY."\n";
+        $outputPFmain .= '</td><td class="main">'."\n";
+        $outputPFmain .= $ipn->fields['mc_currency'] ."\n";
+        $outputPFmain .= '</td></tr>'."\n";
 
-      $outputPFmain .= '<tr><td class="main">'."\n";
-      $outputPFmain .= MODULE_PAYMENT_PAYPAL_ENTRY_GROSS_AMOUNT."\n";
-      $outputPFmain .= '</td><td class="main">'."\n";
-      $outputPFmain .= $ipn->fields['mc_gross']."\n";
-      $outputPFmain .= '</td></tr>'."\n";
+        $outputPFmain .= '<tr><td class="main">'."\n";
+        $outputPFmain .= MODULE_PAYMENT_PAYPAL_ENTRY_GROSS_AMOUNT."\n";
+        $outputPFmain .= '</td><td class="main">'."\n";
+        $outputPFmain .= $ipn->fields['mc_gross']."\n";
+        $outputPFmain .= '</td></tr>'."\n";
 
-      $outputPFmain .= '<tr><td class="main">'."\n";
-      $outputPFmain .= MODULE_PAYMENT_PAYPAL_ENTRY_PAYMENT_FEE."\n";
-      $outputPFmain .= '</td><td class="main">'."\n";
-      $outputPFmain .= $ipn->fields['mc_fee']."\n";
-      $outputPFmain .= '</td></tr>'."\n";
+        $outputPFmain .= '<tr><td class="main">'."\n";
+        $outputPFmain .= MODULE_PAYMENT_PAYPAL_ENTRY_PAYMENT_FEE."\n";
+        $outputPFmain .= '</td><td class="main">'."\n";
+        $outputPFmain .= $ipn->fields['mc_fee']."\n";
+        $outputPFmain .= '</td></tr>'."\n";
 
-      $outputPFmain .= '<tr><td class="main">'."\n";
-      $outputPFmain .= MODULE_PAYMENT_PAYPAL_ENTRY_EXCHANGE_RATE."\n";
-      $outputPFmain .= '</td><td class="main">'."\n";
-      $outputPFmain .= $ipn->fields['exchange_rate']."\n";
-      $outputPFmain .= '</td></tr>'."\n";
+        $outputPFmain .= '<tr><td class="main">'."\n";
+        $outputPFmain .= MODULE_PAYMENT_PAYPAL_ENTRY_EXCHANGE_RATE."\n";
+        $outputPFmain .= '</td><td class="main">'."\n";
+        $outputPFmain .= $ipn->fields['exchange_rate']."\n";
+        $outputPFmain .= '</td></tr>'."\n";
 
-      $outputPFmain .= '<tr><td class="main">'."\n";
-      $outputPFmain .= MODULE_PAYMENT_PAYPAL_ENTRY_CART_ITEMS."\n";
-      $outputPFmain .= '</td><td class="main">'."\n";
-      $outputPFmain .= $ipn->fields['num_cart_items']."\n";
-      $outputPFmain .= '</td></tr>'."\n";
+        $outputPFmain .= '<tr><td class="main">'."\n";
+        $outputPFmain .= MODULE_PAYMENT_PAYPAL_ENTRY_CART_ITEMS."\n";
+        $outputPFmain .= '</td><td class="main">'."\n";
+        $outputPFmain .= $ipn->fields['num_cart_items']."\n";
+        $outputPFmain .= '</td></tr>'."\n";
 
-      $outputPFmain .= '</table></td>'."\n";
+        $outputPFmain .= '</table></td>'."\n";
     }
-
-  } else {
+} else {
     // display all paypal status fields (in admin Orders page):
     $outputPayPal .= '<td valign="top"><table>'."\n";
 
@@ -238,20 +237,21 @@ function characterCount(field, count, maxchars) {
     $outputPayPal .= '</td><td class="main">'."\n";
     $outputPayPal .= urldecode($response['PARENTTRANSACTIONID']) ."\n";
     $outputPayPal .= '</td></tr>'."\n";
-  if (defined('MODULE_PAYMENT_PAYPALWPP_ENTRY_PROTECTIONELIG') && isset($response['PROTECTIONELIGIBILITY']) && $response['PROTECTIONELIGIBILITY'] != '') {
-    $outputPayPal .= '<tr><td class="main">'."\n";
-    $outputPayPal .= MODULE_PAYMENT_PAYPALWPP_ENTRY_PROTECTIONELIG."\n";
-    $outputPayPal .= '</td><td class="main">'."\n";
-    $outputPayPal .= $response['PROTECTIONELIGIBILITY']."\n";
-    $outputPayPal .= '</td></tr>'."\n";
-  }
-  if (defined('MODULE_PAYMENT_PAYPAL_ENTRY_COMMENTS') && $ipn->fields['memo'] != '') {
-    $outputPayPal .= '<tr><td class="main">'."\n";
-    $outputPayPal .= MODULE_PAYMENT_PAYPAL_ENTRY_COMMENTS."\n";
-    $outputPayPal .= '</td><td class="main">'."\n";
-    $outputPayPal .= $ipn->fields['memo']."\n";
-    $outputPayPal .= '</td></tr>'."\n";
-  }
+    
+    if (defined('MODULE_PAYMENT_PAYPALWPP_ENTRY_PROTECTIONELIG') && isset($response['PROTECTIONELIGIBILITY']) && $response['PROTECTIONELIGIBILITY'] != '') {
+        $outputPayPal .= '<tr><td class="main">'."\n";
+        $outputPayPal .= MODULE_PAYMENT_PAYPALWPP_ENTRY_PROTECTIONELIG."\n";
+        $outputPayPal .= '</td><td class="main">'."\n";
+        $outputPayPal .= $response['PROTECTIONELIGIBILITY']."\n";
+        $outputPayPal .= '</td></tr>'."\n";
+    }
+    if (defined('MODULE_PAYMENT_PAYPAL_ENTRY_COMMENTS') && $ipn->fields['memo'] != '') {
+        $outputPayPal .= '<tr><td class="main">'."\n";
+        $outputPayPal .= MODULE_PAYMENT_PAYPAL_ENTRY_COMMENTS."\n";
+        $outputPayPal .= '</td><td class="main">'."\n";
+        $outputPayPal .= $ipn->fields['memo']."\n";
+        $outputPayPal .= '</td></tr>'."\n";
+    }
 
     $outputPayPal .= '</table></td>'."\n";
 
@@ -328,20 +328,20 @@ function characterCount(field, count, maxchars) {
     $outputPayPal .= '</td></tr>'."\n";
 
     $outputPayPal .= '</table></td>'."\n";
-  }
+}
 
-  if (method_exists($this, '_doRefund')) {
+if (method_exists($this, '_doRefund')) {
     $outputRefund .= '<td><table class="noprint">'."\n";
     $outputRefund .= '<tr style="background-color : #eeeeee; border-style : dotted;">'."\n";
     $outputRefund .= '<td class="main">' . MODULE_PAYMENT_PAYPAL_ENTRY_REFUND_TITLE . '<br />'. "\n";
     $outputRefund .= zen_draw_form('pprefund', FILENAME_ORDERS, zen_get_all_get_params(array('action')) . 'action=doRefund', 'post', '', true) . zen_hide_session_id();
     if (!isset($response['RESPMSG'])) {
-    // full refund (only for PayPal transactions, not Payflow)
-      $outputRefund .= MODULE_PAYMENT_PAYPAL_ENTRY_REFUND_FULL;
-      $outputRefund .= '<br /><input type="submit" name="fullrefund" value="' . MODULE_PAYMENT_PAYPAL_ENTRY_REFUND_BUTTON_TEXT_FULL . '" title="' . MODULE_PAYMENT_PAYPAL_ENTRY_REFUND_BUTTON_TEXT_FULL . '" />' . ' ' . MODULE_PAYMENT_PAYPALWPP_TEXT_REFUND_FULL_CONFIRM_CHECK . zen_draw_checkbox_field('reffullconfirm', '', false) . '<br />';
-      $outputRefund .= MODULE_PAYMENT_PAYPAL_ENTRY_REFUND_TEXT_FULL_OR;
+        // full refund (only for PayPal transactions, not Payflow)
+        $outputRefund .= MODULE_PAYMENT_PAYPAL_ENTRY_REFUND_FULL;
+        $outputRefund .= '<br /><input type="submit" name="fullrefund" value="' . MODULE_PAYMENT_PAYPAL_ENTRY_REFUND_BUTTON_TEXT_FULL . '" title="' . MODULE_PAYMENT_PAYPAL_ENTRY_REFUND_BUTTON_TEXT_FULL . '" />' . ' ' . MODULE_PAYMENT_PAYPALWPP_TEXT_REFUND_FULL_CONFIRM_CHECK . zen_draw_checkbox_field('reffullconfirm', '', false) . '<br />';
+        $outputRefund .= MODULE_PAYMENT_PAYPAL_ENTRY_REFUND_TEXT_FULL_OR;
     } else {
-      $outputRefund .= MODULE_PAYMENT_PAYPAL_ENTRY_REFUND_PAYFLOW_TEXT;
+        $outputRefund .= MODULE_PAYMENT_PAYPAL_ENTRY_REFUND_PAYFLOW_TEXT;
     }
     //partial refund - input field
     $outputRefund .= MODULE_PAYMENT_PAYPAL_ENTRY_REFUND_PARTIAL_TEXT . ' ' . zen_draw_input_field('refamt', 'enter amount', 'length="8"');
@@ -355,9 +355,9 @@ function characterCount(field, count, maxchars) {
     $outputRefund .= '<br />' . MODULE_PAYMENT_PAYPAL_ENTRY_REFUND_SUFFIX;
     $outputRefund .= '</form>';
     $outputRefund .='</td></tr></table></td>'."\n";
-  }
+}
 
-  if (method_exists($this, '_doAuth') && !isset($response['RESPMSG'])) {
+if (method_exists($this, '_doAuth') && !isset($response['RESPMSG'])) {
     $outputAuth .= '<td valign="top"><table class="noprint">'."\n";
     $outputAuth .= '<tr style="background-color : #eeeeee; border-style : dotted;">'."\n";
     $outputAuth .= '<td class="main">' . MODULE_PAYMENT_PAYPAL_ENTRY_AUTH_TITLE . '<br />'. "\n";
@@ -369,9 +369,9 @@ function characterCount(field, count, maxchars) {
     $outputAuth .= '<br />' . MODULE_PAYMENT_PAYPAL_ENTRY_AUTH_SUFFIX;
     $outputAuth .= '</form>';
     $outputAuth .='</td></tr></table></td>'."\n";
-  }
+}
 
-  if (method_exists($this, '_doCapt')) {
+if (method_exists($this, '_doCapt')) {
     $outputCapt .= '<td valign="top"><table class="noprint">'."\n";
     $outputCapt .= '<tr style="background-color : #eeeeee; border-style : dotted;">'."\n";
     $outputCapt .= '<td class="main">' . MODULE_PAYMENT_PAYPAL_ENTRY_CAPTURE_TITLE . '<br />'. "\n";
@@ -386,9 +386,9 @@ function characterCount(field, count, maxchars) {
     $outputCapt .= '<br />' . MODULE_PAYMENT_PAYPAL_ENTRY_CAPTURE_SUFFIX;
     $outputCapt .= '</form>';
     $outputCapt .='</td></tr></table></td>'."\n";
-  }
+}
 
-  if (method_exists($this, '_doVoid')) {
+if (method_exists($this, '_doVoid')) {
     $outputVoid .= '<td valign="top"><table class="noprint">'."\n";
     $outputVoid .= '<tr style="background-color : #eeeeee; border-style : dotted;">'."\n";
     $outputVoid .= '<td class="main">' . MODULE_PAYMENT_PAYPAL_ENTRY_VOID_TITLE . '<br />'. "\n";
@@ -401,43 +401,54 @@ function characterCount(field, count, maxchars) {
     $outputVoid .= '<br />' . MODULE_PAYMENT_PAYPAL_ENTRY_VOID_SUFFIX;
     $outputVoid .= '</form>';
     $outputVoid .='</td></tr></table></td>'."\n";
-  }
-
-
-
+}
 
 // prepare output based on suitable content components
-  $output = '<!-- BOF: pp admin transaction processing tools -->';
-  $output .= $outputStartBlock;
+$output = '<!-- BOF: pp admin transaction processing tools -->';
+$output .= $outputStartBlock;
 
-//debug
-//$output .= '<pre>' . print_r($response, true) . '</pre>';
-
-  if (isset($response['RESPMSG']) /*|| defined('MODULE_PAYMENT_PAYFLOW_STATUS')*/) { // payflow
+if (isset($response['RESPMSG']) /*|| defined('MODULE_PAYMENT_PAYFLOW_STATUS')*/) { // payflow
     $output .= $outputPFmain;
-    if (method_exists($this, '_doVoid') && (MODULE_PAYMENT_PAYPALDP_TRANSACTION_MODE == 'Auth Only' || MODULE_PAYMENT_PAYFLOW_TRANSACTION_MODE == 'Auth Only' || (isset($_GET['authcapt']) && $_GET['authcapt']=='on'))) $output .= $outputVoid;
-    if (method_exists($this, '_doCapt') && (MODULE_PAYMENT_PAYPALDP_TRANSACTION_MODE == 'Auth Only' || MODULE_PAYMENT_PAYFLOW_TRANSACTION_MODE == 'Auth Only' || (isset($_GET['authcapt']) && $_GET['authcapt']=='on'))) $output .= $outputCapt;
-    if (method_exists($this, '_doRefund')) $output .= $outputRefund;
-  } else {  // PayPal
+    if (method_exists($this, '_doVoid') && (MODULE_PAYMENT_PAYPALDP_TRANSACTION_MODE == 'Auth Only' || MODULE_PAYMENT_PAYFLOW_TRANSACTION_MODE == 'Auth Only' || (isset($_GET['authcapt']) && $_GET['authcapt']=='on'))) {
+        $output .= $outputVoid;
+    }
+    if (method_exists($this, '_doCapt') && (MODULE_PAYMENT_PAYPALDP_TRANSACTION_MODE == 'Auth Only' || MODULE_PAYMENT_PAYFLOW_TRANSACTION_MODE == 'Auth Only' || (isset($_GET['authcapt']) && $_GET['authcapt']=='on'))) {
+        $output .= $outputCapt;
+    }
+    if (method_exists($this, '_doRefund')) {
+        $output .= $outputRefund;
+    }
+} else {  // PayPal
     $output .= $outputPayPal;
 
     if (defined('MODULE_PAYMENT_PAYPALWPP_STATUS') || defined('MODULE_PAYMENT_PAYPALDP_STATUS')) {
-      $output .= $outputEndBlock;
-      $output .= '</tr><tr>' . "\n";
-      $output .= $outputStartBlock;
-      $output .= $outputStartBlock;
-      if ($response['TRANSACTION_TYPE'] == 'Authorization' || (in_array($response['TRANSACTIONTYPE'], array('cart','expresscheckout','webaccept') ) && $response['PAYMENTTYPE'] == 'instant' && $response['PENDINGREASON'] == 'authorization') || (isset($_GET['authcapt']) && $_GET['authcapt']=='on')) {
-        if (method_exists($this, '_doRefund') && ($response['PAYMENTTYPE'] != 'instant' || $module == 'paypaldp')) $output .= $outputRefund;
-        if (method_exists($this, '_doAuth') && (MODULE_PAYMENT_PAYPALWPP_TRANSACTION_MODE == 'Auth Only' || MODULE_PAYMENT_PAYPALDP_TRANSACTION_MODE == 'Auth Only')) $output .= $outputAuth;
-        if (method_exists($this, '_doCapt') && (MODULE_PAYMENT_PAYPALWPP_TRANSACTION_MODE == 'Auth Only' || MODULE_PAYMENT_PAYPALDP_TRANSACTION_MODE == 'Auth Only')) $output .= $outputCapt;
-        if (method_exists($this, '_doVoid')) $output .= $outputVoid;
-      } else {
-        if (method_exists($this, '_doRefund') /* && ($response['PAYMENTTYPE'] != 'instant' || $module == 'paypaldp') */) $output .= $outputRefund;
-        if (method_exists($this, '_doVoid') && $response['PAYMENTTYPE'] == 'instant' && $response['PAYMENTSTATUS'] != 'Voided' && $module != 'paypaldp') $output .= $outputVoid;
-      }
+        $output .= $outputEndBlock;
+        $output .= '</tr><tr>' . "\n";
+        $output .= $outputStartBlock;
+        $output .= $outputStartBlock;
+        if ($response['TRANSACTION_TYPE'] == 'Authorization' || (in_array($response['TRANSACTIONTYPE'], array('cart','expresscheckout','webaccept') ) && $response['PAYMENTTYPE'] == 'instant' && $response['PENDINGREASON'] == 'authorization') || (isset($_GET['authcapt']) && $_GET['authcapt']=='on')) {
+            if (method_exists($this, '_doRefund') && ($response['PAYMENTTYPE'] != 'instant' || $module == 'paypaldp')) {
+                $output .= $outputRefund;
+            }
+            if (method_exists($this, '_doAuth') && (MODULE_PAYMENT_PAYPALWPP_TRANSACTION_MODE == 'Auth Only' || MODULE_PAYMENT_PAYPALDP_TRANSACTION_MODE == 'Auth Only')) {
+                $output .= $outputAuth;
+            }
+            if (method_exists($this, '_doCapt') && (MODULE_PAYMENT_PAYPALWPP_TRANSACTION_MODE == 'Auth Only' || MODULE_PAYMENT_PAYPALDP_TRANSACTION_MODE == 'Auth Only')) {
+                $output .= $outputCapt;
+            }
+            if (method_exists($this, '_doVoid')) {
+                $output .= $outputVoid;
+            }
+        } else {
+            if (method_exists($this, '_doRefund') /* && ($response['PAYMENTTYPE'] != 'instant' || $module == 'paypaldp') */) {
+                $output .= $outputRefund;
+            }
+            if (method_exists($this, '_doVoid') && $response['PAYMENTTYPE'] == 'instant' && $response['PAYMENTSTATUS'] != 'Voided' && $module != 'paypaldp') {
+                $output .= $outputVoid;
+            }
+        }
     }
-  }
-  $output .= $outputEndBlock;
-  $output .= $outputEndBlock;
-  $output .= '<!-- EOF: pp admin transaction processing tools -->';
-
+}
+$output .= $outputEndBlock;
+$output .= $outputEndBlock;
+$output .= '<!-- EOF: pp admin transaction processing tools -->';

--- a/includes/modules/payment/paypal/paypalwpp_admin_notification.php
+++ b/includes/modules/payment/paypal/paypalwpp_admin_notification.php
@@ -46,7 +46,7 @@ $outputEndBlock .= '</tr>'."\n";
 $outputEndBlock .='</table></td>'."\n";
 
 
-if ($response['RESPMSG'] != '') {
+if (!empty($response['RESPMSG'])) {
     // these would be payflow transactions
 
     $outputPFmain .= '<td valign="top"><table>'."\n";
@@ -100,7 +100,7 @@ if ($response['RESPMSG'] != '') {
     $outputPFmain .= $response['TRANSSTATE'] ."\n";
     $outputPFmain .= '</td></tr>'."\n";
 
-    if ($response['DAYS_TO_SETTLE'] != '' ) {
+    if (!empty($response['DAYS_TO_SETTLE'])) {
         $outputPFmain .= '<tr><td class="main">'."\n";
         $outputPFmain .= MODULE_PAYMENT_PAYPAL_ENTRY_DAYSTOSETTLE."\n";
         $outputPFmain .= '</td><td class="main">'."\n";
@@ -160,36 +160,42 @@ if ($response['RESPMSG'] != '') {
     $outputPayPal .= urldecode($response['LASTNAME']) ."\n";
     $outputPayPal .= '</td></tr>'."\n";
 
-    $outputPayPal .= '<tr><td class="main">'."\n";
-    $outputPayPal .= MODULE_PAYMENT_PAYPAL_ENTRY_BUSINESS_NAME."\n";
-    $outputPayPal .= '</td><td class="main">'."\n";
-    $outputPayPal .= urldecode($response['BUSINESS']) ."\n";
-    $outputPayPal .= '</td></tr>'."\n";
+    if (!empty($response['BUSINESS'])) {
+        $outputPayPal .= '<tr><td class="main">'."\n";
+        $outputPayPal .= MODULE_PAYMENT_PAYPAL_ENTRY_BUSINESS_NAME."\n";
+        $outputPayPal .= '</td><td class="main">'."\n";
+        $outputPayPal .= urldecode($response['BUSINESS']) ."\n";
+        $outputPayPal .= '</td></tr>'."\n";
+    }
 
     $outputPayPal .= '<tr><td class="main">'."\n";
     $outputPayPal .= MODULE_PAYMENT_PAYPAL_ENTRY_ADDRESS_NAME."\n";
     $outputPayPal .= '</td><td class="main">'."\n";
-    $outputPayPal .= urldecode($response['NAME']) ."\n";
+    $outputPayPal .= urldecode($response['SHIPTONAME']) ."\n";
     $outputPayPal .= '</td></tr>'."\n";
+    
     $outputPayPal .= '<tr><td class="main">'."\n";
     $outputPayPal .= MODULE_PAYMENT_PAYPAL_ENTRY_ADDRESS_STREET."\n";
     $outputPayPal .= '</td><td class="main">'."\n";
-    $outputPayPal .= urldecode($response['SHIPTOSTREET']) . ' ' . urldecode($response['SHIPTOSTREET2']) ."\n";
+    $outputPayPal .= urldecode($response['SHIPTOSTREET']) . ' ' . (!empty($response['SHIPTOSTREET2']) ? urldecode($response['SHIPTOSTREET2']) : '') ."\n";
     $outputPayPal .= '</td></tr>'."\n";
+    
     $outputPayPal .= '<tr><td class="main">'."\n";
     $outputPayPal .= MODULE_PAYMENT_PAYPAL_ENTRY_ADDRESS_CITY."\n";
     $outputPayPal .= '</td><td class="main">'."\n";
     $outputPayPal .= urldecode($response['SHIPTOCITY']) ."\n";
     $outputPayPal .= '</td></tr>'."\n";
+    
     $outputPayPal .= '<tr><td class="main">'."\n";
     $outputPayPal .= MODULE_PAYMENT_PAYPAL_ENTRY_ADDRESS_STATE."\n";
     $outputPayPal .= '</td><td class="main">'."\n";
     $outputPayPal .= urldecode($response['SHIPTOSTATE']) . ' ' . urldecode($response['SHIPTOZIP']) ."\n";
     $outputPayPal .= '</td></tr>'."\n";
+    
     $outputPayPal .= '<tr><td class="main">'."\n";
     $outputPayPal .= MODULE_PAYMENT_PAYPAL_ENTRY_ADDRESS_COUNTRY."\n";
     $outputPayPal .= '</td><td class="main">'."\n";
-    $outputPayPal .= urldecode($response['SHIPTOCOUNTRY']) ."\n";
+    $outputPayPal .= urldecode($response['SHIPTOCOUNTRYNAME']) ."\n";
     $outputPayPal .= '</td></tr>'."\n";
 
     $outputPayPal .= '</table></td>'."\n";
@@ -205,7 +211,7 @@ if ($response['RESPMSG'] != '') {
     $outputPayPal .= '<tr><td class="main">'."\n";
     $outputPayPal .= MODULE_PAYMENT_PAYPAL_ENTRY_EBAY_ID."\n";
     $outputPayPal .= '</td><td class="main">'."\n";
-    $outputPayPal .= urldecode($response['BUYERID']) ."\n";
+    $outputPayPal .= (!empty($response['BUYERID']) ? urldecode($response['BUYERID']) : '') ."\n";
     $outputPayPal .= '</td></tr>'."\n";
 
     $outputPayPal .= '<tr><td class="main">'."\n";
@@ -235,10 +241,10 @@ if ($response['RESPMSG'] != '') {
     $outputPayPal .= '<tr><td class="main">'."\n";
     $outputPayPal .= MODULE_PAYMENT_PAYPAL_ENTRY_PARENT_TXN_ID."\n";
     $outputPayPal .= '</td><td class="main">'."\n";
-    $outputPayPal .= urldecode($response['PARENTTRANSACTIONID']) ."\n";
+    $outputPayPal .= (!empty($response['PARENTTRANSACTIONID']) ? urldecode($response['PARENTTRANSACTIONID']) : '') ."\n";
     $outputPayPal .= '</td></tr>'."\n";
     
-    if (defined('MODULE_PAYMENT_PAYPALWPP_ENTRY_PROTECTIONELIG') && isset($response['PROTECTIONELIGIBILITY']) && $response['PROTECTIONELIGIBILITY'] != '') {
+    if (defined('MODULE_PAYMENT_PAYPALWPP_ENTRY_PROTECTIONELIG') && !empty($response['PROTECTIONELIGIBILITY'])) {
         $outputPayPal .= '<tr><td class="main">'."\n";
         $outputPayPal .= MODULE_PAYMENT_PAYPALWPP_ENTRY_PROTECTIONELIG."\n";
         $outputPayPal .= '</td><td class="main">'."\n";
@@ -300,7 +306,7 @@ if ($response['RESPMSG'] != '') {
     $outputPayPal .= '<tr><td class="main">'."\n";
     $outputPayPal .= MODULE_PAYMENT_PAYPAL_ENTRY_CURRENCY."\n";
     $outputPayPal .= '</td><td class="main">'."\n";
-    $outputPayPal .= $ipn->fields['mc_currency'] . ' ' . urldecode($response['CURRENCY']) ."\n";
+    $outputPayPal .= $ipn->fields['mc_currency'] . ' ' . urldecode($response['CURRENCYCODE']) ."\n";
     $outputPayPal .= '</td></tr>'."\n";
 
     $outputPayPal .= '<tr><td class="main">'."\n";
@@ -318,7 +324,7 @@ if ($response['RESPMSG'] != '') {
     $outputPayPal .= '<tr><td class="main">'."\n";
     $outputPayPal .= MODULE_PAYMENT_PAYPAL_ENTRY_EXCHANGE_RATE."\n";
     $outputPayPal .= '</td><td class="main">'."\n";
-    $outputPayPal .= urldecode($response['EXCHANGERATE']) ."\n";
+    $outputPayPal .= (!empty($response['EXCHANGERATE']) ? urldecode($response['EXCHANGERATE']) : '') ."\n";
     $outputPayPal .= '</td></tr>'."\n";
 
     $outputPayPal .= '<tr><td class="main">'."\n";
@@ -347,7 +353,7 @@ if (method_exists($this, '_doRefund')) {
     $outputRefund .= MODULE_PAYMENT_PAYPAL_ENTRY_REFUND_PARTIAL_TEXT . ' ' . zen_draw_input_field('refamt', 'enter amount', 'length="8"');
     $outputRefund .= '<input type="submit" name="partialrefund" value="' . MODULE_PAYMENT_PAYPAL_ENTRY_REFUND_BUTTON_TEXT_PARTIAL . '" title="' . MODULE_PAYMENT_PAYPAL_ENTRY_REFUND_BUTTON_TEXT_PARTIAL . '" /><br />';
     //comment field
-    $counterParams = ' onKeyDown="characterCount(this.form[\'refnote\'],this.form.remainingRefund,255);" onKeyUp="characterCount(this.form[\'refnote\'],this.form.remainingRefund,255);"';
+    $counterParams = ' onkeydown="characterCount(this.form[\'refnote\'],this.form.remainingRefund,255);" onkeyup="characterCount(this.form[\'refnote\'],this.form.remainingRefund,255);"';
     $outputRefund .= '<br />' . MODULE_PAYMENT_PAYPAL_ENTRY_REFUND_TEXT_COMMENTS;
     $outputRefund .= '<div style="text-align:right;margin-top:-1.2em"><input disabled="disabled" type="text" name="remainingRefund" size="3" maxlength="3" value="255" /> ' . TEXT_MAXIMUM_CHARACTERS_ALLOWED . '</div>';
     $outputRefund .= zen_draw_textarea_field('refnote', 'soft', '50', '3', MODULE_PAYMENT_PAYPAL_ENTRY_REFUND_DEFAULT_MESSAGE, $counterParams);
@@ -407,12 +413,14 @@ if (method_exists($this, '_doVoid')) {
 $output = '<!-- BOF: pp admin transaction processing tools -->';
 $output .= $outputStartBlock;
 
+$authcapt_on = (isset($_GET['authcapt']) && $_GET['authcapt'] == 'on');
+
 if (isset($response['RESPMSG']) /*|| defined('MODULE_PAYMENT_PAYFLOW_STATUS')*/) { // payflow
     $output .= $outputPFmain;
-    if (method_exists($this, '_doVoid') && (MODULE_PAYMENT_PAYPALDP_TRANSACTION_MODE == 'Auth Only' || MODULE_PAYMENT_PAYFLOW_TRANSACTION_MODE == 'Auth Only' || (isset($_GET['authcapt']) && $_GET['authcapt']=='on'))) {
+    if (method_exists($this, '_doVoid') && (MODULE_PAYMENT_PAYPALDP_TRANSACTION_MODE == 'Auth Only' || MODULE_PAYMENT_PAYFLOW_TRANSACTION_MODE == 'Auth Only' || $authcapt_on)) {
         $output .= $outputVoid;
     }
-    if (method_exists($this, '_doCapt') && (MODULE_PAYMENT_PAYPALDP_TRANSACTION_MODE == 'Auth Only' || MODULE_PAYMENT_PAYFLOW_TRANSACTION_MODE == 'Auth Only' || (isset($_GET['authcapt']) && $_GET['authcapt']=='on'))) {
+    if (method_exists($this, '_doCapt') && (MODULE_PAYMENT_PAYPALDP_TRANSACTION_MODE == 'Auth Only' || MODULE_PAYMENT_PAYFLOW_TRANSACTION_MODE == 'Auth Only' || $authcapt_on)) {
         $output .= $outputCapt;
     }
     if (method_exists($this, '_doRefund')) {
@@ -426,15 +434,19 @@ if (isset($response['RESPMSG']) /*|| defined('MODULE_PAYMENT_PAYFLOW_STATUS')*/)
         $output .= '</tr><tr>' . "\n";
         $output .= $outputStartBlock;
         $output .= $outputStartBlock;
-        if ($response['TRANSACTION_TYPE'] == 'Authorization' || (in_array($response['TRANSACTIONTYPE'], array('cart','expresscheckout','webaccept') ) && $response['PAYMENTTYPE'] == 'instant' && $response['PENDINGREASON'] == 'authorization') || (isset($_GET['authcapt']) && $_GET['authcapt']=='on')) {
+        $transaction_type_authorization = (isset($response['TRANSACTION_TYPE']) && $response['TRANSACTION_TYPE'] == 'Authorization');
+        $transactiontype_payment = in_array($response['TRANSACTIONTYPE'], array('cart', 'expresscheckout', 'webaccept'));
+        if ($transaction_type_authorization || ($transactiontype_payment && $response['PAYMENTTYPE'] == 'instant' && $response['PENDINGREASON'] == 'authorization') || $authcapt_on) {
             if (method_exists($this, '_doRefund') && ($response['PAYMENTTYPE'] != 'instant' || $module == 'paypaldp')) {
                 $output .= $outputRefund;
             }
-            if (method_exists($this, '_doAuth') && (MODULE_PAYMENT_PAYPALWPP_TRANSACTION_MODE == 'Auth Only' || MODULE_PAYMENT_PAYPALDP_TRANSACTION_MODE == 'Auth Only')) {
-                $output .= $outputAuth;
-            }
-            if (method_exists($this, '_doCapt') && (MODULE_PAYMENT_PAYPALWPP_TRANSACTION_MODE == 'Auth Only' || MODULE_PAYMENT_PAYPALDP_TRANSACTION_MODE == 'Auth Only')) {
-                $output .= $outputCapt;
+            if (MODULE_PAYMENT_PAYPALWPP_TRANSACTION_MODE == 'Auth Only' || MODULE_PAYMENT_PAYPALDP_TRANSACTION_MODE == 'Auth Only') {
+                if (method_exists($this, '_doAuth')) {
+                    $output .= $outputAuth;
+                }
+                if (method_exists($this, '_doCapt')) {
+                    $output .= $outputCapt;
+                }
             }
             if (method_exists($this, '_doVoid')) {
                 $output .= $outputVoid;


### PR DESCRIPTION
Correcting various PHP notices thrown during admin Customers::Orders processing when the order has been placed via the `paypalwpp` payment method.

Note that testing was done using US-based PayPal processing; I don't know if there are additional, optional response elements for the PayFlow side of things.