### PR TITLE
Correct password_forgotten PHP notice

### DIFF
--- a/includes/modules/pages/password_forgotten/header_php.php
+++ b/includes/modules/pages/password_forgotten/header_php.php
@@ -20,14 +20,12 @@ $_SESSION['navigation']->remove_current_page();
 
 if (isset($_GET['action']) && ($_GET['action'] == 'process')) {
 // Slam prevention:
-  if ($_SESSION['login_attempt'] > 9)
-  {
+  if (isset($_SESSION['login_attempt']) && $_SESSION['login_attempt'] > 9) {
     header('HTTP/1.1 406 Not Acceptable');
     exit(0);
   }
   // BEGIN SLAM PREVENTION
-  if (!empty($_POST['email_address']))
-  {
+  if (!empty($_POST['email_address'])) {
     if (! isset($_SESSION['login_attempt'])) $_SESSION['login_attempt'] = 0;
     $_SESSION['login_attempt'] ++;
   } // END SLAM PREVENTION


### PR DESCRIPTION
Generating a notice similar to
```
[14-Aug-2019 14:53:24 UTC] Request URI: /forgotten-password?action=process, IP address: xx.xx.xx.xx
#1 require(/home/site/mystore/includes/modules/pages/password_forgotten/header_php.php) called at [/home/site/mystore/index.php:36]
--> PHP Notice: Undefined index: login_attempt in /home/site/mystore/includes/modules/pages/password_forgotten/header_php.php on line 23.
```