### PR TITLE
Correct PHP notice on discount-coupon lookup

### DIFF
--- a/includes/templates/template_default/templates/tpl_discount_coupon_default.php
+++ b/includes/templates/template_default/templates/tpl_discount_coupon_default.php
@@ -24,7 +24,7 @@
 <fieldset>
 <legend><?php echo TEXT_DISCOUNT_COUPON_ID_INFO; ?></legend>
 <label class="inputLabel" for="lookup-discount-coupon"><?php echo TEXT_DISCOUNT_COUPON_ID; ?></label>
-<?php echo zen_draw_input_field('lookup_discount_coupon', $_POST['lookup_discount_coupon'], 'size="40" id="lookup-discount-coupon"');?>
+<?php echo zen_draw_input_field('lookup_discount_coupon', (isset($_POST['lookup_discount_coupon'])) ? $_POST['lookup_discount_coupon'] : '', 'size="40" id="lookup-discount-coupon"');?>
 </fieldset>
 
 <?php if ($text_coupon_help == '') { ?>


### PR DESCRIPTION
Generating a notice similar to the following on initial entry to the page (no post data):
```
[14-Aug-2019 20:23:35 UTC] Request URI: /discount-coupons, IP address: xx.xx.xx.xx
#1 require(/home/store/mystore/includes/templates/template_default/templates/tpl_discount_coupon_default.php) called at [/home/store/mystore/includes/templates/my_rc/common/tpl_main_page.php:174]
#2 require(/home/store/mystore/includes/templates/my_rc/common/tpl_main_page.php) called at [/home/store/mystore/index.php:97]
--> PHP Notice: Undefined index: lookup_discount_coupon in /home/store/mystore/includes/templates/template_default/templates/tpl_discount_coupon_default.php on line 27.
```