### PR TITLE
Limited-profile admin can't log in after plugin removed

### DIFF
--- a/admin/includes/functions/admin_access.php
+++ b/admin/includes/functions/admin_access.php
@@ -820,34 +820,35 @@ function zen_insert_pages_into_profile($id, $pages)
 
 function zen_get_admin_menu_for_user()
 {
-  global $db;
-  if (zen_is_superuser())
-  {
-    // get all registered admin pages that should appear in the menu
-    $retVal = zen_get_admin_pages(TRUE);
-  } else
-  {
-    // get only those registered pages allowed by the current user's profile
-    $retVal = array();
-    $sql = "SELECT ap.menu_key, ap.page_key, ap.main_page, ap.page_params, ap.language_key as pageName
-            FROM " . TABLE_ADMIN . " a
-            LEFT JOIN " . TABLE_ADMIN_PAGES_TO_PROFILES . " ap2p ON ap2p.profile_id = a.admin_profile
-            LEFT JOIN " . TABLE_ADMIN_PAGES . " ap ON ap.page_key = ap2p.page_key
-            LEFT JOIN " . TABLE_ADMIN_MENUS . " am ON am.menu_key = ap.menu_key
-            WHERE a.admin_id = :user:
-            AND   ap.display_on_menu = 'Y'
-            ORDER BY am.sort_order, ap.sort_order";
-    $sql = $db->bindVars($sql, ':user:', $_SESSION['admin_id'], 'integer');
-    $result = $db->Execute($sql);
-    while (!$result->EOF)
-    {
-      $retVal[$result->fields['menu_key']][$result->fields['page_key']] = array('name' => constant($result->fields['pageName']),
-                                                                                'file' => constant($result->fields['main_page']),
-                                                                                'params' => $result->fields['page_params']);
-      $result->MoveNext();
+    global $db;
+    if (zen_is_superuser()) {
+        // get all registered admin pages that should appear in the menu
+        $retVal = zen_get_admin_pages(true);
+    } else {
+        // get only those registered pages allowed by the current user's profile
+        $retVal = array();
+        $sql = "SELECT ap.menu_key, ap.page_key, ap.main_page, ap.page_params, ap.language_key as pageName
+                FROM " . TABLE_ADMIN . " a
+                LEFT JOIN " . TABLE_ADMIN_PAGES_TO_PROFILES . " ap2p ON ap2p.profile_id = a.admin_profile
+                LEFT JOIN " . TABLE_ADMIN_PAGES . " ap ON ap.page_key = ap2p.page_key
+                LEFT JOIN " . TABLE_ADMIN_MENUS . " am ON am.menu_key = ap.menu_key
+                WHERE a.admin_id = :user:
+                AND   ap.display_on_menu = 'Y'
+                ORDER BY am.sort_order, ap.sort_order";
+        $sql = $db->bindVars($sql, ':user:', $_SESSION['admin_id'], 'integer');
+        $result = $db->Execute($sql);
+        while (!$result->EOF) {
+            if (defined($result->fields['pageName']) && defined($result->fields['main_page'])) {
+                $retVal[$result->fields['menu_key']][$result->fields['page_key']] = array(
+                    'name' => constant($result->fields['pageName']),
+                    'file' => constant($result->fields['main_page']),
+                    'params' => $result->fields['page_params']
+                );
+            }
+            $result->MoveNext();
+        }
     }
-  }
-  return $retVal;
+    return $retVal;
 }
 
 function zen_get_menu_titles()


### PR DESCRIPTION
If a plugin is removed from a store and the use of the plugin has been authorized for a non-superuser admin-profile, admins using that profile can no longer sign in.  For instance, if the Sales Report was previously installed, the following PHP issues are logged on the admin login attempt:
```
[26-Aug-2019 07:42:36 America/New_York] Request URI: /myadmin/index.php, IP address: 127.0.0.1
#1  constant() called at [C:\xampp\htdocs\zc156c\myadmin\includes\functions\admin_access.php:837]
#2  zen_get_admin_menu_for_user() called at [C:\xampp\htdocs\zc156c\myadmin\includes\header_navigation.php:56]
#3  require(C:\xampp\htdocs\zc156c\myadmin\includes\header_navigation.php) called at [C:\xampp\htdocs\zc156c\myadmin\includes\header.php:257]
#4  require(C:\xampp\htdocs\zc156c\myadmin\includes\header.php) called at [C:\xampp\htdocs\zc156c\myadmin\index_dashboard.php:225]
#5  require(C:\xampp\htdocs\zc156c\myadmin\index_dashboard.php) called at [C:\xampp\htdocs\zc156c\myadmin\index.php:26]
--> PHP Warning: constant(): Couldn't find constant BOX_REPORTS_SALES_REPORT in C:\xampp\htdocs\zc156c\myadmin\includes\functions\admin_access.php on line 837.

[26-Aug-2019 07:42:36 America/New_York] Request URI: /myadmin/index.php, IP address: 127.0.0.1
#1  constant() called at [C:\xampp\htdocs\zc156c\myadmin\includes\functions\admin_access.php:838]
#2  zen_get_admin_menu_for_user() called at [C:\xampp\htdocs\zc156c\myadmin\includes\header_navigation.php:56]
#3  require(C:\xampp\htdocs\zc156c\myadmin\includes\header_navigation.php) called at [C:\xampp\htdocs\zc156c\myadmin\includes\header.php:257]
#4  require(C:\xampp\htdocs\zc156c\myadmin\includes\header.php) called at [C:\xampp\htdocs\zc156c\myadmin\index_dashboard.php:225]
#5  require(C:\xampp\htdocs\zc156c\myadmin\index_dashboard.php) called at [C:\xampp\htdocs\zc156c\myadmin\index.php:26]
--> PHP Warning: constant(): Couldn't find constant FILENAME_STATS_SALES_REPORT in C:\xampp\htdocs\zc156c\myadmin\includes\functions\admin_access.php on line 838.

[26-Aug-2019 07:42:36 America/New_York] Request URI: /myadmin/index.php, IP address: 127.0.0.1
#1  trigger_error() called at [C:\xampp\htdocs\zc156c\myadmin\includes\functions\html_output.php:16]
#2  zen_href_link() called at [C:\xampp\htdocs\zc156c\myadmin\includes\header_navigation.php:61]
#3  require(C:\xampp\htdocs\zc156c\myadmin\includes\header_navigation.php) called at [C:\xampp\htdocs\zc156c\myadmin\includes\header.php:257]
#4  require(C:\xampp\htdocs\zc156c\myadmin\includes\header.php) called at [C:\xampp\htdocs\zc156c\myadmin\index_dashboard.php:225]
#5  require(C:\xampp\htdocs\zc156c\myadmin\index_dashboard.php) called at [C:\xampp\htdocs\zc156c\myadmin\index.php:26]
--> PHP Fatal error: zen_href_link(, , SSL), unable to determine the page link. in C:\xampp\htdocs\zc156c\myadmin\includes\functions\html_output.php on line 16.

```

This PR updates the `zen_get_admin_menu_for_user` function to ensure that an admin-page's 'pageName' and 'main_page' constants are _defined_ before attempting to use them as constants.  I also took the liberty of providing PSR-2 formatting to that function.

Note that this doesn't address the underlying issue where those now-unused page-definitions are still in the database.