### PR TITLE
Exclude "hidden" order-status updates from account-history

### DIFF
--- a/includes/classes/split_page_results.php
+++ b/includes/classes/split_page_results.php
@@ -63,7 +63,7 @@ class splitPageResults extends base {
     $pos_having = strpos($query_lower, ' having', $pos_from);
     if (($pos_having < $pos_to) && ($pos_having != false)) $pos_to = $pos_having;
 
-    $pos_order_by = strpos($query_lower, ' order by', $pos_from);
+    $pos_order_by = strrpos($query_lower, ' order by', $pos_from);
     if (($pos_order_by < $pos_to) && ($pos_order_by != false)) $pos_to = $pos_order_by;
 
     if (strpos($query_lower, 'distinct') || strpos($query_lower, 'group by')) {

--- a/includes/modules/pages/account/header_php.php
+++ b/includes/modules/pages/account/header_php.php
@@ -39,7 +39,9 @@ $orders_query = "SELECT o.orders_id, o.date_purchased, o.delivery_name,
                  WHERE  o.customers_id = :customersID
                  AND    o.orders_id = ot.orders_id
                  AND    ot.class = 'ot_total'
-                 AND    o.orders_status = s.orders_status_id
+                 AND    s.orders_status_id = 
+                          (SELECT orders_status_id FROM " . TABLE_ORDERS_STATUS_HISTORY . " osh 
+                           WHERE osh.orders_id = o.orders_id AND osh.customer_notified >= 0 ORDER BY osh.date_added DESC LIMIT 1)
                  AND   s.language_id = :languagesID
                  ORDER BY orders_id DESC LIMIT 3";
 

--- a/includes/modules/pages/account_history/header_php.php
+++ b/includes/modules/pages/account_history/header_php.php
@@ -30,7 +30,9 @@ if ($orders_total > 0) {
                         WHERE      o.customers_id = :customersID
                         AND        o.orders_id = ot.orders_id
                         AND        ot.class = 'ot_total'
-                        AND        o.orders_status = s.orders_status_id
+                        AND    s.orders_status_id = 
+                          (SELECT orders_status_id FROM " . TABLE_ORDERS_STATUS_HISTORY . " osh 
+                           WHERE osh.orders_id = o.orders_id AND osh.customer_notified >= 0 ORDER BY osh.date_added DESC LIMIT 1)
                         AND        s.language_id = :languagesID
                         ORDER BY   orders_id DESC";
 


### PR DESCRIPTION
While a "hidden" admin-only order-status comment is excluded from display catalog-side, the "Order Status" name was being displayed, which might not be appropriate for customer to see.
This PR changes it to show the last non-hidden order-status-name in the My Account page and the My Account History page (which is accessed by clicking the Show All Orders) from the My Account page).