### PR TITLE
Correct download-by-redirect PHP notice

### DIFF
--- a/includes/classes/observers/auto.downloads_via_redirect.php
+++ b/includes/classes/observers/auto.downloads_via_redirect.php
@@ -96,7 +96,7 @@ class zcObserverDownloadsViaRedirect extends base {
     if (defined('DOWNLOADS_SKIP_DOT_PREFIX_ON_REDIRECT') && DOWNLOADS_SKIP_DOT_PREFIX_ON_REDIRECT === TRUE) $dirname = '';
     $length = floor(zen_rand(16,20));
     for ($i = 1; $i <= $length; $i++) {
-      $q = floor(zen_rand(0,25));
+      $q = (int)floor(zen_rand(0,25));
       $dirname .= $letters[$q];
     }
     return $dirname;


### PR DESCRIPTION
Running PHP 7.1.32 and seeing logs similar to the following when a customer goes to download their virtual products.  Noting that `floor` returns a float, so casting the return to an int corrects the issue.
```
[11-Sep-2019 19:04:11 UTC] Request URI: /index.php?main_page=download&order=1234&id=1759, IP address: xx.xx.xx.xx
#1 zcObserverDownloadsViaRedirect->generateRandomName() called at [/home/store/mysite/includes/classes/observers/auto.downloads_via_redirect.php:72]
#2 zcObserverDownloadsViaRedirect->updateNotifyDownloadReadyToRedirect() called at [/home/store/mysite/includes/classes/class.base.php:103]
#3 base->notify() called at [/home/store/mysite/includes/modules/pages/download/header_php.php:212]
#4 require(/home/store/mysite/includes/modules/pages/download/header_php.php) called at [/home/store/mysite/index.php:36]
--> PHP Notice: String offset cast occurred in /home/store/mysite/includes/classes/observers/auto.downloads_via_redirect.php on line 100.
```