### PR TITLE
Add csv|txt to accepted files

### DIFF
--- a/admin/.htaccess
+++ b/admin/.htaccess
@@ -41,7 +41,7 @@ DirectoryIndex index.php
 </FilesMatch>
 
 # but now allow just *certain* necessary files:
-<FilesMatch "(?i).*\.(php|js|css|html?|ico|otf|jpe?g|gif|webp|png|swf|flv|xml|xsl|csv|CSV|txt|TXT)$">
+<FilesMatch "(?i).*\.(php|js|css|html?|ico|otf|jpe?g|gif|webp|png|swf|flv|xml|xsl|csv|txt)$">
   <IfModule mod_authz_core.c>
     Require all granted
   </IfModule>


### PR DESCRIPTION
Hope I put this in the right place suggest a change to 1.7!! 
Many people use Easy Populate and this is a required change at least in 1.5.6 version in order for the files to be downloadable in EZP.