### PR TITLE
add missing $check_status query on update_order action

### DIFF
--- a/admin/orders.php
+++ b/admin/orders.php
@@ -158,6 +158,10 @@ if (zen_not_null($action) && $order_exists == true) {
       $status_updated = zen_update_orders_history($oID, $comments, null, $status, $customer_notified, $email_include_message);
       $order_updated = ($status_updated > 0);
 
+      $check_status = $db->Execute("select customers_name, customers_email_address, orders_status,
+                                      date_purchased from " . TABLE_ORDERS . "
+                                      where orders_id = '" . (int)$oID . "'");
+
       // trigger any appropriate updates which should be sent back to the payment gateway:
       $order = new order((int)$oID);
       if ($order->info['payment_module_code']) {

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -158,9 +158,9 @@ if (zen_not_null($action) && $order_exists == true) {
       $status_updated = zen_update_orders_history($oID, $comments, null, $status, $customer_notified, $email_include_message);
       $order_updated = ($status_updated > 0);
 
-      $check_status = $db->Execute("select customers_name, customers_email_address, orders_status,
-                                      date_purchased from " . TABLE_ORDERS . "
-                                      where orders_id = '" . (int)$oID . "'");
+      $check_status = $db->Execute("SELECT customers_name, customers_email_address, orders_status, date_purchased
+                                    FROM " . TABLE_ORDERS . "
+                                    WHERE orders_id = " . (int)$oID);
 
       // trigger any appropriate updates which should be sent back to the payment gateway:
       $order = new order((int)$oID);


### PR DESCRIPTION
I just upgraded to 1.5.6 and noticed an issue introduced with #1550.  
```
Request URI: /admin/orders.php?oID=12345&action=update_order
#1  mktime() called at [/admin/includes/functions/general.php:3303]
#2  zen_date_diff() called at [/admin/orders.php:203]
--> PHP Warning: mktime() expects parameter 6 to be int, string given in /admin/includes/functions/general.php on line 3303.
```

## Steps to recreate
* Update an order with downloadable products to "UPDATE" status
* Get the warning in the logs and date does not update correctly.

It happens because the `$check_status->fields['date_purchased']` is undefined in the call to
`zen_date_diff` on `line 203`

**NOTE**: would also happen inside `if ($order->info['payment_module_code'])` block... on `line 169`

**NOTE**: the `customers_name` and `customers_email_address` from the query is not used but was present in 1.5.5, so I left it.