### PR TITLE
Admin category listing: enable/disable subcategories and products

### DIFF
--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -79,8 +79,8 @@ if (zen_not_null($action)) {
           //set categories_status
             if ($categories[$i]['id'] == $categories_id) {//always update THIS category
                 $sql = "UPDATE " . TABLE_CATEGORIES . "
-                    SET categories_status = " . $category_status . "
-                    WHERE categories_id = " . $categories[$i]['id'];
+                    SET categories_status = " . (int)$category_status . "
+                    WHERE categories_id = " . (int)$categories[$i]['id'];
                 $db->Execute($sql);
 
           } elseif ($subcategories_status != '') {//optionally update subcategories if a change was selected

--- a/admin/includes/languages/english.php
+++ b/admin/includes/languages/english.php
@@ -379,6 +379,7 @@ define('IMAGE_PRODUCTS_TO_CATEGORIES', 'Multiple Categories Link Manager');
 define('IMAGE_ICON_STATUS_ON', 'Status - Enabled');
 define('IMAGE_ICON_STATUS_OFF', 'Status - Disabled');
 define('IMAGE_ICON_LINKED', 'Product is Linked');
+define('IMAGE_ICON_LINKED_CATEGORY', 'Category contains Linked Products');
 
 define('IMAGE_REMOVE_SPECIAL','Remove Special Price Info');
 define('IMAGE_REMOVE_FEATURED','Remove Featured Product Info');

--- a/admin/includes/languages/english/category_product_listing.php
+++ b/admin/includes/languages/english/category_product_listing.php
@@ -28,8 +28,8 @@ define('TEXT_DELETE_CATEGORY_INTRO_LINKED_PRODUCTS', '<strong>Warning:</strong> 
 define('TEXT_INFO_HEADING_MOVE_CATEGORY', 'Move Category');
 define('TEXT_MOVE_CATEGORIES_INTRO', 'Please select which category you wish <b>%s</b> to reside in');
 define('TEXT_MOVE', 'Move <b>%s</b> to:');
-define('TEXT_INFO_HEADING_DELETE_PRODUCT', 'Delete Product');
-define('TEXT_DELETE_PRODUCT_INTRO', 'Are you sure you want to permanently delete this product?<br /><br /><strong>Warning:</strong> On Linked Products<br />1 Make sure the Master Category has been changed if you are deleting the Product from the Master Category<br />2 Check the checkbox for the Category to Delete the Product from');
+define('TEXT_INFO_HEADING_DELETE_PRODUCT', 'Delete Product/Links');
+define('TEXT_DELETE_PRODUCT_INTRO', 'Delete this product\'s links to categories or delete the product completely.<br />For easier linking/unlinking of products to multiple categories, you may also use the <a href="index.php?cmd=' . FILENAME_PRODUCTS_TO_CATEGORIES . '&amp;products_filter=%u">Multiple Categories Link Manager</a>.<br /><br /><strong>Linked categories</strong> are pre-selected ready for deletion.<br />The <strong>Master Category</strong> (<span class="text-danger">highlighted</span>) is de-selected to prevent accidental deletion.<br /><br />To delete a product completely, select ALL categories including the Master Category.');
 define('TEXT_INFO_HEADING_MOVE_PRODUCT', 'Move Product');
 define('TEXT_MOVE_PRODUCTS_INTRO', 'Please select which category you wish <b>%s</b> to reside in');
 define('TEXT_INFO_CURRENT_CATEGORIES', 'Current Categories: ');


### PR DESCRIPTION
add missing icon alt/title text used in category_listing.php

fix required for php notice when disabling categories if no subcategories, due to $_POST['set_subcategories_status'] not being set.

Reworked the code so
a) the evaluation for subcategories/products status is done once: it was mistakenly inside the category tree loop.
b) status updates are only done when a subcategories/products status **change** has been selected.