### PR TITLE
Consolidate TEXT_OPTION_DIVIDER definition

### DIFF
--- a/includes/languages/english.php
+++ b/includes/languages/english.php
@@ -645,6 +645,9 @@ define('EMP_SHOPPING_FOR_MESSAGE', 'Currently shopping for %1$s (%2$s).');
 //
 define('EMP_SHOPPING_FOR_MESSAGE_SEVERITY', 'success');
 
+// Constants shared between multiple pages
+define('TEXT_OPTION_DIVIDER', '&nbsp;-&nbsp;');
+
 ///////////////////////////////////////////////////////////
 
   $file_list = array(FILENAME_EMAIL_EXTRAS, FILENAME_HEADER, FILENAME_BUTTON_NAMES, FILENAME_ICON_NAMES, FILENAME_OTHER_IMAGES_NAMES, FILENAME_CREDIT_CARDS, FILENAME_WHOS_ONLINE, FILENAME_META_TAGS); 

--- a/includes/languages/english/account_history_info.php
+++ b/includes/languages/english/account_history_info.php
@@ -36,5 +36,3 @@ define('TABLE_HEADING_STATUS_ORDER_STATUS', 'Order Status');
 define('TABLE_HEADING_STATUS_COMMENTS', 'Comments');
 define('QUANTITY_SUFFIX', '&nbsp;ea.  ');
 define('ORDER_HEADING_DIVIDER', '&nbsp;-&nbsp;');
-define('TEXT_OPTION_DIVIDER', '&nbsp;-&nbsp;');
-?>

--- a/includes/languages/english/checkout_success.php
+++ b/includes/languages/english/checkout_success.php
@@ -51,4 +51,3 @@ define('TABLE_HEADING_STATUS_ORDER_STATUS', 'Order Status');
 define('TABLE_HEADING_STATUS_COMMENTS', 'Comments');
 define('QUANTITY_SUFFIX', '&nbsp;ea.  ');
 define('ORDER_HEADING_DIVIDER', '&nbsp;-&nbsp;');
-define('TEXT_OPTION_DIVIDER', '&nbsp;-&nbsp;');

--- a/includes/languages/english/shopping_cart.php
+++ b/includes/languages/english/shopping_cart.php
@@ -24,4 +24,3 @@ define('TEXT_TOTAL_AMOUNT', '&nbsp;&nbsp;Amount: ');
 
 define('TEXT_CART_HELP', '<a href="javascript:session_win();">[help (?)]</a>');
 define('TEXT_VISITORS_CART', TEXT_CART_HELP); // legacy define
-define('TEXT_OPTION_DIVIDER', '&nbsp;-&nbsp;');


### PR DESCRIPTION
The subject constant is currently defined in the `account_history_info`, `checkout_success` and `shopping_cart` pages' page-specific language files.  Consolidate into the base language file.