### PR TITLE
admin: prev-next removed as table layout

### DIFF
--- a/admin/attributes_controller.php
+++ b/admin/attributes_controller.php
@@ -993,13 +993,8 @@ function zen_js_option_values_list($selectedName, $fieldName) {
       if ($action == '') {
         ?>
         <div class="row">
-          <div class="table-responsive">
-            <table class="table">
-                <?php require(DIR_WS_MODULES . FILENAME_PREV_NEXT_DISPLAY); ?>
-            </table>
-          </div>
+           <?php require(DIR_WS_MODULES . FILENAME_PREV_NEXT_DISPLAY); ?>
         </div>
-
         <div class="row">
             <?php echo zen_draw_form('set_products_filter_id', FILENAME_ATTRIBUTES_CONTROLLER, 'action=set_products_filter', 'post', 'class="form-horizontal"'); ?>
             <?php echo zen_draw_hidden_field('products_filter', $products_filter); ?>

--- a/admin/includes/modules/products_previous_next_display.php
+++ b/admin/includes/modules/products_previous_next_display.php
@@ -12,14 +12,12 @@ if (!defined('IS_ADMIN_FLAG')) {
 // used following load of products_previous_next.php
 ?>
 <!-- bof: products_previous_next_display -->
-  <tr>
-    <td>
         <div class="row"><strong>
           <?php echo (HEADING_TITLE == '' ? HEADING_TITLE2 : HEADING_TITLE); ?>&nbsp;-&nbsp;<?php echo zen_output_generated_category_path($current_category_id); ?></strong>
           <?php echo '<br />' . TEXT_CATEGORIES_PRODUCTS; ?>
         </div>
         <div class="row"><?php echo (zen_get_categories_status($current_category_id) == '0' ? TEXT_CATEGORIES_STATUS_INFO_OFF : '') . (zen_get_products_status($products_filter) == '0' ? ' ' . TEXT_PRODUCTS_STATUS_INFO_OFF : ''); ?></div>
-      <div class="row text-center"><?php echo ($counter > 0 ? (PREV_NEXT_PRODUCT) . ($position+1 . "/" . $counter) : '&nbsp;'); ?></div>
+      <div class="row"><?php echo ($counter > 0 ? (PREV_NEXT_PRODUCT) . ($position+1 . "/" . $counter) : '&nbsp;'); ?></div>
       <div class="row">
   <?php if ($counter > 0 ) { ?>
           <div class="col-sm-2 text-center">
@@ -44,6 +42,4 @@ if (!defined('IS_ADMIN_FLAG')) {
           </div>
         <?php } ?>
       </div>
-    </td>
-  </tr>
 <!-- eof: products_previous_next_display -->

--- a/admin/includes/modules/products_previous_next_display.php
+++ b/admin/includes/modules/products_previous_next_display.php
@@ -7,39 +7,47 @@
  * @version $Id: Zen4All Wed Jan 17 12:01:19 2018 +0100 Modified in v1.5.6 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
-  die('Illegal Access');
+    die('Illegal Access');
 }
 // used following load of products_previous_next.php
 ?>
 <!-- bof: products_previous_next_display -->
-        <div class="row"><strong>
-          <?php echo (HEADING_TITLE == '' ? HEADING_TITLE2 : HEADING_TITLE); ?>&nbsp;-&nbsp;<?php echo zen_output_generated_category_path($current_category_id); ?></strong>
-          <?php echo '<br />' . TEXT_CATEGORIES_PRODUCTS; ?>
-        </div>
-        <div class="row"><?php echo (zen_get_categories_status($current_category_id) == '0' ? TEXT_CATEGORIES_STATUS_INFO_OFF : '') . (zen_get_products_status($products_filter) == '0' ? ' ' . TEXT_PRODUCTS_STATUS_INFO_OFF : ''); ?></div>
-      <div class="row"><?php echo ($counter > 0 ? (PREV_NEXT_PRODUCT) . ($position+1 . "/" . $counter) : '&nbsp;'); ?></div>
-      <div class="row">
-  <?php if ($counter > 0 ) { ?>
-          <div class="col-sm-2 text-center">
+<!-- heading -->
+<div class="row"><strong>
+        <?php echo(HEADING_TITLE == '' ? HEADING_TITLE2 : HEADING_TITLE); ?>&nbsp;-&nbsp;<?php echo zen_output_generated_category_path($current_category_id); ?></strong>
+    <?php echo '<br />' . TEXT_CATEGORIES_PRODUCTS; ?>
+</div>
+<!-- heading eof -->
+<!-- category/product status -->
+<div class="row"><?php echo (zen_get_categories_status($current_category_id) == '0' ? TEXT_CATEGORIES_STATUS_INFO_OFF : '') . (zen_get_products_status($products_filter) == '0' ? ' ' . TEXT_PRODUCTS_STATUS_INFO_OFF : ''); ?></div>
+<!-- category/product status eof -->
+<!-- product count -->
+<div class="row"><?php echo($counter > 0 ? (PREV_NEXT_PRODUCT) . ($position + 1 . "/" . $counter) : '&nbsp;'); ?></div>
+<!-- product count eof-->
+<!-- prev-cat-next navigation -->
+<div class="row">
+    <?php if ($counter > 0) { ?>
+        <div class="col-sm-2 text-center">
             <a href="<?php echo zen_href_link($curr_page, "products_filter=" . $previous . '&current_category_id=' . $current_category_id); ?>" class="btn btn-default" role="button"><?php echo BUTTON_PREVIOUS_ALT; ?></a>
-          </div>
-        <?php } ?>
-        <div class="col-sm-4">
-          <?php echo zen_draw_form('new_category', $curr_page, '', 'get'); ?>
-            <?php echo zen_draw_pull_down_menu('current_category_id', zen_get_category_tree('', '', '0', '', '', true), $current_category_id, 'onChange="this.form.submit();" class="form-control"'); ?>
-              <?php
-              if (isset($_GET['products_filter'])) {
-                echo zen_draw_hidden_field('products_filter', $_GET['products_filter']);
-              }
-              echo zen_hide_session_id();
-              echo zen_draw_hidden_field('action', 'new_cat');
-              ?>
-        <?php echo '</form>'; ?>
         </div>
-        <?php if ($counter > 0 ) { ?>
-          <div class="col-sm-2 text-center">
+    <?php } ?>
+    <div class="col-sm-4">
+        <?php echo zen_draw_form('new_category', $curr_page, '', 'get'); ?>
+        <?php echo zen_draw_pull_down_menu('current_category_id', zen_get_category_tree('', '', '0', '', '', true), $current_category_id, 'onChange="this.form.submit();" class="form-control"'); ?>
+        <?php
+        if (isset($_GET['products_filter'])) {
+            echo zen_draw_hidden_field('products_filter', $_GET['products_filter']);
+        }
+        echo zen_hide_session_id();
+        echo zen_draw_hidden_field('action', 'new_cat');
+        ?>
+        <?php echo '</form>'; ?>
+    </div>
+    <?php if ($counter > 0) { ?>
+        <div class="col-sm-2 text-center">
             <a href="<?php echo zen_href_link($curr_page, "products_filter=" . $next_item . '&current_category_id=' . $current_category_id); ?>" class="btn btn-default" role="button"><?php echo BUTTON_NEXT_ALT; ?></a>
-          </div>
-        <?php } ?>
-      </div>
+        </div>
+    <?php } ?>
+</div>
+<!-- prev-cat-next navigation eof -->
 <!-- eof: products_previous_next_display -->

--- a/admin/products_price_manager.php
+++ b/admin/products_price_manager.php
@@ -309,11 +309,7 @@ if (zen_not_null($action)) {
       if ($action != 'edit_update') {
         ?>
         <div class="row">
-          <div class="table-responsive">
-            <table class="table">
-                <?php require(DIR_WS_MODULES . FILENAME_PREV_NEXT_DISPLAY); ?>
-            </table>
-          </div>
+           <?php require(DIR_WS_MODULES . FILENAME_PREV_NEXT_DISPLAY); ?>
         </div>
         <div class="row">
             <?php echo zen_draw_form('set_products_filter', FILENAME_PRODUCTS_PRICE_MANAGER, 'action=set_products_filter', 'post', 'class="form-horizontal"'); ?>

--- a/admin/products_to_categories.php
+++ b/admin/products_to_categories.php
@@ -449,8 +449,7 @@ $products_list = $db->Execute("SELECT products_id, categories_id
       }
     </script>
   </head>
-  <!-- <body onload="init()"> -->
-  <body onload="init()">
+  <body onload="init();">
     <!-- header //-->
     <?php require(DIR_WS_INCLUDES . 'header.php'); ?>
     <!-- header_eof //-->
@@ -595,7 +594,6 @@ $products_list = $db->Execute("SELECT products_id, categories_id
         <?php if ($products_filter >0 && $product_to_copy->fields['master_categories_id'] > 0) { //a product is selected AND it has a master category ?>
         <div class="row">
           <!-- bof: link to categories //-->
-          <div>
               <?php echo zen_draw_separator('pixel_black.gif', '100%', '1'); ?>
               <div class="row"><?php echo TEXT_INFO_PRODUCTS_TO_CATEGORIES_LINKER_INTRO; ?></div>
               <?php echo zen_draw_separator('pixel_trans.gif', '100%', '2'); ?>
@@ -774,7 +772,6 @@ $products_list = $db->Execute("SELECT products_id, categories_id
         <?php echo '</form>'; ?>
         <!-- eof: reset master_categories_id //-->
       </div>
-    </div>
     <!-- body_text_eof //-->
     </div>
     <!-- body_eof //-->

--- a/admin/products_to_categories.php
+++ b/admin/products_to_categories.php
@@ -480,7 +480,7 @@ $products_list = $db->Execute("SELECT products_id, categories_id
         <?php echo zen_draw_label(TEXT_PRODUCT_TO_VIEW, 'products_filter'); ?>
         <?php echo zen_draw_products_pull_down('products_filter', 'size="10" class="form-control" id="products_filter"', $excluded_products, true, $products_filter, true, true); ?>
         <button type="submit" class="btn btn-info"><?php echo IMAGE_DISPLAY; ?></button>
-        </form>
+        <?php echo '</form>'; ?>
         <?php echo zen_draw_separator('pixel_trans.gif', '100%', '2'); ?>
         <div><!--pricing and linked category count-->
             <?php
@@ -512,7 +512,7 @@ $products_list = $db->Execute("SELECT products_id, categories_id
             <span class="alert"><?php echo WARNING_MASTER_CATEGORIES_ID; ?></span>
             <?php } ?></div>
         <div><?php echo TEXT_INFO_MASTER_CATEGORY_CHANGE; ?></div>
-        </form>
+        <?php echo '</form>'; ?>
     </div>
     </div><!--end of masterCategorySelect-->
     </div><!-- end leftBlock-->

--- a/admin/products_to_categories.php
+++ b/admin/products_to_categories.php
@@ -459,11 +459,11 @@ $products_list = $db->Execute("SELECT products_id, categories_id
     <div class="container-fluid">
         <!-- body_text //-->
         <h1><?php echo HEADING_TITLE; ?></h1>
-        <div class="row"><?php echo zen_draw_separator('pixel_black.gif', '100%', '2'); ?></div>
-        <?php require(DIR_WS_MODULES . FILENAME_PREV_NEXT_DISPLAY); ?>
+	<div><?php echo zen_draw_separator('pixel_black.gif', '100%', '2'); ?></div>
+        <div class="row">
+          <?php require(DIR_WS_MODULES . FILENAME_PREV_NEXT_DISPLAY); ?>
+        </div>
         <?php if ($products_filter > 0) {//a product is selected ?>
-        <div class="row"><?php echo zen_draw_separator('pixel_trans.gif', '100%', '20'); ?></div>
-
     <div class="row"><!--Product Block-->
     <div id="leftBlock" class="col-xs-12 col-sm-9 col-md-9 col-lg-9">
     <div id="productSelect">
@@ -571,7 +571,7 @@ $products_list = $db->Execute("SELECT products_id, categories_id
                                     '<a href="' . zen_href_link(FILENAME_PRODUCT,
                                         'action=new_product' . '&cPath=' . zen_get_parent_category_id($products_filter) . '&pID=' . $products_filter . '&product_type=' . zen_get_products_type($products_filter)) . '" class="btn btn-info" role="button">' . IMAGE_EDIT_PRODUCT . '</a>'
                             );
-                            $contents[] = array('text' => zen_image(DIR_WS_IMAGES . 'pixel_black.gif', '', '100%', '3'));
+                            $contents[] = array('text' => zen_draw_separator('pixel_black.gif', '100%', '1'));
                             $contents[] = array(
                                 'align' => 'center',
                                 'text' => zen_draw_form('new_products_to_categories', FILENAME_PRODUCTS_TO_CATEGORIES,
@@ -775,8 +775,10 @@ $products_list = $db->Execute("SELECT products_id, categories_id
         <!-- eof: reset master_categories_id //-->
       </div>
     </div>
-
     <!-- body_text_eof //-->
+    </div>
+    <!-- body_eof //-->
+
     <!-- footer //-->
     <?php require(DIR_WS_INCLUDES . 'footer.php'); ?>
     <!-- footer_eof //-->


### PR DESCRIPTION
The entire prev_next block was build into a <tr> tag (rather than a complete table).
Simplified this to a div and removed the enclosing table tags from the three files that use this.

Also corrected a missing /div in products_to_categories and a minor validation error with a separator width in the infobox.
