### PR TITLE
zc157: Correct misplaced form closure when only 1 address-book entry

### DIFF
--- a/includes/templates/responsive_classic/templates/tpl_checkout_payment_address_default.php
+++ b/includes/templates/responsive_classic/templates/tpl_checkout_payment_address_default.php
@@ -52,12 +52,12 @@
 ?>
 </fieldset>
 <div class="buttonRow forward"><?php echo zen_draw_hidden_field('action', 'submit') . zen_image_submit(BUTTON_IMAGE_CONTINUE, BUTTON_CONTINUE_ALT); ?></div>
+</form>
 <?php
      }
 ?>
 
 <div class="buttonRow back"><?php echo TITLE_CONTINUE_CHECKOUT_PROCEDURE . '<br />' . TEXT_CONTINUE_CHECKOUT_PROCEDURE; ?></div>
 
-</form>
 <div class="buttonRow back clearBoth"><?php echo zen_back_link() . zen_image_button(BUTTON_IMAGE_BACK, BUTTON_BACK_ALT) . '</a>'; ?></div>
 </div>

--- a/includes/templates/responsive_classic/templates/tpl_checkout_shipping_address_default.php
+++ b/includes/templates/responsive_classic/templates/tpl_checkout_shipping_address_default.php
@@ -54,6 +54,7 @@
 ?>
 </fieldset>
 <div class="buttonRow forward"><?php echo zen_draw_hidden_field('action', 'submit') . zen_image_submit(BUTTON_IMAGE_CONTINUE, BUTTON_CONTINUE_ALT); ?></div>
+</form>
 <?php
      }
   }
@@ -62,6 +63,5 @@
 
 <div class="buttonRow back"><?php echo TITLE_CONTINUE_CHECKOUT_PROCEDURE . '<br />' . TEXT_CONTINUE_CHECKOUT_PROCEDURE; ?></div>
 
-</form>
 <div class="buttonRow back clearBoth"><?php echo zen_back_link() . zen_image_button(BUTTON_IMAGE_BACK, BUTTON_BACK_ALT) . '</a>'; ?></div>
 </div>

--- a/includes/templates/template_default/templates/tpl_checkout_payment_address_default.php
+++ b/includes/templates/template_default/templates/tpl_checkout_payment_address_default.php
@@ -51,13 +51,13 @@
 ?>
 </fieldset>
 <div class="buttonRow forward"><?php echo zen_draw_hidden_field('action', 'submit') . zen_image_submit(BUTTON_IMAGE_CONTINUE, BUTTON_CONTINUE_ALT); ?></div>
+</form>
 <?php
      }
 ?>
 
 <div class="buttonRow back"><?php echo TITLE_CONTINUE_CHECKOUT_PROCEDURE . '<br />' . TEXT_CONTINUE_CHECKOUT_PROCEDURE; ?></div>
 
-</form>
 <?php
   if ($process == true) {
 ?>

--- a/includes/templates/template_default/templates/tpl_checkout_shipping_address_default.php
+++ b/includes/templates/template_default/templates/tpl_checkout_shipping_address_default.php
@@ -54,6 +54,7 @@
 ?>
 </fieldset>
 <div class="buttonRow forward"><?php echo zen_draw_hidden_field('action', 'submit') . zen_image_submit(BUTTON_IMAGE_CONTINUE, BUTTON_CONTINUE_ALT); ?></div>
+</form>
 <?php
      }
   }
@@ -62,7 +63,6 @@
 
 <div class="buttonRow back"><?php echo TITLE_CONTINUE_CHECKOUT_PROCEDURE . '<br />' . TEXT_CONTINUE_CHECKOUT_PROCEDURE; ?></div>
 
-</form>
 <?php
   if ($process == true) {
 ?>


### PR DESCRIPTION
If a customer has only one entry in their address-book, the 'Select current address' section of the `checkout_payment_address` and `checkout_shipping_address` pages renders the `</form>` for that section, even though the `<form>` has not been opened.

The issue is present in both the `responsive_classic` and `template_default` templates' versions.

Noting that the issue is also present in the zc156 branch; suggest backport.