### PR TITLE
Fix address/amount layout on payment page

### DIFF
--- a/includes/templates/template_default/templates/tpl_checkout_payment_default.php
+++ b/includes/templates/template_default/templates/tpl_checkout_payment_default.php
@@ -37,6 +37,7 @@
 
 <div class="floatingBox important forward"><?php echo TEXT_SELECTED_BILLING_DESTINATION; ?></div>
 <br class="clearBoth" />
+<br />
 <?php // ** BEGIN PAYPAL EXPRESS CHECKOUT **
       }
       // ** END PAYPAL EXPRESS CHECKOUT ** ?>


### PR DESCRIPTION
without this fix, the payment page order summary is squeezed.   See attached image. 
<img width="545" alt="payment_issue" src="https://user-images.githubusercontent.com/4391638/66269427-38b7b980-e816-11e9-8ddf-1481d3dfb652.png">
