### PR TITLE
Remove redundant coupon_type check

### DIFF
--- a/includes/modules/order_total/ot_coupon.php
+++ b/includes/modules/order_total/ot_coupon.php
@@ -203,7 +203,7 @@ class ot_coupon {
 
       $coupon_result=$db->Execute($sql);
 
-      if (!$coupon_result->EOF && $coupon_result->fields['coupon_type'] != 'G') {
+      if (!$coupon_result->EOF) {
 
         if ($coupon_result->RecordCount() < 1 ) {
           $messageStack->add_session('redemptions', TEXT_INVALID_REDEEM_COUPON . ' ' . $dc_check,'caution');


### PR DESCRIPTION
Query already includes a clause ensuring coupon_type is not 'G' we don't need to check it in the `if` block processing the results. 