### PR TITLE
Refactor to eliminate php notice

### DIFF
--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -2537,9 +2537,9 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
   function zen_get_configuration_key_value($lookup) {
     global $db;
     $configuration_query= $db->Execute("select configuration_value from " . TABLE_CONFIGURATION . " where configuration_key='" . zen_db_input($lookup) . "'");
-    $lookup_value= $configuration_query->fields['configuration_value'];
-    if ( $configuration_query->RecordCount() == 0 ) {
-      $lookup_value='<span class="lookupAttention">' . $lookup . '</span>';
+    $lookup_value = '<span class="lookupAttention">' . $lookup . '</span>';
+    if ( $configuration_query->RecordCount() > 0 ) {
+      $lookup_value = $configuration_query->fields['configuration_value'];
     }
     return $lookup_value;
   }


### PR DESCRIPTION
If the query returns no results, then attempting to obtain `configuration_value` from the query results causes a PHP notice that will become an error in the future.  By assigning a value to `$lookup_value` first and then reassigning to an alternate value if there is a record returned, no notice/error is generated.