### PR TITLE
Fix PHP notice on empty query result

### DIFF
--- a/admin/includes/init_includes/init_db_config_read.php
+++ b/admin/includes/init_includes/init_db_config_read.php
@@ -12,7 +12,7 @@ if (!defined('IS_ADMIN_FLAG')) {
 
   $sql = "SELECT configuration_value FROM " . TABLE_CONFIGURATION . " WHERE configuration_key = 'GLOBAL_AUTH_KEY'";
   $authkey = $db->Execute($sql);
-  if ($authkey->fields['configuration_value'] == '') {
+  if (!$authkey->EOF && $authkey->fields['configuration_value'] == '') {
       $hashable = hash('sha256', openssl_random_pseudo_bytes(64));
       $sql = "UPDATE " . TABLE_CONFIGURATION . " SET configuration_value = :hash: WHERE configuration_key = 'GLOBAL_AUTH_KEY'";
       $sql = $db->bindVars($sql, ':hash:', $hashable, 'string');


### PR DESCRIPTION
Until the `configuration_key` is inserted into the database, a php notice that is expected to become an error in the future is issued.  This at least allows continued execution while the `configuration_key` is still not yet inserted without throwing the notice.  It also will mean that the internal code will not be executed if the `configuration_key` is removed from the database in the future.  I have not yet seen how this `configuration_key` is used in the code, to possibly advise of anything different.