### PR TITLE
Fix js check for onsite payment when only 1 module available

### DIFF
--- a/includes/modules/pages/checkout_payment/jscript_main.php
+++ b/includes/modules/pages/checkout_payment/jscript_main.php
@@ -42,6 +42,9 @@ function methodSelect(theMethod) {
             if($('#pmt-'+paymentValue).is(':checked')) {
                 return true;
             }
+            if ($("[name='payment']").length == 1) {
+              return true;
+            }
         }
         return false;
     }


### PR DESCRIPTION
If there is only one payment method (say Authorize AIM), there isn't a group of radio buttons with name "payment" that you can inspect to see if one is checked - there's only  one hidden field named "payment".  So an additional test is required in the onsite payment check. 