### PR TITLE
Correct banner-manager PHP notices

### DIFF
--- a/admin/banner_manager.php
+++ b/admin/banner_manager.php
@@ -113,7 +113,7 @@ if (zen_not_null($action)) {
       }
 
       if ($banner_error == false) {
-        $db_image_location = (zen_not_null($banners_image_local)) ? $banners_image_local : $banners_image_target . $banners_image->filename;
+        $db_image_location = (zen_not_null($banners_image_local) || !isset($banners_image)) ? $banners_image_local : $banners_image_target . $banners_image->filename;
         $db_image_location = zen_limit_image_filename($db_image_location, TABLE_BANNERS, 'banners_image');
         $banners_url = zen_limit_image_filename($banners_url, TABLE_BANNERS, 'banners_url');
         $sql_data_array = array(


### PR DESCRIPTION
If a banner includes _no_ image (only HTML text), PHP notices similar to the following are thrown:
```
[19-Oct-2019 10:14:46 America/Chicago] Request URI: /myadmin/banner_manager.php?page=1&action=upd, IP address: 127.0.0.1
--> PHP Notice: Undefined variable: banners_image in C:\xampp\htdocs\mystore\myadmin\banner_manager.php on line 116.

[19-Oct-2019 10:14:46 America/Chicago] Request URI: /myadmin/banner_manager.php?page=1&action=upd, IP address: 127.0.0.1
--> PHP Notice: Trying to get property of non-object in C:\xampp\htdocs\mystore\myadmin\banner_manager.php on line 116.
```
... since the `$banner_image` object is not created/available in that case.