### PR TITLE
remove unnecessary semicolon from jscript_framework

### DIFF
--- a/includes/templates/template_default/jscript/jscript_framework.php
+++ b/includes/templates/template_default/jscript/jscript_framework.php
@@ -9,7 +9,7 @@
 <script>
 if (typeof zcJS == "undefined" || !zcJS) {
   window.zcJS = { name: 'zcJS', version: '0.1.0.0' };
-};
+}
 
 zcJS.ajax = function (options) {
   options.url = options.url.replace("&amp;", unescape("&amp;"));


### PR DESCRIPTION
I note that phpstorm complains about quite a few more minor things in this file, for which I not qualified to "correct"...someone should have a look.