### PR TITLE
Shipping-cart, use 'exactly equal to' comparison

### DIFF
--- a/includes/classes/shopping_cart.php
+++ b/includes/classes/shopping_cart.php
@@ -1780,7 +1780,7 @@ class shoppingCart extends base {
         //   product dependencies and reduction of product to allow a larger increase
         //   at each product's modification.
         //   This will maximize the maximum product quantities available.
-        if ($chk_mixed == true && !array_key_exists(zen_get_prid($_POST['products_id'][$i]), $change_state)) {
+        if ($chk_mixed === true && !array_key_exists(zen_get_prid($_POST['products_id'][$i]), $change_state)) {
           $change_check = $this->in_cart_product_mixed_changed($_POST['products_id'][$i], 'decrease'); // Returns full data on products.
           $change_state[zen_get_prid($_POST['products_id'][$i])] = $change_check;
           if (is_array($change_check) && count($change_state[zen_get_prid($_POST['products_id'][$i])]['decrease']) > 0) {


### PR DESCRIPTION
The return value from `zen_get_products_quantity_mixed` can be one of (bool)true, (bool)false or (string)'none'.

Using a simple equality check for the function's return value results in an unwanted entry to the following code section when the product does not have attributes since both 'none' and (bool)true will trigger a condition 'match'.