### PR TITLE
Fixes #2889: Correcting various PayPal-related PHP notices

### DIFF
--- a/includes/modules/payment/paypal/paypal_functions.php
+++ b/includes/modules/payment/paypal/paypal_functions.php
@@ -50,7 +50,7 @@
     $stored_session = $db->Execute($sql);
     if ($stored_session->recordCount() < 1) {
       global $isECtransaction, $isDPtransaction;
-      if ($_POST['payment_type'] == 'instant' && $isDPtransaction && ((isset($_POST['auth_status']) && $_POST['auth_status'] == 'Completed') || $_POST['payment_status'] == 'Completed')) {
+      if (isset($_POST['payment_type']) && $_POST['payment_type'] == 'instant' && $isDPtransaction && ((isset($_POST['auth_status']) && $_POST['auth_status'] == 'Completed') || $_POST['payment_status'] == 'Completed')) {
         $session_stuff[1] = '(EC/DP transaction)';
       }
       ipn_debug_email('IPN ERROR :: Could not find stored session {' . $session_stuff[1] . '} in DB; thus cannot validate or re-create session as a transaction awaiting PayPal Website Payments Standard confirmation initiated by this store. Might be an Express Checkout or eBay transaction or some other action that triggers PayPal IPN notifications.');
@@ -73,9 +73,9 @@
                 FROM " . TABLE_PAYPAL . "
                 WHERE txn_id = :transactionID: OR invoice = :transactionID:
                 ORDER BY order_id DESC LIMIT 1 ";
-    $sqlParent = $db->bindVars($sql, ':transactionID:', $postArray['parent_txn_id'], 'string');
-    $sqlTxn = $db->bindVars($sql, ':transactionID:', $postArray['txn_id'], 'string');
+
     if (isset($postArray['parent_txn_id']) && trim($postArray['parent_txn_id']) != '') {
+      $sqlParent = $db->bindVars($sql, ':transactionID:', $postArray['parent_txn_id'], 'string');
       $ipn_id = $db->Execute($sqlParent);
       if($ipn_id->RecordCount() > 0) {
         ipn_debug_email('IPN NOTICE :: This transaction HAS a parent record. Thus this is an update of some sort.');
@@ -84,6 +84,7 @@
         $paypalipnID = $ipn_id->fields['paypal_ipn_id'];
       }
     } else {
+      $sqlTxn = $db->bindVars($sql, ':transactionID:', $postArray['txn_id'], 'string');
       $ipn_id = $db->Execute($sqlTxn);
       if ($ipn_id->RecordCount() <= 0) {
         ipn_debug_email('IPN NOTICE :: Could not find matched txn_id record in DB. Therefore is new to us. ');

--- a/includes/modules/payment/paypal/paypalwpp_admin_notification.php
+++ b/includes/modules/payment/paypal/paypalwpp_admin_notification.php
@@ -168,6 +168,20 @@ if (!empty($response['RESPMSG'])) {
         $outputPayPal .= '</td></tr>'."\n";
     }
 
+    $optional_fields = array(
+        'SHIPTONAME',
+        'SHIPTOSTREET',
+        'SHIPTOCITY',
+        'SHIPTOSTATE',
+        'SHIPTOZIP',
+        'SHIPTOCOUNTRYNAME',
+        'FEEAMT',               //- Not present when the last PayPal action was a refund/void
+    );
+    foreach ($optional_fields as $optional) {
+        if (!isset($response[$optional])) {
+            $response[$optional] = 'n/a';
+        }
+    }
     $outputPayPal .= '<tr><td class="main">'."\n";
     $outputPayPal .= MODULE_PAYMENT_PAYPAL_ENTRY_ADDRESS_NAME."\n";
     $outputPayPal .= '</td><td class="main">'."\n";


### PR DESCRIPTION
paypaldp.php:

Line 1162: Check for variable presence prior to use.
Line 1842: (starting) Check for L_ERRORCODE0 presence prior to use.
Line 1851: Check for L_ERRORCODE0 presence prior to use.
Line 1863: (starting) Account for lack of session information when loaded during admin orders' processing.

paypal_functions.php

Line 53: Check for payment_type variable presence prior to use.
Lines 77-87: Move usage of txn_id since it might not be set.

paypal_admin_notifications.php

Lines 172-185: Shipping address might not be present, e.g. a virtual order.  Initialize values for subsequent use

paypalwpp.php

Lines 327-330: Initialize PAYMENTREQUEST_0_PAYMENTACTION prior to use
Line 386-388: PAYMENTREQUEST_0_SHIPTOCITY isn't set for virtual orders.
Line 782: $_GET['token'] might not be present
Line 1063: Initialize variable for follow-on use.
Line 1295: Check for module presence, it's not present if the shipping method was 'free_free'.
Lines 1831-1852: Account for variable absence (and optional elements), prevents follow-on PHP notices when one or more elements are missing.
Lines 1861-1871: More optional elements, initialize if not present
Line 1882: Correct ship-to country name array element 'name'
Line 1892: There's no SHIPTOSTREET1, replace with SHIPTOSTREET.
Lines 2678-2680: entry_gender might not be supplied