### PR TITLE
Fix #2889: Correcting various PayPal PHP notices (zc156)

### DIFF
--- a/includes/modules/payment/paypal/paypal_functions.php
+++ b/includes/modules/payment/paypal/paypal_functions.php
@@ -50,7 +50,7 @@
     $stored_session = $db->Execute($sql);
     if ($stored_session->recordCount() < 1) {
       global $isECtransaction, $isDPtransaction;
-      if ($_POST['payment_type'] == 'instant' && $isDPtransaction && ((isset($_POST['auth_status']) && $_POST['auth_status'] == 'Completed') || $_POST['payment_status'] == 'Completed')) {
+      if (isset($_POST['payment_type']) && $_POST['payment_type'] == 'instant' && $isDPtransaction && ((isset($_POST['auth_status']) && $_POST['auth_status'] == 'Completed') || $_POST['payment_status'] == 'Completed')) {
         $session_stuff[1] = '(EC/DP transaction)';
       }
       ipn_debug_email('IPN ERROR :: Could not find stored session {' . $session_stuff[1] . '} in DB; thus cannot validate or re-create session as a transaction awaiting PayPal Website Payments Standard confirmation initiated by this store. Might be an Express Checkout or eBay transaction or some other action that triggers PayPal IPN notifications.');
@@ -73,9 +73,9 @@
                 FROM " . TABLE_PAYPAL . "
                 WHERE txn_id = :transactionID: OR invoice = :transactionID:
                 ORDER BY order_id DESC LIMIT 1 ";
-    $sqlParent = $db->bindVars($sql, ':transactionID:', $postArray['parent_txn_id'], 'string');
-    $sqlTxn = $db->bindVars($sql, ':transactionID:', $postArray['txn_id'], 'string');
+
     if (isset($postArray['parent_txn_id']) && trim($postArray['parent_txn_id']) != '') {
+      $sqlParent = $db->bindVars($sql, ':transactionID:', $postArray['parent_txn_id'], 'string');
       $ipn_id = $db->Execute($sqlParent);
       if($ipn_id->RecordCount() > 0) {
         ipn_debug_email('IPN NOTICE :: This transaction HAS a parent record. Thus this is an update of some sort.');
@@ -84,6 +84,7 @@
         $paypalipnID = $ipn_id->fields['paypal_ipn_id'];
       }
     } else {
+      $sqlTxn = $db->bindVars($sql, ':transactionID:', $postArray['txn_id'], 'string');
       $ipn_id = $db->Execute($sqlTxn);
       if ($ipn_id->RecordCount() <= 0) {
         ipn_debug_email('IPN NOTICE :: Could not find matched txn_id record in DB. Therefore is new to us. ');

--- a/includes/modules/payment/paypal/paypalwpp_admin_notification.php
+++ b/includes/modules/payment/paypal/paypalwpp_admin_notification.php
@@ -46,7 +46,7 @@ function characterCount(field, count, maxchars) {
     $outputEndBlock .='</table></td>'."\n";
 
 
-  if ($response['RESPMSG'] != '') {
+if (!empty($response['RESPMSG'])) {
     // these would be payflow transactions
 
     $outputPFmain .= '<td valign="top"><table>'."\n";
@@ -100,7 +100,7 @@ function characterCount(field, count, maxchars) {
     $outputPFmain .= $response['TRANSSTATE'] ."\n";
     $outputPFmain .= '</td></tr>'."\n";
 
-    if ($response['DAYS_TO_SETTLE'] != '' ) {
+    if (!empty($response['DAYS_TO_SETTLE'])) {
       $outputPFmain .= '<tr><td class="main">'."\n";
       $outputPFmain .= MODULE_PAYMENT_PAYPAL_ENTRY_DAYSTOSETTLE."\n";
       $outputPFmain .= '</td><td class="main">'."\n";
@@ -161,21 +161,38 @@ function characterCount(field, count, maxchars) {
     $outputPayPal .= urldecode($response['LASTNAME']) ."\n";
     $outputPayPal .= '</td></tr>'."\n";
 
+    if (!empty($response['BUSINESS'])) {
     $outputPayPal .= '<tr><td class="main">'."\n";
     $outputPayPal .= MODULE_PAYMENT_PAYPAL_ENTRY_BUSINESS_NAME."\n";
     $outputPayPal .= '</td><td class="main">'."\n";
     $outputPayPal .= urldecode($response['BUSINESS']) ."\n";
     $outputPayPal .= '</td></tr>'."\n";
+    }
+
+    $optional_fields = array(
+        'SHIPTONAME',
+        'SHIPTOSTREET',
+        'SHIPTOCITY',
+        'SHIPTOSTATE',
+        'SHIPTOZIP',
+        'SHIPTOCOUNTRYNAME',
+        'FEEAMT',               //- Not present when the last PayPal action was a refund/void
+    );
+    foreach ($optional_fields as $optional) {
+        if (!isset($response[$optional])) {
+            $response[$optional] = 'n/a';
+        }
+    }
 
     $outputPayPal .= '<tr><td class="main">'."\n";
     $outputPayPal .= MODULE_PAYMENT_PAYPAL_ENTRY_ADDRESS_NAME."\n";
     $outputPayPal .= '</td><td class="main">'."\n";
-    $outputPayPal .= urldecode($response['NAME']) ."\n";
+    $outputPayPal .= urldecode($response['SHIPTONAME']) ."\n";
     $outputPayPal .= '</td></tr>'."\n";
     $outputPayPal .= '<tr><td class="main">'."\n";
     $outputPayPal .= MODULE_PAYMENT_PAYPAL_ENTRY_ADDRESS_STREET."\n";
     $outputPayPal .= '</td><td class="main">'."\n";
-    $outputPayPal .= urldecode($response['SHIPTOSTREET']) . ' ' . urldecode($response['SHIPTOSTREET2']) ."\n";
+    $outputPayPal .= urldecode($response['SHIPTOSTREET']) . ' ' . (!empty($response['SHIPTOSTREET2']) ? urldecode($response['SHIPTOSTREET2']) : '') ."\n";
     $outputPayPal .= '</td></tr>'."\n";
     $outputPayPal .= '<tr><td class="main">'."\n";
     $outputPayPal .= MODULE_PAYMENT_PAYPAL_ENTRY_ADDRESS_CITY."\n";
@@ -190,7 +207,7 @@ function characterCount(field, count, maxchars) {
     $outputPayPal .= '<tr><td class="main">'."\n";
     $outputPayPal .= MODULE_PAYMENT_PAYPAL_ENTRY_ADDRESS_COUNTRY."\n";
     $outputPayPal .= '</td><td class="main">'."\n";
-    $outputPayPal .= urldecode($response['SHIPTOCOUNTRY']) ."\n";
+    $outputPayPal .= urldecode($response['SHIPTOCOUNTRYNAME']) ."\n";
     $outputPayPal .= '</td></tr>'."\n";
 
     $outputPayPal .= '</table></td>'."\n";
@@ -206,7 +223,7 @@ function characterCount(field, count, maxchars) {
     $outputPayPal .= '<tr><td class="main">'."\n";
     $outputPayPal .= MODULE_PAYMENT_PAYPAL_ENTRY_EBAY_ID."\n";
     $outputPayPal .= '</td><td class="main">'."\n";
-    $outputPayPal .= urldecode($response['BUYERID']) ."\n";
+    $outputPayPal .= (!empty($response['BUYERID']) ? urldecode($response['BUYERID']) : '') ."\n";
     $outputPayPal .= '</td></tr>'."\n";
 
     $outputPayPal .= '<tr><td class="main">'."\n";
@@ -236,9 +253,9 @@ function characterCount(field, count, maxchars) {
     $outputPayPal .= '<tr><td class="main">'."\n";
     $outputPayPal .= MODULE_PAYMENT_PAYPAL_ENTRY_PARENT_TXN_ID."\n";
     $outputPayPal .= '</td><td class="main">'."\n";
-    $outputPayPal .= urldecode($response['PARENTTRANSACTIONID']) ."\n";
+    $outputPayPal .= (!empty($response['PARENTTRANSACTIONID']) ? urldecode($response['PARENTTRANSACTIONID']) : '') ."\n";
     $outputPayPal .= '</td></tr>'."\n";
-  if (defined('MODULE_PAYMENT_PAYPALWPP_ENTRY_PROTECTIONELIG') && isset($response['PROTECTIONELIGIBILITY']) && $response['PROTECTIONELIGIBILITY'] != '') {
+    if (defined('MODULE_PAYMENT_PAYPALWPP_ENTRY_PROTECTIONELIG') && !empty($response['PROTECTIONELIGIBILITY'])) {
     $outputPayPal .= '<tr><td class="main">'."\n";
     $outputPayPal .= MODULE_PAYMENT_PAYPALWPP_ENTRY_PROTECTIONELIG."\n";
     $outputPayPal .= '</td><td class="main">'."\n";
@@ -300,7 +317,7 @@ function characterCount(field, count, maxchars) {
     $outputPayPal .= '<tr><td class="main">'."\n";
     $outputPayPal .= MODULE_PAYMENT_PAYPAL_ENTRY_CURRENCY."\n";
     $outputPayPal .= '</td><td class="main">'."\n";
-    $outputPayPal .= $ipn->fields['mc_currency'] . ' ' . urldecode($response['CURRENCY']) ."\n";
+    $outputPayPal .= $ipn->fields['mc_currency'] . ' ' . urldecode($response['CURRENCYCODE']) ."\n";
     $outputPayPal .= '</td></tr>'."\n";
 
     $outputPayPal .= '<tr><td class="main">'."\n";
@@ -318,7 +335,7 @@ function characterCount(field, count, maxchars) {
     $outputPayPal .= '<tr><td class="main">'."\n";
     $outputPayPal .= MODULE_PAYMENT_PAYPAL_ENTRY_EXCHANGE_RATE."\n";
     $outputPayPal .= '</td><td class="main">'."\n";
-    $outputPayPal .= urldecode($response['EXCHANGERATE']) ."\n";
+    $outputPayPal .= (!empty($response['EXCHANGERATE']) ? urldecode($response['EXCHANGERATE']) : '') ."\n";
     $outputPayPal .= '</td></tr>'."\n";
 
     $outputPayPal .= '<tr><td class="main">'."\n";
@@ -410,14 +427,19 @@ function characterCount(field, count, maxchars) {
   $output = '<!-- BOF: pp admin transaction processing tools -->';
   $output .= $outputStartBlock;
 
-//debug
-//$output .= '<pre>' . print_r($response, true) . '</pre>';
+  $authcapt_on = (isset($_GET['authcapt']) && $_GET['authcapt'] == 'on');
 
   if (isset($response['RESPMSG']) /*|| defined('MODULE_PAYMENT_PAYFLOW_STATUS')*/) { // payflow
     $output .= $outputPFmain;
-    if (method_exists($this, '_doVoid') && (MODULE_PAYMENT_PAYPALDP_TRANSACTION_MODE == 'Auth Only' || MODULE_PAYMENT_PAYFLOW_TRANSACTION_MODE == 'Auth Only' || (isset($_GET['authcapt']) && $_GET['authcapt']=='on'))) $output .= $outputVoid;
-    if (method_exists($this, '_doCapt') && (MODULE_PAYMENT_PAYPALDP_TRANSACTION_MODE == 'Auth Only' || MODULE_PAYMENT_PAYFLOW_TRANSACTION_MODE == 'Auth Only' || (isset($_GET['authcapt']) && $_GET['authcapt']=='on'))) $output .= $outputCapt;
-    if (method_exists($this, '_doRefund')) $output .= $outputRefund;
+    if (method_exists($this, '_doVoid') && (MODULE_PAYMENT_PAYPALDP_TRANSACTION_MODE == 'Auth Only' || MODULE_PAYMENT_PAYFLOW_TRANSACTION_MODE == 'Auth Only' || $authcapt_on)) {
+        $output .= $outputVoid;
+    }
+    if (method_exists($this, '_doCapt') && (MODULE_PAYMENT_PAYPALDP_TRANSACTION_MODE == 'Auth Only' || MODULE_PAYMENT_PAYFLOW_TRANSACTION_MODE == 'Auth Only' || $authcapt_on)) {
+        $output .= $outputCapt;
+    }
+    if (method_exists($this, '_doRefund')) {
+        $output .= $outputRefund;
+    }
   } else {  // PayPal
     $output .= $outputPayPal;
 
@@ -426,14 +448,30 @@ function characterCount(field, count, maxchars) {
       $output .= '</tr><tr>' . "\n";
       $output .= $outputStartBlock;
       $output .= $outputStartBlock;
-      if ($response['TRANSACTION_TYPE'] == 'Authorization' || (in_array($response['TRANSACTIONTYPE'], array('cart','expresscheckout','webaccept') ) && $response['PAYMENTTYPE'] == 'instant' && $response['PENDINGREASON'] == 'authorization') || (isset($_GET['authcapt']) && $_GET['authcapt']=='on')) {
-        if (method_exists($this, '_doRefund') && ($response['PAYMENTTYPE'] != 'instant' || $module == 'paypaldp')) $output .= $outputRefund;
-        if (method_exists($this, '_doAuth') && (MODULE_PAYMENT_PAYPALWPP_TRANSACTION_MODE == 'Auth Only' || MODULE_PAYMENT_PAYPALDP_TRANSACTION_MODE == 'Auth Only')) $output .= $outputAuth;
-        if (method_exists($this, '_doCapt') && (MODULE_PAYMENT_PAYPALWPP_TRANSACTION_MODE == 'Auth Only' || MODULE_PAYMENT_PAYPALDP_TRANSACTION_MODE == 'Auth Only')) $output .= $outputCapt;
-        if (method_exists($this, '_doVoid')) $output .= $outputVoid;
+      $transaction_type_authorization = (isset($response['TRANSACTION_TYPE']) && $response['TRANSACTION_TYPE'] == 'Authorization');
+      $transactiontype_payment = in_array($response['TRANSACTIONTYPE'], array('cart', 'expresscheckout', 'webaccept'));
+      if ($transaction_type_authorization || ($transactiontype_payment && $response['PAYMENTTYPE'] == 'instant' && $response['PENDINGREASON'] == 'authorization') || $authcapt_on) {
+        if (method_exists($this, '_doRefund') && ($response['PAYMENTTYPE'] != 'instant' || $module == 'paypaldp')) {
+          $output .= $outputRefund;
+        }
+        if (MODULE_PAYMENT_PAYPALWPP_TRANSACTION_MODE == 'Auth Only' || MODULE_PAYMENT_PAYPALDP_TRANSACTION_MODE == 'Auth Only') {
+          if (method_exists($this, '_doAuth')) {
+            $output .= $outputAuth;
+          }
+          if (method_exists($this, '_doCapt')) {
+            $output .= $outputCapt;
+          }
+        }
+        if (method_exists($this, '_doVoid')) {
+          $output .= $outputVoid;
+        }
       } else {
-        if (method_exists($this, '_doRefund') /* && ($response['PAYMENTTYPE'] != 'instant' || $module == 'paypaldp') */) $output .= $outputRefund;
-        if (method_exists($this, '_doVoid') && $response['PAYMENTTYPE'] == 'instant' && $response['PAYMENTSTATUS'] != 'Voided' && $module != 'paypaldp') $output .= $outputVoid;
+        if (method_exists($this, '_doRefund') /* && ($response['PAYMENTTYPE'] != 'instant' || $module == 'paypaldp') */) {
+          $output .= $outputRefund;
+        }
+        if (method_exists($this, '_doVoid') && $response['PAYMENTTYPE'] == 'instant' && $response['PAYMENTSTATUS'] != 'Voided' && $module != 'paypaldp') {
+          $output .= $outputVoid;
+        }
       }
     }
   }

--- a/includes/modules/payment/paypaldp.php
+++ b/includes/modules/payment/paypaldp.php
@@ -678,7 +678,7 @@ class paypaldp extends base {
       $order->info['ip_address'] = $cc_owner_ip;
 
       // Set currency
-      $my_currency = $this->selectCurrency($order->info['currency'], 'DP');
+      $my_currency = $this->selectCurrency($order->info['currency']);
 
       // if CC is maestro or solo, must be GBP
       if (in_array($cc_type, array('Solo', 'Maestro'))) {
@@ -1159,7 +1159,7 @@ class paypaldp extends base {
    */
   function paypal_init() {
     $nvp = (MODULE_PAYMENT_PAYPALWPP_APIPASSWORD != '' && MODULE_PAYMENT_PAYPALWPP_APISIGNATURE != '') ? true : false;
-    $ec = ($nvp && $_GET['type'] == 'ec') ? true : false;
+    $ec = ($nvp && isset($_GET['type']) && $_GET['type'] == 'ec') ? true : false;
     if (MODULE_PAYMENT_PAYPALDP_MERCHANT_COUNTRY == 'UK' && !$ec) {
       $doPayPal = new paypal_curl(array('mode' => 'payflow',
                                         'user' =>   trim(MODULE_PAYMENT_PAYPALWPP_PFUSER),
@@ -1839,12 +1839,16 @@ class paypaldp extends base {
     global $messageStack, $doPayPal;
     $gateway_mode = (isset($response['PNREF']) && $response['PNREF'] != '');
     $basicError = (!$response || (isset($response['RESULT']) && $response['RESULT'] != 0) || (isset($response['ACK']) && !strstr($response['ACK'], 'Success')) || (!isset($response['RESULT']) && !isset($response['ACK'])));
-    $ignoreList = explode(',', str_replace(' ', '', $ignore_codes));
-    foreach($ignoreList as $key=>$value) {
-      if ($value != '' && $response['L_ERRORCODE0'] == $value) $basicError = false;
+    if (isset($response['L_ERRORCODE0'])) {
+        $ignoreList = explode(',', str_replace(' ', '', $ignore_codes));
+        foreach ($ignoreList as $key=>$value) {
+            if ($value != '' && $response['L_ERRORCODE0'] == $value) {
+                $basicError = false;
+            }
+        }
     }
     /** Handle FMF Scenarios **/
-    if (in_array($operation, array('DoExpressCheckoutPayment', 'DoDirectPayment')) && $response['PAYMENTSTATUS'] == 'Pending' && $response['L_ERRORCODE0'] == 11610) {
+    if (in_array($operation, array('DoExpressCheckoutPayment', 'DoDirectPayment')) && $response['PAYMENTSTATUS'] == 'Pending' && isset($response['L_ERRORCODE0']) && $response['L_ERRORCODE0'] == 11610) {
       $this->fmfResponse = urldecode($response['L_SHORTMESSAGE0']);
       $this->fmfErrors = array();
       if ($response['ACK'] == 'SuccessWithWarning' && isset($response['L_FMFPENDINGID0'])) {
@@ -1856,7 +1860,11 @@ class paypaldp extends base {
     }
     //echo '<br />basicError='.$basicError.'<br />' . urldecode(print_r($response,true)); die('halted');
     if (!isset($response['L_SHORTMESSAGE0']) && isset($response['RESPMSG']) && $response['RESPMSG'] != '') $response['L_SHORTMESSAGE0'] = $response['RESPMSG'];
-    $errorInfo = 'Problem occurred while customer ' . zen_output_string_protected($_SESSION['customer_id'] . ' ' . $_SESSION['customer_first_name'] . ' ' . $_SESSION['customer_last_name']) . ' was attempting checkout with PayPal Website Payments Pro.';
+    if (IS_ADMIN_FLAG === false) {
+        $errorInfo = 'Problem occurred while customer ' . zen_output_string_protected($_SESSION['customer_id'] . ' ' . $_SESSION['customer_first_name'] . ' ' . $_SESSION['customer_last_name']) . ' was attempting checkout with PayPal Website Payments Pro.';
+    } else {
+        $errorInfo = 'Problem occurred during admin updates using PayPal Website Payments Pro.';
+    }
 
     switch($operation) {
       case 'DoDirectPayment':


### PR DESCRIPTION
paypaldp.php:

Line 1162: Check for variable presence prior to use.
Line 1842: (starting) Check for L_ERRORCODE0 presence prior to use.
Line 1851: Check for L_ERRORCODE0 presence prior to use.
Line 1863: (starting) Account for lack of session information when loaded during admin orders' processing.

paypal_functions.php

Line 53: Check for payment_type variable presence prior to use.
Lines 77-87: Move usage of txn_id since it might not be set.

paypal_admin_notifications.php

Line 49: Use empty() to check variable presence.
Line 103: Ditto
Lines 163-169: 'BUSINESS' might not be populated, check first
Lines 172-185: Shipping address might not be present, e.g. a virtual order.  Initialize values for subsequent use
Line 190: NAME -> SHIPTONAME
Line 195: SHIPTOSTREET2 is an optional entry, check for presence prior to use
Line 210: SHIPTOCOUNTRY -> SHIPTOCOUNTRYNAME
Line 226: BUYERID might not be populated, check for presence
Line 256: PARENTTRANSACTIONID might not be populated, check for presence
Line 264: Simplify check for PROTECTIONELIGIBILITY
Line 320: CURRENCY -> CURRENCYCODE
Line 338: EXCHANGERATE might not be populated, check for presence
Lines 430-478: Simplify checks for auth-capture

paypalwpp.php

Line 185: Check for definition prior to use
Lines 328-333: Use correct array index
Line 386-388: PAYMENTREQUEST_0_SHIPTOCITY isn't set for virtual orders.
Line 447: Check for variable presence prior to use
Line 473: Values are in response array, not class variable
Line 520: PNREF might not be present.
Line 529: Correct variable name
Line 544: PAYMENTINFO_0_SETTLEAMT might not be present
Line 546: PAYMENTINFO_0_EXCHANGERATE might not be present.
Line 782: $_GET['token'] might not be present
Line 1064: Initialize variable for follow-on use.
Line 1295: Check for module presence, it's not present if the shipping method was 'free_free'.
Line 1614: Correct 'spelling' of array-index name
Lines 1670-1672: The phone number might be empty, generating PHP notice on substr
Line 1713: Check for variable presence prior to use
Line 1738: Ditto.
Lines 1831-1852: Account for variable absence (and optional elements), prevents follow-on PHP notices when one or more elements are missing.
Lines 1861-1871: More optional elements, initialize if not present
Line 1882: Correct ship-to country name array element 'name'
Line 1892: There's no SHIPTOSTREET1, replace with SHIPTOSTREET.
Lines 2678-2680: entry_gender might not be supplied