### PR TITLE
prevent advanced search result PHP notice Undefined index: keyword

### DIFF
--- a/includes/modules/pages/advanced_search_result/header_php.php
+++ b/includes/modules/pages/advanced_search_result/header_php.php
@@ -25,7 +25,11 @@ require(zen_get_index_filters_directory($typefilter . '_filter.php'));
 $error = false;
 $missing_one_input = false;
 
-$_GET['keyword'] = trim($_GET['keyword']);
+if (empty($_GET['keyword'])) {
+    zen_redirect(zen_href_link(FILENAME_ADVANCED_SEARCH));
+} else {
+    trim($_GET['keyword']);
+}
 
 // -----
 // Give an observer the chance to indicate that there's another element to the search


### PR DESCRIPTION
check keyword to prevent php notice when spider hits page with no keyword and causes php notice

PHP Notice:  Undefined index: keyword in \public_html\zencart-157\includes\modules\pages\advanced_search_result\header_php.php on line 28