### PR TITLE
advanced_search_result: Correcting PHP notice

### DIFF
--- a/includes/modules/pages/advanced_search_result/header_php.php
+++ b/includes/modules/pages/advanced_search_result/header_php.php
@@ -25,7 +25,7 @@ require(zen_get_index_filters_directory($typefilter . '_filter.php'));
 $error = false;
 $missing_one_input = false;
 
-$_GET['keyword'] = trim($_GET['keyword']);
+$_GET['keyword'] = isset($_GET['keyword']) ? trim($_GET['keyword']) : '';
 
 // -----
 // Give an observer the chance to indicate that there's another element to the search
@@ -35,7 +35,7 @@ $search_additional_clause = false;
 $zco_notifier->notify('NOTIFY_ADVANCED_SEARCH_RESULTS_ADDL_CLAUSE', array(), $search_additional_clause);
 
 if ($search_additional_clause === false && 
-(isset($_GET['keyword']) && (empty($_GET['keyword']) || $_GET['keyword']== HEADER_SEARCH_DEFAULT_TEXT || $_GET['keyword'] == KEYWORD_FORMAT_STRING ) ) &&
+(empty($_GET['keyword']) || $_GET['keyword'] == HEADER_SEARCH_DEFAULT_TEXT || $_GET['keyword'] == KEYWORD_FORMAT_STRING) &&
 (isset($_GET['dfrom']) && (empty($_GET['dfrom']) || ($_GET['dfrom'] == DOB_FORMAT_STRING))) &&
 (isset($_GET['dto']) && (empty($_GET['dto']) || ($_GET['dto'] == DOB_FORMAT_STRING))) &&
 (isset($_GET['pfrom']) && !is_numeric($_GET['pfrom'])) &&


### PR DESCRIPTION
... when `$_GET['keyword']` isn't supplied.  Also simplifies the initial "any variables set" check.