### PR TITLE
add message stack texts for developer email testing notifications

### DIFF
--- a/admin/includes/init_includes/init_errors.php
+++ b/admin/includes/init_includes/init_errors.php
@@ -31,9 +31,8 @@ if (!defined('IS_ADMIN_FLAG')) {
 // check if email sending has been disabled by developer switch
   if (defined('DEVELOPER_OVERRIDE_EMAIL_STATUS') && DEVELOPER_OVERRIDE_EMAIL_STATUS == 'false') {
       $messageStack->add(WARNING_EMAIL_SYSTEM_DEVELOPER_OVERRIDE, 'info');
-  }
 // check if email destinations have been diverted by developer switch
-  if (defined('DEVELOPER_OVERRIDE_EMAIL_ADDRESS') && DEVELOPER_OVERRIDE_EMAIL_ADDRESS != '') {
+  } elseif (defined('DEVELOPER_OVERRIDE_EMAIL_ADDRESS') && DEVELOPER_OVERRIDE_EMAIL_ADDRESS != '') {
       $messageStack->add(sprintf(WARNING_EMAIL_SYSTEM_DEVELOPER_EMAIL, DEVELOPER_OVERRIDE_EMAIL_ADDRESS), 'info');
   }
 

--- a/admin/includes/init_includes/init_errors.php
+++ b/admin/includes/init_includes/init_errors.php
@@ -33,7 +33,7 @@ if (!defined('IS_ADMIN_FLAG')) {
       $messageStack->add(WARNING_EMAIL_SYSTEM_DEVELOPER_OVERRIDE, 'info');
 // check if email destinations have been diverted by developer switch
   } elseif (defined('DEVELOPER_OVERRIDE_EMAIL_ADDRESS') && DEVELOPER_OVERRIDE_EMAIL_ADDRESS != '') {
-      $messageStack->add(sprintf(WARNING_EMAIL_SYSTEM_DEVELOPER_EMAIL, DEVELOPER_OVERRIDE_EMAIL_ADDRESS), 'info');
+      $messageStack->add(sprintf(zen_output_string_protected(WARNING_EMAIL_SYSTEM_DEVELOPER_EMAIL), DEVELOPER_OVERRIDE_EMAIL_ADDRESS), 'info');
   }
 
   // this will let the admin know that the website is DOWN FOR MAINTENANCE to the public

--- a/admin/includes/init_includes/init_errors.php
+++ b/admin/includes/init_includes/init_errors.php
@@ -28,6 +28,14 @@ if (!defined('IS_ADMIN_FLAG')) {
   if (SEND_EMAILS != 'true') {
     $messageStack->add(WARNING_EMAIL_SYSTEM_DISABLED, 'error');
   }
+// check if email sending has been disabled by developer switch
+  if (defined('DEVELOPER_OVERRIDE_EMAIL_STATUS') && DEVELOPER_OVERRIDE_EMAIL_STATUS == 'false') {
+      $messageStack->add(WARNING_EMAIL_SYSTEM_DEVELOPER_OVERRIDE, 'info');
+  }
+// check if email destinations have been diverted by developer switch
+  if (defined('DEVELOPER_OVERRIDE_EMAIL_ADDRESS') && DEVELOPER_OVERRIDE_EMAIL_ADDRESS != '') {
+      $messageStack->add(sprintf(WARNING_EMAIL_SYSTEM_DEVELOPER_EMAIL, DEVELOPER_OVERRIDE_EMAIL_ADDRESS), 'info');
+  }
 
   // this will let the admin know that the website is DOWN FOR MAINTENANCE to the public
   if (DOWN_FOR_MAINTENANCE == 'true') {

--- a/admin/includes/languages/english.php
+++ b/admin/includes/languages/english.php
@@ -758,8 +758,10 @@ define('EMAIL_SALUTATION', 'Dear');
 
   define('WARNING_WELCOME_DISCOUNT_COUPON_EXPIRES_IN', 'WARNING! Welcome Email Discount Coupon expires in %s days');
 
-define('WARNING_ADMIN_FOLDERNAME_VULNERABLE', 'CAUTION: <a href="http://tutorials.zen-cart.com/index.php?article=33" target="_blank">Your /admin/ foldername should be renamed to something less common</a>, to prevent unauthorized access.');
-define('WARNING_EMAIL_SYSTEM_DISABLED', 'WARNING: The email subsystem is turned off. No emails will be sent until it is re-enabled in Admin->Configuration->Email Options.');
+define('WARNING_ADMIN_FOLDERNAME_VULNERABLE', 'CAUTION: <a href="https://tutorials.zen-cart.com/index.php?article=33" target="_blank">Your /admin/ foldername should be renamed to something less common</a>, to prevent unauthorized access.');
+define('WARNING_EMAIL_SYSTEM_DISABLED', 'WARNING: The email subsystem is disabled. No emails will be sent until it is re-enabled in Admin->Configuration->Email Options.');
+define('WARNING_EMAIL_SYSTEM_DEVELOPER_OVERRIDE', 'WARNING: The sending of emails has been disabled as developer switch "DEVELOPER_OVERRIDE_EMAIL_STATUS" is set to "false".');
+define('WARNING_EMAIL_SYSTEM_DEVELOPER_EMAIL', 'WARNING: ALL emails will be sent to %s as switch "DEVELOPER_OVERRIDE_EMAIL_ADDRESS" is defined as such.');
 define('TEXT_CURRENT_VER_IS', 'You are presently using: ');
 define('ERROR_NO_DATA_TO_SAVE', 'ERROR: The data you submitted was found to be empty. YOUR CHANGES HAVE *NOT* BEEN SAVED. You may have a problem with your browser or your internet connection.');
 define('TEXT_HIDDEN', 'Hidden');

--- a/admin/includes/languages/english.php
+++ b/admin/includes/languages/english.php
@@ -761,7 +761,7 @@ define('EMAIL_SALUTATION', 'Dear');
 define('WARNING_ADMIN_FOLDERNAME_VULNERABLE', 'CAUTION: <a href="https://tutorials.zen-cart.com/index.php?article=33" target="_blank">Your /admin/ foldername should be renamed to something less common</a>, to prevent unauthorized access.');
 define('WARNING_EMAIL_SYSTEM_DISABLED', 'WARNING: The email subsystem is disabled. No emails will be sent until it is re-enabled in Admin->Configuration->Email Options.');
 define('WARNING_EMAIL_SYSTEM_DEVELOPER_OVERRIDE', 'WARNING: The sending of emails has been disabled as developer switch "DEVELOPER_OVERRIDE_EMAIL_STATUS" is set to "false".');
-define('WARNING_EMAIL_SYSTEM_DEVELOPER_EMAIL', 'WARNING: ALL emails will be sent to %s as switch "DEVELOPER_OVERRIDE_EMAIL_ADDRESS" is defined as such.');
+define('WARNING_EMAIL_SYSTEM_DEVELOPER_EMAIL', 'WARNING: ALL emails will be sent to %s (as defined in "DEVELOPER_OVERRIDE_EMAIL_ADDRESS").');
 define('TEXT_CURRENT_VER_IS', 'You are presently using: ');
 define('ERROR_NO_DATA_TO_SAVE', 'ERROR: The data you submitted was found to be empty. YOUR CHANGES HAVE *NOT* BEEN SAVED. You may have a problem with your browser or your internet connection.');
 define('TEXT_HIDDEN', 'Hidden');


### PR DESCRIPTION
I was deliberating if the developer disable email switch was simply a duplication of the admin switch, but it has its use, placed in a /local/configure.php.

![Clipboard01](https://user-images.githubusercontent.com/4391026/68087882-053e6e00-fe5a-11e9-9911-99e63f2f03df.gif)
