### PR TITLE
options_values_manager: Correcting PHP notice

### DIFF
--- a/admin/options_values_manager.php
+++ b/admin/options_values_manager.php
@@ -86,6 +86,7 @@ if (zen_not_null($action)) {
 
 // alert if possible duplicate
       $duplicate_option_values = '';
+      $check_dups = '';
       for ($i = 0, $n = sizeof($languages); $i < $n; $i ++) {
         $value_name = zen_db_prepare_input($value_name_array[$languages[$i]['id']]);
 


### PR DESCRIPTION
Seeing notices similar to the following:
```
[03-Nov-2019 09:31:28 America/Chicago] Request URI: /myadmin/options_values_manager.php?action=add_product_option_values&value_page=6, IP address: redacted
--> PHP Notice: Undefined variable: check_dups in /home/mystore/public_html/myadmin/options_values_manager.php on line 101.
```