### PR TITLE
Eliminate php notices when viewing gv_faq

### DIFF
--- a/includes/languages/english/gv_faq.php
+++ b/includes/languages/english/gv_faq.php
@@ -17,6 +17,9 @@ define('TEXT_INFORMATION', '<a name="Top"></a>
   <a href="'.zen_href_link(FILENAME_GV_FAQ,'faq_item=4','NONSSL').'">Redeeming ' . TEXT_GV_NAMES . '</a><br />
   <a href="'.zen_href_link(FILENAME_GV_FAQ,'faq_item=5','NONSSL').'">When problems occur</a><br />
 ');
+if (empty($_GET['faq_item'])) {
+  $_GET['faq_item'] == '0';
+}
 switch ($_GET['faq_item']) {
   case '1':
 define('SUB_HEADING_TITLE','Purchasing ' . TEXT_GV_NAMES);

--- a/includes/modules/pages/gv_faq/header_php.php
+++ b/includes/modules/pages/gv_faq/header_php.php
@@ -14,7 +14,10 @@ $zco_notifier->notify('NOTIFY_HEADER_START_GV_FAQ');
 
 require(DIR_WS_MODULES . zen_get_module_directory('require_languages.php'));
 
-if ($_SESSION['customer_id']) {
+$customer_has_gv_balance = false;
+$customer_gv_balance = 0;
+
+if (zen_is_logged_in() && !zen_in_guest_checkout()) {
 
   $gv_query = "SELECT amount
                FROM " . TABLE_COUPON_GV_CUSTOMER . "
@@ -32,4 +35,3 @@ $breadcrumb->add(NAVBAR_TITLE);
 
 // This should be last line of the script:
 $zco_notifier->notify('NOTIFY_HEADER_END_GV_FAQ');
-?>

--- a/includes/templates/template_default/templates/tpl_gv_faq_default.php
+++ b/includes/templates/template_default/templates/tpl_gv_faq_default.php
@@ -15,7 +15,7 @@
 
 <?php
 // only show when there is a GV balance
-  if ($customer_has_gv_balance ) {
+  if (!empty($customer_has_gv_balance) ) {
 ?>
 <div id="sendSpendWrapper">
 <?php require($template->get_template_dir('tpl_modules_send_or_spend.php',DIR_WS_TEMPLATE, $current_page_base,'templates'). '/tpl_modules_send_or_spend.php'); ?>
@@ -41,7 +41,7 @@
 <fieldset>
 <legend><?php echo TEXT_GV_REDEEM_INFO; ?></legend>
 <label class="inputLabel" for="lookup-gv-redeem"><?php echo TEXT_GV_REDEEM_ID; ?></label>
-<?php echo zen_draw_input_field('gv_no', $_GET['gv_no'], 'size="18" id="lookup-gv-redeem"');?>
+<?php echo zen_draw_input_field('gv_no', isset($_GET['gv_no']) ? $_GET['gv_no'] : '0', 'size="18" id="lookup-gv-redeem"');?>
 </fieldset>
 <div class="buttonRow forward"><?php echo zen_image_submit(BUTTON_IMAGE_REDEEM, BUTTON_REDEEM_ALT); ?></div>
 </form>


### PR DESCRIPTION
Ensure that $_GET['faq_item'] is always set to something to support
the switch/case operation.

Assign default values to variables before they are used in the
template.
Use/apply the review of an individual being logged in or possibly
a guest to at least eliminate notices of testing an unassigned variable.
Either place a value of zero or the value of the $_GET['gv_no'].