### PR TITLE
address_book_process: Correct PHP notice on address removal

### DIFF
--- a/includes/modules/pages/address_book_process/header_php.php
+++ b/includes/modules/pages/address_book_process/header_php.php
@@ -320,6 +320,7 @@ if (isset($_GET['edit']) && is_numeric($_GET['edit'])) {
 /*
  * Set flags for template use:
  */
+if (!isset($_GET['delete'])) {
   if ($process == false) {
     $selected_country = $entry->fields['entry_country_id'];
   } else {
@@ -329,7 +330,7 @@ if (isset($_GET['edit']) && is_numeric($_GET['edit'])) {
   $flag_show_pulldown_states = ((($process == true || $entry_state_has_zones == true) && $zone_name == '') || ACCOUNT_STATE_DRAW_INITIAL_DROPDOWN == 'true' || $error_state_input) ? true : false;
   $state = ($flag_show_pulldown_states && $state != FALSE) ? $state : $zone_name;
   $state_field_label = ($flag_show_pulldown_states) ? '' : ENTRY_STATE;
-
+}
 
 
 if (!isset($_GET['delete']) && !isset($_GET['edit'])) {


### PR DESCRIPTION
Seeing logs similar to
```
[16-Nov-2019 13:06:56 America/Chicago] Request URI: /my-account/address-book/address-details?delete=59482, IP address: 127.0.0.1
#1  require(C:\xampp\htdocs\mystore\includes\modules\pages\address_book_process\header_php.php) called at [C:\xampp\htdocs\mystore\index.php:36]
--> PHP Notice: Trying to get property of non-object in C:\xampp\htdocs\mystore\includes\modules\pages\address_book_process\header_php.php on line 326.
```

on the 'Confirm deletion' path of the page's processing.