### PR TITLE
Order class, notification when the cart-to-order process begins

### DIFF
--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -252,6 +252,9 @@ class order extends base {
 
   function cart() {
     global $db, $currencies;
+
+    $this->notify('NOTIFY_ORDER_CART_BEGINS');
+
     $billto = (!empty($_SESSION['billto']) ? (int)$_SESSION['billto'] : 0);
     $sendto = (!empty($_SESSION['sendto']) ? (int)$_SESSION['sendto'] : 0);
 


### PR DESCRIPTION
Some stores' customizations need to know when the cart-to-order process begins.  Add a notification to indicate that process start, in a similar manner to all the other 'primary' order-related processes.