### PR TITLE
Correct 'missing breadcrumb' on popup attr page

### DIFF
--- a/includes/modules/pages/popup_attributes_qty_prices/header_php.php
+++ b/includes/modules/pages/popup_attributes_qty_prices/header_php.php
@@ -8,6 +8,4 @@
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: header_php.php 2982 2006-02-07 07:56:41Z birdbrain $
  */
-require(DIR_WS_MODULES . zen_get_module_directory('require_languages.php'));
-$breadcrumb->add(NAVBAR_TITLE_1);
-?>
+require DIR_WS_MODULES . zen_get_module_directory('require_languages.php');


### PR DESCRIPTION
As identified in [this](https://www.zen-cart.com/showthread.php?225843-popup_attributes_qty_prices-page-missing-NAVBAR-title) Zen Cart posting.