### PR TITLE
init_add_crumbs, remove trailing PHP 'end'

### DIFF
--- a/includes/init_includes/init_add_crumbs.php
+++ b/includes/init_includes/init_add_crumbs.php
@@ -68,4 +68,3 @@ if (isset($_GET['products_id'])) {
     $breadcrumb->add($productname->fields['products_name'], zen_href_link(zen_get_info_page($_GET['products_id']), 'cPath=' . $cPath . '&products_id=' . $_GET['products_id']));
   }
 }
-?>


### PR DESCRIPTION
The module currently includes the `?>` followed by a blank line.