### PR TITLE
Fix spelling of alt tag

### DIFF
--- a/includes/templates/template_default/templates/tpl_customers_authorization_default.php
+++ b/includes/templates/template_default/templates/tpl_customers_authorization_default.php
@@ -16,7 +16,7 @@
 
 <h1 id="customerAuthDefaultHeading"><?php echo HEADING_TITLE; ?></h1>
 
-<div id="customerAuthDefaultImage"><?php echo zen_image(DIR_WS_TEMPLATE_IMAGES . OTHER_IMAGE_CUSTOMERS_AUTHORIZATION, OTHER_CUSTOMERS_AUTHORIZATION_ALT); ?></div>
+<div id="customerAuthDefaultImage"><?php echo zen_image(DIR_WS_TEMPLATE_IMAGES . OTHER_IMAGE_CUSTOMERS_AUTHORIZATION, OTHER_IMAGE_CUSTOMERS_AUTHORIZATION_ALT); ?></div>
 
 <div id="customerAuthDefaultMainContent" class="content"><?php echo CUSTOMERS_AUTHORIZATION_TEXT_INFORMATION; ?></div>
 


### PR DESCRIPTION
without this change, you get the notice, 
PHP Warning: Use of undefined constant OTHER_CUSTOMERS_AUTHORIZATION_ALT - assumed 'OTHER_CUSTOMERS_AUTHORIZATION_ALT'