### PR TITLE
Refactor zen_copy_products_attributes() to return a status

### DIFF
--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -2044,43 +2044,48 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
   global $messageStack;
   global $copy_attributes_delete_first, $copy_attributes_duplicates_skipped, $copy_attributes_duplicates_overwrite, $copy_attributes_include_downloads, $copy_attributes_include_filename;
 
-// Check for errors in copy request
-  if ( (!zen_has_product_attributes($products_id_from, 'false') or !zen_products_id_valid($products_id_to)) or $products_id_to == $products_id_from ) {
+  // Check for errors in copy request
+    // same products_id
     if ($products_id_to == $products_id_from) {
-      // same products_id
       $messageStack->add_session(sprintf(WARNING_ATTRIBUTE_COPY_SAME_ID, $products_id_from, $products_id_to), 'caution');
-    } else {
-      if (!zen_has_product_attributes($products_id_from, 'false')) {
-        // no attributes found to copy
-        $messageStack->add_session(sprintf(WARNING_ATTRIBUTE_COPY_NO_ATTRIBUTES, $products_id_from, zen_get_products_name($products_id_from)), 'caution');
-      } else {
-        // invalid products_id
-        $messageStack->add_session(sprintf(WARNING_ATTRIBUTE_COPY_INVALID_ID, $products_id_to), 'caution');
-      }
+      return false;
     }
-  } else {
+    // no attributes found to copy
+    if (!zen_has_product_attributes($products_id_from, 'false')) {
+        $messageStack->add_session(sprintf(WARNING_ATTRIBUTE_COPY_NO_ATTRIBUTES, $products_id_from, zen_get_products_name($products_id_from)), 'caution');
+        return false;
+    }
+    // invalid products_id
+    if (!zen_products_id_valid($products_id_to)) {
+        $messageStack->add_session(sprintf(WARNING_ATTRIBUTE_COPY_INVALID_ID, $products_id_to), 'caution');
+        return false;
+    }
+
 // FIX HERE - remove once working
 
-// check if product already has attributes
-    $check_attributes = zen_has_product_attributes($products_id_to, 'false');
+    // check if product already has attributes
+    $already_has_attributes = zen_has_product_attributes($products_id_to, 'false');
 
-    if ($copy_attributes_delete_first=='1' and $check_attributes == true) {
-// die('DELETE FIRST - Copying from ' . $products_id_from . ' to ' . $products_id_to . ' Do I delete first? ' . $copy_attributes_delete_first);
+    if ($copy_attributes_delete_first=='1' and $already_has_attributes == true) {
       // delete all attributes first from products_id_to
       zen_products_attributes_download_delete($products_id_to);
       $db->Execute("delete from " . TABLE_PRODUCTS_ATTRIBUTES . " where products_id = '" . (int)$products_id_to . "'");
     }
 
-// get attributes to copy from
+    // get attributes to copy from
     $products_copy_from= $db->Execute("select * from " . TABLE_PRODUCTS_ATTRIBUTES . " where products_id='" . (int)$products_id_from . "'" . " order by products_attributes_id");
 
     while ( !$products_copy_from->EOF ) {
-// This must match the structure of your products_attributes table
-
       $update_attribute = false;
       $add_attribute = true;
-      $check_duplicate = $db->Execute("select * from " . TABLE_PRODUCTS_ATTRIBUTES . " where products_id='" . (int)$products_id_to . "'" . " and options_id= '" . (int)$products_copy_from->fields['options_id'] . "' and options_values_id='" . (int)$products_copy_from->fields['options_values_id'] .  "'");
-      if ($check_attributes == true) {
+
+      $check_duplicate = $db->Execute("select * from " . TABLE_PRODUCTS_ATTRIBUTES . " 
+          where products_id='" . (int)$products_id_to . "'" . " 
+          and options_id= '" . (int)$products_copy_from->fields['options_id'] . "' 
+          and options_values_id='" . (int)$products_copy_from->fields['options_values_id'] .  "'"
+      );
+
+      if ($already_has_attributes == true) {
         if ($check_duplicate->RecordCount() == 0) {
           $update_attribute = false;
           $add_attribute = true;
@@ -2098,73 +2103,85 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
         $add_attribute = true;
       }
 
-// die('UPDATE/IGNORE - Checking Copying from ' . $products_id_from . ' to ' . $products_id_to . ' Do I delete first? ' . ($copy_attributes_delete_first == '1' ? TEXT_YES : TEXT_NO) . ' Do I add? ' . ($add_attribute == true ? TEXT_YES : TEXT_NO) . ' Do I Update? ' . ($update_attribute == true ? TEXT_YES : TEXT_NO) . ' Do I skip it? ' . ($copy_attributes_duplicates_skipped=='1' ? TEXT_YES : TEXT_NO) . ' Found attributes in From: ' . $check_duplicate->RecordCount());
-
       if ($copy_attributes_duplicates_skipped == '1' and $check_duplicate->RecordCount() != 0) {
-        // skip it
           $messageStack->add_session(sprintf(TEXT_ATTRIBUTE_COPY_SKIPPING, (int)$products_copy_from->fields['products_attributes_id'], (int)$products_id_to), 'caution');
-      } else {
-        if ($add_attribute == true) {
-          // New attribute - insert it
-          $db->Execute("insert into " . TABLE_PRODUCTS_ATTRIBUTES . " (products_id, options_id, options_values_id, options_values_price, price_prefix, products_options_sort_order, product_attribute_is_free, products_attributes_weight, products_attributes_weight_prefix, attributes_display_only, attributes_default, attributes_discounted, attributes_image, attributes_price_base_included, attributes_price_onetime, attributes_price_factor, attributes_price_factor_offset, attributes_price_factor_onetime, attributes_price_factor_onetime_offset, attributes_qty_prices, attributes_qty_prices_onetime, attributes_price_words, attributes_price_words_free, attributes_price_letters, attributes_price_letters_free, attributes_required)
-                        values ('" . (int)$products_id_to . "',
-          '" . $products_copy_from->fields['options_id'] . "',
-          '" . $products_copy_from->fields['options_values_id'] . "',
-          '" . $products_copy_from->fields['options_values_price'] . "',
-          '" . $products_copy_from->fields['price_prefix'] . "',
-          '" . $products_copy_from->fields['products_options_sort_order'] . "',
-          '" . $products_copy_from->fields['product_attribute_is_free'] . "',
-          '" . $products_copy_from->fields['products_attributes_weight'] . "',
-          '" . $products_copy_from->fields['products_attributes_weight_prefix'] . "',
-          '" . $products_copy_from->fields['attributes_display_only'] . "',
-          '" . $products_copy_from->fields['attributes_default'] . "',
-          '" . $products_copy_from->fields['attributes_discounted'] . "',
-          '" . $products_copy_from->fields['attributes_image'] . "',
-          '" . $products_copy_from->fields['attributes_price_base_included'] . "',
-          '" . $products_copy_from->fields['attributes_price_onetime'] . "',
-          '" . $products_copy_from->fields['attributes_price_factor'] . "',
-          '" . $products_copy_from->fields['attributes_price_factor_offset'] . "',
-          '" . $products_copy_from->fields['attributes_price_factor_onetime'] . "',
-          '" . $products_copy_from->fields['attributes_price_factor_onetime_offset'] . "',
-          '" . $products_copy_from->fields['attributes_qty_prices'] . "',
-          '" . $products_copy_from->fields['attributes_qty_prices_onetime'] . "',
-          '" . $products_copy_from->fields['attributes_price_words'] . "',
-          '" . $products_copy_from->fields['attributes_price_words_free'] . "',
-          '" . $products_copy_from->fields['attributes_price_letters'] . "',
-          '" . $products_copy_from->fields['attributes_price_letters_free'] . "',
-          '" . $products_copy_from->fields['attributes_required'] . "')");
+          // skip it
+          $products_copy_from->MoveNext();
+      }
+
+      // New attribute - insert it
+      if ($add_attribute == true) {
+          $db->Execute("INSERT INTO " . TABLE_PRODUCTS_ATTRIBUTES . " 
+              (products_id, options_id, options_values_id, options_values_price, price_prefix, products_options_sort_order, 
+              product_attribute_is_free, products_attributes_weight, products_attributes_weight_prefix, attributes_display_only, 
+              attributes_default, attributes_discounted, attributes_image, attributes_price_base_included, 
+              attributes_price_onetime, attributes_price_factor, attributes_price_factor_offset, attributes_price_factor_onetime, 
+              attributes_price_factor_onetime_offset, attributes_qty_prices, attributes_qty_prices_onetime, 
+              attributes_price_words, attributes_price_words_free, attributes_price_letters, attributes_price_letters_free, 
+              attributes_required)
+              VALUES ('" . (int)$products_id_to . "',
+              '" . $products_copy_from->fields['options_id'] . "',
+              '" . $products_copy_from->fields['options_values_id'] . "',
+              '" . $products_copy_from->fields['options_values_price'] . "',
+              '" . $products_copy_from->fields['price_prefix'] . "',
+              '" . $products_copy_from->fields['products_options_sort_order'] . "',
+              '" . $products_copy_from->fields['product_attribute_is_free'] . "',
+              '" . $products_copy_from->fields['products_attributes_weight'] . "',
+              '" . $products_copy_from->fields['products_attributes_weight_prefix'] . "',
+              '" . $products_copy_from->fields['attributes_display_only'] . "',
+              '" . $products_copy_from->fields['attributes_default'] . "',
+              '" . $products_copy_from->fields['attributes_discounted'] . "',
+              '" . $products_copy_from->fields['attributes_image'] . "',
+              '" . $products_copy_from->fields['attributes_price_base_included'] . "',
+              '" . $products_copy_from->fields['attributes_price_onetime'] . "',
+              '" . $products_copy_from->fields['attributes_price_factor'] . "',
+              '" . $products_copy_from->fields['attributes_price_factor_offset'] . "',
+              '" . $products_copy_from->fields['attributes_price_factor_onetime'] . "',
+              '" . $products_copy_from->fields['attributes_price_factor_onetime_offset'] . "',
+              '" . $products_copy_from->fields['attributes_qty_prices'] . "',
+              '" . $products_copy_from->fields['attributes_qty_prices_onetime'] . "',
+              '" . $products_copy_from->fields['attributes_price_words'] . "',
+              '" . $products_copy_from->fields['attributes_price_words_free'] . "',
+              '" . $products_copy_from->fields['attributes_price_letters'] . "',
+              '" . $products_copy_from->fields['attributes_price_letters_free'] . "',
+              '" . $products_copy_from->fields['attributes_required'] . "')"
+          );
           $messageStack->add_session(sprintf(TEXT_ATTRIBUTE_COPY_INSERTING, (int)$products_copy_from->fields['products_attributes_id'], (int)$products_id_from, (int)$products_id_to), 'success');
-        }
-        if ($update_attribute == true) {
-          // Update attribute - Just attribute settings not ids
-          $db->Execute("update " . TABLE_PRODUCTS_ATTRIBUTES . " set
-          options_values_price='" . $products_copy_from->fields['options_values_price'] . "',
-          price_prefix='" . $products_copy_from->fields['price_prefix'] . "',
-          products_options_sort_order='" . $products_copy_from->fields['products_options_sort_order'] . "',
-          product_attribute_is_free='" . $products_copy_from->fields['product_attribute_is_free'] . "',
-          products_attributes_weight='" . $products_copy_from->fields['products_attributes_weight'] . "',
-          products_attributes_weight_prefix='" . $products_copy_from->fields['products_attributes_weight_prefix'] . "',
-          attributes_display_only='" . $products_copy_from->fields['attributes_display_only'] . "',
-          attributes_default='" . $products_copy_from->fields['attributes_default'] . "',
-          attributes_discounted='" . $products_copy_from->fields['attributes_discounted'] . "',
-          attributes_image='" . $products_copy_from->fields['attributes_image'] . "',
-          attributes_price_base_included='" . $products_copy_from->fields['attributes_price_base_included'] . "',
-          attributes_price_onetime='" . $products_copy_from->fields['attributes_price_onetime'] . "',
-          attributes_price_factor='" . $products_copy_from->fields['attributes_price_factor'] . "',
-          attributes_price_factor_offset='" . $products_copy_from->fields['attributes_price_factor_offset'] . "',
-          attributes_price_factor_onetime='" . $products_copy_from->fields['attributes_price_factor_onetime'] . "',
-          attributes_price_factor_onetime_offset='" . $products_copy_from->fields['attributes_price_factor_onetime_offset'] . "',
-          attributes_qty_prices='" . $products_copy_from->fields['attributes_qty_prices'] . "',
-          attributes_qty_prices_onetime='" . $products_copy_from->fields['attributes_qty_prices_onetime'] . "',
-          attributes_price_words='" . $products_copy_from->fields['attributes_price_words'] . "',
-          attributes_price_words_free='" . $products_copy_from->fields['attributes_price_words_free'] . "',
-          attributes_price_letters='" . $products_copy_from->fields['attributes_price_letters'] . "',
-          attributes_price_letters_free='" . $products_copy_from->fields['attributes_price_letters_free'] . "',
-          attributes_required='" . $products_copy_from->fields['attributes_required'] . "'"
-           . " where products_id='" . (int)$products_id_to . "'" . " and options_id= '" . $products_copy_from->fields['options_id'] . "' and options_values_id='" . $products_copy_from->fields['options_values_id'] . "'");
-//           . " where products_id='" . $products_id_to . "'" . " and options_id= '" . $products_copy_from->fields['options_id'] . "' and options_values_id='" . $products_copy_from->fields['options_values_id'] . "' and attributes_image='" . $products_copy_from->fields['attributes_image'] . "' and attributes_price_base_included='" . $products_copy_from->fields['attributes_price_base_included'] .  "'");
+      }
+
+      // Update attribute - Just attribute settings not ids
+      if ($update_attribute == true) {
+          $db->Execute("UPDATE " . TABLE_PRODUCTS_ATTRIBUTES . " set
+              options_values_price='" . $products_copy_from->fields['options_values_price'] . "',
+              price_prefix='" . $products_copy_from->fields['price_prefix'] . "',
+              products_options_sort_order='" . $products_copy_from->fields['products_options_sort_order'] . "',
+              product_attribute_is_free='" . $products_copy_from->fields['product_attribute_is_free'] . "',
+              products_attributes_weight='" . $products_copy_from->fields['products_attributes_weight'] . "',
+              products_attributes_weight_prefix='" . $products_copy_from->fields['products_attributes_weight_prefix'] . "',
+              attributes_display_only='" . $products_copy_from->fields['attributes_display_only'] . "',
+              attributes_default='" . $products_copy_from->fields['attributes_default'] . "',
+              attributes_discounted='" . $products_copy_from->fields['attributes_discounted'] . "',
+              attributes_image='" . $products_copy_from->fields['attributes_image'] . "',
+              attributes_price_base_included='" . $products_copy_from->fields['attributes_price_base_included'] . "',
+              attributes_price_onetime='" . $products_copy_from->fields['attributes_price_onetime'] . "',
+              attributes_price_factor='" . $products_copy_from->fields['attributes_price_factor'] . "',
+              attributes_price_factor_offset='" . $products_copy_from->fields['attributes_price_factor_offset'] . "',
+              attributes_price_factor_onetime='" . $products_copy_from->fields['attributes_price_factor_onetime'] . "',
+              attributes_price_factor_onetime_offset='" . $products_copy_from->fields['attributes_price_factor_onetime_offset'] . "',
+              attributes_qty_prices='" . $products_copy_from->fields['attributes_qty_prices'] . "',
+              attributes_qty_prices_onetime='" . $products_copy_from->fields['attributes_qty_prices_onetime'] . "',
+              attributes_price_words='" . $products_copy_from->fields['attributes_price_words'] . "',
+              attributes_price_words_free='" . $products_copy_from->fields['attributes_price_words_free'] . "',
+              attributes_price_letters='" . $products_copy_from->fields['attributes_price_letters'] . "',
+              attributes_price_letters_free='" . $products_copy_from->fields['attributes_price_letters_free'] . "',
+              attributes_required='" . $products_copy_from->fields['attributes_required'] . "
+              WHERE products_id=" . (int)$products_id_to . "
+               AND options_id= '" . $products_copy_from->fields['options_id'] . "' 
+               AND options_values_id='" . $products_copy_from->fields['options_values_id'] . "'"
+// and attributes_image='" . $products_copy_from->fields['attributes_image'] . "'
+// and attributes_price_base_included=" . $products_copy_from->fields['attributes_price_base_included']
+          );
           $messageStack->add_session(sprintf(TEXT_ATTRIBUTE_COPY_UPDATING, (int)$products_copy_from->fields['products_attributes_id'], (int)$products_id_to), 'success');
-        }
       }
 
       $products_copy_from->MoveNext();
@@ -2172,7 +2189,8 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
 
      // reset products_price_sorter for searches etc.
      zen_update_products_price_sorter($products_id_to);
-  } // end of no attributes or other errors
+
+    return true;
 } // eof: zen_copy_products_attributes
 
 

--- a/admin/includes/modules/copy_product_confirm.php
+++ b/admin/includes/modules/copy_product_confirm.php
@@ -126,8 +126,10 @@ if (isset($_POST['products_id']) && isset($_POST['categories_id'])) {
                 $copy_attributes_include_filename = '0';
             }
 
-            zen_copy_products_attributes($products_id, $dup_products_id);
-            $messageStack->add_session(sprintf(TEXT_COPY_AS_DUPLICATE_ATTRIBUTES, $products_id, $dup_products_id), 'success');
+            $copy_result = zen_copy_products_attributes($products_id, $dup_products_id);
+            if ($copy_result === true) {
+                $messageStack->add_session(sprintf(TEXT_COPY_AS_DUPLICATE_ATTRIBUTES, $products_id, $dup_products_id), 'success');
+            }
         }
 
 // copy meta tags to Duplicate
@@ -185,7 +187,7 @@ if (isset($_POST['products_id']) && isset($_POST['categories_id'])) {
         }
 
         zen_record_admin_activity('Product ' . $products_id . ' duplicated as product ' . $dup_products_id . ' via admin console.', 'info');
-        
+
         $zco_notifier->notify('NOTIFY_MODULES_COPY_TO_CONFIRM_DUPLICATE', array('products_id' => $products_id, 'dup_products_id' => $dup_products_id));
 
         $products_id = $dup_products_id;//reset for further use in price update and final redirect to new linked product or new duplicated product

--- a/admin/includes/modules/product_music/copy_product_confirm.php
+++ b/admin/includes/modules/product_music/copy_product_confirm.php
@@ -150,8 +150,10 @@ if (isset($_POST['products_id']) && isset($_POST['categories_id'])) {
                 $copy_attributes_include_filename = '0';
             }
 
-            zen_copy_products_attributes($products_id, $dup_products_id);
-            $messageStack->add_session(sprintf(TEXT_COPY_AS_DUPLICATE_ATTRIBUTES, $products_id, $dup_products_id), 'success');
+            $copy_result = zen_copy_products_attributes($products_id, $dup_products_id);
+            if ($copy_result) {
+                $messageStack->add_session(sprintf(TEXT_COPY_AS_DUPLICATE_ATTRIBUTES, $products_id, $dup_products_id), 'success');
+            }
         }
 
 // copy meta tags to Duplicate
@@ -209,7 +211,7 @@ if (isset($_POST['products_id']) && isset($_POST['categories_id'])) {
         }
 
         zen_record_admin_activity('Product ' . $products_id . ' duplicated as product ' . $dup_products_id . ' via admin console.', 'info');
-        
+
         $zco_notifier->notify('NOTIFY_PRODUCT_MUSIC_COPY_TO_CONFIRM_DUPLICATE', array('products_id' => $products_id, 'dup_products_id' => $dup_products_id));
 
         $products_id = $dup_products_id;//reset for further use in price update and final redirect to new linked product or new duplicated product


### PR DESCRIPTION
Returns false if unacceptable conditions occur.
Returns true if copy is successful, even if a duplicate causes a skip

Addresses concern raised in https://github.com/zencart/zencart/pull/2971#issuecomment-569550040