### PR TITLE
admin instantiate message stack earlier

### DIFF
--- a/admin/includes/auto_loaders/config.core.php
+++ b/admin/includes/auto_loaders/config.core.php
@@ -111,6 +111,15 @@ if (!defined('USE_PCONNECT')) define('USE_PCONNECT', 'false');
                                 'className'=>'sniffer',
                                 'objectName'=>'sniffer');
 /**
+ * Breakpoint 32.
+ *
+ * $messageStack = new messageStack();
+ *
+ */
+  $autoLoadConfig[32][] = array('autoType'=>'classInstantiate',
+                                 'className'=>'messageStack',
+                                 'objectName'=>'messageStack');
+/**
  * Breakpoint 35.
  *
  * require(DIR_WS_FUNCTIONS . 'admin_access.php');
@@ -186,12 +195,12 @@ if (!defined('USE_PCONNECT')) define('USE_PCONNECT', 'false');
 /**
  * Breakpoint 100.
  *
- * $messageStack = new messageStack();
+ * $messageStack->add_from_session();
  *
  */
-  $autoLoadConfig[100][] = array('autoType'=>'classInstantiate',
-                                 'className'=>'messageStack',
-                                 'objectName'=>'messageStack');
+  $autoLoadConfig[100][] = array('autoType'=>'objectMethod',
+                                 'object'=>'messageStack',
+                                 'method'=>'add_from_session');
 /**
  * Breakpoint 120.
  *

--- a/admin/includes/classes/message_stack.php
+++ b/admin/includes/classes/message_stack.php
@@ -26,12 +26,7 @@ if (!defined('IS_ADMIN_FLAG')) {
 
       $this->errors = array();
 
-      if (isset($_SESSION['messageToStack']) && is_array($_SESSION['messageToStack'])) {
-        for ($i = 0, $n = sizeof($_SESSION['messageToStack']); $i < $n; $i++) {
-          $this->add($_SESSION['messageToStack'][$i]['text'], $_SESSION['messageToStack'][$i]['type']);
-        }
-        $_SESSION['messageToStack'] = '';
-      }
+      $this->add_from_session();
     }
 
     function add($message, $type = 'error') {
@@ -60,6 +55,15 @@ if (!defined('IS_ADMIN_FLAG')) {
       }
 
       $_SESSION['messageToStack'][] = array('text' => $message, 'type' => $type);
+    }
+    
+    function add_from_session() {
+      if (isset($_SESSION['messageToStack']) && is_array($_SESSION['messageToStack'])) {
+        for ($i = 0, $n = sizeof($_SESSION['messageToStack']); $i < $n; $i++) {
+          $this->add($_SESSION['messageToStack'][$i]['text'], $_SESSION['messageToStack'][$i]['type']);
+        }
+        $_SESSION['messageToStack'] = '';
+      }
     }
 
     function reset() {


### PR DESCRIPTION
Creates a method for adding data from the session as that code was removed from the `__construct` and loads the class earlier in processing to support using `$messageStack` and its `add` method earlier in code processing to include providing messages when using early loaded functions.

Doesn't completely fix the referenced issue, but provides a method/process to be able to do so.