### PR TITLE
Prevent invalid template access even when bypassing apache

### DIFF
--- a/includes/templates/responsive_classic/common/html_header.php
+++ b/includes/templates/responsive_classic/common/html_header.php
@@ -11,6 +11,10 @@
  * @version $Id: DrByte 09-Jan-2020  Modified in v1.5.7 $
  */
 
+if (!defined('IS_ADMIN_FLAG')) {
+    die('Illegal Access');
+}
+
 $zco_notifier->notify('NOTIFY_HTML_HEAD_START', $current_page_base, $template_dir);
 
 // Prevent clickjacking risks by setting X-Frame-Options:SAMEORIGIN

--- a/includes/templates/responsive_classic/common/main_template_vars.php
+++ b/includes/templates/responsive_classic/common/main_template_vars.php
@@ -15,6 +15,10 @@
  * @version $Id: DrByte 09-Jan-2020  Modified in v1.5.7 $
  */
 
+if (!defined('IS_ADMIN_FLAG')) {
+    die('Illegal Access');
+}
+
   $zco_notifier->notify('NOTIFY_MAIN_TEMPLATE_VARS_START', $template_dir);
 
 /**

--- a/includes/templates/responsive_classic/common/tpl_main_page.php
+++ b/includes/templates/responsive_classic/common/tpl_main_page.php
@@ -38,6 +38,10 @@
  * @version $Id: DrByte 09-Jan-2020  Modified in v1.5.7 $
  */
 
+if (!defined('IS_ADMIN_FLAG')) {
+    die('Illegal Access');
+}
+
 /** bof DESIGNER TESTING ONLY: */
 // $messageStack->add('header', 'this is a sample error message', 'error');
 // $messageStack->add('header', 'this is a sample caution message', 'caution');

--- a/includes/templates/template_default/common/html_header.php
+++ b/includes/templates/template_default/common/html_header.php
@@ -11,6 +11,10 @@
  * @version $Id: DrByte 09-Jan-2020  Modified in v1.5.7 $
  */
 
+if (!defined('IS_ADMIN_FLAG')) {
+    die('Illegal Access');
+}
+
 $zco_notifier->notify('NOTIFY_HTML_HEAD_START', $current_page_base, $template_dir);
 
 // Prevent clickjacking risks by setting X-Frame-Options:SAMEORIGIN

--- a/includes/templates/template_default/common/main_template_vars.php
+++ b/includes/templates/template_default/common/main_template_vars.php
@@ -15,6 +15,10 @@
  * @version $Id: DrByte 09-Jan-2020  Modified in v1.5.7 $
  */
 
+if (!defined('IS_ADMIN_FLAG')) {
+    die('Illegal Access');
+}
+
   $zco_notifier->notify('NOTIFY_MAIN_TEMPLATE_VARS_START', $template_dir);
 
 /**

--- a/includes/templates/template_default/common/tpl_main_page.php
+++ b/includes/templates/template_default/common/tpl_main_page.php
@@ -38,6 +38,10 @@
  * @version $Id: DrByte 09-Jan-2020  Modified in v1.5.7 $
  */
 
+if (!defined('IS_ADMIN_FLAG')) {
+    die('Illegal Access');
+}
+
 /** bof DESIGNER TESTING ONLY: */
 // $messageStack->add('header', 'this is a sample error message', 'error');
 // $messageStack->add('header', 'this is a sample caution message', 'caution');


### PR DESCRIPTION
While the templates aren't useful when accessed directly, and default configs deny access to the files implicitly, if those protections are bypassed the templates will output undesired, unhelpful, and unwanted content. This can lead to unwanted side effects including but not limited to visitor/customer confusion.