### PR TITLE
Split checkout-payment jscript files

### DIFF
--- a/includes/modules/pages/checkout_payment/jscript_main.php
+++ b/includes/modules/pages/checkout_payment/jscript_main.php
@@ -3,20 +3,15 @@
  * jscript_main
  *
  * @package page
- * @copyright Copyright 2003-2016 Zen Cart Development Team
+ * @copyright Copyright 2003-2020 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Fri Jul 15 2016  Modified in v1.5.5 $
+ * @version $Id: 09-Jan-2020  Modified in v1.5.7 $
  */
 ?>
 <script type="text/javascript">
 var selected;
 var submitter = null;
-
-function concatExpiresFields(fields) {
-    return $(":input[name=" + fields[0] + "]").val() + $(":input[name=" + fields[1] + "]").val();
-}
-
 
 function popupWindow(url) {
   window.open(url,'popupWindow','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no,width=450,height=320,screenX=150,screenY=150,top=150,left=150')
@@ -29,52 +24,5 @@ function submitFunction($gv,$total) {
     submitter = 1;
   }
 }
-
-function methodSelect(theMethod) {
-  if (document.getElementById(theMethod)) {
-    document.getElementById(theMethod).checked = 'checked';
-  }
-}
-
-    function doesCollectsCardDataOnsite(paymentValue)
-    {
-        if ($('#'+paymentValue+'_collects_onsite').val()) {
-            if($('#pmt-'+paymentValue).is(':checked')) {
-                return true;
-            }
-            if ($("[name='payment']").length == 1) {
-              return true;
-            }
-        }
-        return false;
-    }
-
-function doCollectsCardDataOnsite()
-{
-   var str = $('form[name="checkout_payment"]').serializeArray();
-
-   zcJS.ajax({
-    url: "ajax.php?act=ajaxPayment&method=prepareConfirmation",
-    data: str
-  }).done(function( response ) {
-   $('#checkoutPayment').hide();
-   $('#navBreadCrumb').html(response.breadCrumbHtml);
-   $('#checkoutPayment').before(response.confirmationHtml);
-   $(document).attr('title', response.pageTitle);
- });
-}
-
-    $(document).ready(function(){
-      $('form[name="checkout_payment"]').submit(function() {
-          $('#paymentSubmit').attr('disabled', true);
-        <?php if ($flagOnSubmit) { ?>
-          formPassed = check_form();
-          if (formPassed == false) {
-              $('#paymentSubmit').attr('disabled', false);
-          }
-          return formPassed;
-        <?php } ?>
-      });
-    });
 
 </script>

--- a/includes/modules/pages/checkout_payment/jscript_pmt_support.php
+++ b/includes/modules/pages/checkout_payment/jscript_pmt_support.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * jscript_pmt_support
+ *
+ * @package page
+ * @copyright Copyright 2003-2020 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: Jan 09 2020  New in v1.5.7 $
+ */
+?>
+<script type="text/javascript">
+
+function concatExpiresFields(fields) {
+    return $(":input[name=" + fields[0] + "]").val() + $(":input[name=" + fields[1] + "]").val();
+}
+
+function methodSelect(theMethod) {
+  if (document.getElementById(theMethod)) {
+    document.getElementById(theMethod).checked = 'checked';
+  }
+}
+
+function doesCollectsCardDataOnsite(paymentValue)
+{
+    if ($('#'+paymentValue+'_collects_onsite').val()) {
+        if($('#pmt-'+paymentValue).is(':checked')) {
+            return true;
+        }
+        if ($("[name='payment']").length == 1) {
+          return true;
+        }
+    }
+    return false;
+}
+
+function doCollectsCardDataOnsite()
+{
+   var str = $('form[name="checkout_payment"]').serializeArray();
+
+   zcJS.ajax({
+    url: "ajax.php?act=ajaxPayment&method=prepareConfirmation",
+    data: str
+  }).done(function( response ) {
+   $('#checkoutPayment').hide();
+   $('#navBreadCrumb').html(response.breadCrumbHtml);
+   $('#checkoutPayment').before(response.confirmationHtml);
+   $(document).attr('title', response.pageTitle);
+ });
+}
+
+$(document).ready(function(){
+  $('form[name="checkout_payment"]').submit(function() {
+      $('#paymentSubmit').attr('disabled', true);
+    <?php if ($flagOnSubmit) { ?>
+      formPassed = check_form();
+      if (formPassed == false) {
+          $('#paymentSubmit').attr('disabled', false);
+      }
+      return formPassed;
+    <?php } ?>
+  });
+});
+
+</script>


### PR DESCRIPTION
This could potentially help make it easier to customize the ajax response markup specific to a given template
(eg minimize changes to zcAjaxPayment class by stuffing wrapper HTML into the javascript used to output the response)

Ref https://github.com/zcadditions/ZCA-Bootstrap-Template-for-1.5.6-v2.0.0c/commit/c45d5f38e27fac19eee3a0012190e8272ce39124#r36733927