### PR TITLE
Add ability to translate a string provided constant to session's language

### DIFF
--- a/admin/includes/classes/message_stack.php
+++ b/admin/includes/classes/message_stack.php
@@ -60,7 +60,12 @@ if (!defined('IS_ADMIN_FLAG')) {
     function add_from_session() {
       if (isset($_SESSION['messageToStack']) && is_array($_SESSION['messageToStack'])) {
         for ($i = 0, $n = sizeof($_SESSION['messageToStack']); $i < $n; $i++) {
+          // Check for and use the language defined value of the text version of the constant pushed to the session.
+          if (defined($_SESSION['messageToStack'][$i]['text'])) {
+            $_SESSION['messageToStack'][$i]['text'] = constant($_SESSION['messageToStack'][$i]['text']);
+          } 
           $this->add($_SESSION['messageToStack'][$i]['text'], $_SESSION['messageToStack'][$i]['type']);
+          
         }
         $_SESSION['messageToStack'] = '';
       }


### PR DESCRIPTION
Was identified in #3033 that by moving the loading of `$messageStack` to before the `$_SESSION` has been started and before the language has been identified, that messages pushed to `$messageStack` would not be language dependent.  This adds the ability to push the expected language constant as a string that would be translated to the current session language when the session was available and the additional message(s) were then presented.