### PR TITLE
update for Admin Specials

### DIFF
--- a/admin/includes/languages/english/specials.php
+++ b/admin/includes/languages/english/specials.php
@@ -29,24 +29,20 @@ define('TABLE_HEADING_AVAILABLE_DATE', 'Available');
 define('TABLE_HEADING_EXPIRES_DATE','Expires');
 define('TABLE_HEADING_STATUS', 'Status');
 define('TABLE_HEADING_ACTION', 'Action');
-define('TEXT_ADD_SPECIAL', 'Add Special Discount');
+define('TEXT_ADD_SPECIAL_SELECT', 'Add Special by Selection');
+define('TEXT_ADD_SPECIAL_PID', 'Add Special by Product ID');
+define('TEXT_SEARCH_SPECIALS', 'Search current Specials');
 
 define('TEXT_SPECIALS_PRODUCT', 'Product:');
 define('TEXT_SPECIALS_SPECIAL_PRICE', 'Special Price:');
 define('TEXT_SPECIALS_EXPIRES_DATE', 'Date Special Expires:');
 define('TEXT_SPECIALS_AVAILABLE_DATE', 'Date Special Available:');
-define('TEXT_SPECIALS_PRICE_NOTES', '<b>Notes:</b><ul>
-<li>Special Price may be a new price (ex-vat). The decimal separator must be a '.' (decimal-point), eg: <b>49.99</b>.</li>
-<li>Special Price may be a percentage discount, eg: <b>20%</b>.</li>
-<li>Dates are not obligatory. Leave the expiry date empty for no expiration.</li>
-<li>When dates are set, the status of the Special price is automatically enabled/disabled accordingly.</li>
-</ul>');
 
 define('TEXT_INFO_DATE_ADDED', 'Date Added:');
 define('TEXT_INFO_LAST_MODIFIED', 'Last Modified:');
-define('TEXT_INFO_NEW_PRICE', 'New Price:');
+define('TEXT_INFO_NEW_PRICE', 'Special Price:');
 define('TEXT_INFO_ORIGINAL_PRICE', 'Original Price:');
-define('TEXT_INFO_DISPLAY_PRICE', 'Display Price:');
+define('TEXT_INFO_DISPLAY_PRICE', 'Currently Displayed Price:');
 define('TEXT_INFO_AVAILABLE_DATE', 'Available From:');
 define('TEXT_INFO_EXPIRES_DATE', 'Expires:');
 define('TEXT_INFO_STATUS_CHANGE', 'Status Change:');
@@ -59,7 +55,9 @@ define('SUCCESS_SPECIALS_PRE_ADD', 'Successful: Pre-Add of Special ... please up
 define('WARNING_SPECIALS_PRE_ADD_EMPTY', 'Warning: No Product ID specified ... nothing was added ...');
 define('WARNING_SPECIALS_PRE_ADD_DUPLICATE', 'Warning: Product ID already on Special ... nothing was added ...');
 define('WARNING_SPECIALS_PRE_ADD_BAD_PRODUCTS_ID', 'Warning: Product ID is invalid ... nothing was added ...');
-define('TEXT_INFO_HEADING_PRE_ADD_SPECIALS', 'Manually add new Special by Product ID');
-define('TEXT_INFO_PRE_ADD_INTRO', 'You may manually Add a Special by Product ID.<br><br>This method may be appropriate for shops with many products if the page takes too long to render or selecting a product from the dropdown becomes unwieldy.');
-define('TEXT_PRE_ADD_PRODUCTS_ID', 'Please enter the Product ID to be Pre-Added: ');
+define('TEXT_INFO_HEADING_PRE_ADD_SPECIALS', 'Add Special Price by Product ID');
+define('TEXT_INFO_PRE_ADD_INTRO', 'You may manually add a Special Price by Product ID. This method may be appropriate for shops with many products, if the selection page takes too long to render / selecting a product from the dropdown becomes unwieldy.');
+define('TEXT_PRE_ADD_PRODUCTS_ID', 'Enter the Product ID: ');
 define('TEXT_INFO_MANUAL', 'Product ID to be Manually Added as a Special');
+
+define('TEXT_SPECIALS_PRICE_NOTES', '<b>Notes:</b><ul><li>Special Price may be a new price (ex-tax). The decimal separator must be a "." (decimal-point), eg: <b>49.99</b>.</li><li>Special Price may be a percentage discount, eg: <b>20%</b>.</li><li>Dates are not obligatory. Leave the expiry date empty for no expiration.</li><li>When dates are set, the status of the Special Price is automatically enabled/disabled accordingly.</li><li>' . TEXT_INFO_PRE_ADD_INTRO . '</li></ul>');

--- a/admin/includes/languages/english/specials.php
+++ b/admin/includes/languages/english/specials.php
@@ -22,8 +22,8 @@
 
 define('HEADING_TITLE', 'Specials');
 
-define('TABLE_HEADING_PRODUCTS', 'Products');
-define('TABLE_HEADING_PRODUCTS_PRICE', 'Products Price/Special/Sale');
+define('TABLE_HEADING_PRODUCTS', 'Product');
+define('TABLE_HEADING_PRODUCTS_PRICE', 'Price/Special/Sale');
 define('TABLE_HEADING_PRODUCTS_PERCENTAGE','Percentage');
 define('TABLE_HEADING_AVAILABLE_DATE', 'Available');
 define('TABLE_HEADING_EXPIRES_DATE','Expires');
@@ -52,9 +52,10 @@ define('TEXT_INFO_HEADING_DELETE_SPECIALS', 'Delete Special');
 define('TEXT_INFO_DELETE_INTRO', 'Are you sure you want to delete the Special Price for this product?');
 
 define('SUCCESS_SPECIALS_PRE_ADD', 'Successful: Pre-Add of Special ... please update the price and dates ...');
-define('WARNING_SPECIALS_PRE_ADD_EMPTY', 'Warning: No Product ID specified ... nothing was added ...');
-define('WARNING_SPECIALS_PRE_ADD_DUPLICATE', 'Warning: Product ID already on Special ... nothing was added ...');
-define('WARNING_SPECIALS_PRE_ADD_BAD_PRODUCTS_ID', 'Warning: Product ID is invalid ... nothing was added ...');
+define('WARNING_SPECIALS_PRE_ADD_PID_EMPTY', 'Warning: No Product ID was specified.');
+define('WARNING_SPECIALS_PRE_ADD_PID_DUPLICATE', 'Warning: Product ID#%u already on Special.');
+define('WARNING_SPECIALS_PRE_ADD_PID_NO_EXIST', 'Warning: Product ID#%u does not exist.');
+define('WARNING_SPECIALS_PRE_ADD_PID_GIFT', 'Warning: Product ID3%u is a ' . TEXT_GV_NAME . '.');
 define('TEXT_INFO_HEADING_PRE_ADD_SPECIALS', 'Add Special Price by Product ID');
 define('TEXT_INFO_PRE_ADD_INTRO', 'You may add a Special Price by Product ID. This method may be appropriate for shops with many products, if the selection page takes too long to render / selecting a product from the dropdown becomes unwieldy.');
 define('TEXT_PRE_ADD_PRODUCTS_ID', 'Enter the Product ID: ');

--- a/admin/includes/languages/english/specials.php
+++ b/admin/includes/languages/english/specials.php
@@ -27,12 +27,13 @@ define('TABLE_HEADING_PRODUCTS_PRICE', 'Price/Special/Sale');
 define('TABLE_HEADING_PRODUCTS_PERCENTAGE','Percentage');
 define('TABLE_HEADING_AVAILABLE_DATE', 'Available');
 define('TABLE_HEADING_EXPIRES_DATE','Expires');
-define('TABLE_HEADING_STATUS', 'Status');
+define('TABLE_HEADING_STATUS', 'Special Status');
 define('TABLE_HEADING_ACTION', 'Action');
 define('TEXT_ADD_SPECIAL_SELECT', 'Add Special by Selection');
 define('TEXT_ADD_SPECIAL_PID', 'Add Special by Product ID');
 define('TEXT_SEARCH_SPECIALS', 'Search current Specials');
-
+define('TEXT_SPECIAL_ACTIVE', 'Special Price Active');
+define('TEXT_SPECIAL_INACTIVE', 'Special Price Inactive');
 define('TEXT_SPECIALS_PRODUCT', 'Product:');
 define('TEXT_SPECIALS_SPECIAL_PRICE', 'Special Price:');
 define('TEXT_SPECIALS_EXPIRES_DATE', 'Date Special Expires:');
@@ -60,8 +61,7 @@ if (!defined('TEXT_GV_NAME')) {
 }
 define('WARNING_SPECIALS_PRE_ADD_PID_GIFT', 'Warning: Product ID#%u is a ' . TEXT_GV_NAME . '.');
 define('TEXT_INFO_HEADING_PRE_ADD_SPECIALS', 'Add Special Price by Product ID');
-define('TEXT_INFO_PRE_ADD_INTRO', 'You may add a Special Price by Product ID. This method may be appropriate for shops with many products, if the selection page takes too long to render / selecting a product from the dropdown becomes unwieldy.');
+define('TEXT_INFO_PRE_ADD_INTRO', 'You may add a Special Price by Product ID. This method may be appropriate for shops with many products if the selection page takes too long to render or selecting a product from the dropdown becomes unwieldy.');
 define('TEXT_PRE_ADD_PRODUCTS_ID', 'Enter the Product ID: ');
-define('TEXT_INFO_MANUAL', 'Product ID to be Manually Added as a Special');
 
 define('TEXT_SPECIALS_PRICE_NOTES', '<b>Notes:</b><ul><li>Special Price may be a new price (ex-tax). The decimal separator must be a "." (decimal-point), eg: <b>49.99</b>.</li><li>Special Price may be a percentage discount, eg: <b>20%</b>.</li><li>Dates are not obligatory. Leave the expiry date empty for no expiration.</li><li>When dates are set, the status of the Special Price is automatically enabled/disabled accordingly.</li><li>' . TEXT_INFO_PRE_ADD_INTRO . '</li></ul>');

--- a/admin/includes/languages/english/specials.php
+++ b/admin/includes/languages/english/specials.php
@@ -33,17 +33,22 @@ define('TEXT_ADD_SPECIAL', 'Add Special Discount');
 
 define('TEXT_SPECIALS_PRODUCT', 'Product:');
 define('TEXT_SPECIALS_SPECIAL_PRICE', 'Special Price:');
-define('TEXT_SPECIALS_EXPIRES_DATE', 'Expiry Date:');
-define('TEXT_SPECIALS_AVAILABLE_DATE', 'Available Date:');
-define('TEXT_SPECIALS_PRICE_TIP', '<b>Specials Notes:</b><ul><li>You can enter a percentage to deduct in the Specials Price field, for example: <b>20%</b></li><li>If you enter a new price, the decimal separator must be a \'.\' (decimal-point), example: <b>49.99</b></li><li>Leave the expiry date empty for no expiration</li></ul>');
+define('TEXT_SPECIALS_EXPIRES_DATE', 'Date Special Expires:');
+define('TEXT_SPECIALS_AVAILABLE_DATE', 'Date Special Available:');
+define('TEXT_SPECIALS_PRICE_NOTES', '<b>Notes:</b><ul>
+<li>Special Price may be a new price (ex-vat). The decimal separator must be a '.' (decimal-point), eg: <b>49.99</b>.</li>
+<li>Special Price may be a percentage discount, eg: <b>20%</b>.</li>
+<li>Dates are not obligatory. Leave the expiry date empty for no expiration.</li>
+<li>When dates are set, the status of the Special price is automatically enabled/disabled accordingly.</li>
+</ul>');
 
 define('TEXT_INFO_DATE_ADDED', 'Date Added:');
 define('TEXT_INFO_LAST_MODIFIED', 'Last Modified:');
 define('TEXT_INFO_NEW_PRICE', 'New Price:');
 define('TEXT_INFO_ORIGINAL_PRICE', 'Original Price:');
-define('TEXT_INFO_DISPLAY_PRICE', 'Display Price:<br />');
-define('TEXT_INFO_AVAILABLE_DATE', 'Available On:');
-define('TEXT_INFO_EXPIRES_DATE', 'Expires At:');
+define('TEXT_INFO_DISPLAY_PRICE', 'Display Price:');
+define('TEXT_INFO_AVAILABLE_DATE', 'Available From:');
+define('TEXT_INFO_EXPIRES_DATE', 'Expires:');
 define('TEXT_INFO_STATUS_CHANGE', 'Status Change:');
 define('TEXT_IMAGE_NONEXISTENT', 'No Image Exists');
 
@@ -55,7 +60,6 @@ define('WARNING_SPECIALS_PRE_ADD_EMPTY', 'Warning: No Product ID specified ... n
 define('WARNING_SPECIALS_PRE_ADD_DUPLICATE', 'Warning: Product ID already on Special ... nothing was added ...');
 define('WARNING_SPECIALS_PRE_ADD_BAD_PRODUCTS_ID', 'Warning: Product ID is invalid ... nothing was added ...');
 define('TEXT_INFO_HEADING_PRE_ADD_SPECIALS', 'Manually add new Special by Product ID');
-define('TEXT_INFO_PRE_ADD_INTRO', 'On large databases, you may Manually Add a Special by the Product ID<br /><br />This is best used when the page takes too long to render and trying to select a Product from the dropdown becomes difficult due to too many Products from which to choose.');
+define('TEXT_INFO_PRE_ADD_INTRO', 'You may manually Add a Special by Product ID.<br><br>This method may be appropriate for shops with many products if the page takes too long to render or selecting a product from the dropdown becomes unwieldy.');
 define('TEXT_PRE_ADD_PRODUCTS_ID', 'Please enter the Product ID to be Pre-Added: ');
 define('TEXT_INFO_MANUAL', 'Product ID to be Manually Added as a Special');
-

--- a/admin/includes/languages/english/specials.php
+++ b/admin/includes/languages/english/specials.php
@@ -1,24 +1,12 @@
 <?php
-//
-// +----------------------------------------------------------------------+
-// |zen-cart Open Source E-commerce                                       |
-// +----------------------------------------------------------------------+
-// | Copyright (c) 2003 The zen-cart developers                           |
-// |                                                                      |
-// | http://www.zen-cart.com/index.php                                    |
-// |                                                                      |
-// | Portions Copyright (c) 2003 osCommerce                               |
-// +----------------------------------------------------------------------+
-// | This source file is subject to version 2.0 of the GPL license,       |
-// | that is bundled with this package in the file LICENSE, and is        |
-// | available through the world-wide-web at the following url:           |
-// | http://www.zen-cart.com/license/2_0.txt.                             |
-// | If you did not receive a copy of the zen-cart license and are unable |
-// | to obtain it through the world-wide-web, please send a note to       |
-// | license@zen-cart.com so we can mail you a copy immediately.          |
-// +----------------------------------------------------------------------+
-//  $Id: specials.php 4533 2006-09-17 17:21:10Z ajeh $
-//
+/**
+ * @package admin
+ * @copyright Copyright 2003-2018 Zen Cart Development Team
+ * @copyright Portions Copyright 2003 osCommerce
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: torvista 2020 Jan 26 Modified in v1.5.7 $
+ */
+
 
 define('HEADING_TITLE', 'Specials');
 
@@ -34,6 +22,7 @@ define('TEXT_ADD_SPECIAL_PID', 'Add Special by Product ID');
 define('TEXT_SEARCH_SPECIALS', 'Search current Specials');
 define('TEXT_SPECIAL_ACTIVE', 'Special Price Active');
 define('TEXT_SPECIAL_INACTIVE', 'Special Price Inactive');
+define('TEXT_SPECIAL_STATUS_BY_DATE', 'Status set by dates');
 
 define('TEXT_SPECIALS_PRODUCT', 'Product:');
 define('TEXT_SPECIALS_SPECIAL_PRICE', 'Special Price:');
@@ -62,4 +51,4 @@ define('TEXT_INFO_HEADING_PRE_ADD_SPECIALS', 'Add Special Price by Product ID');
 define('TEXT_INFO_PRE_ADD_INTRO', 'You may add a Special Price by Product ID. This method may be appropriate for shops with many products if the selection page takes too long to render or selecting a product from the dropdown becomes unwieldy.');
 define('TEXT_PRE_ADD_PRODUCTS_ID', 'Enter the Product ID: ');
 
-define('TEXT_SPECIALS_PRICE_NOTES', '<b>Notes:</b><ul><li>Special Price may be a new price (ex-tax). The decimal separator must be a "." (decimal-point), eg: <b>49.99</b>.</li><li>Special Price may be a percentage discount, eg: <b>20%</b>.</li><li>Dates are not obligatory. Leave the expiry date empty for no expiration.</li><li>When dates are set, the status of the Special Price is automatically enabled/disabled accordingly.</li><li>' . TEXT_INFO_PRE_ADD_INTRO . '</li></ul>');
+define('TEXT_SPECIALS_PRICE_NOTES', '<b>Notes:</b><ul><li>Special Price may be a price (ex-tax). The decimal separator must be a "." (decimal-point), eg: <b>49.99</b>. The calculated percentage discount is shown next to the product\'s new price in the catalog.</li><li>Special Price may be a percentage discount, eg: <b>20%</b>.</li><li>Start/End dates are not obligatory. You may leave the expiry date empty for no expiration.</li><li>When dates are set, the status of the Special Price is automatically enabled/disabled accordingly.</li><li>' . TEXT_INFO_PRE_ADD_INTRO . '</li></ul>');

--- a/admin/includes/languages/english/specials.php
+++ b/admin/includes/languages/english/specials.php
@@ -46,10 +46,10 @@ define('TEXT_INFO_DISPLAY_PRICE', 'Currently Displayed Price:');
 define('TEXT_INFO_AVAILABLE_DATE', 'Available From:');
 define('TEXT_INFO_EXPIRES_DATE', 'Expires:');
 define('TEXT_INFO_STATUS_CHANGED', 'Status Changed:');
-define('TEXT_IMAGE_NONEXISTENT', 'No Image Exists');
+define('TEXT_IMAGE_NONEXISTENT', '(no image defined)');
 
 define('TEXT_INFO_HEADING_DELETE_SPECIALS', 'Delete Special');
-define('TEXT_INFO_DELETE_INTRO', 'Are you sure you want to delete the special products price?');
+define('TEXT_INFO_DELETE_INTRO', 'Are you sure you want to delete the Special Price for this product?');
 
 define('SUCCESS_SPECIALS_PRE_ADD', 'Successful: Pre-Add of Special ... please update the price and dates ...');
 define('WARNING_SPECIALS_PRE_ADD_EMPTY', 'Warning: No Product ID specified ... nothing was added ...');

--- a/admin/includes/languages/english/specials.php
+++ b/admin/includes/languages/english/specials.php
@@ -55,7 +55,10 @@ define('SUCCESS_SPECIALS_PRE_ADD', 'Successful: Pre-Add of Special ... please up
 define('WARNING_SPECIALS_PRE_ADD_PID_EMPTY', 'Warning: No Product ID was specified.');
 define('WARNING_SPECIALS_PRE_ADD_PID_DUPLICATE', 'Warning: Product ID#%u already on Special.');
 define('WARNING_SPECIALS_PRE_ADD_PID_NO_EXIST', 'Warning: Product ID#%u does not exist.');
-define('WARNING_SPECIALS_PRE_ADD_PID_GIFT', 'Warning: Product ID3%u is a ' . TEXT_GV_NAME . '.');
+if (!defined('TEXT_GV_NAME')) {
+    require DIR_WS_LANGUAGES . $_SESSION['language'] . '/' . 'gv_name.php';
+}
+define('WARNING_SPECIALS_PRE_ADD_PID_GIFT', 'Warning: Product ID#%u is a ' . TEXT_GV_NAME . '.');
 define('TEXT_INFO_HEADING_PRE_ADD_SPECIALS', 'Add Special Price by Product ID');
 define('TEXT_INFO_PRE_ADD_INTRO', 'You may add a Special Price by Product ID. This method may be appropriate for shops with many products, if the selection page takes too long to render / selecting a product from the dropdown becomes unwieldy.');
 define('TEXT_PRE_ADD_PRODUCTS_ID', 'Enter the Product ID: ');

--- a/admin/includes/languages/english/specials.php
+++ b/admin/includes/languages/english/specials.php
@@ -23,36 +23,34 @@
 define('HEADING_TITLE', 'Specials');
 
 define('TABLE_HEADING_PRODUCTS', 'Product');
+define('TABLE_HEADING_STOCK', 'Stock');
 define('TABLE_HEADING_PRODUCTS_PRICE', 'Price/Special/Sale');
-define('TABLE_HEADING_PRODUCTS_PERCENTAGE','Percentage');
-define('TABLE_HEADING_AVAILABLE_DATE', 'Available');
-define('TABLE_HEADING_EXPIRES_DATE','Expires');
+define('TABLE_HEADING_AVAILABLE_DATE', 'Active From');
+define('TABLE_HEADING_EXPIRES_DATE','Expires On');
 define('TABLE_HEADING_STATUS', 'Special Status');
-define('TABLE_HEADING_ACTION', 'Action');
+define('TABLE_HEADING_ACTION', 'Actions');
 define('TEXT_ADD_SPECIAL_SELECT', 'Add Special by Selection');
 define('TEXT_ADD_SPECIAL_PID', 'Add Special by Product ID');
 define('TEXT_SEARCH_SPECIALS', 'Search current Specials');
 define('TEXT_SPECIAL_ACTIVE', 'Special Price Active');
 define('TEXT_SPECIAL_INACTIVE', 'Special Price Inactive');
+
 define('TEXT_SPECIALS_PRODUCT', 'Product:');
 define('TEXT_SPECIALS_SPECIAL_PRICE', 'Special Price:');
+define('TEXT_SPECIALS_AVAILABLE_DATE', 'Date Special Active:');
 define('TEXT_SPECIALS_EXPIRES_DATE', 'Date Special Expires:');
-define('TEXT_SPECIALS_AVAILABLE_DATE', 'Date Special Available:');
 
 define('TEXT_INFO_DATE_ADDED', 'Date Added:');
 define('TEXT_INFO_LAST_MODIFIED', 'Last Modified:');
 define('TEXT_INFO_NEW_PRICE', 'Special Price:');
 define('TEXT_INFO_ORIGINAL_PRICE', 'Original Price:');
 define('TEXT_INFO_DISPLAY_PRICE', 'Currently Displayed Price:');
-define('TEXT_INFO_AVAILABLE_DATE', 'Available From:');
-define('TEXT_INFO_EXPIRES_DATE', 'Expires:');
 define('TEXT_INFO_STATUS_CHANGED', 'Status Changed:');
 define('TEXT_IMAGE_NONEXISTENT', '(no image defined)');
 
 define('TEXT_INFO_HEADING_DELETE_SPECIALS', 'Delete Special');
 define('TEXT_INFO_DELETE_INTRO', 'Are you sure you want to delete the Special Price for this product?');
 
-define('SUCCESS_SPECIALS_PRE_ADD', 'Successful: Pre-Add of Special ... please update the price and dates ...');
 define('WARNING_SPECIALS_PRE_ADD_PID_EMPTY', 'Warning: No Product ID was specified.');
 define('WARNING_SPECIALS_PRE_ADD_PID_DUPLICATE', 'Warning: Product ID#%u already on Special.');
 define('WARNING_SPECIALS_PRE_ADD_PID_NO_EXIST', 'Warning: Product ID#%u does not exist.');

--- a/admin/includes/languages/english/specials.php
+++ b/admin/includes/languages/english/specials.php
@@ -45,7 +45,7 @@ define('TEXT_INFO_ORIGINAL_PRICE', 'Original Price:');
 define('TEXT_INFO_DISPLAY_PRICE', 'Currently Displayed Price:');
 define('TEXT_INFO_AVAILABLE_DATE', 'Available From:');
 define('TEXT_INFO_EXPIRES_DATE', 'Expires:');
-define('TEXT_INFO_STATUS_CHANGE', 'Status Change:');
+define('TEXT_INFO_STATUS_CHANGED', 'Status Changed:');
 define('TEXT_IMAGE_NONEXISTENT', 'No Image Exists');
 
 define('TEXT_INFO_HEADING_DELETE_SPECIALS', 'Delete Special');
@@ -56,7 +56,7 @@ define('WARNING_SPECIALS_PRE_ADD_EMPTY', 'Warning: No Product ID specified ... n
 define('WARNING_SPECIALS_PRE_ADD_DUPLICATE', 'Warning: Product ID already on Special ... nothing was added ...');
 define('WARNING_SPECIALS_PRE_ADD_BAD_PRODUCTS_ID', 'Warning: Product ID is invalid ... nothing was added ...');
 define('TEXT_INFO_HEADING_PRE_ADD_SPECIALS', 'Add Special Price by Product ID');
-define('TEXT_INFO_PRE_ADD_INTRO', 'You may manually add a Special Price by Product ID. This method may be appropriate for shops with many products, if the selection page takes too long to render / selecting a product from the dropdown becomes unwieldy.');
+define('TEXT_INFO_PRE_ADD_INTRO', 'You may add a Special Price by Product ID. This method may be appropriate for shops with many products, if the selection page takes too long to render / selecting a product from the dropdown becomes unwieldy.');
 define('TEXT_PRE_ADD_PRODUCTS_ID', 'Enter the Product ID: ');
 define('TEXT_INFO_MANUAL', 'Product ID to be Manually Added as a Special');
 

--- a/admin/includes/languages/english/specials.php
+++ b/admin/includes/languages/english/specials.php
@@ -29,6 +29,7 @@ define('TABLE_HEADING_AVAILABLE_DATE', 'Available');
 define('TABLE_HEADING_EXPIRES_DATE','Expires');
 define('TABLE_HEADING_STATUS', 'Status');
 define('TABLE_HEADING_ACTION', 'Action');
+define('TEXT_ADD_SPECIAL', 'Add Special Discount');
 
 define('TEXT_SPECIALS_PRODUCT', 'Product:');
 define('TEXT_SPECIALS_SPECIAL_PRICE', 'Special Price:');
@@ -57,4 +58,4 @@ define('TEXT_INFO_HEADING_PRE_ADD_SPECIALS', 'Manually add new Special by Produc
 define('TEXT_INFO_PRE_ADD_INTRO', 'On large databases, you may Manually Add a Special by the Product ID<br /><br />This is best used when the page takes too long to render and trying to select a Product from the dropdown becomes difficult due to too many Products from which to choose.');
 define('TEXT_PRE_ADD_PRODUCTS_ID', 'Please enter the Product ID to be Pre-Added: ');
 define('TEXT_INFO_MANUAL', 'Product ID to be Manually Added as a Special');
-?>
+

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -303,7 +303,7 @@ if (zen_not_null($action)) {
             <div class="form-group">
                 <?php if (isset($sInfo->products_name)) { ?>
                     <p class="col-sm-3 control-label"><strong><?php echo TEXT_SPECIALS_PRODUCT; ?></strong></p>
-                    <div class="col-sm-9 col-md-6"><?php echo $sInfo->products_model . ' - "' . $sInfo->products_name . '" (' . $currencies->format($sInfo->products_price) . ')'; ?></div>
+                    <div class="col-sm-9 col-md-6"><span class="form-control" style="border:none; -webkit-box-shadow: none"><?php echo $sInfo->products_model . ' - "' . $sInfo->products_name . '" (' . $currencies->format($sInfo->products_price) . ')'; ?></span></div>
                 <?php } else {
                     echo zen_draw_label(TEXT_SPECIALS_PRODUCT, 'products_id', 'class="col-sm-3 control-label"'); ?>
                     <div class="col-sm-9 col-md-6">

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -349,7 +349,8 @@ if (zen_not_null($action)) {
         } else {
           ?>
           <div class="row">
-              <a href="<?php echo zen_href_link(FILENAME_SPECIALS, ((isset($_GET['page']) && $_GET['page'] > 0) ? 'page=' . $_GET['page'] . '&' : '') . 'action=new'); ?>" class="btn btn-primary" role="button"><?php echo TEXT_ADD_SPECIAL; ?></a>
+              <a href="<?php echo zen_href_link(FILENAME_SPECIALS, ((isset($_GET['page']) && $_GET['page'] > 0) ? 'page=' . $_GET['page'] . '&' : '') . 'action=new'); ?>" class="btn btn-primary" role="button"><?php echo TEXT_ADD_SPECIAL_SELECT; ?></a>
+              <a href="<?php echo zen_href_link(FILENAME_SPECIALS, 'action=pre_add' . ((isset($_GET['page']) && $_GET['page'] > 0) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')); ?>" class="btn btn-primary" role="button"><?php echo TEXT_ADD_SPECIAL_PID; ?></a>
           </div>
           <hr />
           <div class="row">
@@ -540,8 +541,6 @@ if (zen_not_null($action)) {
                       $contents[] = array('text' => '<br>' . TEXT_INFO_EXPIRES_DATE . ' <b>' . (($sInfo->expires_date != '0001-01-01' and $sInfo->expires_date != '') ? zen_date_short($sInfo->expires_date) : TEXT_NONE) . '</b>');
                       $contents[] = array('text' => TEXT_INFO_STATUS_CHANGE . ' ' . zen_date_short($sInfo->date_status_change));
                       $contents[] = array('align' => 'text-center', 'text' => '<a href="' . zen_href_link(FILENAME_PRODUCT, '&action=new_product' . '&cPath=' . zen_get_product_path($sInfo->products_id, 'override') . '&pID=' . $sInfo->products_id . '&product_type=' . zen_get_products_type($sInfo->products_id)) . '" class="btn btn-primary" role="button">' . IMAGE_EDIT_PRODUCT . '</a>');
-
-                      $contents[] = array('align' => 'text-center', 'text' => '<a href="' . zen_href_link(FILENAME_SPECIALS, 'action=pre_add' . ((isset($_GET['page']) && $_GET['page'] > 0) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . '" class="btn btn-primary" role="button">' . IMAGE_SELECT . '</a><br>' . TEXT_INFO_MANUAL);
                     } else {
                       $heading[] = array('text' => '<h4>' . TEXT_NONE . '</h4>');
                       $contents[] = array('align' => 'text-center', 'text' => '<a href="' . zen_href_link(FILENAME_SPECIALS, 'action=pre_add' . ((isset($_GET['page']) && $_GET['page'] > 0) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . '" class="btn btn-primary" role="button">' . IMAGE_SELECT . '</a><br>' . TEXT_INFO_MANUAL);

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -322,7 +322,7 @@ if (zen_not_null($action)) {
                     echo zen_draw_label(TEXT_SPECIALS_PRODUCT, 'products_id', 'class="col-sm-3 control-label"'); ?>
                     <div class="col-sm-9 col-md-6">
                         <?php
-                        echo zen_draw_products_pull_down('products_id', 'size="15" class="form-control"', $specials_array, true, (!empty($_GET['add_products_id']) ? $_GET['add_products_id'] : ''), true);
+                        echo zen_draw_products_pull_down('products_id', 'size="15" class="form-control" id="products_id"', $specials_array, true, (!empty($_GET['add_products_id']) ? $_GET['add_products_id'] : ''), true);
                         echo zen_draw_hidden_field('products_price', (isset($sInfo->products_price) ? $sInfo->products_price : ''));
                         ?>
                     </div>
@@ -332,7 +332,7 @@ if (zen_not_null($action)) {
               <?php echo zen_draw_label(TEXT_SPECIALS_SPECIAL_PRICE, 'specials_price', 'class="col-sm-3 control-label"'); ?>
             <div class="col-sm-9 col-md-6">
                 <?php
-                echo zen_draw_input_field('specials_price', (isset($sInfo->specials_new_products_price) ? $sInfo->specials_new_products_price : ''), 'class="form-control"');
+                echo zen_draw_input_field('specials_price', (isset($sInfo->specials_new_products_price) ? $sInfo->specials_new_products_price : ''), 'class="form-control" id="specials_price"');
                 echo zen_draw_hidden_field('products_priced_by_attribute', $sInfo->products_priced_by_attribute);
                 echo zen_draw_hidden_field('update_products_id', $sInfo->products_id);
                 ?>

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -354,19 +354,16 @@ if (zen_not_null($action)) {
           </div>
           <hr />
           <div class="row">
-            <div style ="margin-bottom: 5px">
+              <div style="margin-bottom: 5px">
                   <?php echo zen_draw_form('search', FILENAME_SPECIALS, '', 'get');
+                  $keywords = (isset($_GET['search']) && zen_not_null($_GET['search'])) ? zen_db_input(zen_db_prepare_input($_GET['search'])) : '';
+                  echo TEXT_SEARCH_SPECIALS . ' ' . zen_draw_input_field('search', $keywords) . zen_hide_session_id();
                   // show reset search
-                  if (isset($_GET['search']) && zen_not_null($_GET['search'])) {
-                      echo '<a href="' . zen_href_link(FILENAME_SPECIALS) . '">' . zen_image_button('button_reset.gif', IMAGE_RESET) . '</a>&nbsp;&nbsp;';
-                  }
-                  echo TEXT_SEARCH_SPECIALS . ' ' . zen_draw_input_field('search') . zen_hide_session_id();
-                  if (isset($_GET['search']) && zen_not_null($_GET['search'])) {
-                      $keywords = zen_db_input(zen_db_prepare_input($_GET['search']));
-                      echo '<br>' . TEXT_INFO_SEARCH_DETAIL_FILTER . $keywords;
-                  }
+                  if (isset($_GET['search']) && zen_not_null($_GET['search'])) { ?>
+                      <a href="<?php echo zen_href_link(FILENAME_SPECIALS); ?>" class="btn btn-default" role="button"><?php echo IMAGE_RESET; ?></a>
+                  <?php }
                   echo '</form>'; ?>
-            </div>
+              </div>
             <div><?php echo TEXT_STATUS_WARNING; ?></div>
             <div class="col-xs-12 col-sm-12 col-md-9 col-lg-9 configurationColumnLeft">
               <table class="table table-hover">
@@ -508,7 +505,7 @@ if (zen_not_null($action)) {
 
                     $contents = array('form' => zen_draw_form('specials', FILENAME_SPECIALS, 'page=' . $_GET['page'] . '&action=deleteconfirm' . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . zen_draw_hidden_field('sID', $sInfo->specials_id));
                     $contents[] = array('text' => TEXT_INFO_DELETE_INTRO);
-                    $contents[] = array('text' => '<br><b>' . $sInfo->products_name . '</b>');
+                    $contents[] = array('text' => '<b>' . $sInfo->products_model . ' - ' . $sInfo->products_name . '</b>');
                     $contents[] = array('align' => 'text-center', 'text' => '<br><button type="submit" class="btn btn-danger">' . IMAGE_DELETE . '</button> <a href="' . zen_href_link(FILENAME_SPECIALS, 'page=' . $_GET['page'] . '&sID=' . $sInfo->specials_id . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>');
                     break;
                   case 'pre_add':

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -515,40 +515,45 @@ if (zen_not_null($action)) {
                     $heading[] = array('text' => '<h4>' . TEXT_INFO_HEADING_PRE_ADD_SPECIALS . '</h4>');
                     $contents = array('form' => zen_draw_form('specials', FILENAME_SPECIALS, 'action=pre_add_confirmation' . ((isset($_GET['page']) && $_GET['page'] > 0) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : ''), 'post', 'class="form-horizontal"'));
                     $contents[] = array('text' => TEXT_INFO_PRE_ADD_INTRO);
-                    $contents[] = array('text' => '<br>' . zen_draw_label(TEXT_PRE_ADD_PRODUCTS_ID, 'pre_add_products_id', 'class="control-label"') . zen_draw_input_field('pre_add_products_id', '', zen_set_field_length(TABLE_SPECIALS, 'products_id') . 'class="form-control"'));
-                    $contents[] = array('align' => 'text-center', 'text' => '<br><button type="submit" class="btn btn-primary">' . IMAGE_CONFIRM . '</button> <a href="' . zen_href_link(FILENAME_SPECIALS, 'page=' . $_GET['page'] . '&sID=' . $sInfo->specials_id . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>');
+                    $contents[] = array('text' => zen_draw_label(TEXT_PRE_ADD_PRODUCTS_ID, 'pre_add_products_id', 'class="control-label"') . zen_draw_input_field('pre_add_products_id', '', zen_set_field_length(TABLE_SPECIALS, 'products_id') . ' class="form-control" id="pre_add_products_id"'));
+                    $contents[] = array('align' => 'text-center', 'text' => '<button type="submit" class="btn btn-primary">' . IMAGE_CONFIRM . '</button> <a href="' . zen_href_link(FILENAME_SPECIALS, 'page=' . $_GET['page'] . '&sID=' . $sInfo->specials_id . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>');
                     break;
                   default:
-                    if (isset($sInfo) && is_object($sInfo)) {
-                      $heading[] = array('text' => '<h4>' . $sInfo->products_name . '</h4>');
+                      if (isset($sInfo) && is_object($sInfo)) {
+                          $heading[] = array('text' => '<h4>' . $sInfo->products_name . '</h4>');
 
-                      if ($sInfo->products_priced_by_attribute == '1') {
-                        $specials_current_price = zen_get_products_base_price($sInfo->products_id);
-                      } else {
-                        $specials_current_price = $sInfo->products_price;
+                          if ($sInfo->products_priced_by_attribute == '1') {
+                              $specials_current_price = zen_get_products_base_price($sInfo->products_id);
+                          } else {
+                              $specials_current_price = $sInfo->products_price;
+                          }
+
+                          $contents[] = array('align' => 'text-center',
+                              'text' => '<a href="' . zen_href_link(FILENAME_SPECIALS,
+                                      'page=' . $_GET['page'] . '&sID=' . $sInfo->specials_id . '&action=edit' . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . '" class="btn btn-primary" role="button">' . IMAGE_EDIT . '</a> <a href="' . zen_href_link(FILENAME_SPECIALS,
+                                      'page=' . $_GET['page'] . '&sID=' . $sInfo->specials_id . '&action=delete' . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . '" class="btn btn-warning" role="button">' . TEXT_INFO_HEADING_DELETE_SPECIALS . '</a>'
+                          );
+                          $contents[] = array('align' => 'text-center', 'text' => '<a href="' . zen_href_link(FILENAME_PRODUCTS_PRICE_MANAGER, 'action=edit&products_filter=' . $sInfo->products_id) . '" class="btn btn-primary" role="button">' . IMAGE_PRODUCTS_PRICE_MANAGER . '</a>');
+                          $contents[] = array('text' => TEXT_INFO_ORIGINAL_PRICE . ' ' . $currencies->format($specials_current_price));
+                          $contents[] = array('text' => TEXT_INFO_NEW_PRICE . ' ' . $currencies->format($sInfo->specials_new_products_price));
+                          $contents[] = array('text' => TEXT_INFO_DISPLAY_PRICE . ' ' . zen_get_products_display_price($sInfo->products_id));
+                          $contents[] = array('text' => TEXT_INFO_AVAILABLE_DATE . ' ' . (($sInfo->specials_date_available != '0001-01-01' and $sInfo->specials_date_available != '') ? zen_date_short($sInfo->specials_date_available) : TEXT_NONE));
+                          $contents[] = array('text' => TEXT_INFO_EXPIRES_DATE . ' ' . (($sInfo->expires_date != '0001-01-01' and $sInfo->expires_date != '') ? zen_date_short($sInfo->expires_date) : TEXT_NONE));
+                          if ($sInfo->date_status_change !== null && $sInfo->date_status_change !== '0001-01-01 00:00:00') {
+                          $contents[] = array('text' => TEXT_INFO_STATUS_CHANGED . ' ' . zen_date_short($sInfo->date_status_change));
+                          }
+                          $contents[] = array('text' => '' . TEXT_INFO_LAST_MODIFIED . ' ' . zen_date_short($sInfo->specials_last_modified));
+                          $contents[] = array('text' => TEXT_INFO_DATE_ADDED . ' ' . zen_date_short($sInfo->specials_date_added));
+                          $contents[] = array('align' => 'text-center', 'text' => zen_info_image($sInfo->products_image, $sInfo->products_name, SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT));
+                          $contents[] = array('align' => 'text-center', 'text' =>
+                              '<a href="' . zen_href_link(FILENAME_PRODUCT, '&action=new_product' . '&cPath=' . zen_get_product_path($sInfo->products_id, 'override') . '&pID=' . $sInfo->products_id . '&product_type=' . zen_get_products_type($sInfo->products_id)) .
+                              '" class="btn btn-primary" role="button">' . IMAGE_EDIT_PRODUCT . '</a>'
+                          );
                       }
-
-                      $contents[] = array('align' => 'text-center', 'text' => '<a href="' . zen_href_link(FILENAME_SPECIALS, 'page=' . $_GET['page'] . '&sID=' . $sInfo->specials_id . '&action=edit' . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . '" class="btn btn-primary" role="button">' . IMAGE_EDIT . '</a> <a href="' . zen_href_link(FILENAME_SPECIALS, 'page=' . $_GET['page'] . '&sID=' . $sInfo->specials_id . '&action=delete' . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . '" class="btn btn-warning" role="button">' . IMAGE_DELETE . '</a>');
-                      $contents[] = array('align' => 'text-center', 'text' => '<a href="' . zen_href_link(FILENAME_PRODUCTS_PRICE_MANAGER, 'action=edit&products_filter=' . $sInfo->products_id) . '" class="btn btn-primary" role="button">' . IMAGE_PRODUCTS_PRICE_MANAGER . '</a>');
-                      $contents[] = array('text' => '<br>' . TEXT_INFO_DATE_ADDED . ' ' . zen_date_short($sInfo->specials_date_added));
-                      $contents[] = array('text' => '' . TEXT_INFO_LAST_MODIFIED . ' ' . zen_date_short($sInfo->specials_last_modified));
-                      $contents[] = array('align' => 'text-center', 'text' => '<br>' . zen_info_image($sInfo->products_image, $sInfo->products_name, SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT));
-                      $contents[] = array('text' => '<br>' . TEXT_INFO_ORIGINAL_PRICE . ' ' . $currencies->format($specials_current_price));
-                      $contents[] = array('text' => TEXT_INFO_NEW_PRICE . ' ' . $currencies->format($sInfo->specials_new_products_price));
-                      $contents[] = array('text' => TEXT_INFO_DISPLAY_PRICE . '<br>' . zen_get_products_display_price($sInfo->products_id));
-
-                      $contents[] = array('text' => '<br>' . TEXT_INFO_AVAILABLE_DATE . ' <b>' . (($sInfo->specials_date_available != '0001-01-01' and $sInfo->specials_date_available != '') ? zen_date_short($sInfo->specials_date_available) : TEXT_NONE) . '</b>');
-                      $contents[] = array('text' => '<br>' . TEXT_INFO_EXPIRES_DATE . ' <b>' . (($sInfo->expires_date != '0001-01-01' and $sInfo->expires_date != '') ? zen_date_short($sInfo->expires_date) : TEXT_NONE) . '</b>');
-                      $contents[] = array('text' => TEXT_INFO_STATUS_CHANGE . ' ' . zen_date_short($sInfo->date_status_change));
-                      $contents[] = array('align' => 'text-center', 'text' => '<a href="' . zen_href_link(FILENAME_PRODUCT, '&action=new_product' . '&cPath=' . zen_get_product_path($sInfo->products_id, 'override') . '&pID=' . $sInfo->products_id . '&product_type=' . zen_get_products_type($sInfo->products_id)) . '" class="btn btn-primary" role="button">' . IMAGE_EDIT_PRODUCT . '</a>');
-                    } else {
-                      $heading[] = array('text' => '<h4>' . TEXT_NONE . '</h4>');
-                      $contents[] = array('align' => 'text-center', 'text' => '<a href="' . zen_href_link(FILENAME_SPECIALS, 'action=pre_add' . ((isset($_GET['page']) && $_GET['page'] > 0) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . '" class="btn btn-primary" role="button">' . IMAGE_SELECT . '</a><br>' . TEXT_INFO_MANUAL);
-                    }
-                    break;
+                      break;
                 }
                 if ((zen_not_null($heading)) && (zen_not_null($contents))) {
-                  $box = new box;
+                  $box = new box();
                   echo $box->infoBox($heading, $contents);
                 }
                 ?>

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -277,12 +277,15 @@ if (zen_not_null($action)) {
                     <p class="col-sm-3 control-label"><strong><?php echo TEXT_SPECIALS_PRODUCT; ?></strong></p>
                     <div class="col-sm-9 col-md-6"><span class="form-control" style="border:none; -webkit-box-shadow: none">
                             <?php echo 'ID#' . $sInfo->products_id . ': ' . $sInfo->products_model . ' - "' . zen_clean_html($sInfo->products_name) . '" (' . $currencies->format($sInfo->products_price) . ')'; ?></span></div>
+
                 <?php } elseif (!empty($_GET['preID'])) { // new Special: insert by product ID
                     $preID = (int)$_GET['preID']; ?>
                     <p class="col-sm-3 control-label"><strong><?php echo TEXT_SPECIALS_PRODUCT; ?></strong></p>
-                    <div class="col-sm-9 col-md-6"><span class="form-control" style="border:none; -webkit-box-shadow: none"><?php echo 'ID#' . $preID . ': ' . zen_get_products_model($preID) . ' - "' . zen_clean_html(zen_get_products_name($preID)) . '" (' . $currencies->format(zen_get_products_base_price($preID)) . ')'; ?></span>
+                    <div class="col-sm-9 col-md-6">
+                        <span class="form-control" style="border:none; -webkit-box-shadow: none"><?php echo 'ID#' . $preID . ': ' . zen_get_products_model($preID) . ' - "' . zen_clean_html(zen_get_products_name($preID)) . '" (' . $currencies->format(zen_get_products_base_price($preID)) . ')'; ?></span>
                     </div>
                     <?php echo zen_draw_hidden_field('products_id', $preID); ?>
+
                 <?php } else { // new Special: insert by dropdown
                     echo zen_draw_label(TEXT_SPECIALS_PRODUCT, 'products_id', 'class="col-sm-3 control-label"'); ?>
                     <div class="col-sm-9 col-md-6">
@@ -447,8 +450,8 @@ if (zen_not_null($action)) {
                   <td class="dataTableContent text-center"><?php echo $special['products_id']; ?></td>
                   <td class="dataTableContent"><?php echo $special['products_model']; ?></td>
                   <td class="dataTableContent"><?php echo zen_clean_html($special['products_name']); ?></td>
-                  <td class="dataTableContent text-center"><?php
-                      $oos_style = $specials->fields['products_quantity'] <= 0 ? ' style="color:red;font-weight:bold"' : ''; ?>
+                  <td class="dataTableContent text-center">
+		  <?php $oos_style = $specials->fields['products_quantity'] <= 0 ? ' style="color:red;font-weight:bold"' : ''; ?>
                       <span<?php echo $oos_style; ?>><?php echo $special['products_quantity']; ?></span></td>
                   <td class="dataTableContent text-right"><?php echo zen_get_products_display_price($special['products_id']); ?></td>
                   <td class="dataTableContent text-center"><?php echo (($special['specials_date_available'] != '0001-01-01' && $special['specials_date_available'] != '') ? zen_date_short($special['specials_date_available']) : TEXT_NONE); ?></td>
@@ -506,7 +509,8 @@ if (zen_not_null($action)) {
                     $contents[] = array('text' => TEXT_INFO_DELETE_INTRO);
                     $contents[] = array('text' => '<b>' . $sInfo->products_model . ' - "' . zen_clean_html($sInfo->products_name) . '"</b>');
                     $contents[] = array('align' => 'text-center', 'text' => '<br><button type="submit" class="btn btn-danger">' . IMAGE_DELETE . '</button> <a href="' . zen_href_link(FILENAME_SPECIALS, 'page=' . $_GET['page'] . '&sID=' . $sInfo->specials_id . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>');
-                    break;
+                  break;
+
                   case 'pre_add':
                     $heading[] = array('text' => '<h4>' . TEXT_INFO_HEADING_PRE_ADD_SPECIALS . '</h4>');
                     $contents = array('form' => zen_draw_form('specials', FILENAME_SPECIALS, 'action=pre_add_confirmation' . ((isset($_GET['page']) && $_GET['page'] > 0) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : ''), 'post', 'class="form-horizontal"'));
@@ -515,39 +519,44 @@ if (zen_not_null($action)) {
                     $max_product_id = $result->fields['lastproductid'];
                     $contents[] = array('text' => zen_draw_label(TEXT_PRE_ADD_PRODUCTS_ID, 'pre_add_products_id', 'class="control-label"') . zen_draw_input_field('pre_add_products_id', '', zen_set_field_length(TABLE_SPECIALS, 'products_id') . ' class="form-control" id="pre_add_products_id" required max="' . $max_product_id . '"', '', 'number'));
                     $contents[] = array('align' => 'text-center', 'text' => '<button type="submit" class="btn btn-primary">' . IMAGE_CONFIRM . '</button> <a href="' . zen_href_link(FILENAME_SPECIALS, 'page=' . $_GET['page'] . '&sID=' . $sInfo->specials_id . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>');
-                    break;
-                  default:
-                      if (isset($sInfo) && is_object($sInfo)) {
-                          $heading[] = array('text' => '<h4>ID#' . $sInfo->products_id . ': ' . $sInfo->products_model . ' - "' . zen_clean_html($sInfo->products_name) . '"</h4>');
+                  break;
 
-                          if ($sInfo->products_priced_by_attribute == '1') {
-                              $specials_current_price = zen_get_products_base_price($sInfo->products_id);
-                          } else {
-                              $specials_current_price = $sInfo->products_price;
-                          }
-
-                          $contents[] = array('align' => 'text-center',
-                              'text' => '<a href="' . zen_href_link(FILENAME_SPECIALS,
-                                      'page=' . $_GET['page'] . '&sID=' . $sInfo->specials_id . '&action=edit' . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . '" class="btn btn-primary" role="button">' . IMAGE_EDIT . '</a> <a href="' . zen_href_link(FILENAME_SPECIALS,
-                                      'page=' . $_GET['page'] . '&sID=' . $sInfo->specials_id . '&action=delete' . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . '" class="btn btn-warning" role="button">' . TEXT_INFO_HEADING_DELETE_SPECIALS . '</a>'
-                          );
-                          $contents[] = array('align' => 'text-center', 'text' => '<a href="' . zen_href_link(FILENAME_PRODUCTS_PRICE_MANAGER, 'action=edit&products_filter=' . $sInfo->products_id) . '" class="btn btn-primary" role="button">' . IMAGE_PRODUCTS_PRICE_MANAGER . '</a>');
-                          $contents[] = array('text' => TEXT_INFO_ORIGINAL_PRICE . ' ' . $currencies->format($specials_current_price));
-                          $contents[] = array('text' => TEXT_INFO_NEW_PRICE . ' ' . $currencies->format($sInfo->specials_new_products_price));
-                          $contents[] = array('text' => '<b>' . TEXT_INFO_DISPLAY_PRICE . '<br>' . zen_get_products_display_price($sInfo->products_id) . '</b>');
-                          $contents[] = array('text' => TEXT_SPECIALS_AVAILABLE_DATE . ' ' . (($sInfo->specials_date_available != '0001-01-01' && $sInfo->specials_date_available != '') ? zen_date_short($sInfo->specials_date_available) : TEXT_NONE));
-                          $contents[] = array('text' => TEXT_SPECIALS_EXPIRES_DATE . ' ' . (($sInfo->expires_date != '0001-01-01' && $sInfo->expires_date != '') ? zen_date_short($sInfo->expires_date) : TEXT_NONE));
-                          if ($sInfo->date_status_change != null && $sInfo->date_status_change !== '0001-01-01 00:00:00') {
-                          $contents[] = array('text' => TEXT_INFO_STATUS_CHANGED . ' ' . zen_date_short($sInfo->date_status_change));
-                          }
-                          $contents[] = array('text' => TEXT_INFO_LAST_MODIFIED . ' ' . zen_date_short($sInfo->specials_last_modified));
-                          $contents[] = array('text' => TEXT_INFO_DATE_ADDED . ' ' . zen_date_short($sInfo->specials_date_added));
-                          $contents[] = array('align' => 'text-center', 'text' => zen_info_image($sInfo->products_image, htmlspecialchars($sInfo->products_name), SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT));
-                          $contents[] = array('align' => 'text-center', 'text' =>
-                              '<a href="' . zen_href_link(FILENAME_PRODUCT, '&action=new_product' . '&cPath=' . zen_get_product_path($sInfo->products_id, 'override') . '&pID=' . $sInfo->products_id . '&product_type=' . zen_get_products_type($sInfo->products_id)) . '" class="btn btn-primary" role="button">' . IMAGE_EDIT_PRODUCT . '</a>'
-                          );
-                      }
-                      break;
+                    default:
+                        if (isset($sInfo) && is_object($sInfo)) {
+                            $heading[] = array('text' => '<h4>ID#' . $sInfo->products_id . ': ' . $sInfo->products_model . ' - "' . zen_clean_html($sInfo->products_name) . '"</h4>');
+                            if ($sInfo->products_priced_by_attribute == '1') {
+                                $specials_current_price = zen_get_products_base_price($sInfo->products_id);
+                            } else {
+                                $specials_current_price = $sInfo->products_price;
+                            }
+                            $contents[] = array(
+                                'align' => 'text-center',
+                                'text' => '
+                                <a href="' . zen_href_link(FILENAME_SPECIALS, 'page=' . $_GET['page'] . '&sID=' . $sInfo->specials_id . '&action=edit' .
+                                        (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . '" class="btn btn-primary" role="button">' . IMAGE_EDIT . '</a> 
+                                <a href="' . zen_href_link(FILENAME_SPECIALS, 'page=' . $_GET['page'] . '&sID=' . $sInfo->specials_id . '&action=delete' .
+                                        (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . '" class="btn btn-warning" role="button">' . TEXT_INFO_HEADING_DELETE_SPECIALS . '</a>'
+                            );
+                            $contents[] = array(
+                                'align' => 'text-center',
+                                'text' => '<a href="' . zen_href_link(FILENAME_PRODUCTS_PRICE_MANAGER, 'action=edit&products_filter=' . $sInfo->products_id) . '" class="btn btn-primary" role="button">' . IMAGE_PRODUCTS_PRICE_MANAGER . '</a>');
+                            $contents[] = array('text' => TEXT_INFO_ORIGINAL_PRICE . ' ' . $currencies->format($specials_current_price));
+                            $contents[] = array('text' => TEXT_INFO_NEW_PRICE . ' ' . $currencies->format($sInfo->specials_new_products_price));
+                            $contents[] = array('text' => '<b>' . TEXT_INFO_DISPLAY_PRICE . '<br>' . zen_get_products_display_price($sInfo->products_id) . '</b>');
+                            $contents[] = array('text' => TEXT_SPECIALS_AVAILABLE_DATE . ' ' . (($sInfo->specials_date_available != '0001-01-01' && $sInfo->specials_date_available != '') ? zen_date_short($sInfo->specials_date_available) : TEXT_NONE));
+                            $contents[] = array('text' => TEXT_SPECIALS_EXPIRES_DATE . ' ' . (($sInfo->expires_date != '0001-01-01' && $sInfo->expires_date != '') ? zen_date_short($sInfo->expires_date) : TEXT_NONE));
+                            if ($sInfo->date_status_change != null && $sInfo->date_status_change !== '0001-01-01 00:00:00') {
+                                $contents[] = array('text' => TEXT_INFO_STATUS_CHANGED . ' ' . zen_date_short($sInfo->date_status_change));
+                            }
+                            $contents[] = array('text' => TEXT_INFO_LAST_MODIFIED . ' ' . zen_date_short($sInfo->specials_last_modified));
+                            $contents[] = array('text' => TEXT_INFO_DATE_ADDED . ' ' . zen_date_short($sInfo->specials_date_added));
+                            $contents[] = array('align' => 'text-center', 'text' => zen_info_image($sInfo->products_image, htmlspecialchars($sInfo->products_name), SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT));
+                            $contents[] = array(
+                                'align' => 'text-center',
+                                'text' => '<a href="' . zen_href_link(FILENAME_PRODUCT, '&action=new_product' . '&cPath=' . zen_get_product_path($sInfo->products_id, 'override') . '&pID=' . $sInfo->products_id . '&product_type=' . zen_get_products_type($sInfo->products_id)) . '" class="btn btn-primary" role="button">' . IMAGE_EDIT_PRODUCT . '</a>'
+                            );
+                        }
+                        break;
                 }
                 if ((zen_not_null($heading)) && (zen_not_null($contents))) {
                   $box = new box();
@@ -557,23 +566,8 @@ if (zen_not_null($action)) {
             </div>
           </div>
           <div class="row">
-            <table class="table">
-              <tr>
-                <td><?php echo $specials_split->display_count($specials_query_numrows, MAX_DISPLAY_SEARCH_RESULTS, $_GET['page'], TEXT_DISPLAY_NUMBER_OF_SPECIALS); ?></td>
-                <td class="text-right"><?php echo $specials_split->display_links($specials_query_numrows, MAX_DISPLAY_SEARCH_RESULTS, MAX_DISPLAY_PAGE_LINKS, $_GET['page'], zen_get_all_get_params(array('page', 'sID'))); ?></td>
-              </tr>
-              <?php
-              if (empty($action)) {
-                ?>
-                <tr>
-                  <td colspan="2" class="text-right">
-                    <a href="<?php echo zen_href_link(FILENAME_SPECIALS, ((isset($_GET['page']) && $_GET['page'] > 0) ? 'page=' . $_GET['page'] . '&' : '') . 'action=new'); ?>" class="btn btn-primary" role="button"><?php echo IMAGE_NEW_PRODUCT; ?></a>
-                  </td>
-                </tr>
-                <?php
-              }
-              ?>
-            </table>
+              <div class="col-sm-6"><?php echo $specials_split->display_count($specials_query_numrows, MAX_DISPLAY_SEARCH_RESULTS, $_GET['page'], TEXT_DISPLAY_NUMBER_OF_SPECIALS); ?></div>
+              <div class="col-sm-6 text-right"><?php echo $specials_split->display_links($specials_query_numrows, MAX_DISPLAY_SEARCH_RESULTS, MAX_DISPLAY_PAGE_LINKS, $_GET['page'], zen_get_all_get_params(array('page', 'sID'))); ?></div>
           </div>
           <?php
         }

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -174,6 +174,14 @@ if (zen_not_null($action)) {
     <link rel="stylesheet" type="text/css" href="includes/cssjsmenuhover.css" media="all" id="hoverJS">
     <script src="includes/menu.js"></script>
     <script src="includes/general.js"></script>
+    <?php
+    if (($action == 'new') || ($action == 'edit')) {
+      ?>
+      <link rel="stylesheet" type="text/css" href="includes/javascript/spiffyCal/spiffyCal_v2_1.css">
+      <script src="includes/javascript/spiffyCal/spiffyCal_v2_1.js"></script>
+      <?php
+    }
+    ?>
     <script>
       function init() {
           cssjsmenu('navbar');
@@ -185,6 +193,7 @@ if (zen_not_null($action)) {
     </script>
   </head>
   <body onload="init()">
+    <div id="spiffycalendar" class="text"></div>
     <!-- header //-->
     <?php require(DIR_WS_INCLUDES . 'header.php'); ?>
     <!-- header_eof //-->
@@ -213,7 +222,7 @@ if (zen_not_null($action)) {
           if ($sInfo->products_priced_by_attribute == '1') {
             $sInfo->products_price = zen_get_products_base_price($product->fields['products_id']);
           }
-        } elseif (empty($_GET['preID'])) { // not a manual product ID: use the product select dropdown
+        } elseif (empty($_GET['preID'])) { // insert by product select dropdown
           $sInfo = new objectInfo(array());
 
 // create an array of products on special, which will be excluded from the pull down menu of products
@@ -252,6 +261,10 @@ if (zen_not_null($action)) {
 
         }
         ?>
+        <script>
+          var StartDate = new ctlSpiffyCalendarBox("StartDate", "new_special", "start", "btnDate1", "<?php echo (($sInfo->specials_date_available == '0001-01-01') ? '' : zen_date_short($sInfo->specials_date_available)); ?>", scBTNMODE_CUSTOMBLUE);
+          var EndDate = new ctlSpiffyCalendarBox("EndDate", "new_special", "end", "btnDate2", "<?php echo (($sInfo->expires_date == '0001-01-01') ? '' : zen_date_short($sInfo->expires_date)); ?>", scBTNMODE_CUSTOMBLUE);
+        </script>
         <div class="row">
             <?php echo zen_draw_form('new_special', FILENAME_SPECIALS, zen_get_all_get_params(array('action', 'info', 'sID')) . 'action=' . $form_action . (!empty($_GET['go_back']) ? '&go_back=' . $_GET['go_back'] : ''), 'post', 'onsubmit="return check_dates(start, StartDate.required, end, EndDate.required);" class="form-horizontal"'); ?>
             <?php
@@ -262,15 +275,15 @@ if (zen_not_null($action)) {
             <div class="form-group">
                 <?php if (isset($sInfo->products_name)) { // Special is already defined/this is an update ?>
                     <p class="col-sm-3 control-label"><strong><?php echo TEXT_SPECIALS_PRODUCT; ?></strong></p>
-                    <div class="col-sm-9 col-md-6"><span class="form-control"
-                                                         style="border:none; -webkit-box-shadow: none"><?php echo 'ID#' . $sInfo->products_id . ': ' . $sInfo->products_model . ' - "' . zen_clean_html($sInfo->products_name) . '" (' . $currencies->format($sInfo->products_price) . ')'; ?></span></div>
-                <?php } elseif (!empty($_GET['preID'])) { // new Special direct from a product ID
+                    <div class="col-sm-9 col-md-6"><span class="form-control" style="border:none; -webkit-box-shadow: none">
+                            <?php echo 'ID#' . $sInfo->products_id . ': ' . $sInfo->products_model . ' - "' . zen_clean_html($sInfo->products_name) . '" (' . $currencies->format($sInfo->products_price) . ')'; ?></span></div>
+                <?php } elseif (!empty($_GET['preID'])) { // new Special: insert by product ID
                     $preID = (int)$_GET['preID']; ?>
                     <p class="col-sm-3 control-label"><strong><?php echo TEXT_SPECIALS_PRODUCT; ?></strong></p>
-                    <div class="col-sm-9 col-md-6"><span class="form-control" style="border:none; -webkit-box-shadow: none"><?php echo 'ID#' . $preID . ': ' . zen_get_products_model($preID) . ' - "' . zen_clean_html(zen_get_products_name($preID)) . '" (' . $currencies->format($sInfo->products_price) . ')'; ?></span>
+                    <div class="col-sm-9 col-md-6"><span class="form-control" style="border:none; -webkit-box-shadow: none"><?php echo 'ID#' . $preID . ': ' . zen_get_products_model($preID) . ' - "' . zen_clean_html(zen_get_products_name($preID)) . '" (' . $currencies->format(zen_get_products_base_price($preID)) . ')'; ?></span>
                     </div>
                     <?php echo zen_draw_hidden_field('products_id', $preID); ?>
-                <?php } else {
+                <?php } else { // new Special: insert by dropdown
                     echo zen_draw_label(TEXT_SPECIALS_PRODUCT, 'products_id', 'class="col-sm-3 control-label"'); ?>
                     <div class="col-sm-9 col-md-6">
                         <?php
@@ -294,32 +307,22 @@ if (zen_not_null($action)) {
             </div>
           </div>
 
-            <div class="form-group">
-                <?php echo zen_draw_label(TEXT_SPECIALS_AVAILABLE_DATE, 'start', 'class="col-sm-3 control-label"'); ?>
-                <div class="col-sm-9 col-md-6">
-                    <div class="date input-group">
-                        <span class="input-group-addon datepicker_icon"> <i class="fa fa-calendar fa-lg">&nbsp;</i></span>
-                        <?php echo zen_draw_input_field('start', (!empty($sInfo->specials_date_available) ? $sInfo->specials_date_available : ''), 'class="form-control" id="start"'); ?>
-                    </div>
-                    <span class="help-block errorText">(<?php echo (strtoupper(DATE_FORMAT_DATE_PICKER)); ?>)</span>
-                </div>
+          <div class="form-group">
+              <?php echo zen_draw_label(TEXT_SPECIALS_AVAILABLE_DATE, 'start', 'class="col-sm-3 control-label"'); ?>
+            <div class="col-sm-9 col-md-6">
+              <script>StartDate.writeControl(); StartDate.dateFormat = "<?php echo DATE_FORMAT_SPIFFYCAL; ?>";</script>
             </div>
-
-            <div class="form-group">
-                <?php echo zen_draw_label(TEXT_SPECIALS_EXPIRES_DATE, 'end', 'class="col-sm-3 control-label"'); ?>
-                <div class="col-sm-9 col-md-6">
-                    <div class="date input-group">
-                        <span class="input-group-addon datepicker_icon"><i class="fa fa-calendar fa-lg">&nbsp;</i></span>
-                        <?php echo zen_draw_input_field('end', (!empty($sInfo->expires_date) ? $sInfo->expires_date : ''), 'class="form-control" id="end"'); ?>
-                    </div>
-                    <span class="help-block errorText">(<?php echo (strtoupper(DATE_FORMAT_DATE_PICKER)); ?>)</span>
-                </div>
+          </div>
+          <div class="form-group">
+              <?php echo zen_draw_label(TEXT_SPECIALS_EXPIRES_DATE, 'end', 'class="col-sm-3 control-label"'); ?>
+            <div class="col-sm-9 col-md-6">
+              <script>EndDate.writeControl(); EndDate.dateFormat = "<?php echo DATE_FORMAT_SPIFFYCAL; ?>";</script>
             </div>
+          </div>
 
             <div class="text-right"><button type="submit" class="btn btn-primary"><?php echo(($form_action == 'insert') ? IMAGE_INSERT : IMAGE_UPDATE); ?></button>
             <?php
-            if (empty($_GET['manual']) || (int)$_GET['manual'] == 0) {
-                if (isset($_GET['go_back']) && $_GET['go_back'] == 'ON') {
+                if (isset($_GET['go_back']) && $_GET['go_back'] == 'ON') { // 'go_back' set in Products Price Manager
                     $cancel_link = zen_href_link(FILENAME_PRODUCTS_PRICE_MANAGER, 'products_filter=' . $_GET['add_products_id'] . '&current_category_id=' . $_GET['current_category_id']);
                 } else {
                     $cancel_link = zen_href_link(FILENAME_SPECIALS,
@@ -329,7 +332,6 @@ if (zen_not_null($action)) {
                     );
                 } ?>
                 <a class="btn btn-default" role="button" href="<?php echo $cancel_link; ?>"><?php echo IMAGE_CANCEL; ?></a>
-            <?php } ?>
             </div>
             <?php echo '</form>'; ?>
             <hr />
@@ -359,9 +361,9 @@ if (zen_not_null($action)) {
               <table class="table table-hover">
                 <thead>
                   <tr class="dataTableHeadingRow">
-                    <th class="dataTableHeadingContent text-right"><?php echo 'ID#'; ?></th>
-                    <th class="dataTableHeadingContent"><?php echo TABLE_HEADING_PRODUCTS; ?></th>
+                    <th class="dataTableHeadingContent text-center"><?php echo 'ID#'; ?></th>
                     <th class="dataTableHeadingContent"><?php echo TABLE_HEADING_PRODUCTS_MODEL; ?></th>
+                    <th class="dataTableHeadingContent"><?php echo TABLE_HEADING_PRODUCTS; ?></th>
                     <th class="dataTableHeadingContent text-right"><?php echo TABLE_HEADING_PRODUCTS_PRICE; ?></th>
                     <th class="dataTableHeadingContent text-center"><?php echo TABLE_HEADING_AVAILABLE_DATE; ?></th>
                     <th class="dataTableHeadingContent text-center"><?php echo TABLE_HEADING_EXPIRES_DATE; ?></th>
@@ -404,11 +406,8 @@ if (zen_not_null($action)) {
                           }
                           $check_count++;
                         }
-                        $_GET['page'] = round((($check_count / MAX_DISPLAY_SEARCH_RESULTS) + (fmod_round($check_count, MAX_DISPLAY_SEARCH_RESULTS) != 0 ? .5 : 0)), 0);
+                        $_GET['page'] = round((($check_count / MAX_DISPLAY_SEARCH_RESULTS) + (fmod_round($check_count, MAX_DISPLAY_SEARCH_RESULTS) != 0 ? .5 : 0)));
                         $page = $_GET['page'];
-                        if ($old_page != $_GET['page']) {
-// do nothing
-                        }
                       } else {
                         $_GET['page'] = 1;
                       }
@@ -441,9 +440,9 @@ if (zen_not_null($action)) {
 
                       $sale_price = zen_get_products_special_price($special['products_id'], false);
                       ?>
-                  <td class="dataTableContent text-right"><?php echo $special['products_id']; ?>&nbsp;</td>
+                  <td class="dataTableContent text-center"><?php echo $special['products_id']; ?></td>
+                  <td class="dataTableContent"><?php echo $special['products_model']; ?></td>
                   <td class="dataTableContent"><?php echo zen_clean_html($special['products_name']); ?></td>
-                  <td class="dataTableContent"><?php echo $special['products_model']; ?>&nbsp;</td>
                   <td class="dataTableContent text-right"><?php echo zen_get_products_display_price($special['products_id']); ?></td>
                   <td class="dataTableContent text-center"><?php echo (($special['specials_date_available'] != '0001-01-01' && $special['specials_date_available'] != '') ? zen_date_short($special['specials_date_available']) : TEXT_NONE); ?></td>
                   <td class="dataTableContent text-center"><?php echo (($special['expires_date'] != '0001-01-01' && $special['expires_date'] != '') ? zen_date_short($special['expires_date']) : TEXT_NONE); ?></td>
@@ -452,14 +451,14 @@ if (zen_not_null($action)) {
                       if ($special['status'] == '1') {
                         echo zen_draw_form('setflag_products_' . $special['products_id'] , FILENAME_SPECIALS, 'action=setflag&id=' . $special['specials_id'] . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : ''));
                         ?>
-                      <input type="image" src="<?php echo DIR_WS_IMAGES ?>icon_green_on.gif" title="<?php echo IMAGE_ICON_STATUS_ON; ?>" alt="<?php echo IMAGE_ICON_STATUS_ON; ?>" />
+                      <input type="image" src="<?php echo DIR_WS_IMAGES ?>icon_green_on.gif" title="<?php echo TEXT_SPECIAL_ACTIVE; ?>" alt="<?php echo TEXT_SPECIAL_ACTIVE; ?>" />
                       <input type="hidden" name="flag" value="0" />
                       <?php echo '</form>'; ?>
                       <?php
                     } else {
                       echo zen_draw_form('setflag_products_' . $special['products_id'], FILENAME_SPECIALS, 'action=setflag&id=' . $special['specials_id'] . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : ''));
                       ?>
-                      <input type="image" src="<?php echo DIR_WS_IMAGES ?>icon_red_on.gif" title="<?php echo IMAGE_ICON_STATUS_OFF; ?>" alt="<?php echo IMAGE_ICON_STATUS_OFF; ?>" />
+                      <input type="image" src="<?php echo DIR_WS_IMAGES ?>icon_red_on.gif" title="<?php echo TEXT_SPECIAL_INACTIVE; ?>" alt="<?php echo TEXT_SPECIAL_INACTIVE; ?>" />
                       <input type="hidden" name="flag" value="1" />
                       <?php echo '</form>'; ?>
                       <?php
@@ -494,14 +493,14 @@ if (zen_not_null($action)) {
                     $heading[] = array('text' => '<h4>' . TEXT_INFO_HEADING_DELETE_SPECIALS . '</h4>');
                     $contents = array('form' => zen_draw_form('specials', FILENAME_SPECIALS, 'page=' . $_GET['page'] . '&action=deleteconfirm' . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . zen_draw_hidden_field('sID', $sInfo->specials_id));
                     $contents[] = array('text' => TEXT_INFO_DELETE_INTRO);
-                    $contents[] = array('text' => '<b>' . $sInfo->products_model . ' - ' . zen_clean_html($sInfo->products_name) . '</b>');
+                    $contents[] = array('text' => '<b>' . $sInfo->products_model . ' - "' . zen_clean_html($sInfo->products_name) . '"</b>');
                     $contents[] = array('align' => 'text-center', 'text' => '<br><button type="submit" class="btn btn-danger">' . IMAGE_DELETE . '</button> <a href="' . zen_href_link(FILENAME_SPECIALS, 'page=' . $_GET['page'] . '&sID=' . $sInfo->specials_id . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>');
                     break;
                   case 'pre_add':
                     $heading[] = array('text' => '<h4>' . TEXT_INFO_HEADING_PRE_ADD_SPECIALS . '</h4>');
                     $contents = array('form' => zen_draw_form('specials', FILENAME_SPECIALS, 'action=pre_add_confirmation' . ((isset($_GET['page']) && $_GET['page'] > 0) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : ''), 'post', 'class="form-horizontal"'));
                     $contents[] = array('text' => TEXT_INFO_PRE_ADD_INTRO);
-                    $result = $db->Execute("select max(products_id) as lastproductid from " . TABLE_PRODUCTS);
+                    $result = $db->Execute("SELECT MAX(products_id) AS lastproductid FROM " . TABLE_PRODUCTS);
                     $max_product_id = $result->fields['lastproductid'];
                     $contents[] = array('text' => zen_draw_label(TEXT_PRE_ADD_PRODUCTS_ID, 'pre_add_products_id', 'class="control-label"') . zen_draw_input_field('pre_add_products_id', '', zen_set_field_length(TABLE_SPECIALS, 'products_id') . ' class="form-control" id="pre_add_products_id" required max="' . $max_product_id . '"', '', 'number'));
                     $contents[] = array('align' => 'text-center', 'text' => '<button type="submit" class="btn btn-primary">' . IMAGE_CONFIRM . '</button> <a href="' . zen_href_link(FILENAME_SPECIALS, 'page=' . $_GET['page'] . '&sID=' . $sInfo->specials_id . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>');
@@ -525,9 +524,9 @@ if (zen_not_null($action)) {
                           $contents[] = array('text' => TEXT_INFO_ORIGINAL_PRICE . ' ' . $currencies->format($specials_current_price));
                           $contents[] = array('text' => TEXT_INFO_NEW_PRICE . ' ' . $currencies->format($sInfo->specials_new_products_price));
                           $contents[] = array('text' => '<b>' . TEXT_INFO_DISPLAY_PRICE . '<br>' . zen_get_products_display_price($sInfo->products_id) . '</b>');
-                          $contents[] = array('text' => TEXT_INFO_AVAILABLE_DATE . ' ' . (($sInfo->specials_date_available != '0001-01-01' and $sInfo->specials_date_available != '') ? zen_date_short($sInfo->specials_date_available) : TEXT_NONE));
-                          $contents[] = array('text' => TEXT_INFO_EXPIRES_DATE . ' ' . (($sInfo->expires_date != '0001-01-01' and $sInfo->expires_date != '') ? zen_date_short($sInfo->expires_date) : TEXT_NONE));
-                          if ($sInfo->date_status_change !== null && $sInfo->date_status_change !== '0001-01-01 00:00:00') {
+                          $contents[] = array('text' => TEXT_INFO_AVAILABLE_DATE . ' ' . (($sInfo->specials_date_available != '0001-01-01' && $sInfo->specials_date_available != '') ? zen_date_short($sInfo->specials_date_available) : TEXT_NONE));
+                          $contents[] = array('text' => TEXT_INFO_EXPIRES_DATE . ' ' . (($sInfo->expires_date != '0001-01-01' && $sInfo->expires_date != '') ? zen_date_short($sInfo->expires_date) : TEXT_NONE));
+                          if ($sInfo->date_status_change !== null && $sInfo->date_status_change !== '0001-01-01') {
                           $contents[] = array('text' => TEXT_INFO_STATUS_CHANGED . ' ' . zen_date_short($sInfo->date_status_change));
                           }
                           $contents[] = array('text' => '' . TEXT_INFO_LAST_MODIFIED . ' ' . zen_date_short($sInfo->specials_last_modified));
@@ -571,20 +570,6 @@ if (zen_not_null($action)) {
         ?>
       <!-- body_text_eof //-->
     <!-- body_eof //-->
-    </div>
-    <?php
-    if (($action == 'new') || ($action == 'edit')) {
-        ?>
-        <!-- script for datepicker -->
-        <script>
-            $(function () {
-                $('input[name="start"]').datepicker();
-                $('input[name="end"]').datepicker();
-            })
-        </script>
-        <?php
-    }
-    ?>
     <!-- footer //-->
     <?php require(DIR_WS_INCLUDES . 'footer.php'); ?>
     <!-- footer_eof //-->

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -350,10 +350,22 @@ if (zen_not_null($action)) {
           <table class="table">
             <tr>
               <td><?php echo TEXT_SPECIALS_PRICE_TIP; ?></td>
-              <td class="text-right">
-                <button type="submit" class="btn btn-primary"><?php echo (($form_action == 'insert') ? IMAGE_INSERT : IMAGE_UPDATE); ?></button>
-                <?php echo ((empty($_GET['manual']) || (int)$_GET['manual'] == 0) ? '&nbsp;<a href="' . (isset($_GET['go_back']) && $_GET['go_back'] == 'ON' ? zen_href_link(FILENAME_PRODUCTS_PRICE_MANAGER, 'products_filter=' . $_GET['add_products_id'] . '&current_category_id=' . $_GET['current_category_id']) : zen_href_link(FILENAME_SPECIALS, 'page=' . $_GET['page'] . ((isset($_GET['sID']) && $_GET['sID'] != '') ? '&sID=' . $_GET['sID'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : ''))) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>' : ''); ?>
-              </td>
+                <td class="text-right">
+                    <button type="submit" class="btn btn-primary"><?php echo(($form_action == 'insert') ? IMAGE_INSERT : IMAGE_UPDATE); ?></button>
+                    <?php
+                    if (empty($_GET['manual']) || (int)$_GET['manual'] == 0) {
+                        if (isset($_GET['go_back']) && $_GET['go_back'] == 'ON') {
+                            $cancel_link = zen_href_link(FILENAME_PRODUCTS_PRICE_MANAGER, 'products_filter=' . $_GET['add_products_id'] . '&current_category_id=' . $_GET['current_category_id']);
+                        } else {
+                            $cancel_link = zen_href_link(FILENAME_SPECIALS,
+                                (!empty($_GET['page']) ? 'page=' . $_GET['page'] : '') .
+                                (!empty($_GET['sID']) ? '&sID=' . $_GET['sID'] : '') .
+                                (!empty($_GET['search']) ? '&search=' . $_GET['search'] : '')
+                            );
+                        } ?>
+                        <a class="btn btn-default" role="button" href="<?php echo $cancel_link; ?>"><?php echo IMAGE_CANCEL; ?></a>
+                    <?php } ?>
+                </td>
             </tr>
           </table>
           <?php echo '</form>'; ?>

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -496,6 +496,10 @@ if (zen_not_null($action)) {
                 ?>
                 </tbody>
               </table>
+                <div class="row">
+                    <div class="col-sm-6"><?php echo $specials_split->display_count($specials_query_numrows, MAX_DISPLAY_SEARCH_RESULTS, $_GET['page'], TEXT_DISPLAY_NUMBER_OF_SPECIALS); ?></div>
+                    <div class="col-sm-6 text-right"><?php echo $specials_split->display_links($specials_query_numrows, MAX_DISPLAY_SEARCH_RESULTS, MAX_DISPLAY_PAGE_LINKS, $_GET['page'], zen_get_all_get_params(array('page', 'sID'))); ?></div>
+                </div>
             </div>
             <div class="col-xs-12 col-sm-12 col-md-3 col-lg-3 configurationColumnRight">
                 <?php
@@ -564,10 +568,6 @@ if (zen_not_null($action)) {
                 }
                 ?>
             </div>
-          </div>
-          <div class="row">
-              <div class="col-sm-6"><?php echo $specials_split->display_count($specials_query_numrows, MAX_DISPLAY_SEARCH_RESULTS, $_GET['page'], TEXT_DISPLAY_NUMBER_OF_SPECIALS); ?></div>
-              <div class="col-sm-6 text-right"><?php echo $specials_split->display_links($specials_query_numrows, MAX_DISPLAY_SEARCH_RESULTS, MAX_DISPLAY_PAGE_LINKS, $_GET['page'], zen_get_all_get_params(array('page', 'sID'))); ?></div>
           </div>
           <?php
         }

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -70,7 +70,7 @@ if (zen_not_null($action)) {
         // reset products_price_sorter for searches etc.
         zen_update_products_price_sorter((int)$products_id);
       } // nothing selected
-      if ($_GET['go_back'] == 'ON') {
+      if (isset($_GET['go_back']) && $_GET['go_back'] === 'ON') {
         zen_redirect(zen_href_link(FILENAME_PRODUCTS_PRICE_MANAGER, 'products_filter=' . $products_id . '&current_category_id=' . $_GET['current_category_id']));
       } else {
         zen_redirect(zen_href_link(FILENAME_SPECIALS, (isset($_GET['page']) && $_GET['page'] > 0 ? 'page=' . $_GET['page'] . '&' : '') . 'sID=' . $new_special->fields['specials_id'] . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')));

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -369,6 +369,7 @@ if (zen_not_null($action)) {
             </tr>
           </table>
           <?php echo '</form>'; ?>
+        </div>
           <?php
         } else {
           ?>
@@ -583,11 +584,9 @@ if (zen_not_null($action)) {
           <?php
         }
         ?>
-      </div>
       <!-- body_text_eof //-->
-    </div>
     <!-- body_eof //-->
-
+    </div>
     <!-- footer //-->
     <?php require(DIR_WS_INCLUDES . 'footer.php'); ?>
     <!-- footer_eof //-->

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -460,13 +460,13 @@ if (zen_not_null($action)) {
 
                       $sale_price = zen_get_products_special_price($special['products_id'], false);
                       ?>
-                  <td  class="dataTableContent text-right"><?php echo $special['products_id']; ?>&nbsp;</td>
-                  <td  class="dataTableContent"><?php echo $special['products_name']; ?></td>
-                  <td  class="dataTableContent"><?php echo $special['products_model']; ?>&nbsp;</td>
+                  <td class="dataTableContent text-right"><?php echo $special['products_id']; ?>&nbsp;</td>
+                  <td class="dataTableContent"><?php echo $special['products_name']; ?></td>
+                  <td class="dataTableContent"><?php echo $special['products_model']; ?>&nbsp;</td>
                   <td colspan="2" class="dataTableContent text-right"><?php echo zen_get_products_display_price($special['products_id']); ?></td>
-                  <td  class="dataTableContent text-center"><?php echo (($special['specials_date_available'] != '0001-01-01' && $special['specials_date_available'] != '') ? zen_date_short($special['specials_date_available']) : TEXT_NONE); ?></td>
-                  <td  class="dataTableContent text-center"><?php echo (($special['expires_date'] != '0001-01-01' && $special['expires_date'] != '') ? zen_date_short($special['expires_date']) : TEXT_NONE); ?></td>
-                  <td  class="dataTableContent text-center">
+                  <td class="dataTableContent text-center"><?php echo (($special['specials_date_available'] != '0001-01-01' && $special['specials_date_available'] != '') ? zen_date_short($special['specials_date_available']) : TEXT_NONE); ?></td>
+                  <td class="dataTableContent text-center"><?php echo (($special['expires_date'] != '0001-01-01' && $special['expires_date'] != '') ? zen_date_short($special['expires_date']) : TEXT_NONE); ?></td>
+                  <td class="dataTableContent text-center">
                       <?php
                       if ($special['status'] == '1') {
                         echo zen_draw_form('setflag_products', FILENAME_SPECIALS, 'action=setflag&id=' . $special['specials_id'] . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : ''));

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -469,14 +469,14 @@ if (zen_not_null($action)) {
                   <td class="dataTableContent text-center">
                       <?php
                       if ($special['status'] == '1') {
-                        echo zen_draw_form('setflag_products', FILENAME_SPECIALS, 'action=setflag&id=' . $special['specials_id'] . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : ''));
+                        echo zen_draw_form('setflag_products_' . $special['products_id'] , FILENAME_SPECIALS, 'action=setflag&id=' . $special['specials_id'] . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : ''));
                         ?>
                       <input type="image" src="<?php echo DIR_WS_IMAGES ?>icon_green_on.gif" title="<?php echo IMAGE_ICON_STATUS_ON; ?>" alt="<?php echo IMAGE_ICON_STATUS_ON; ?>" />
                       <input type="hidden" name="flag" value="0" />
                       <?php echo '</form>'; ?>
                       <?php
                     } else {
-                      echo zen_draw_form('setflag_products', FILENAME_SPECIALS, 'action=setflag&id=' . $special['specials_id'] . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : ''));
+                      echo zen_draw_form('setflag_products_' . $special['products_id'], FILENAME_SPECIALS, 'action=setflag&id=' . $special['specials_id'] . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : ''));
                       ?>
                       <input type="image" src="<?php echo DIR_WS_IMAGES ?>icon_red_on.gif" title="<?php echo IMAGE_ICON_STATUS_OFF; ?>" alt="<?php echo IMAGE_ICON_STATUS_OFF; ?>" />
                       <input type="hidden" name="flag" value="1" />

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -4,7 +4,7 @@
  * @copyright Copyright 2003-2019 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Zen4All 2019 Feb 14 Modified in v1.5.6b $
+ * @version $Id: torvista 2020 Jan 26 Modified in v1.5.7 $
  */
 require('includes/application_top.php');
 
@@ -455,22 +455,26 @@ if (zen_not_null($action)) {
                   <td class="dataTableContent text-center"><?php echo (($special['expires_date'] != '0001-01-01' && $special['expires_date'] != '') ? zen_date_short($special['expires_date']) : TEXT_NONE); ?></td>
                   <td class="dataTableContent text-center">
                       <?php
-                      if ($special['status'] == '1') {
-                        echo zen_draw_form('setflag_products_' . $special['products_id'] , FILENAME_SPECIALS, 'action=setflag&id=' . $special['specials_id'] . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : ''));
-                        ?>
-                      <input type="image" src="<?php echo DIR_WS_IMAGES ?>icon_green_on.gif" title="<?php echo TEXT_SPECIAL_ACTIVE; ?>" alt="<?php echo TEXT_SPECIAL_ACTIVE; ?>" />
-                      <input type="hidden" name="flag" value="0" />
-                      <?php echo '</form>'; ?>
-                      <?php
-                    } else {
-                      echo zen_draw_form('setflag_products_' . $special['products_id'], FILENAME_SPECIALS, 'action=setflag&id=' . $special['specials_id'] . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : ''));
+                      if (($special['specials_date_available'] != '0001-01-01' && $special['specials_date_available'] != '') || ($special['expires_date'] != '0001-01-01' && $special['expires_date'] != '')) {
+                          echo $special['status'] === '1' ? '<img src="' . DIR_WS_IMAGES . 'icon_green_on.gif" title="' . TEXT_SPECIAL_ACTIVE . ': ' . TEXT_SPECIAL_STATUS_BY_DATE . '" alt="' . TEXT_SPECIAL_ACTIVE  . ': ' . TEXT_SPECIAL_STATUS_BY_DATE. '">' : '<img src="' . DIR_WS_IMAGES . 'icon_red_on.gif" title="' . TEXT_SPECIAL_INACTIVE . ': ' . TEXT_SPECIAL_STATUS_BY_DATE . '" alt="' . TEXT_SPECIAL_INACTIVE . ': ' . TEXT_SPECIAL_STATUS_BY_DATE . '">';
+                      } else {
+                          if ($special['status'] == '1') {
+                              echo zen_draw_form('setflag_products_' . $special['products_id'], FILENAME_SPECIALS, 'action=setflag&id=' . $special['specials_id'] . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : ''));
+                              ?>
+                              <input type="image" src="<?php echo DIR_WS_IMAGES ?>icon_green_on.gif" title="<?php echo TEXT_SPECIAL_ACTIVE; ?>" alt="<?php echo TEXT_SPECIAL_ACTIVE; ?>"/>
+                              <input type="hidden" name="flag" value="0"/>
+                              <?php echo '</form>'; ?>
+                              <?php
+                          } else {
+                              echo zen_draw_form('setflag_products_' . $special['products_id'], FILENAME_SPECIALS, 'action=setflag&id=' . $special['specials_id'] . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : ''));
+                              ?>
+                              <input type="image" src="<?php echo DIR_WS_IMAGES ?>icon_red_on.gif" title="<?php echo TEXT_SPECIAL_INACTIVE; ?>" alt="<?php echo TEXT_SPECIAL_INACTIVE; ?>"/>
+                              <input type="hidden" name="flag" value="1"/>
+                              <?php echo '</form>'; ?>
+                              <?php
+                          }
+                      }
                       ?>
-                      <input type="image" src="<?php echo DIR_WS_IMAGES ?>icon_red_on.gif" title="<?php echo TEXT_SPECIAL_INACTIVE; ?>" alt="<?php echo TEXT_SPECIAL_INACTIVE; ?>" />
-                      <input type="hidden" name="flag" value="1" />
-                      <?php echo '</form>'; ?>
-                      <?php
-                    }
-                    ?>
                   </td>
                   <td class="dataTableContent text-right">
                       <?php echo '<a href="' . zen_href_link(FILENAME_SPECIALS, 'page=' . $_GET['page'] . '&sID=' . $special['specials_id'] . '&action=edit' . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . '">' . zen_image(DIR_WS_IMAGES . 'icon_edit.gif', ICON_EDIT) . '</a>'; ?>
@@ -576,6 +580,7 @@ if (zen_not_null($action)) {
         ?>
       <!-- body_text_eof //-->
     <!-- body_eof //-->
+    </div>
     <!-- footer //-->
     <?php require(DIR_WS_INCLUDES . 'footer.php'); ?>
     <!-- footer_eof //-->

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -443,7 +443,7 @@ if (zen_not_null($action)) {
                         if (isset($sInfo) && is_object($sInfo) && ($special['specials_id'] == $sInfo->specials_id)) { ?>
                         <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href='<?php echo zen_href_link(FILENAME_SPECIALS, 'page=' . $_GET['page'] . '&sID=' . $sInfo->specials_id . '&action=edit' . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')); ?>'">
                       <?php } else { ?>
-                        <tr class="dataTableRow" onclick="document.location.href='<?php echo zen_href_link(FILENAME_SPECIALS, 'page=' . $_GET['page'] . '&sID=' . $special['specials_id'] . '&action=edit' . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')); ?>'">
+                        <tr class="dataTableRow" onclick="document.location.href='<?php echo zen_href_link(FILENAME_SPECIALS, 'page=' . $_GET['page'] . '&sID=' . $special['specials_id'] . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')); ?>'">
                       <?php }
 
                       if ($special['products_priced_by_attribute'] == '1') {

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -544,7 +544,7 @@ if (zen_not_null($action)) {
                           }
                           $contents[] = array('text' => '' . TEXT_INFO_LAST_MODIFIED . ' ' . zen_date_short($sInfo->specials_last_modified));
                           $contents[] = array('text' => TEXT_INFO_DATE_ADDED . ' ' . zen_date_short($sInfo->specials_date_added));
-                          $contents[] = array('align' => 'text-center', 'text' => zen_info_image($sInfo->products_image, $sInfo->products_name, SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT));
+                          $contents[] = array('align' => 'text-center', 'text' => zen_info_image($sInfo->products_image, htmlspecialchars($sInfo->products_name), SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT));
                           $contents[] = array('align' => 'text-center', 'text' =>
                               '<a href="' . zen_href_link(FILENAME_PRODUCT, '&action=new_product' . '&cPath=' . zen_get_product_path($sInfo->products_id, 'override') . '&pID=' . $sInfo->products_id . '&product_type=' . zen_get_products_type($sInfo->products_id)) .
                               '" class="btn btn-primary" role="button">' . IMAGE_EDIT_PRODUCT . '</a>'

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -471,14 +471,14 @@ if (zen_not_null($action)) {
                       if ($special['status'] == '1') {
                         echo zen_draw_form('setflag_products', FILENAME_SPECIALS, 'action=setflag&id=' . $special['specials_id'] . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : ''));
                         ?>
-                      <input type="image" src="<?php echo DIR_WS_IMAGES ?>icon_green_on.gif" title="<?php echo IMAGE_ICON_STATUS_ON; ?>" />
+                      <input type="image" src="<?php echo DIR_WS_IMAGES ?>icon_green_on.gif" title="<?php echo IMAGE_ICON_STATUS_ON; ?>" alt="<?php echo IMAGE_ICON_STATUS_ON; ?>" />
                       <input type="hidden" name="flag" value="0" />
                       <?php echo '</form>'; ?>
                       <?php
                     } else {
                       echo zen_draw_form('setflag_products', FILENAME_SPECIALS, 'action=setflag&id=' . $special['specials_id'] . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : ''));
                       ?>
-                      <input type="image" src="<?php echo DIR_WS_IMAGES ?>icon_red_on.gif" title="<?php echo IMAGE_ICON_STATUS_OFF; ?>" />
+                      <input type="image" src="<?php echo DIR_WS_IMAGES ?>icon_red_on.gif" title="<?php echo IMAGE_ICON_STATUS_OFF; ?>" alt="<?php echo IMAGE_ICON_STATUS_OFF; ?>" />
                       <input type="hidden" name="flag" value="1" />
                       <?php echo '</form>'; ?>
                       <?php

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -308,18 +308,21 @@ if (zen_not_null($action)) {
                     echo zen_draw_label(TEXT_SPECIALS_PRODUCT, 'products_id', 'class="col-sm-3 control-label"'); ?>
                     <div class="col-sm-9 col-md-6">
                         <?php
-                        echo zen_draw_products_pull_down('products_id', 'size="15" class="form-control" id="products_id"', $specials_array, true, (!empty($_GET['add_products_id']) ? $_GET['add_products_id'] : ''), true);
-                        echo zen_draw_hidden_field('products_price', (!empty($sInfo->products_price) ? $sInfo->products_price : ''));
+                        echo zen_draw_products_pull_down('products_id', 'required size="15" class="form-control" id="products_id"', $specials_array, true, (!empty($_GET['add_products_id']) ? $_GET['add_products_id'] : ''), true);
                         ?>
                     </div>
                 <?php } ?>
             </div>
+
           <div class="form-group">
-              <?php echo zen_draw_label(TEXT_SPECIALS_SPECIAL_PRICE, 'specials_price', 'class="col-sm-3 control-label"'); ?>
+              <?php
+              echo zen_draw_label(TEXT_SPECIALS_SPECIAL_PRICE, 'specials_price', 'class="col-sm-3 control-label"');
+              ?>
             <div class="col-sm-9 col-md-6">
                 <?php
-                echo zen_draw_input_field('specials_price', (!empty($sInfo->specials_new_products_price) ? $sInfo->specials_new_products_price : ''), 'class="form-control" id="specials_price"');
+                echo zen_draw_input_field('specials_price', (!empty($sInfo->specials_new_products_price) ? $sInfo->specials_new_products_price : ''), 'required class="form-control" id="specials_price"');
                 echo zen_draw_hidden_field('products_priced_by_attribute', $sInfo->products_priced_by_attribute);
+                echo zen_draw_hidden_field('products_price', (!empty($sInfo->products_price) ? $sInfo->products_price : ''));
                 echo zen_draw_hidden_field('update_products_id', $sInfo->products_id);
                 ?>
             </div>

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -446,11 +446,11 @@ if (zen_not_null($action)) {
                         $sInfo = new objectInfo($sInfo_array);
                       }
 
-                      if (isset($sInfo) && is_object($sInfo) && ($special['specials_id'] == $sInfo->specials_id)) {
-                        echo '                  <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href=\'' . zen_href_link(FILENAME_SPECIALS, 'page=' . $_GET['page'] . '&sID=' . $sInfo->specials_id . '&action=edit' . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . '\'" role="button">' . "\n";
-                      } else {
-                        echo '                  <tr class="dataTableRow" onclick="document.location.href=\'' . zen_href_link(FILENAME_SPECIALS, 'page=' . $_GET['page'] . '&sID=' . $special['specials_id'] . '&action=edit' . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . '\'" role="button">' . "\n";
-                      }
+                        if (isset($sInfo) && is_object($sInfo) && ($special['specials_id'] == $sInfo->specials_id)) { ?>
+                        <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href='<?php echo zen_href_link(FILENAME_SPECIALS, 'page=' . $_GET['page'] . '&sID=' . $sInfo->specials_id . '&action=edit' . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')); ?>'">
+                      <?php } else { ?>
+                        <tr class="dataTableRow" onclick="document.location.href='<?php echo zen_href_link(FILENAME_SPECIALS, 'page=' . $_GET['page'] . '&sID=' . $special['specials_id'] . '&action=edit' . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')); ?>'">
+                      <?php }
 
                       if ($special['products_priced_by_attribute'] == '1') {
                         $specials_current_price = zen_get_products_base_price($special['products_id']);

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -209,30 +209,6 @@ if (zen_not_null($action)) {
       <!-- body //-->
       <h1><?php echo HEADING_TITLE; ?></h1>
       <!-- body_text //-->
-      <div class="row text-right">
-          <?php echo zen_draw_form('search', FILENAME_SPECIALS, '', 'get'); ?>
-          <?php
-// show reset search
-          if (isset($_GET['search']) && zen_not_null($_GET['search'])) {
-            echo '<a href="' . zen_href_link(FILENAME_SPECIALS) . '">' . zen_image_button('button_reset.gif', IMAGE_RESET) . '</a>&nbsp;&nbsp;';
-          }
-          echo HEADING_TITLE_SEARCH_DETAIL . ' ' . zen_draw_input_field('search') . zen_hide_session_id();
-          if (isset($_GET['search']) && zen_not_null($_GET['search'])) {
-            $keywords = zen_db_input(zen_db_prepare_input($_GET['search']));
-            echo '<br>' . TEXT_INFO_SEARCH_DETAIL_FILTER . $keywords;
-          }
-          ?>
-          <?php echo '</form>'; ?>
-      </div>
-      <?php
-      if (empty($action)) {
-        ?>
-        <div class="row text-center">
-          <a href="<?php echo zen_href_link(FILENAME_SPECIALS, ((isset($_GET['page']) && $_GET['page'] > 0) ? 'page=' . $_GET['page'] . '&' : '') . 'action=new'); ?>" class="btn btn-primary" role="button"><?php echo TEXT_ADD_SPECIAL; ?></a>
-        </div>
-        <?php
-      }
-      ?>
       <?php
       if (($action == 'new') || ($action == 'edit')) {
         $form_action = 'insert';
@@ -373,6 +349,24 @@ if (zen_not_null($action)) {
         } else {
           ?>
           <div class="row">
+              <a href="<?php echo zen_href_link(FILENAME_SPECIALS, ((isset($_GET['page']) && $_GET['page'] > 0) ? 'page=' . $_GET['page'] . '&' : '') . 'action=new'); ?>" class="btn btn-primary" role="button"><?php echo TEXT_ADD_SPECIAL; ?></a>
+          </div>
+          <hr />
+          <div class="row">
+            <div style ="margin-bottom: 5px">
+                  <?php echo zen_draw_form('search', FILENAME_SPECIALS, '', 'get');
+                  // show reset search
+                  if (isset($_GET['search']) && zen_not_null($_GET['search'])) {
+                      echo '<a href="' . zen_href_link(FILENAME_SPECIALS) . '">' . zen_image_button('button_reset.gif', IMAGE_RESET) . '</a>&nbsp;&nbsp;';
+                  }
+                  echo TEXT_SEARCH_SPECIALS . ' ' . zen_draw_input_field('search') . zen_hide_session_id();
+                  if (isset($_GET['search']) && zen_not_null($_GET['search'])) {
+                      $keywords = zen_db_input(zen_db_prepare_input($_GET['search']));
+                      echo '<br>' . TEXT_INFO_SEARCH_DETAIL_FILTER . $keywords;
+                  }
+                  echo '</form>'; ?>
+            </div>
+            <div><?php echo TEXT_STATUS_WARNING; ?></div>
             <div class="col-xs-12 col-sm-12 col-md-9 col-lg-9 configurationColumnLeft">
               <table class="table table-hover">
                 <thead>

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -381,7 +381,7 @@ if (zen_not_null($action)) {
                     <th class="dataTableHeadingContent text-right"><?php echo 'ID#'; ?></th>
                     <th class="dataTableHeadingContent"><?php echo TABLE_HEADING_PRODUCTS; ?></th>
                     <th class="dataTableHeadingContent"><?php echo TABLE_HEADING_PRODUCTS_MODEL; ?></th>
-                    <th colspan="2" class="dataTableHeadingContent text-right"><?php echo TABLE_HEADING_PRODUCTS_PRICE; ?></th>
+                    <th class="dataTableHeadingContent text-right"><?php echo TABLE_HEADING_PRODUCTS_PRICE; ?></th>
                     <th class="dataTableHeadingContent text-center"><?php echo TABLE_HEADING_AVAILABLE_DATE; ?></th>
                     <th class="dataTableHeadingContent text-center"><?php echo TABLE_HEADING_EXPIRES_DATE; ?></th>
                     <th class="dataTableHeadingContent text-center"><?php echo TABLE_HEADING_STATUS; ?></th>
@@ -463,7 +463,7 @@ if (zen_not_null($action)) {
                   <td class="dataTableContent text-right"><?php echo $special['products_id']; ?>&nbsp;</td>
                   <td class="dataTableContent"><?php echo $special['products_name']; ?></td>
                   <td class="dataTableContent"><?php echo $special['products_model']; ?>&nbsp;</td>
-                  <td colspan="2" class="dataTableContent text-right"><?php echo zen_get_products_display_price($special['products_id']); ?></td>
+                  <td class="dataTableContent text-right"><?php echo zen_get_products_display_price($special['products_id']); ?></td>
                   <td class="dataTableContent text-center"><?php echo (($special['specials_date_available'] != '0001-01-01' && $special['specials_date_available'] != '') ? zen_date_short($special['specials_date_available']) : TEXT_NONE); ?></td>
                   <td class="dataTableContent text-center"><?php echo (($special['expires_date'] != '0001-01-01' && $special['expires_date'] != '') ? zen_date_short($special['expires_date']) : TEXT_NONE); ?></td>
                   <td class="dataTableContent text-center">
@@ -572,7 +572,7 @@ if (zen_not_null($action)) {
               if (empty($action)) {
                 ?>
                 <tr>
-                  <td colspan="2" align="right">
+                  <td colspan="2" class="text-right">
                     <a href="<?php echo zen_href_link(FILENAME_SPECIALS, ((isset($_GET['page']) && $_GET['page'] > 0) ? 'page=' . $_GET['page'] . '&' : '') . 'action=new'); ?>" class="btn btn-primary" role="button"><?php echo IMAGE_NEW_PRODUCT; ?></a>
                   </td>
                 </tr>

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -350,28 +350,24 @@ if (zen_not_null($action)) {
                 </div>
             </div>
 
-          <table class="table">
-            <tr>
-              <td><?php echo TEXT_SPECIALS_PRICE_NOTES; ?></td>
-                <td class="text-right">
-                    <button type="submit" class="btn btn-primary"><?php echo(($form_action == 'insert') ? IMAGE_INSERT : IMAGE_UPDATE); ?></button>
-                    <?php
-                    if (empty($_GET['manual']) || (int)$_GET['manual'] == 0) {
-                        if (isset($_GET['go_back']) && $_GET['go_back'] == 'ON') {
-                            $cancel_link = zen_href_link(FILENAME_PRODUCTS_PRICE_MANAGER, 'products_filter=' . $_GET['add_products_id'] . '&current_category_id=' . $_GET['current_category_id']);
-                        } else {
-                            $cancel_link = zen_href_link(FILENAME_SPECIALS,
-                                (!empty($_GET['page']) ? 'page=' . $_GET['page'] : '') .
-                                (!empty($_GET['sID']) ? '&sID=' . $_GET['sID'] : '') .
-                                (!empty($_GET['search']) ? '&search=' . $_GET['search'] : '')
-                            );
-                        } ?>
-                        <a class="btn btn-default" role="button" href="<?php echo $cancel_link; ?>"><?php echo IMAGE_CANCEL; ?></a>
-                    <?php } ?>
-                </td>
-            </tr>
-          </table>
-          <?php echo '</form>'; ?>
+            <div class="text-right"><button type="submit" class="btn btn-primary"><?php echo(($form_action == 'insert') ? IMAGE_INSERT : IMAGE_UPDATE); ?></button>
+            <?php
+            if (empty($_GET['manual']) || (int)$_GET['manual'] == 0) {
+                if (isset($_GET['go_back']) && $_GET['go_back'] == 'ON') {
+                    $cancel_link = zen_href_link(FILENAME_PRODUCTS_PRICE_MANAGER, 'products_filter=' . $_GET['add_products_id'] . '&current_category_id=' . $_GET['current_category_id']);
+                } else {
+                    $cancel_link = zen_href_link(FILENAME_SPECIALS,
+                        (!empty($_GET['page']) ? 'page=' . $_GET['page'] : '') .
+                        (!empty($_GET['sID']) ? '&sID=' . $_GET['sID'] : '') .
+                        (!empty($_GET['search']) ? '&search=' . $_GET['search'] : '')
+                    );
+                } ?>
+                <a class="btn btn-default" role="button" href="<?php echo $cancel_link; ?>"><?php echo IMAGE_CANCEL; ?></a>
+            <?php } ?>
+            </div>
+            <?php echo '</form>'; ?>
+            <hr />
+            <?php echo TEXT_SPECIALS_PRICE_NOTES; ?>
         </div>
           <?php
         } else {

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -248,7 +248,7 @@ if (zen_not_null($action)) {
         if (($action == 'edit') && isset($_GET['sID'])) {
           $form_action = 'update';
 
-          $product = $db->Execute("SELECT p.products_id, pd.products_name, p.products_price, p.products_priced_by_attribute,
+          $product = $db->Execute("SELECT p.products_id, p.products_model, pd.products_name, p.products_price, p.products_priced_by_attribute,
                                           s.specials_new_products_price, s.expires_date, s.specials_date_available
                                    FROM " . TABLE_PRODUCTS . " p,
                                         " . TABLE_PRODUCTS_DESCRIPTION . " pd,
@@ -308,21 +308,26 @@ if (zen_not_null($action)) {
         </script>
         <div class="row"><?php echo zen_draw_separator('pixel_trans.gif', '100%', '5'); ?></div>
         <div class="row">
-            <?php echo zen_draw_form('new_special', FILENAME_SPECIALS, zen_get_all_get_params(array('action', 'info', 'sID')) . 'action=' . $form_action . (!empty($_GET['go_back']) ? '&go_back=' . $_GET['go_back'] : ''), 'post', 'onsubmit="return check_dates(start,StartDate.required, end, EndDate.required);" class="form-horizontal"'); ?>
+            <?php echo zen_draw_form('new_special', FILENAME_SPECIALS, zen_get_all_get_params(array('action', 'info', 'sID')) . 'action=' . $form_action . (!empty($_GET['go_back']) ? '&go_back=' . $_GET['go_back'] : ''), 'post', 'onsubmit="return check_dates(start, StartDate.required, end, EndDate.required);" class="form-horizontal"'); ?>
             <?php
             if ($form_action == 'update') {
               echo zen_draw_hidden_field('specials_id', $_GET['sID']);
             }
             ?>
-          <div class="form-group">
-              <?php echo zen_draw_label(TEXT_SPECIALS_PRODUCT, 'products_id', 'class="col-sm-3 control-label"'); ?>
-            <div class="col-sm-9 col-md-6">
-                <?php
-                echo (isset($sInfo->products_name)) ? $sInfo->products_name . ' (' . $currencies->format($sInfo->products_price) . ')' : zen_draw_products_pull_down('products_id', 'size="15" class="form-control"', $specials_array, true, (!empty($_GET['add_products_id']) ? $_GET['add_products_id'] : ''), true);
-                echo zen_draw_hidden_field('products_price', (isset($sInfo->products_price) ? $sInfo->products_price : ''));
-                ?>
+            <div class="form-group">
+                <?php if (isset($sInfo->products_name)) { ?>
+                    <p class="col-sm-3 control-label"><strong><?php echo TEXT_SPECIALS_PRODUCT; ?></strong></p>
+                    <div class="col-sm-9 col-md-6"><?php echo $sInfo->products_model . ' - "' . $sInfo->products_name . '" (' . $currencies->format($sInfo->products_price) . ')'; ?></div>
+                <?php } else {
+                    echo zen_draw_label(TEXT_SPECIALS_PRODUCT, 'products_id', 'class="col-sm-3 control-label"'); ?>
+                    <div class="col-sm-9 col-md-6">
+                        <?php
+                        echo zen_draw_products_pull_down('products_id', 'size="15" class="form-control"', $specials_array, true, (!empty($_GET['add_products_id']) ? $_GET['add_products_id'] : ''), true);
+                        echo zen_draw_hidden_field('products_price', (isset($sInfo->products_price) ? $sInfo->products_price : ''));
+                        ?>
+                    </div>
+                <?php } ?>
             </div>
-          </div>
           <div class="form-group">
               <?php echo zen_draw_label(TEXT_SPECIALS_SPECIAL_PRICE, 'specials_price', 'class="col-sm-3 control-label"'); ?>
             <div class="col-sm-9 col-md-6">

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -137,7 +137,7 @@ if (zen_not_null($action)) {
                 FROM " . TABLE_PRODUCTS . "
                 WHERE products_id = " . (int)$_POST['pre_add_products_id'];
         $check_product = $db->Execute($sql);
-          if ($check_product->RecordCount() < 1) {// check for PID valid
+          if ($check_product->RecordCount() < 1) {// check for valid PID
               $skip_special = true;
               $messageStack->add_session(sprintf(WARNING_SPECIALS_PRE_ADD_PID_NO_EXIST, (int)$_POST['pre_add_products_id']), 'caution');
           } elseif ((!defined('MODULE_ORDER_TOTAL_GV_SPECIAL') || MODULE_ORDER_TOTAL_GV_SPECIAL == 'false') && (substr($check_product->fields['products_model'], 0, 4) == 'GIFT')) { // check for PID as a gift voucher
@@ -279,7 +279,7 @@ if (zen_not_null($action)) {
             <div class="form-group">
                 <?php if (isset($sInfo->products_name)) { ?>
                     <p class="col-sm-3 control-label"><strong><?php echo TEXT_SPECIALS_PRODUCT; ?></strong></p>
-                    <div class="col-sm-9 col-md-6"><span class="form-control" style="border:none; -webkit-box-shadow: none"><?php echo $sInfo->products_model . ' - "' . $sInfo->products_name . '" (' . $currencies->format($sInfo->products_price) . ')'; ?></span></div>
+                    <div class="col-sm-9 col-md-6"><span class="form-control" style="border:none; -webkit-box-shadow: none"><?php echo 'ID#' . $sInfo->products_id . ': ' . $sInfo->products_model . ' - "' . zen_clean_html($sInfo->products_name) . '" (' . $currencies->format($sInfo->products_price) . ')'; ?></span></div>
                 <?php } else {
                     echo zen_draw_label(TEXT_SPECIALS_PRODUCT, 'products_id', 'class="col-sm-3 control-label"'); ?>
                     <div class="col-sm-9 col-md-6">
@@ -350,7 +350,7 @@ if (zen_not_null($action)) {
           ?>
           <div class="row">
               <a href="<?php echo zen_href_link(FILENAME_SPECIALS, ((isset($_GET['page']) && $_GET['page'] > 0) ? 'page=' . $_GET['page'] . '&' : '') . 'action=new'); ?>" class="btn btn-primary" role="button"><?php echo TEXT_ADD_SPECIAL_SELECT; ?></a>
-              <a href="<?php echo zen_href_link(FILENAME_SPECIALS, 'action=pre_add' . ((isset($_GET['page']) && $_GET['page'] > 0) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')); ?>" class="btn btn-primary" role="button"><?php echo TEXT_ADD_SPECIAL_PID; ?></a>
+              <a href="<?php echo zen_href_link(FILENAME_SPECIALS, 'action=pre_add' . ((isset($_GET['page']) && $_GET['page'] > 0) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')); ?>" class="btn btn-primary" role="button" title="<?php echo TEXT_INFO_PRE_ADD_INTRO; ?>"><?php echo TEXT_ADD_SPECIAL_PID; ?></a>
           </div>
           <hr />
           <div class="row">
@@ -452,7 +452,7 @@ if (zen_not_null($action)) {
                       $sale_price = zen_get_products_special_price($special['products_id'], false);
                       ?>
                   <td class="dataTableContent text-right"><?php echo $special['products_id']; ?>&nbsp;</td>
-                  <td class="dataTableContent"><?php echo $special['products_name']; ?></td>
+                  <td class="dataTableContent"><?php echo zen_clean_html($special['products_name']); ?></td>
                   <td class="dataTableContent"><?php echo $special['products_model']; ?>&nbsp;</td>
                   <td class="dataTableContent text-right"><?php echo zen_get_products_display_price($special['products_id']); ?></td>
                   <td class="dataTableContent text-center"><?php echo (($special['specials_date_available'] != '0001-01-01' && $special['specials_date_available'] != '') ? zen_date_short($special['specials_date_available']) : TEXT_NONE); ?></td>
@@ -478,7 +478,7 @@ if (zen_not_null($action)) {
                   </td>
                   <td class="dataTableContent text-right">
                       <?php echo '<a href="' . zen_href_link(FILENAME_SPECIALS, 'page=' . $_GET['page'] . '&sID=' . $special['specials_id'] . '&action=edit' . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . '">' . zen_image(DIR_WS_IMAGES . 'icon_edit.gif', ICON_EDIT) . '</a>'; ?>
-                      <?php echo '<a href="' . zen_href_link(FILENAME_SPECIALS, 'page=' . $_GET['page'] . '&sID=' . $special['specials_id'] . '&action=delete' . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . '">' . zen_image(DIR_WS_IMAGES . 'icon_delete.gif', ICON_DELETE) . '</a>'; ?>
+                      <?php echo '<a href="' . zen_href_link(FILENAME_SPECIALS, 'page=' . $_GET['page'] . '&sID=' . $special['specials_id'] . '&action=delete' . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . '">' . zen_image(DIR_WS_IMAGES . 'icon_delete.gif', TEXT_INFO_HEADING_DELETE_SPECIALS) . '</a>'; ?>
                       <?php
                       if (isset($sInfo) && is_object($sInfo) && ($special['specials_id'] == $sInfo->specials_id)) {
                         echo zen_image(DIR_WS_IMAGES . 'icon_arrow_right.gif', '');
@@ -502,22 +502,23 @@ if (zen_not_null($action)) {
                 switch ($action) {
                   case 'delete':
                     $heading[] = array('text' => '<h4>' . TEXT_INFO_HEADING_DELETE_SPECIALS . '</h4>');
-
                     $contents = array('form' => zen_draw_form('specials', FILENAME_SPECIALS, 'page=' . $_GET['page'] . '&action=deleteconfirm' . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . zen_draw_hidden_field('sID', $sInfo->specials_id));
                     $contents[] = array('text' => TEXT_INFO_DELETE_INTRO);
-                    $contents[] = array('text' => '<b>' . $sInfo->products_model . ' - ' . $sInfo->products_name . '</b>');
+                    $contents[] = array('text' => '<b>' . $sInfo->products_model . ' - ' . zen_clean_html($sInfo->products_name) . '</b>');
                     $contents[] = array('align' => 'text-center', 'text' => '<br><button type="submit" class="btn btn-danger">' . IMAGE_DELETE . '</button> <a href="' . zen_href_link(FILENAME_SPECIALS, 'page=' . $_GET['page'] . '&sID=' . $sInfo->specials_id . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>');
                     break;
                   case 'pre_add':
                     $heading[] = array('text' => '<h4>' . TEXT_INFO_HEADING_PRE_ADD_SPECIALS . '</h4>');
                     $contents = array('form' => zen_draw_form('specials', FILENAME_SPECIALS, 'action=pre_add_confirmation' . ((isset($_GET['page']) && $_GET['page'] > 0) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : ''), 'post', 'class="form-horizontal"'));
                     $contents[] = array('text' => TEXT_INFO_PRE_ADD_INTRO);
-                    $contents[] = array('text' => zen_draw_label(TEXT_PRE_ADD_PRODUCTS_ID, 'pre_add_products_id', 'class="control-label"') . zen_draw_input_field('pre_add_products_id', '', zen_set_field_length(TABLE_SPECIALS, 'products_id') . ' class="form-control" id="pre_add_products_id"'));
+                    $result = $db->Execute("select max(products_id) as lastproductid from " . TABLE_PRODUCTS);
+                    $max_product_id = $result->fields['lastproductid'];
+                    $contents[] = array('text' => zen_draw_label(TEXT_PRE_ADD_PRODUCTS_ID, 'pre_add_products_id', 'class="control-label"') . zen_draw_input_field('pre_add_products_id', '', zen_set_field_length(TABLE_SPECIALS, 'products_id') . ' class="form-control" id="pre_add_products_id" required max="' . $max_product_id . '"', '', 'number'));
                     $contents[] = array('align' => 'text-center', 'text' => '<button type="submit" class="btn btn-primary">' . IMAGE_CONFIRM . '</button> <a href="' . zen_href_link(FILENAME_SPECIALS, 'page=' . $_GET['page'] . '&sID=' . $sInfo->specials_id . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>');
                     break;
                   default:
                       if (isset($sInfo) && is_object($sInfo)) {
-                          $heading[] = array('text' => '<h4>' . $sInfo->products_name . '</h4>');
+                          $heading[] = array('text' => '<h4>ID#' . $sInfo->products_id . ': ' . $sInfo->products_model . ' - "' . zen_clean_html($sInfo->products_name) . '"</h4>');
 
                           if ($sInfo->products_priced_by_attribute == '1') {
                               $specials_current_price = zen_get_products_base_price($sInfo->products_id);
@@ -533,7 +534,7 @@ if (zen_not_null($action)) {
                           $contents[] = array('align' => 'text-center', 'text' => '<a href="' . zen_href_link(FILENAME_PRODUCTS_PRICE_MANAGER, 'action=edit&products_filter=' . $sInfo->products_id) . '" class="btn btn-primary" role="button">' . IMAGE_PRODUCTS_PRICE_MANAGER . '</a>');
                           $contents[] = array('text' => TEXT_INFO_ORIGINAL_PRICE . ' ' . $currencies->format($specials_current_price));
                           $contents[] = array('text' => TEXT_INFO_NEW_PRICE . ' ' . $currencies->format($sInfo->specials_new_products_price));
-                          $contents[] = array('text' => TEXT_INFO_DISPLAY_PRICE . ' ' . zen_get_products_display_price($sInfo->products_id));
+                          $contents[] = array('text' => '<b>' . TEXT_INFO_DISPLAY_PRICE . '<br>' . zen_get_products_display_price($sInfo->products_id) . '</b>');
                           $contents[] = array('text' => TEXT_INFO_AVAILABLE_DATE . ' ' . (($sInfo->specials_date_available != '0001-01-01' and $sInfo->specials_date_available != '') ? zen_date_short($sInfo->specials_date_available) : TEXT_NONE));
                           $contents[] = array('text' => TEXT_INFO_EXPIRES_DATE . ' ' . (($sInfo->expires_date != '0001-01-01' and $sInfo->expires_date != '') ? zen_date_short($sInfo->expires_date) : TEXT_NONE));
                           if ($sInfo->date_status_change !== null && $sInfo->date_status_change !== '0001-01-01 00:00:00') {

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -233,7 +233,6 @@ if (zen_not_null($action)) {
           ?>
           <?php echo '</form>'; ?>
       </div>
-      <div class="row"><?php echo TEXT_STATUS_WARNING; ?></div>
       <?php
       if (empty($action)) {
         ?>
@@ -349,7 +348,7 @@ if (zen_not_null($action)) {
           </div>
           <table class="table">
             <tr>
-              <td><?php echo TEXT_SPECIALS_PRICE_TIP; ?></td>
+              <td><?php echo TEXT_SPECIALS_PRICE_NOTES; ?></td>
                 <td class="text-right">
                     <button type="submit" class="btn btn-primary"><?php echo(($form_action == 'insert') ? IMAGE_INSERT : IMAGE_UPDATE); ?></button>
                     <?php
@@ -541,7 +540,7 @@ if (zen_not_null($action)) {
                       $contents[] = array('align' => 'text-center', 'text' => '<br>' . zen_info_image($sInfo->products_image, $sInfo->products_name, SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT));
                       $contents[] = array('text' => '<br>' . TEXT_INFO_ORIGINAL_PRICE . ' ' . $currencies->format($specials_current_price));
                       $contents[] = array('text' => TEXT_INFO_NEW_PRICE . ' ' . $currencies->format($sInfo->specials_new_products_price));
-                      $contents[] = array('text' => TEXT_INFO_DISPLAY_PRICE . ' ' . zen_get_products_display_price($sInfo->products_id));
+                      $contents[] = array('text' => TEXT_INFO_DISPLAY_PRICE . '<br>' . zen_get_products_display_price($sInfo->products_id));
 
                       $contents[] = array('text' => '<br>' . TEXT_INFO_AVAILABLE_DATE . ' <b>' . (($sInfo->specials_date_available != '0001-01-01' and $sInfo->specials_date_available != '') ? zen_date_short($sInfo->specials_date_available) : TEXT_NONE) . '</b>');
                       $contents[] = array('text' => '<br>' . TEXT_INFO_EXPIRES_DATE . ' <b>' . (($sInfo->expires_date != '0001-01-01' and $sInfo->expires_date != '') ? zen_date_short($sInfo->expires_date) : TEXT_NONE) . '</b>');

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -191,14 +191,6 @@ if (zen_not_null($action)) {
     <link rel="stylesheet" type="text/css" href="includes/cssjsmenuhover.css" media="all" id="hoverJS">
     <script src="includes/menu.js"></script>
     <script src="includes/general.js"></script>
-    <?php
-    if (($action == 'new') || ($action == 'edit')) {
-      ?>
-      <link rel="stylesheet" type="text/css" href="includes/javascript/spiffyCal/spiffyCal_v2_1.css">
-      <script src="includes/javascript/spiffyCal/spiffyCal_v2_1.js"></script>
-      <?php
-    }
-    ?>
     <script>
       function init() {
           cssjsmenu('navbar');
@@ -210,7 +202,6 @@ if (zen_not_null($action)) {
     </script>
   </head>
   <body onload="init()">
-    <div id="spiffycalendar" class="text"></div>
     <!-- header //-->
     <?php require(DIR_WS_INCLUDES . 'header.php'); ?>
     <!-- header_eof //-->
@@ -302,11 +293,6 @@ if (zen_not_null($action)) {
 
         }
         ?>
-        <script>
-          var StartDate = new ctlSpiffyCalendarBox("StartDate", "new_special", "start", "btnDate1", "<?php echo (($sInfo->specials_date_available == '0001-01-01') ? '' : zen_date_short($sInfo->specials_date_available)); ?>", scBTNMODE_CUSTOMBLUE);
-          var EndDate = new ctlSpiffyCalendarBox("EndDate", "new_special", "end", "btnDate2", "<?php echo (($sInfo->expires_date == '0001-01-01') ? '' : zen_date_short($sInfo->expires_date)); ?>", scBTNMODE_CUSTOMBLUE);
-        </script>
-        <div class="row"><?php echo zen_draw_separator('pixel_trans.gif', '100%', '5'); ?></div>
         <div class="row">
             <?php echo zen_draw_form('new_special', FILENAME_SPECIALS, zen_get_all_get_params(array('action', 'info', 'sID')) . 'action=' . $form_action . (!empty($_GET['go_back']) ? '&go_back=' . $_GET['go_back'] : ''), 'post', 'onsubmit="return check_dates(start, StartDate.required, end, EndDate.required);" class="form-horizontal"'); ?>
             <?php
@@ -323,7 +309,7 @@ if (zen_not_null($action)) {
                     <div class="col-sm-9 col-md-6">
                         <?php
                         echo zen_draw_products_pull_down('products_id', 'size="15" class="form-control" id="products_id"', $specials_array, true, (!empty($_GET['add_products_id']) ? $_GET['add_products_id'] : ''), true);
-                        echo zen_draw_hidden_field('products_price', (isset($sInfo->products_price) ? $sInfo->products_price : ''));
+                        echo zen_draw_hidden_field('products_price', (!empty($sInfo->products_price) ? $sInfo->products_price : ''));
                         ?>
                     </div>
                 <?php } ?>
@@ -332,25 +318,35 @@ if (zen_not_null($action)) {
               <?php echo zen_draw_label(TEXT_SPECIALS_SPECIAL_PRICE, 'specials_price', 'class="col-sm-3 control-label"'); ?>
             <div class="col-sm-9 col-md-6">
                 <?php
-                echo zen_draw_input_field('specials_price', (isset($sInfo->specials_new_products_price) ? $sInfo->specials_new_products_price : ''), 'class="form-control" id="specials_price"');
+                echo zen_draw_input_field('specials_price', (!empty($sInfo->specials_new_products_price) ? $sInfo->specials_new_products_price : ''), 'class="form-control" id="specials_price"');
                 echo zen_draw_hidden_field('products_priced_by_attribute', $sInfo->products_priced_by_attribute);
                 echo zen_draw_hidden_field('update_products_id', $sInfo->products_id);
                 ?>
             </div>
           </div>
 
-          <div class="form-group">
-              <?php echo zen_draw_label(TEXT_SPECIALS_AVAILABLE_DATE, 'start', 'class="col-sm-3 control-label"'); ?>
-            <div class="col-sm-9 col-md-6">
-              <script>StartDate.writeControl(); StartDate.dateFormat = "<?php echo DATE_FORMAT_SPIFFYCAL; ?>";</script>
+            <div class="form-group">
+                <?php echo zen_draw_label(TEXT_SPECIALS_AVAILABLE_DATE, 'start', 'class="col-sm-3 control-label"'); ?>
+                <div class="col-sm-9 col-md-6">
+                    <div class="date input-group">
+                        <span class="input-group-addon datepicker_icon"> <i class="fa fa-calendar fa-lg">&nbsp;</i></span>
+                        <?php echo zen_draw_input_field('start', (!empty($sInfo->specials_date_available) ? $sInfo->specials_date_available : ''), 'class="form-control" id="start"'); ?>
+                    </div>
+                    <span class="help-block errorText">(<?php echo (strtoupper(DATE_FORMAT_DATE_PICKER)); ?>)</span>
+                </div>
             </div>
-          </div>
-          <div class="form-group">
-              <?php echo zen_draw_label(TEXT_SPECIALS_EXPIRES_DATE, 'end', 'class="col-sm-3 control-label"'); ?>
-            <div class="col-sm-9 col-md-6">
-              <script>EndDate.writeControl(); EndDate.dateFormat = "<?php echo DATE_FORMAT_SPIFFYCAL; ?>";</script>
+
+            <div class="form-group">
+                <?php echo zen_draw_label(TEXT_SPECIALS_EXPIRES_DATE, 'end', 'class="col-sm-3 control-label"'); ?>
+                <div class="col-sm-9 col-md-6">
+                    <div class="date input-group">
+                        <span class="input-group-addon datepicker_icon"><i class="fa fa-calendar fa-lg">&nbsp;</i></span>
+                        <?php echo zen_draw_input_field('end', (!empty($sInfo->expires_date) ? $sInfo->expires_date : ''), 'class="form-control" id="end"'); ?>
+                    </div>
+                    <span class="help-block errorText">(<?php echo (strtoupper(DATE_FORMAT_DATE_PICKER)); ?>)</span>
+                </div>
             </div>
-          </div>
+
           <table class="table">
             <tr>
               <td><?php echo TEXT_SPECIALS_PRICE_NOTES; ?></td>
@@ -591,6 +587,19 @@ if (zen_not_null($action)) {
       <!-- body_text_eof //-->
     <!-- body_eof //-->
     </div>
+    <?php
+    if (($action == 'new') || ($action == 'edit')) {
+        ?>
+        <!-- script for datepicker -->
+        <script>
+            $(function () {
+                $('input[name="start"]').datepicker();
+                $('input[name="end"]').datepicker();
+            })
+        </script>
+        <?php
+    }
+    ?>
     <!-- footer //-->
     <?php require(DIR_WS_INCLUDES . 'footer.php'); ?>
     <!-- footer_eof //-->

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -238,7 +238,7 @@ if (zen_not_null($action)) {
       if (empty($action)) {
         ?>
         <div class="row text-center">
-          <a href="<?php echo zen_href_link(FILENAME_SPECIALS, ((isset($_GET['page']) && $_GET['page'] > 0) ? 'page=' . $_GET['page'] . '&' : '') . 'action=new'); ?>" class="btn btn-primary" role="button"><?php echo IMAGE_NEW_PRODUCT; ?></a>
+          <a href="<?php echo zen_href_link(FILENAME_SPECIALS, ((isset($_GET['page']) && $_GET['page'] > 0) ? 'page=' . $_GET['page'] . '&' : '') . 'action=new'); ?>" class="btn btn-primary" role="button"><?php echo TEXT_ADD_SPECIAL; ?></a>
         </div>
         <?php
       }


### PR DESCRIPTION
Main changes:
Originally adding a special by product ID created a new special, then went to the update screen with no option to Cancel (as it required a deletion). Changed that to use the insert screen.
Reformatted to offer Add by pID as equal option (instead of hidden at the bottom of an unrelated infobox).
Status buttons are disabled as links when dates are set.
Clicking on a special in the table list went straight to edit instead of showing the infobox: fixed.
Improved error messages and texts in general.
Make product selection and price fields required.
Fixes for html validation/unbalanced divs etc.
Did not replace spiffycal with datepicker as issues are still outstanding for that.
Todo: table sorting.
