### PR TITLE
Adminn Copy Product - add edit duplicate checkbox

### DIFF
--- a/admin/includes/languages/english/category_product_listing.php
+++ b/admin/includes/languages/english/category_product_listing.php
@@ -41,6 +41,7 @@ define('TEXT_COPY_AS_LINK','Link this product into another category as selected 
 define('TEXT_COPY_AS_DUPLICATE','Create a Duplicate product in the category selected above');
 define('TEXT_COPY_METATAGS','Copy Metatags to Duplicate?');
 define('TEXT_COPY_LINKED_CATEGORIES','Copy Linked Categories to Duplicate?');
+define('TEXT_COPY_EDIT_DUPLICATE', 'Open Duplicate Product for editing');
 
 //these four constants used in copy_product_confirm
 define('TEXT_COPY_AS_DUPLICATE_ATTRIBUTES', 'Attributes copied from Product ID#%u to duplicate Product ID#%u');

--- a/admin/includes/modules/copy_product.php
+++ b/admin/includes/modules/copy_product.php
@@ -8,7 +8,7 @@
  * @version $Id: Drbyte Sat May 19 07:36:05 2018 -0400 New in v1.5.6 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
-  die('Illegal Access');
+    die('Illegal Access');
 }
 
 $copy_attributes_delete_first = '0';
@@ -28,22 +28,26 @@ if (empty($pInfo->products_id)) {
 }
 
 $contents = array('form' => zen_draw_form('copy_product', FILENAME_CATEGORY_PRODUCT_LISTING, 'action=copy_product_confirm&cPath=' . $cPath . (isset($_GET['page']) ? '&page=' . $_GET['page'] : ''), 'post', 'class="form-horizontal"') . zen_draw_hidden_field('products_id', $pInfo->products_id));
-$contents[] = array('text' => TEXT_INFO_CURRENT_PRODUCT . '<br><strong>' . $pInfo->products_model . ' - ' . $pInfo->products_name . ' [ ID#' . $pInfo->products_id . ' ]</strong>');
+$contents[] = array('text' => TEXT_INFO_CURRENT_PRODUCT . '<br><strong>' . $pInfo->products_model . ' - ' . $pInfo->products_name . ' [ID#' . $pInfo->products_id . ']</strong>');
 $contents[] = array('text' => TEXT_INFO_CURRENT_CATEGORIES . '<br><strong>' . zen_output_generated_category_path($pInfo->products_id, 'product') . '</strong>');
 $contents[] = array('text' => zen_draw_label(TEXT_CATEGORIES, 'categories_id', 'class="control-label"') . zen_draw_pull_down_menu('categories_id', zen_get_category_tree(), $current_category_id, 'class="form-control" id="categories_id"'));
 
-$contents[] = array('text' => '<h5>'. TEXT_HOW_TO_COPY . '</h5>' .
-    '<div class="radio h6"><label>' . zen_draw_radio_field('copy_as', 'link', true) . TEXT_COPY_AS_LINK . '</label></div>' .
-    zen_image(DIR_WS_IMAGES . 'pixel_black.gif', '', '', '1', 'style="width:100%"') .
-    '<div class="radio h6"><label>' . zen_draw_radio_field('copy_as', 'duplicate') . TEXT_COPY_AS_DUPLICATE . '</label></div>');
+$contents[] = array(
+    'text' => '<h5>' . TEXT_HOW_TO_COPY . '</h5>' .
+        '<div class="radio h6"><label>' . zen_draw_radio_field('copy_as', 'link', true) . TEXT_COPY_AS_LINK . '</label></div>' .
+        zen_image(DIR_WS_IMAGES . 'pixel_black.gif', '', '', '1', 'style="width:100%"') .
+        '<div class="radio h6"><label>' . zen_draw_radio_field('copy_as', 'duplicate') . TEXT_COPY_AS_DUPLICATE . '</label></div>'
+);
 
 // only ask about attributes if defined
 if (zen_has_product_attributes($pInfo->products_id, 'false')) {
-  $contents[] = array('text' => '<h6>'. TEXT_COPY_ATTRIBUTES . '</h6>' .
-      '<div class="radio"><label>' . zen_draw_radio_field('copy_attributes', 'copy_attributes_yes', true) . TEXT_YES . '</label></div>' .
-      '<div class="radio"><label>' . zen_draw_radio_field('copy_attributes', 'copy_attributes_no') . TEXT_NO . '</label></div>');
+    $contents[] = array(
+        'text' => '<h6>' . TEXT_COPY_ATTRIBUTES . '</h6>' .
+            '<div class="radio"><label>' . zen_draw_radio_field('copy_attributes', 'copy_attributes_yes', true) . TEXT_YES . '</label></div>' .
+            '<div class="radio"><label>' . zen_draw_radio_field('copy_attributes', 'copy_attributes_no') . TEXT_NO . '</label></div>'
+    );
 
-  $zco_notifier->notify('NOTIFY_ADMIN_PRODUCT_COPY_TO_ATTRIBUTES', $pInfo, $contents);
+    $zco_notifier->notify('NOTIFY_ADMIN_PRODUCT_COPY_TO_ATTRIBUTES', $pInfo, $contents);
 }
 //are any metatags defined
 $metatags_defined = false;
@@ -64,21 +68,26 @@ if ($metatags_defined) {
 }
 //only ask about linked categories if defined
 if (zen_get_product_is_linked($pInfo->products_id) == 'true') {
-    $contents[] = array('text' => '<h6>'. TEXT_COPY_LINKED_CATEGORIES . '</h6>' .
-        '<div class="radio"><label>' . zen_draw_radio_field('copy_linked_categories', 'copy_linked_categories_yes', true) . TEXT_YES . '</label></div>' .
-        '<div class="radio"><label>' . zen_draw_radio_field('copy_linked_categories', 'copy_linked_categories_no') . TEXT_NO . '</label></div>'
+    $contents[] = array(
+        'text' => '<h6>' . TEXT_COPY_LINKED_CATEGORIES . '</h6>' .
+            '<div class="radio"><label>' . zen_draw_radio_field('copy_linked_categories', 'copy_linked_categories_yes', true) . TEXT_YES . '</label></div>' .
+            '<div class="radio"><label>' . zen_draw_radio_field('copy_linked_categories', 'copy_linked_categories_no') . TEXT_NO . '</label></div>'
     );
 }
 // only ask if product has qty discounts defined
 if (zen_has_product_discounts($pInfo->products_id) == 'true') {
-  //$contents[] = array('text' => TEXT_COPY_DISCOUNTS_ONLY);
-  $contents[] = array('text' => '<h6>' . TEXT_COPY_DISCOUNTS . '</h6>' .
-      '<div class="radio"><label>' . zen_draw_radio_field('copy_discounts', 'copy_discounts_yes', true) . TEXT_YES . '</label></div>' .
-      '<div class="radio"><label>' . zen_draw_radio_field('copy_discounts', 'copy_discounts_no') . TEXT_NO . '</label></div>');
+    //$contents[] = array('text' => TEXT_COPY_DISCOUNTS_ONLY);
+    $contents[] = array(
+        'text' => '<h6>' . TEXT_COPY_DISCOUNTS . '</h6>' .
+            '<div class="radio"><label>' . zen_draw_radio_field('copy_discounts', 'copy_discounts_yes', true) . TEXT_YES . '</label></div>' .
+            '<div class="radio"><label>' . zen_draw_radio_field('copy_discounts', 'copy_discounts_no') . TEXT_NO . '</label></div>'
+    );
 }
 $contents[] = array('text' => '<label>' . zen_draw_checkbox_field('edit_duplicate', '1', true) . TEXT_COPY_EDIT_DUPLICATE . '</label>');
 $contents[] = array('text' => zen_image(DIR_WS_IMAGES . 'pixel_black.gif', '', '', '3', 'style="width:100%"'));
-$contents[] = array('align' => 'center', 'text' => '<button type="submit" class="btn btn-primary">' . IMAGE_COPY . '</button> <a href="' . zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING, 'cPath=' . $cPath . '&pID=' . $pInfo->products_id . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '')) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>');
+$contents[] = array('align' => 'center', 'text' => '<button type="submit" class="btn btn-primary">' . IMAGE_COPY . '</button> 
+<a href="' . zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING, 'cPath=' . $cPath . '&pID=' . $pInfo->products_id . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '')) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>'
+);
 
 $contents[] = array('text' => zen_image(DIR_WS_IMAGES . 'pixel_black.gif', '', '', '1', 'style="width:100%"'));
 $contents[] = array('align' => 'center', 'text' => '<a href="' . zen_href_link(FILENAME_PRODUCTS_TO_CATEGORIES, 'products_filter=' . $pInfo->products_id . '&current_category_id=' . $current_category_id) . '" class="btn btn-info" role="button">' . BUTTON_PRODUCTS_TO_CATEGORIES . '</a>');

--- a/admin/includes/modules/copy_product.php
+++ b/admin/includes/modules/copy_product.php
@@ -47,7 +47,7 @@ if (zen_has_product_attributes($pInfo->products_id, 'false')) {
 }
 //are any metatags defined
 $metatags_defined = false;
-for ($i = 0, $n = sizeof($languages); $i < $n; $i++) {
+for ($i = 0, $n = count($languages); $i < $n; $i++) {
     if (zen_get_metatags_description($pInfo->products_id,
             $languages[$i]['id']) . zen_get_metatags_keywords($pInfo->products_id,
             $languages[$i]['id']) . zen_get_metatags_title($pInfo->products_id, $languages[$i]['id']) != '') {

--- a/admin/includes/modules/copy_product.php
+++ b/admin/includes/modules/copy_product.php
@@ -20,10 +20,10 @@ $copy_attributes_include_filename = '1';
 $heading = array();
 $heading[] = array('text' => '<h4>' . TEXT_INFO_HEADING_COPY_TO . '</h4>');
 if (empty($pInfo->products_id)) {
-  if (!is_object($pInfo)) {
-    $pInfo = new objectInfo(array('products_id' => $pID)); 
-  } else {
+  if (is_object($pInfo)) {
     $pInfo->products_id = $pID;
+  } else {
+    $pInfo = new objectInfo(array('products_id' => $pID));
   }
 }
 

--- a/admin/includes/modules/copy_product.php
+++ b/admin/includes/modules/copy_product.php
@@ -76,7 +76,7 @@ if (zen_has_product_discounts($pInfo->products_id) == 'true') {
       '<div class="radio"><label>' . zen_draw_radio_field('copy_discounts', 'copy_discounts_yes', true) . TEXT_YES . '</label></div>' .
       '<div class="radio"><label>' . zen_draw_radio_field('copy_discounts', 'copy_discounts_no') . TEXT_NO . '</label></div>');
 }
-
+$contents[] = array('text' => '<label>' . zen_draw_checkbox_field('edit_duplicate', '1', true) . TEXT_COPY_EDIT_DUPLICATE . '</label>');
 $contents[] = array('text' => zen_image(DIR_WS_IMAGES . 'pixel_black.gif', '', '', '3', 'style="width:100%"'));
 $contents[] = array('align' => 'center', 'text' => '<button type="submit" class="btn btn-primary">' . IMAGE_COPY . '</button> <a href="' . zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING, 'cPath=' . $cPath . '&pID=' . $pInfo->products_id . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '')) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>');
 

--- a/admin/includes/modules/copy_product_confirm.php
+++ b/admin/includes/modules/copy_product_confirm.php
@@ -111,7 +111,7 @@ if (isset($_POST['products_id'], $_POST['categories_id'])) {
 
         $db->Execute("INSERT INTO " . TABLE_PRODUCTS_TO_CATEGORIES . " (products_id, categories_id)
                       VALUES (" . $dup_products_id . ", " . $categories_id . ")");
-                      
+
         // -----
         // Notify that a copy of a "base" product has just been created, enabling an observer to duplicate
         // additional product-related fields.
@@ -145,11 +145,11 @@ if (isset($_POST['products_id'], $_POST['categories_id'])) {
                                              WHERE products_id = '" . $products_id . "'");
 
             $db->Execute("UPDATE " . TABLE_PRODUCTS . " SET
-                metatags_title_status = '" . zen_db_input($metatags_status->fields['metatags_title_status']). "',
-                metatags_products_name_status = '" . zen_db_input($metatags_status->fields['metatags_products_name_status']). "',
-                metatags_model_status = '" . zen_db_input($metatags_status->fields['metatags_model_status']). "',
-                metatags_price_status= '" . zen_db_input($metatags_status->fields['metatags_price_status']). "',
-                metatags_title_tagline_status = '" . zen_db_input($metatags_status->fields['metatags_title_tagline_status']). "'
+                metatags_title_status = '" . zen_db_input($metatags_status->fields['metatags_title_status']) . "',
+                metatags_products_name_status = '" . zen_db_input($metatags_status->fields['metatags_products_name_status']) . "',
+                metatags_model_status = '" . zen_db_input($metatags_status->fields['metatags_model_status']) . "',
+                metatags_price_status= '" . zen_db_input($metatags_status->fields['metatags_price_status']) . "',
+                metatags_title_tagline_status = '" . zen_db_input($metatags_status->fields['metatags_title_tagline_status']) . "'
                 WHERE products_id = " . $dup_products_id);
 
             $metatags_descriptions = $db->Execute("SELECT language_id, metatags_title, metatags_keywords, metatags_description
@@ -163,7 +163,7 @@ if (isset($_POST['products_id'], $_POST['categories_id'])) {
                         '" . (int)$metatags_descriptions->fields['language_id'] . "',
                         '" . zen_db_input($metatags_descriptions->fields['metatags_title']) . "',
                         '" . zen_db_input($metatags_descriptions->fields['metatags_keywords']) . "',
-                        '" . zen_db_input($metatags_descriptions->fields['metatags_description']). "')");
+                        '" . zen_db_input($metatags_descriptions->fields['metatags_description']) . "')");
 
                 $messageStack->add_session(sprintf(TEXT_COPY_AS_DUPLICATE_METATAGS, (int)$metatags_descriptions->fields['language_id'], $products_id, $dup_products_id), 'success');
 

--- a/admin/includes/modules/copy_product_confirm.php
+++ b/admin/includes/modules/copy_product_confirm.php
@@ -94,7 +94,7 @@ if (isset($_POST['products_id'], $_POST['categories_id'])) {
                           '" . zen_db_input($product->fields['products_price_sorter']) . "',
                           '" . zen_db_input($categories_id) . "')");
 
-        $dup_products_id = (int)$db->Insert_ID();
+        $dup_products_id = (int)$db->insert_ID();
 
         $descriptions = $db->Execute("SELECT language_id, products_name, products_description, products_url
                                       FROM " . TABLE_PRODUCTS_DESCRIPTION . "

--- a/admin/includes/modules/copy_product_confirm.php
+++ b/admin/includes/modules/copy_product_confirm.php
@@ -116,7 +116,7 @@ if (isset($_POST['products_id'], $_POST['categories_id'])) {
         // Notify that a copy of a "base" product has just been created, enabling an observer to duplicate
         // additional product-related fields.
         //
-        $zco_notifier->notify('NOTIFY_MODULES_COPY_TO_CONFIRM_DUPLICATE', array('products_id' => $products_id, 'dup_products_id' => $dup_products_id));
+        $zco_notifier->notify('NOTIFY_MODULES_COPY_TO_CONFIRM_DUPLICATE', compact('products_id', 'dup_products_id'));
 
 // FIX HERE
 /////////////////////////////////////////////////////////////////////////////////////////////
@@ -194,7 +194,7 @@ if (isset($_POST['products_id'], $_POST['categories_id'])) {
 
         zen_record_admin_activity('Product ' . $products_id . ' duplicated as product ' . $dup_products_id . ' via admin console.', 'info');
 
-        $zco_notifier->notify('NOTIFY_MODULES_COPY_TO_CONFIRM_DUPLICATE', array('products_id' => $products_id, 'dup_products_id' => $dup_products_id));
+        $zco_notifier->notify('NOTIFY_MODULES_COPY_TO_CONFIRM_DUPLICATE', compact('products_id', 'dup_products_id'));
 
         $products_id = $dup_products_id;//reset for further use in price update and final redirect to new linked product or new duplicated product
     }// EOF duplication

--- a/admin/includes/modules/copy_product_confirm.php
+++ b/admin/includes/modules/copy_product_confirm.php
@@ -10,7 +10,7 @@
 if (!defined('IS_ADMIN_FLAG')) {
     die('Illegal Access');
 }
-if (isset($_POST['products_id']) && isset($_POST['categories_id'])) {
+if (isset($_POST['products_id'], $_POST['categories_id'])) {
     $products_id = (int)$_POST['products_id'];
     $categories_id = (int)$_POST['categories_id'];
 

--- a/admin/includes/modules/copy_product_confirm.php
+++ b/admin/includes/modules/copy_product_confirm.php
@@ -202,4 +202,9 @@ if (isset($_POST['products_id']) && isset($_POST['categories_id'])) {
     // reset products_price_sorter for searches etc.
     zen_update_products_price_sorter($products_id);
 }
-zen_redirect(zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING, 'cPath=' . $categories_id . '&pID=' . $products_id . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '')));
+if ($_POST['copy_as'] === 'duplicate' && !empty($_POST['edit_duplicate'])) {
+    zen_redirect(zen_href_link(FILENAME_PRODUCT, 'action=new_product&cPath=' . $categories_id . '&pID=' . $dup_products_id . '&products_type=' . (int)$product->fields['products_type']));
+} else {
+    zen_redirect(zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING, 'cPath=' . $categories_id . '&pID=' . $products_id . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '')));
+}
+


### PR DESCRIPTION
Allows to open a duplicate product for editing, after the copy
![Clipboard01](https://user-images.githubusercontent.com/4391026/73985367-418ed800-493b-11ea-94ab-dca849a002c3.gif)

Someone asked for this in the forum, can't find the thread, seemed a good idea.
