### PR TITLE
zcObserverLogEventListener warning substr() expects parameter 3 to be int, string given

### DIFF
--- a/admin/includes/classes/class.admin.zcObserverLogEventListener.php
+++ b/admin/includes/classes/class.admin.zcObserverLogEventListener.php
@@ -142,7 +142,7 @@ class zcObserverLogEventListener extends base {
         'ip_address'      => substr($_SERVER['REMOTE_ADDR'],0,45),
         'postdata'        => $postdata,
         'flagged'         => $flagged,
-        'attention'       => ($notes === false ? '' : substr($notes,0,zen_field_length(TABLE_ADMIN_ACTIVITY_LOG, 'attention'))),
+        'attention'       => ($notes === false ? '' : substr($notes,0, (int)zen_field_length(TABLE_ADMIN_ACTIVITY_LOG, 'attention'))),
         'severity'        => strtolower($levels[$severity]),  // converts int to corresponding string
     );
 


### PR DESCRIPTION
On resetting the hit counter I got this:

> Request URI: /zencart-157/admin1/index.php?cmd=store_manager&action=update_counter, IP address: 127.0.0.1
> #1  substr() called at [...\zencart-157\admin1\includes\classes\class.admin.zcObserverLogEventListener.php:145]
> #2  zcObserverLogEventListener::prepareLogdata() called at [...\zencart-157\admin1\includes\classes\class.admin.zcObserverLogEventListener.php:55]
> #3  zcObserverLogEventListener->updateNotifyAdminActivityLogEvent() called at [...\zencart-157\includes\classes\class.base.php:103]
> #4  base->notify() called at [...\zencart-157\admin1\includes\classes\class.admin.zcObserverLogEventListener.php:210]
> #5  zen_record_admin_activity() called at [...\zencart-157\admin1\store_manager.php:105]
> #6  require(...\zencart-157\admin1\store_manager.php) called at [...\zencart-157\admin1\index.php:11]
> --> PHP Warning: substr() expects parameter 3 to be int, string given in ...\zencart-157\admin1\includes\classes\class.admin.zcObserverLogEventListener.php on line 145.

which is this

'attention'       => ($notes === false ? '' : substr($notes,0, zen_field_length(TABLE_ADMIN_ACTIVITY_LOG, 'attention'))),

Error is correct, zen_field_length is a string.