### PR TITLE
Fix display of long config settings when truncated

### DIFF
--- a/admin/configuration.php
+++ b/admin/configuration.php
@@ -160,7 +160,8 @@ if ($gID == 7) {
               <td class="dataTableContent"><?php 
                    $setting = htmlspecialchars($cfgValue, ENT_COMPAT, CHARSET, TRUE); 
                    if (strlen($setting) > 40) { 
-                      echo substr($setting,0, 35) . "..."; 
+
+                      echo htmlspecialchars(substr($cfgValue,0,35), ENT_COMPAT, CHARSET, TRUE); 
                    } else { 
                       echo $setting; 
                    }

--- a/admin/configuration.php
+++ b/admin/configuration.php
@@ -161,7 +161,7 @@ if ($gID == 7) {
                    $setting = htmlspecialchars($cfgValue, ENT_COMPAT, CHARSET, TRUE); 
                    if (strlen($setting) > 40) { 
 
-                      echo htmlspecialchars(substr($cfgValue,0,35), ENT_COMPAT, CHARSET, TRUE); 
+                      echo htmlspecialchars(substr($cfgValue,0,35), ENT_COMPAT, CHARSET, TRUE) . "..."; 
                    } else { 
                       echo $setting; 
                    }


### PR DESCRIPTION
A cart I was working on had the contact us dropdown set to 

Sales <sales@theXXXXXstore.com>, GeneralMailbox <XXXXX@theXXXXXstore.com>

the value shown in the admin configuration page is truncated, which meant it showed up as 

Sales <sales@theABCDEstore.com&amp;g...

Performing the truncation on the **original** string, then running `htmlspecialchars` resolves this issue: 

Sales <sales@theABCDEstore.com>, Ge...