### PR TITLE
fixes admin too many redirects

### DIFF
--- a/admin/includes/init_includes/init_cache_key_check.php
+++ b/admin/includes/init_includes/init_cache_key_check.php
@@ -36,6 +36,13 @@ if (!file_exists(SESSION_WRITE_DIRECTORY) || !is_writable(SESSION_WRITE_DIRECTOR
   }
   if ($selected_dir == '') $selected_dir = DIR_FS_CATALOG . 'cache';
 
+  $sql = "select configuration_key from " . TABLE_CONFIGURATION . "  where configuration_key = 'SESSION_WRITE_DIRECTORY'";
+  $conf_count = $db->Execute($sql);
+
+  if (empty($conf_count->RecordCount())) {
+    $sql = "INSERT INTO " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) VALUES ('Session Directory', 'SESSION_WRITE_DIRECTORY', '/tmp', 'This should point to the folder specified in your DIR_FS_SQL_CACHE setting in your configure.php files.', '15', '1', now())";
+    $db->Execute($sql);
+  }
   $sql = "update " . TABLE_CONFIGURATION . " set configuration_value = '" . $db->prepare_input(trim($selected_dir)) . "' where configuration_key = 'SESSION_WRITE_DIRECTORY'";
   $db->Execute($sql);
   zen_record_admin_activity('Updated SESSION_WRITE_DIRECTORY configuration setting to ' . $selected_dir, 'notice');


### PR DESCRIPTION
in attempting to get my v157 test environment up; i ran into:

 too many redirects 301 error 

when trying to get to the admin.  i was able to chase this down to a missing key.  the modified script in this PR, attempts to modify the key; but there is no check if the key is there.

considering we are already looking at this key and attempting to modify it, it only makes sense that we should look if it is there.  unfortunately, i have seen this error on the boards, with blame on the hosting company, and/or .htaccess file; when in theory it could be the store owner who has messed up an install or upgrade.

very easy to test.  delete the key, you will see the error.  apply this patch, and the error disappears.