### PR TITLE
Allow override of sort order for admin menus

### DIFF
--- a/admin/includes/functions/admin_access.php
+++ b/admin/includes/functions/admin_access.php
@@ -677,6 +677,16 @@ function zen_get_admin_pages($menu_only)
     }
     $result->MoveNext();
   }
+  if ($menu_only) {
+    if (defined('NAME_SORTED_MENUS') && !empty(NAME_SORTED_MENUS)) {
+       $sorted_menus = explode(",", NAME_SORTED_MENUS); 
+       foreach (array_keys($retVal) as $key) {
+         if (in_array($key, $sorted_menus)) {
+           usort($retVal[$key], 'menu_name_sort'); 
+         }
+       }
+    }
+  }
   if (!$menu_only)
   {
     foreach ($productTypes as $pageName => $productType)
@@ -960,4 +970,12 @@ function zen_admin_authorized_to_place_order()
         }
     }
     return ($_SESSION['admin_id'] == (int)EMP_LOGIN_ADMIN_ID || $admin_in_profile);
+}
+
+function menu_name_sort($a, $b) {
+   if ($a['name'] == $b['name'])
+      return 0;
+   if ($a['name'] < $b['name'])
+      return -1;
+   return 1;
 }

--- a/admin/includes/functions/admin_access.php
+++ b/admin/includes/functions/admin_access.php
@@ -678,8 +678,8 @@ function zen_get_admin_pages($menu_only)
     $result->MoveNext();
   }
   if ($menu_only) {
-    if (defined('NAME_SORTED_MENUS') && !empty(NAME_SORTED_MENUS)) {
-       $sorted_menus = explode(",", NAME_SORTED_MENUS); 
+    if (defined('MENU_CATEGORIES_TO_SORT_BY_NAME') && !empty(MENU_CATEGORIES_TO_SORT_BY_NAME)) {
+       $sorted_menus = explode(",", MENU_CATEGORIES_TO_SORT_BY_NAME); 
        foreach (array_keys($retVal) as $key) {
          if (in_array($key, $sorted_menus)) {
            usort($retVal[$key], 'menu_name_sort'); 

--- a/admin/includes/languages/english.php
+++ b/admin/includes/languages/english.php
@@ -780,6 +780,8 @@ define('TEXT_INFO_CURRENCY_UPDATED', 'The exchange rate for %s (%s) was updated 
 define('ERROR_CURRENCY_INVALID', 'Error: The exchange rate for %s (%s) was not updated via %s. Is it a valid currency code?');
 define('WARNING_PRIMARY_SERVER_FAILED', 'Warning: The primary exchange rate server (%s) failed for %s (%s) - trying the secondary exchange rate server.');
 
+// Set to empty string if alpha sorting not desired
+define('NAME_SORTED_MENUS','reports,tools'); 
 
 ///////////////////////////////////////////////////////////
 // include additional files:

--- a/admin/includes/languages/english.php
+++ b/admin/includes/languages/english.php
@@ -781,7 +781,7 @@ define('ERROR_CURRENCY_INVALID', 'Error: The exchange rate for %s (%s) was not u
 define('WARNING_PRIMARY_SERVER_FAILED', 'Warning: The primary exchange rate server (%s) failed for %s (%s) - trying the secondary exchange rate server.');
 
 // Set to empty string if alpha sorting not desired
-define('NAME_SORTED_MENUS','reports,tools'); 
+define('MENU_CATEGORIES_TO_SORT_BY_NAME','reports,tools'); 
 
 ///////////////////////////////////////////////////////////
 // include additional files:


### PR DESCRIPTION
This change allows people to sort specific menus (tools and reports by default) using an alpha sort rather than the numeric sort which is used by default.  Functionality can be disabled by removing entries from the NAME_SORTED_MENUS define in the main language file. 

The motivation for this change is that these two menus are the most often added to by modders, and the menu lists can quickly become long and unwieldy. 