### PR TITLE
Fix Responsive Classic styling of shipping options + OT lines

### DIFF
--- a/includes/templates/responsive_classic/css/responsive_mobile.css
+++ b/includes/templates/responsive_classic/css/responsive_mobile.css
@@ -282,7 +282,7 @@ span.cssButton.normal_button.button.button_continue_shopping, .button_continue_s
 .cartRemoveItemDisplay input[type=checkbox]{display:none;}
 
 /*bof checkout*/
-#checkoutPayment .forward, #checkoutShipping .forward{float:none;width:95%;}
+#checkoutConfirmDefault .forward, #checkoutPayment .forward, #checkoutShipping .forward{float:right;width:auto !important;}
 #checkoutConfirmDefault input.submit_button, #checkoutPayment input.submit_button, #checkoutShipping input.submit_button, #checkoutShipping input.submit_button:hover{display:block !important;width:100% !important;}
 #checkoutConfirmDefault input.cssButtonHover, #checkoutPayment input.cssButtonHover, #checkoutShipping input.cssButtonHover{display:block !important;width:100% !important;}
 #checkoutConfirmDefaultHeadingComments{text-align:center;}

--- a/includes/templates/responsive_classic/css/responsive_tablet.css
+++ b/includes/templates/responsive_classic/css/responsive_tablet.css
@@ -278,4 +278,6 @@ fieldset p{width:90%;margin:0 auto;}
 .gvBal{float:none;}
 #sendSpendWrapper{width:auto;}
 #checkoutSuccess fieldset .buttonRow.forward{margin:0 !important;}
+
+#checkoutConfirmDefault .forward, #checkoutPayment .forward, #checkoutShipping .forward{float:right;width:auto !important;}
 }


### PR DESCRIPTION
Without these fixes, price and title are displayed on two separate lines for shipping options and for order totals. 