### PR TITLE
Changes to error messages for adding invalid coupon in checkout payment

### DIFF
--- a/includes/languages/english.php
+++ b/includes/languages/english.php
@@ -338,21 +338,24 @@
 
   define('TABLE_HEADING_CREDIT_PAYMENT', 'Credits Available');
 
-  define('TEXT_INVALID_REDEEM_COUPON', 'Invalid Coupon Code');
-  define('TEXT_INVALID_REDEEM_COUPON_MINIMUM', 'You must spend at least %s to redeem this coupon');
-  define('TEXT_INVALID_STARTDATE_COUPON', 'This coupon is not available yet');
-  define('TEXT_INVALID_FINISHDATE_COUPON', 'This coupon has expired');
-  define('TEXT_INVALID_USES_COUPON', 'This coupon could only be used ');
-  define('TIMES', ' times.');
-  define('TIME', ' time.');
-  define('TEXT_INVALID_USES_USER_COUPON', 'You have used coupon code: %s the maximum number of times allowed per customer. ');
+//coupon redeem error messages (checkout payment)
+  define('TEXT_COUPON_LINK_TITLE', 'see the Coupon conditions');
+  define('TEXT_INVALID_REDEEM_COUPON', 'Coupon code "%s" is not a valid code.');
+  define('TEXT_INVALID_REDEEM_COUPON_MINIMUM', 'You must spend at least %2$s to redeem Coupon "%1$s".');
+  define('TEXT_INVALID_COUPON_PRODUCT', 'The Coupon "%1$s" is not valid for any product in your shopping cart.');
+  define('TEXT_INVALID_COUPON_ORDER_LIMIT', 'You have exceeded the total number of orders permitted (%2$u), to use the Coupon "%1$s".');
+  define('TEXT_INVALID_STARTDATE_COUPON', 'The Coupon "%1$s" is not valid for use until %2$s.');
+  define('TEXT_INVALID_FINISHDATE_COUPON', 'The Coupon "%1$s" is now not valid (expired %2$s).');
+  define('TEXT_INVALID_USES_COUPON', 'Coupon "%1$s" has already been used the maximum permitted times (%2$u).');
+  define('TEXT_INVALID_USES_USER_COUPON', 'You have used Coupon "%1$s" the maximum number of times allowed per customer (%2$u).');
+  define('TEXT_REMOVE_REDEEM_COUPON_ZONE', 'The Coupon "%s" is not valid for the address you have selected.');
   define('REDEEMED_COUPON', 'a coupon worth ');
   define('REDEEMED_MIN_ORDER', 'on orders over ');
   define('REDEEMED_RESTRICTIONS', ' [Product-Category restrictions apply]');
   define('TEXT_ERROR', 'An error has occurred');
-  define('TEXT_INVALID_COUPON_PRODUCT', 'This coupon code is not valid for any product currently in your cart.');
+
   define('TEXT_VALID_COUPON', 'Congratulations you have redeemed the Discount Coupon');
-  define('TEXT_REMOVE_REDEEM_COUPON_ZONE', 'The coupon code you entered is not valid for the address you have selected.');
+
 
 // more info in place of buy now
   define('MORE_INFO_TEXT','... more info');

--- a/includes/modules/order_total/ot_coupon.php
+++ b/includes/modules/order_total/ot_coupon.php
@@ -324,7 +324,7 @@ class ot_coupon {
         }
 
         $date_query=$db->Execute("select coupon_expire_date from " . TABLE_COUPONS . "
-                                  where coupon_code='" . zen_db_prepare_input($dc_check) . "'");
+                                  where coupon_code='" . zen_db_prepare_input($dc_check) . "' LIMIT 1");
 
           if (date("Y-m-d H:i:s") >= $date_query->fields['coupon_expire_date']) {
           $messageStack->add_session('redemptions', sprintf(TEXT_INVALID_FINISHDATE_COUPON, ($dc_link_count === 0 ? $dc_link : $dc_check), zen_date_short($date_query->fields['coupon_expire_date'])),'caution');

--- a/includes/modules/order_total/ot_coupon.php
+++ b/includes/modules/order_total/ot_coupon.php
@@ -272,7 +272,7 @@ class ot_coupon {
 
         if ($foundvalid == true) {
           $foundvalid = false;
-          for ($i=0; $i<sizeof($products); $i++) {
+          for ($i=0; $i<count($products); $i++) {
             if (is_product_valid($products[$i]['id'], $coupon_result->fields['coupon_id'])) {
               $foundvalid = true;
               continue;
@@ -282,7 +282,7 @@ class ot_coupon {
         if ($foundvalid == true) {
           // check if products on special or sale are valid
           $foundvalid = false;
-          for ($i=0, $n=sizeof($products); $i<$n; $i++) {
+          for ($i=0, $n=count($products); $i<$n; $i++) {
             if (is_coupon_valid_for_sales($products[$i]['id'], $coupon_result->fields['coupon_id'])) {
               $foundvalid = true;
               continue;
@@ -521,7 +521,7 @@ class ot_coupon {
           if ($coupon->fields['coupon_product_count'] && ($coupon->fields['coupon_type'] == 'F' || $coupon->fields['coupon_type'] == 'O')) {
             $products = $_SESSION['cart']->get_products();
             $coupon_product_count = 0;
-            for ($i=0, $n=sizeof($products); $i<$n; $i++) {
+            for ($i=0, $n=count($products); $i<$n; $i++) {
               if (is_product_valid($products[$i]['id'], $coupon->fields['coupon_id'])) {
                 $coupon_product_count += $_SESSION['cart']->get_quantity($products[$i]['id']);
               }
@@ -634,7 +634,7 @@ class ot_coupon {
     $orderTotalTax = $order->info['tax'];
     $orderTotal = $order->info['total'];
     $products = $_SESSION['cart']->get_products();
-    for ($i=0, $n=sizeof($products); $i<$n; $i++) {
+    for ($i=0, $n=count($products); $i<$n; $i++) {
       $is_product_valid = (is_product_valid($products[$i]['id'], $couponCode) && is_coupon_valid_for_sales($products[$i]['id'], $couponCode));
       $GLOBALS['zco_notifier']->notify(
         'NOTIFY_OT_COUPON_PRODUCT_VALIDITY',
@@ -725,7 +725,7 @@ class ot_coupon {
     global $db;
     $keys = '';
     $keys_array = $this->keys();
-    for ($i=0, $n=sizeof($keys_array); $i<$n; $i++) {
+    for ($i=0, $n=count($keys_array); $i<$n; $i++) {
       $keys .= "'" . $keys_array[$i] . "',";
     }
     $keys = substr($keys, 0, -1);


### PR DESCRIPTION
I actually found one undefined constant (TEXT_INVALID_COUPON_ORDER_LIMIT) on the way!

Examples (note this is a frigged output to see all the error messages at once):
![coupon errors](https://user-images.githubusercontent.com/4391026/76100938-d7b32e00-5fcd-11ea-9846-c6df2243ef4a.gif)

order of constants in language file now matches useage order.