### PR TITLE
Allow long configuration values to be displayed

### DIFF
--- a/admin/includes/stylesheet.css
+++ b/admin/includes/stylesheet.css
@@ -442,6 +442,7 @@ tr.attributeBoxContent {
     background-color: #e7e6e0;
     color: #333;
     padding: 5px;
+    word-break: break-word; 
 }
 
 .infoBoxContent a img, .infoBoxContent input[type="image"] {


### PR DESCRIPTION
Long values like table rate shipping rates can now be viewed since they will wrap.  (Before they would cut off at one line.) 