### PR TITLE
Simplify by doing select *.

### DIFF
--- a/includes/modules/pages/account_edit/header_php.php
+++ b/includes/modules/pages/account_edit/header_php.php
@@ -162,9 +162,7 @@ if (isset($_POST['action']) && ($_POST['action'] == 'process')) {
   }
 }
 
-$account_query = "SELECT customers_gender, customers_firstname, customers_lastname,
-                         customers_dob, customers_email_address, customers_telephone, customers_nick,
-                         customers_fax, customers_email_format, customers_referral
+$account_query = "SELECT * 
                   FROM   " . TABLE_CUSTOMERS . "
                   WHERE  customers_id = :customersID";
 


### PR DESCRIPTION
In 1.5.6, the query() function in includes/classes/order.php simplifies the order select by simply doing a `SELECT * `.  This eases the burden when upgrading a shop which has added fields to the orders table.  This change is made in the same spirit. 