### PR TITLE
admin/orders.php: Ensure that order's status information is "fresh".

### DIFF
--- a/admin/orders.php
+++ b/admin/orders.php
@@ -227,9 +227,11 @@ if (zen_not_null($action) && $order_exists == true) {
       $status_updated = zen_update_orders_history($oID, $comments, null, $status, $customer_notified, $email_include_message);
       $order_updated = ($status_updated > 0);
 
-      $check_status = $db->Execute("SELECT customers_name, customers_email_address, orders_status, date_purchased
+      $check_status = $db->ExecuteNoCache("SELECT customers_name, customers_email_address, orders_status, date_purchased
                                     FROM " . TABLE_ORDERS . "
-                                    WHERE orders_id = " . (int)$oID);
+                                    WHERE orders_id = " . (int)$oID . "
+                                    LIMIT 1"
+                                    );
 
       // trigger any appropriate updates which should be sent back to the payment gateway:
       $order = new order((int)$oID);


### PR DESCRIPTION
Augmenting the submission for #2818 to pull the query from the database (since the status could have been updated during the `zen_update_orders_status` processing) and to add a 'LIMIT 1' for performance.