### PR TITLE
set 1 config to do 2 things

### DIFF
--- a/admin/includes/init_includes/init_admin_auth.php
+++ b/admin/includes/init_includes/init_admin_auth.php
@@ -29,6 +29,7 @@ if (basename($PHP_SELF) == FILENAME_AJAX . '.php') {
 // admin folder rename required
 if (!defined('ADMIN_BLOCK_WARNING_OVERRIDE') || ADMIN_BLOCK_WARNING_OVERRIDE == '')
 {
+  define('ADMIN_BLOCK_WARNING_OVERRIDE', false);
   if (basename($PHP_SELF) != FILENAME_ALERT_PAGE . '.php')
   {
     if (substr(DIR_WS_ADMIN, -7) == '/admin/' || substr(DIR_WS_HTTPS_ADMIN, -7) == '/admin/')

--- a/admin/includes/init_includes/init_errors.php
+++ b/admin/includes/init_includes/init_errors.php
@@ -69,7 +69,7 @@ if (!defined('WARN_DOWNLOAD_DIRECTORY_NOT_READABLE')) define('WARN_DOWNLOAD_DIRE
  */
 if (!defined('WARN_DATABASE_VERSION_PROBLEM')) define('WARN_DATABASE_VERSION_PROBLEM','true');
 // check if the installer directory exists, and warn of its existence
-if (WARN_INSTALL_EXISTENCE == 'true') {
+if (WARN_INSTALL_EXISTENCE == 'true' && ADMIN_BLOCK_WARNING_OVERRIDE !== 'true') {
   $check_path = realpath(DIR_FS_CATALOG . '/zc_install');
   if (is_dir($check_path)) {
     $messageStack->add(sprintf(WARNING_INSTALL_DIRECTORY_EXISTS, ($check_path == '' ? '..../zc_install' : $check_path)), 'warning');


### PR DESCRIPTION
i'm not sure if this a fight worth having.  it would be nice to combine these constants.  what i have done here is by setting `ADMIN_BLOCK_WARNING_OVERRIDE` you no longer see the zc_install message.  ideally i would prefer to remove the other constant, but i suppose i can see the value in it.  as someone who debugs ZC constantly, it would be nice to not have so many config switches.  i'm sure most store owners never use them.