### PR TITLE
Bugfix: Messagestack add_session not working

### DIFF
--- a/includes/autoload_func.php
+++ b/includes/autoload_func.php
@@ -44,14 +44,11 @@ foreach ($initSystemList as $entry) {
             //echo 'objectMethod ' . $entry['class'] . "\n";
             $objectName = $entry['object'];
             $methodName = $entry['method'];
-            if (isset($_SESSION[$objectName])) {
-              if (is_object($_SESSION[$objectName])) {
+              if (isset($_SESSION[$objectName]) && is_object($_SESSION[$objectName])) {
                   $_SESSION[$objectName]->$methodName();
-              }
-              if (!is_object($_SESSION[$objectName])) {
+              } else {
                   ${$objectName}->$methodName();
               }
-            }
             break;
 
     }

--- a/includes/autoload_func.php
+++ b/includes/autoload_func.php
@@ -19,21 +19,21 @@ if (!defined('IS_ADMIN_FLAG')) {
 foreach ($initSystemList as $entry) {
     switch ($entry['type']) {
         case 'include':
-            //echo 'include ' . $entry['filePath'] . "\n";
+            //echo 'case "include": ' . $entry['filePath'] . "<br>\n";
             include $entry['filePath'];
             break;
         case 'require':
-            //echo 'require ' . $entry['filePath'] . "\n";
+            //echo 'case "require": ' . $entry['filePath'] . "<br>\n";
             require $entry['filePath'];
             break;
         case 'class':
-            //echo 'class ' . $entry['class'] . "\n";
+            //echo 'case "class": ' . $entry['class'] . "<br>\n";
             $objectName = $entry['object'];
             $className = $entry['class'];
             $$objectName = new $className();
             break;
         case 'sessionClass':
-            //echo 'sessionClass ' . $entry['class'] . "\n";
+            //echo 'case "sessionClass": ' . $entry['class'] . "<br>\n";
             $objectName = $entry['object'];
             $className = $entry['class'];
             if (!$entry['checkInstantiated'] || !isset($_SESSION[$objectName])) {
@@ -41,7 +41,7 @@ foreach ($initSystemList as $entry) {
             }
             break;
         case 'objectMethod':
-            //echo 'objectMethod ' . $entry['class'] . "\n";
+            //echo 'case "objectMethod": ' . '$entry[\'method\']=' . $entry['method'] . ', $entry[\'object\']=' . $entry['object'] . "<br>\n";
             $objectName = $entry['object'];
             $methodName = $entry['method'];
               if (isset($_SESSION[$objectName]) && is_object($_SESSION[$objectName])) {


### PR DESCRIPTION
In
https://github.com/zencart/zencart/pull/3072
A check clause was added to stop a php notice, but it was added around **all** of the case 'objectMethod':
Consequently this never fired the class->method add_session as that item is never in the SESSION array for stacked messages: it's called  "messageToStack".

Also, the previous PR from Wilt added 
if (!is_object($_SESSION[$objectName]))
which causes an php warning as again, SESSION messageToStack does not exist.
In my limited understanding, I don't think that check is needed, as the method messagestack->add_from_session is then used, which **does** check for the correct item (messageToStack).

Works for me, but I am not very aware of the big picture so....
