### PR TITLE
Admin: category image changes

### DIFF
--- a/admin/categories.php
+++ b/admin/categories.php
@@ -405,7 +405,11 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
                     <div class="col-sm-offset-3 col-sm-9 col-md-6">
                         <div><?php echo zen_info_image($cInfo->categories_image, $cInfo->categories_name, '', '', 'class="table-bordered img-responsive"'); ?></div>
                         <br>
-                        <?php echo $cInfo->categories_image; ?>
+                        <?php
+                        [$width, $height] = getimagesize(DIR_FS_CATALOG_IMAGES . $cInfo->categories_image);
+                        $kb = filesize(DIR_FS_CATALOG_IMAGES . $cInfo->categories_image)/1000;
+                        echo sprintf(TEXT_FILENAME,   '/images/' . $cInfo->categories_image, $width, $height, $kb);
+                        ?>
                     </div>
                 </div>
                 <div class="form-group">

--- a/admin/categories.php
+++ b/admin/categories.php
@@ -403,7 +403,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
             if (!empty($cInfo->categories_image)) { ?>
                 <div class="form-group">
                     <div class="col-sm-offset-3 col-sm-9 col-md-6">
-                        <?php echo zen_info_image($cInfo->categories_image, $cInfo->categories_name); ?>
+                        <div><?php echo zen_info_image($cInfo->categories_image, $cInfo->categories_name, '', '', 'class="table-bordered img-responsive"'); ?></div>
                         <br>
                         <?php echo $cInfo->categories_image; ?>
                     </div>

--- a/admin/categories.php
+++ b/admin/categories.php
@@ -161,29 +161,36 @@ if (zen_not_null($action)) {
           zen_db_perform(TABLE_CATEGORIES_DESCRIPTION, $sql_data_array, 'update', "categories_id = '" . (int)$categories_id . "' and language_id = '" . (int)$languages[$i]['id'] . "'");
         }
       }
-
-      if ($_POST['categories_image_manual'] != '') {
-          // add image manually
+      // remove the existing image
+      if (!empty($_POST['image_delete'])) {
+          $db->Execute("UPDATE " . TABLE_CATEGORIES . "
+                            SET categories_image = ''
+                            WHERE categories_id = " . (int)$categories_id);
+          $messageStack->add_session(sprintf(MESSAGE_IMAGE_REMOVED_CATEGORY, (int)$categories_id, zen_get_category_name($categories_id, $_SESSION['languages_id'])), 'success');
+          // or assign a manually-typed/existing image
+      } elseif ($_POST['categories_image_manual'] !== '') {
           $categories_image_name = zen_db_input($_POST['img_dir'] . $_POST['categories_image_manual']);
-          $db->Execute("update " . TABLE_CATEGORIES . "
-                      set categories_image = '" . $categories_image_name . "'
-                      where categories_id = '" . (int)$categories_id . "'");
+          if (file_exists(DIR_FS_CATALOG_IMAGES . $categories_image_name)) {
+              $db->Execute("UPDATE " . TABLE_CATEGORIES . "
+                      SET categories_image = '" . $categories_image_name . "'
+                      WHERE categories_id = " . (int)$categories_id);
+              $messageStack->add_session(sprintf(MESSAGE_IMAGE_ADDED_MANUAL, (int)$categories_id, zen_get_category_name($categories_id, $_SESSION['languages_id']), $categories_image_name), 'success');
+          } else {
+              $messageStack->add_session(sprintf(ERROR_IMAGE_MANUAL_NOT_FOUND, $categories_image_name));
+          }
+          // or upload a new image
       } elseif ($categories_image = new upload('categories_image')) {
           $categories_image->set_extensions(['jpg', 'jpeg', 'gif', 'png', 'webp', 'flv', 'webm', 'ogg']);
           $categories_image->set_destination(DIR_FS_CATALOG_IMAGES . $_POST['img_dir']);
           if ($categories_image->parse() && $categories_image->save()) {
               $categories_image_name = zen_db_input($_POST['img_dir'] . $categories_image->filename);
           }
-          if ($categories_image->filename != 'none' && $categories_image->filename != '' && $_POST['image_delete'] != '1') {
+          if ($categories_image->filename !== 'none' && $categories_image->filename !== '') {
               // save filename when not set to none and not blank
               $db_filename = zen_limit_image_filename($categories_image_name, TABLE_CATEGORIES, 'categories_image');
-              $db->Execute("update " . TABLE_CATEGORIES . "
-                          set categories_image = '" . $db_filename . "'
-                          where categories_id = '" . (int)$categories_id . "'");
-          } elseif ($categories_image->filename != '' || $_POST['image_delete'] === '1') {
-              $db->Execute("update " . TABLE_CATEGORIES . "
-                            set categories_image = ''
-                            where categories_id = '" . (int)$categories_id . "'");
+              $db->Execute("UPDATE " . TABLE_CATEGORIES . "
+                          SET categories_image = '" . $db_filename . "'
+                          WHERE categories_id = " . (int)$categories_id);
           }
       }
 

--- a/admin/categories.php
+++ b/admin/categories.php
@@ -185,7 +185,7 @@ if (zen_not_null($action)) {
           if ($categories_image->parse() && $categories_image->save()) {
               $categories_image_name = zen_db_input($_POST['img_dir'] . $categories_image->filename);
           }
-          if ($categories_image->filename !== 'none' && $categories_image->filename !== '') {
+          if ($categories_image->filename !== 'none' && $categories_image->filename != '') {
               // save filename when not set to none and not blank
               $db_filename = zen_limit_image_filename($categories_image_name, TABLE_CATEGORIES, 'categories_image');
               $db->Execute("UPDATE " . TABLE_CATEGORIES . "

--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -318,9 +318,9 @@
   }
 
 
-  function zen_info_image($image, $alt, $width = '', $height = '') {
+  function zen_info_image($image, $alt, $width = '', $height = '', $params = '') {
     if (zen_not_null($image) && (file_exists(DIR_FS_CATALOG_IMAGES . $image)) ) {
-      $image = zen_image(DIR_WS_CATALOG_IMAGES . $image, $alt, $width, $height);
+      $image = zen_image(DIR_WS_CATALOG_IMAGES . $image, $alt, $width, $height, $params);
     } else {
       $image = TEXT_IMAGE_NONEXISTENT;
     }

--- a/admin/includes/languages/english/categories.php
+++ b/admin/includes/languages/english/categories.php
@@ -13,13 +13,17 @@ define('TEXT_EDIT_INTRO', 'Please edit as required');
 define('TEXT_EDIT_CATEGORIES_NAME', 'Category Name:');
 define('TEXT_CATEGORIES_DESCRIPTION', 'Category Description:');
 define('TEXT_CATEGORIES_IMAGE', 'Category Image:');
+define('TEXT_FILENAME', 'Filename: %1$s (%2$upx x %3$upx / %4$ukB)');
 define('TEXT_EDIT_CATEGORIES_IMAGE', 'Edit Category Image:');
-define('TEXT_CATEGORIES_IMAGE_DIR', 'Upload to:<br>/images/<em>(subdirectory)</em>');
-define('TEXT_CATEGORIES_IMAGE_MANUAL', 'Or, select an existing image file from the server, filename:');
+define('TEXT_CATEGORIES_IMAGE_DIR', 'Upload to / Use an existing image in:<br>/images/<em>(subdirectory)</em>');
+define('TEXT_CATEGORIES_IMAGE_MANUAL', 'Use an existing image file in the above selected directory, filename:');
 define('TEXT_EDIT_SORT_ORDER', 'Sort Order:');
 define('TEXT_RESTRICT_PRODUCT_TYPE', 'Restrict to Product Type');
 define('TEXT_CATEGORY_HAS_RESTRICTIONS', 'This Category has been restricted to these Product Types');
 define('ERROR_CANNOT_ADD_PRODUCT_TYPE', 'The specified Product Type cannot be added to this category. Check your category restrictions.');
+define('ERROR_IMAGE_MANUAL_NOT_FOUND', 'The image "/images/%s" was not found.');
+define('MESSAGE_IMAGE_REMOVED_CATEGORY', 'The image was removed from category ID#%1$u: "%2$s"');
+define('MESSAGE_IMAGE_ADDED_MANUAL', 'The image "/images/%3$s" was assigned to category ID#%1$u: "%2$s"');
 
 // Metatags
 define('TEXT_INFO_HEADING_EDIT_CATEGORY_META_TAGS', 'Categories Meta Tags Definitions');


### PR DESCRIPTION
Bugfix: from prior PR. When no image is defined, no option is presented to delete it so the POST img_delete is not created/passed and a warning is triggered on the preview page.
After reviewing the three options in the image section (delete /upoad new / use existing), I decided to simplify it, rather than just added isset.

The manual filename entry uses the selected subdirectory, which was not evident (not to me anyway), and no check was made on the filename existing: added check and corresponding messagestack texts.

The image shown on the page was at full size: added parameters to zen_info_image to allow use of responsive class.
Added file info (path, sizes, weight) to image info.
![Clipboard01](https://user-images.githubusercontent.com/4391026/78153733-af3b1a00-743b-11ea-9afb-a3c023e80d73.gif)
