### PR TITLE
Misc cleanup: uppercase SQL, remove obsolete comment and end array on new line

### DIFF
--- a/includes/modules/pages/ask_a_question/header_php.php
+++ b/includes/modules/pages/ask_a_question/header_php.php
@@ -13,12 +13,12 @@
 $valid_product = false;
 $zco_notifier->notify('NOTIFY_HEADER_START_ASK_A_QUESTION');
 if (isset($_GET['products_id'])) {
-    $product_info_query = "select pd.products_name, p.products_image, p.products_model
-                           from " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_DESCRIPTION . " pd
-                           where p.products_status = '1'
-                           and p.products_id = " . (int)$_GET['products_id'] . "
-                           and p.products_id = pd.products_id
-                           and pd.language_id = " . (int)$_SESSION['languages_id'];
+    $product_info_query = "SELECT pd.products_name, p.products_image, p.products_model
+                           FROM " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_DESCRIPTION . " pd
+                           WHERE p.products_status = '1'
+                           AND p.products_id = " . (int)$_GET['products_id'] . "
+                           AND p.products_id = pd.products_id
+                           AND pd.language_id = " . (int)$_SESSION['languages_id'];
 
     $product_info = $db->Execute($product_info_query);
 

--- a/includes/modules/pages/product_free_shipping_info/main_template_vars.php
+++ b/includes/modules/pages/product_free_shipping_info/main_template_vars.php
@@ -53,11 +53,11 @@
 // if review must be approved or disabled do not show review
     $review_status = " and r.status = '1'";
 
-    $reviews_query = "select count(*) as count from " . TABLE_REVIEWS . " r, "
+    $reviews_query = "SELECT count(*) AS count FROM " . TABLE_REVIEWS . " r, "
                                                        . TABLE_REVIEWS_DESCRIPTION . " rd
-                       where r.products_id = '" . (int)$_GET['products_id'] . "'
-                       and r.reviews_id = rd.reviews_id
-                       and rd.languages_id = '" . (int)$_SESSION['languages_id'] . "'" .
+                       WHERE r.products_id = '" . (int)$_GET['products_id'] . "'
+                       AND r.reviews_id = rd.reviews_id
+                       AND rd.languages_id = '" . (int)$_SESSION['languages_id'] . "'" .
                        $review_status;
 
     $reviews = $db->Execute($reviews_query);

--- a/includes/modules/pages/product_info/main_template_vars.php
+++ b/includes/modules/pages/product_info/main_template_vars.php
@@ -51,13 +51,13 @@
     require(DIR_WS_MODULES . zen_get_module_directory(FILENAME_ATTRIBUTES));
 
 // if review must be approved or disabled do not show review
-    $review_status = " and r.status = 1";
+    $review_status = " AND r.status = 1";
 
-    $reviews_query = "select count(*) as count from " . TABLE_REVIEWS . " r, "
+    $reviews_query = "SELECT count(*) AS count FROM " . TABLE_REVIEWS . " r, "
                                                        . TABLE_REVIEWS_DESCRIPTION . " rd
-                       where r.products_id = " . (int)$_GET['products_id'] . "
-                       and r.reviews_id = rd.reviews_id
-                       and rd.languages_id = " . (int)$_SESSION['languages_id'] .
+                       WHERE r.products_id = " . (int)$_GET['products_id'] . "
+                       AND r.reviews_id = rd.reviews_id
+                       AND rd.languages_id = " . (int)$_SESSION['languages_id'] .
                        $review_status;
 
     $reviews = $db->Execute($reviews_query);

--- a/includes/modules/pages/shopping_cart/header_php.php
+++ b/includes/modules/pages/shopping_cart/header_php.php
@@ -94,7 +94,6 @@ for ($i=0, $n=sizeof($products); $i<$n; $i++) {
       $attributes = $db->bindVars($attributes, ':optionsValuesID', $value, 'integer');
       $attributes = $db->bindVars($attributes, ':languageID', $_SESSION['languages_id'], 'integer');
       $attributes_values = $db->Execute($attributes);
-      //clr 030714 determine if attribute is a text attribute and assign to $attr_value temporarily
       if ($value == PRODUCTS_OPTIONS_VALUES_TEXT_ID) {
         $attributeHiddenField .= zen_draw_hidden_field('id[' . $products[$i]['id'] . '][' . TEXT_PREFIX . $option . ']',  $products[$i]['attributes_values'][$option]);
         $attr_value = htmlspecialchars($products[$i]['attributes_values'][$option], ENT_COMPAT, CHARSET, TRUE);
@@ -153,7 +152,8 @@ for ($i=0, $n=sizeof($products); $i<$n; $i++) {
                             'buttonDelete'=>$buttonDelete,
                             'checkBoxDelete'=>$checkBoxDelete,
                             'id'=>$products[$i]['id'],
-                            'attributes'=>$attrArray);
+                            'attributes'=>$attrArray,
+                          );
 } // end FOR loop
 
 $define_page = zen_get_file_directory(DIR_WS_LANGUAGES . $_SESSION['language'] . '/html_includes/', FILENAME_DEFINE_SHOPPING_CART, 'false');


### PR DESCRIPTION
These files have already been changed in 1.5.7 - may as well finish the cleanup.

There are more files that have already been changed but haven't had these fixes: 
**in storefront:** 
column_left.php
column_right.php
column_single.php
create_account.php
meta_tags.php
order_total/ot_coupon.php
order_total/ot_gv.php
payment/authorizenet.php
payment/authorizenet_aim.php
payment/firstdata_hco.php
payment/paypal.php
payment/paypal/paypal_functions.php
payment/paypaldp.php
payment/paypalwpp.php
payment/square.php
product_prev_next.php
products_quantity_discounts.php
shipping/freeoptions.php
shipping_estimator.php
sideboxes/best_sellers.php
sideboxes/order_history.php
sideboxes/whos_online.php


**in admin:** 
featured.php
currencies.php
geo_zones.php
products_price_manager.php
gv_queue.php
template_select.php
includes/init_includes/init_templates.php
includes/init_includes/init_db_config_read.php
includes/init_includes/init_cache_key_check.php
includes/init_includes/init_errors.php
includes/header.php
includes/functions/html_output.php
includes/functions/localization.php
includes/functions/admin_access.php
includes/functions/general.php
product_types.php
gv_sent.php
store_manager.php
specials.php
orders_status.php
developers_tool_kit.php
coupon_admin_export.php
manufacturers.php
sqlpatch.php
media_manager.php
reviews.php
coupon_admin.php
popup_image.php
categories.php
customers.php
paypal.php
tax_classes.php
orders.php
