### PR TITLE
Messagestack losing session messages (catalog)

### DIFF
--- a/includes/classes/message_stack.php
+++ b/includes/classes/message_stack.php
@@ -9,7 +9,7 @@
  * @version $Id: mc12345678 2019 Apr 30 Modified in v1.5.6b $
  */
 if (!defined('IS_ADMIN_FLAG')) {
-  die('Illegal Access');
+    die('Illegal Access');
 }
 /**
  * messageStack Class.
@@ -17,91 +17,121 @@ if (!defined('IS_ADMIN_FLAG')) {
  *
  * @package classes
  */
-class messageStack extends base {
+class messageStack extends base 
+{
+    // class constructor
+    function __construct() 
+    {
+        $this->messages = array();
 
-  // class constructor
-  function __construct() {
-
-    $this->messages = array();
-
-    if (isset($_SESSION['messageToStack']) && $_SESSION['messageToStack']) {
-      $messageToStack = $_SESSION['messageToStack'];
-      for ($i=0, $n=sizeof($messageToStack); $i<$n; $i++) {
-        $this->add($messageToStack[$i]['class'], $messageToStack[$i]['text'], $messageToStack[$i]['type']);
-      }
+        if (isset($_SESSION['messageToStack']) && $_SESSION['messageToStack']) {
+            $messageToStack = $_SESSION['messageToStack'];
+            for ($i = 0, $n = count($messageToStack); $i < $n; $i++) {
+                $this->add($messageToStack[$i]['class'], $messageToStack[$i]['text'], $messageToStack[$i]['type']);
+            }
+        }
     }
 
-  }
+    function add($class, $message, $type = 'error') 
+    {
+        global $template, $current_page_base;
+        $message = trim($message);
+        $duplicate = false;
+        if (strlen($message) > 0) {
+            if ($type == 'error') {
+                $theAlert = array(
+                    'params' => 'class="messageStackError larger"', 
+                    'class' => $class, 
+                    'text' => zen_image($template->get_template_dir(ICON_IMAGE_ERROR, DIR_WS_TEMPLATE, $current_page_base,'images/icons'). '/' . ICON_IMAGE_ERROR, ICON_ERROR_ALT) . '  ' . $message
+                );
+            } elseif ($type == 'warning') {
+                $theAlert = array(
+                    'params' => 'class="messageStackWarning larger"', 
+                    'class' => $class, 
+                    'text' => zen_image($template->get_template_dir(ICON_IMAGE_WARNING, DIR_WS_TEMPLATE, $current_page_base,'images/icons'). '/' . ICON_IMAGE_WARNING, ICON_WARNING_ALT) . '  ' . $message
+                );
+            } elseif ($type == 'success') {
+                $theAlert = array(
+                    'params' => 'class="messageStackSuccess larger"', 
+                    'class' => $class, 
+                    'text' => zen_image($template->get_template_dir(ICON_IMAGE_SUCCESS, DIR_WS_TEMPLATE, $current_page_base,'images/icons'). '/' . ICON_IMAGE_SUCCESS, ICON_SUCCESS_ALT) . '  ' . $message
+                );
+            } elseif ($type == 'caution') {
+                $theAlert = array(
+                    'params' => 'class="messageStackCaution larger"', 
+                    'class' => $class, 
+                    'text' => zen_image($template->get_template_dir(ICON_IMAGE_WARNING, DIR_WS_TEMPLATE, $current_page_base,'images/icons'). '/' . ICON_IMAGE_WARNING, ICON_WARNING_ALT) . '  ' . $message
+                );
+            } else {
+                $theAlert = array(
+                    'params' => 'class="messageStackError larger"', 
+                    'class' => $class, 
+                    'text' => $message
+                );
+            }
 
-  function add($class, $message, $type = 'error') {
-    global $template, $current_page_base;
-    $message = trim($message);
-    $duplicate = false;
-    if (strlen($message) > 0) {
-      if ($type == 'error') {
-        $theAlert = array('params' => 'class="messageStackError larger"', 'class' => $class, 'text' => zen_image($template->get_template_dir(ICON_IMAGE_ERROR, DIR_WS_TEMPLATE, $current_page_base,'images/icons'). '/' . ICON_IMAGE_ERROR, ICON_ERROR_ALT) . '  ' . $message);
-      } elseif ($type == 'warning') {
-        $theAlert = array('params' => 'class="messageStackWarning larger"', 'class' => $class, 'text' => zen_image($template->get_template_dir(ICON_IMAGE_WARNING, DIR_WS_TEMPLATE, $current_page_base,'images/icons'). '/' . ICON_IMAGE_WARNING, ICON_WARNING_ALT) . '  ' . $message);
-      } elseif ($type == 'success') {
-        $theAlert = array('params' => 'class="messageStackSuccess larger"', 'class' => $class, 'text' => zen_image($template->get_template_dir(ICON_IMAGE_SUCCESS, DIR_WS_TEMPLATE, $current_page_base,'images/icons'). '/' . ICON_IMAGE_SUCCESS, ICON_SUCCESS_ALT) . '  ' . $message);
-      } elseif ($type == 'caution') {
-        $theAlert = array('params' => 'class="messageStackCaution larger"', 'class' => $class, 'text' => zen_image($template->get_template_dir(ICON_IMAGE_WARNING, DIR_WS_TEMPLATE, $current_page_base,'images/icons'). '/' . ICON_IMAGE_WARNING, ICON_WARNING_ALT) . '  ' . $message);
-      } else {
-        $theAlert = array('params' => 'class="messageStackError larger"', 'class' => $class, 'text' => $message);
-      }
-
-      for ($i=0, $n=sizeof($this->messages); $i<$n; $i++) {
-        if ($theAlert['text'] == $this->messages[$i]['text'] && $theAlert['class'] == $this->messages[$i]['class']) $duplicate = true;
-      }
-      if (!$duplicate) $this->messages[] = $theAlert;
+            for ($i = 0, $n = count($this->messages); $i < $n; $i++) {
+                if ($theAlert['text'] == $this->messages[$i]['text'] && $theAlert['class'] == $this->messages[$i]['class']) {
+                    $duplicate = true;
+                }
+            }
+            if (!$duplicate) {
+                $this->messages[] = $theAlert;
+            }
+        }
     }
-  }
 
-  function add_session($class, $message, $type = 'error') {
+    function add_session($class, $message, $type = 'error') 
+    {
+        if (empty($_SESSION['messageToStack'])) {
+            $messageToStack = array();
+        } else {
+            $messageToStack = $_SESSION['messageToStack'];
+        }
 
-    if (empty($_SESSION['messageToStack'])) {
-      $messageToStack = array();
-    } else {
-      $messageToStack = $_SESSION['messageToStack'];
+        $messageToStack[] = array(
+            'class' => $class, 
+            'text' => $message, 
+            'type' => $type
+        );
+        $_SESSION['messageToStack'] = $messageToStack;
+        $this->add($class, $message, $type);
     }
 
-    $messageToStack[] = array('class' => $class, 'text' => $message, 'type' => $type);
-    $_SESSION['messageToStack'] = $messageToStack;
-    $this->add($class, $message, $type);
-  }
-
-  function reset() {
-    $this->messages = array();
-  }
-
-  function output($class) {
-    global $template, $current_page_base;
-
-    $_SESSION['messageToStack'] = '';
-
-    $output = array();
-    for ($i=0, $n=sizeof($this->messages); $i<$n; $i++) {
-      if ($this->messages[$i]['class'] == $class) {
-        $output[] = $this->messages[$i];
-      }
+    function reset() 
+    {
+        $this->messages = array();
     }
+
+    function output($class) 
+    {
+        global $template, $current_page_base;
+
+        $_SESSION['messageToStack'] = '';
+
+        $output = array();
+        for ($i = 0, $n = count($this->messages); $i < $n; $i++) {
+            if ($this->messages[$i]['class'] == $class) {
+                $output[] = $this->messages[$i];
+            }
+        }
 
     // remove duplicates before displaying
 //    $output = array_values(array_unique($output));
 
-    require($template->get_template_dir('tpl_message_stack_default.php',DIR_WS_TEMPLATE, $current_page_base,'templates'). '/tpl_message_stack_default.php');
-  }
-
-  function size($class) {
-    $count = 0;
-
-    for ($i=0, $n=sizeof($this->messages); $i<$n; $i++) {
-      if ($this->messages[$i]['class'] == $class) {
-        $count++;
-      }
+        require $template->get_template_dir('tpl_message_stack_default.php', DIR_WS_TEMPLATE, $current_page_base, 'templates') . '/tpl_message_stack_default.php';
     }
 
-    return $count;
-  }
+    function size($class) 
+    {
+        $count = 0;
 
+        for ($i = 0, $n = count($this->messages); $i < $n; $i++) {
+            if ($this->messages[$i]['class'] == $class) {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
 }

--- a/includes/classes/message_stack.php
+++ b/includes/classes/message_stack.php
@@ -23,13 +23,6 @@ class messageStack extends base
     function __construct() 
     {
         $this->messages = array();
-
-        if (isset($_SESSION['messageToStack']) && $_SESSION['messageToStack']) {
-            $messageToStack = $_SESSION['messageToStack'];
-            for ($i = 0, $n = count($messageToStack); $i < $n; $i++) {
-                $this->add($messageToStack[$i]['class'], $messageToStack[$i]['text'], $messageToStack[$i]['type']);
-            }
-        }
     }
 
     function add($class, $message, $type = 'error') 
@@ -70,9 +63,10 @@ class messageStack extends base
                 );
             }
 
-            for ($i = 0, $n = count($this->messages); $i < $n; $i++) {
-                if ($theAlert['text'] == $this->messages[$i]['text'] && $theAlert['class'] == $this->messages[$i]['class']) {
+            foreach ($this->messages as $next_message) {
+                if ($theAlert['text'] == $next_message['text'] && $theAlert['class'] == $next_message['class']) {
                     $duplicate = true;
+                    break;
                 }
             }
             if (!$duplicate) {
@@ -107,11 +101,17 @@ class messageStack extends base
     {
         global $template, $current_page_base;
 
-        $_SESSION['messageToStack'] = '';
+        if (!empty($_SESSION['messageToStack'])) {
+            foreach ($_SESSION['messageToStack'] as $next_message) {
+                $this->add($next_message['class'], $next_message['text'], $next_message['type']);
+            }
+        }
+
+        $_SESSION['messageToStack'] = array();
 
         $output = array();
-        for ($i = 0, $n = count($this->messages); $i < $n; $i++) {
-            if ($this->messages[$i]['class'] == $class) {
+        foreach ($this->messages as $next_message) {
+            if ($next_message['class'] == $class) {
                 $output[] = $this->messages[$i];
             }
         }
@@ -126,8 +126,8 @@ class messageStack extends base
     {
         $count = 0;
 
-        for ($i = 0, $n = count($this->messages); $i < $n; $i++) {
-            if ($this->messages[$i]['class'] == $class) {
+        foreach ($this->messages as $next_message) {
+            if ($next_message['class'] == $class) {
                 $count++;
             }
         }

--- a/includes/classes/message_stack.php
+++ b/includes/classes/message_stack.php
@@ -104,7 +104,7 @@ class messageStack extends base
         $output = array();
         foreach ($this->messages as $next_message) {
             if ($next_message['class'] == $class) {
-                $output[] = $this->messages[$i];
+                $output[] = $next_message;
             }
         }
 

--- a/includes/classes/message_stack.php
+++ b/includes/classes/message_stack.php
@@ -101,6 +101,10 @@ class messageStack extends base
     {
         global $template, $current_page_base;
 
+        if ($this->size($class) === 0) {
+            return;
+        }
+        
         $output = array();
         foreach ($this->messages as $next_message) {
             if ($next_message['class'] == $class) {

--- a/includes/classes/message_stack.php
+++ b/includes/classes/message_stack.php
@@ -101,14 +101,6 @@ class messageStack extends base
     {
         global $template, $current_page_base;
 
-        if (!empty($_SESSION['messageToStack'])) {
-            foreach ($_SESSION['messageToStack'] as $next_message) {
-                $this->add($next_message['class'], $next_message['text'], $next_message['type']);
-            }
-        }
-
-        $_SESSION['messageToStack'] = array();
-
         $output = array();
         foreach ($this->messages as $next_message) {
             if ($next_message['class'] == $class) {
@@ -124,6 +116,14 @@ class messageStack extends base
 
     function size($class) 
     {
+        if (!empty($_SESSION['messageToStack'])) {
+            foreach ($_SESSION['messageToStack'] as $next_message) {
+                $this->add($next_message['class'], $next_message['text'], $next_message['type']);
+            }
+        }
+
+        $_SESSION['messageToStack'] = array();
+
         $count = 0;
 
         foreach ($this->messages as $next_message) {


### PR DESCRIPTION
Provides refactoring of code, then moves the `$_SESSION['messageStack']` 'removal' to the class `size` method so that session-based messages aren't lost on a redirect.

Fixes #3171