### PR TITLE
Extend order message to handle admin order updates

### DIFF
--- a/admin/includes/languages/english/email_extras.php
+++ b/admin/includes/languages/english/email_extras.php
@@ -18,6 +18,9 @@
   //
   define ('EMAIL_EXTRA_HEADER_INFO', '');
 
+  // Define a message you'd like to add to an order update email
+  define('EMAIL_ORDER_UPDATE_MESSAGE',''); 
+
 // office use only
   define('OFFICE_FROM','From:');
   define('OFFICE_EMAIL','E-mail:');

--- a/email/email_template_order_status.html
+++ b/email/email_template_order_status.html
@@ -33,6 +33,10 @@ $EMAIL_COMMON_CSS
     <div>$EMAIL_STORE_NAME</div>
   </div>
 
+  <div class="order_message">
+    <div class="order_message">$EMAIL_ORDER_UPDATE_MESSAGE</div>
+  </div>
+
 
   <!-- Footer Section -->
   <div class="footer">

--- a/includes/functions/functions_osh_update.php
+++ b/includes/functions/functions_osh_update.php
@@ -122,7 +122,15 @@ function zen_update_orders_history($orders_id, $message = '', $updated_by = null
                     strip_tags($email_message) .
                     $status_text . $status_value_text .
                     OSH_EMAIL_TEXT_STATUS_PLEASE_REPLY;
-           
+
+                // Add in store specific order message
+                $email_order_message = defined('EMAIL_ORDER_UPDATE_MESSAGE') ? constant('EMAIL_ORDER_UPDATE_MESSAGE') : '';
+                $GLOBALS['zco_notifier']->notify('ZEN_UPDATE_ORDERS_HISTORY_SET_ORDER_UPDATE_MESSAGE'); 
+                if (!empty($email_order_message)) {
+                 $email_text .= "\n\n" . $email_order_message . "\n\n";
+                }
+                $html_msg['EMAIL_ORDER_UPDATE_MESSAGE'] = $email_order_message;
+
                 $html_msg['EMAIL_SALUTATION'] = EMAIL_SALUTATION;
                 $html_msg['EMAIL_CUSTOMERS_NAME']    = $osh_info->fields['customers_name'];
                 $html_msg['EMAIL_TEXT_ORDER_NUMBER'] = OSH_EMAIL_TEXT_ORDER_NUMBER . ' ' . $orders_id;


### PR DESCRIPTION
Extends #1670 so that a message may be added to admin order update emails as well. 