### PR TITLE
fixes countable error

### DIFF
--- a/includes/modules/payment/square.php
+++ b/includes/modules/payment/square.php
@@ -1107,7 +1107,7 @@ class square extends base
             $messageStack->add_session(MODULE_PAYMENT_SQUARE_TEXT_COMM_ERROR, 'error');
         }
 
-        if (count($errors_object)) {
+        if (is_array($errors_object) && count($errors_object)) {
             $error = $this->parse_error_response($errors_object);
             $messageStack->add_session(MODULE_PAYMENT_SQUARE_TEXT_UPDATE_FAILED . ' [' . $error['detail'] . ']', 'error');
 


### PR DESCRIPTION
if the transaction completes successfully, the `$result->getErrors()` on line 1100 returns something other than an array.  probably empty....  this will address that situation.