### PR TITLE
Remove unused parm from help call; add dashboard help

### DIFF
--- a/admin/includes/functions/functions_help.php
+++ b/admin/includes/functions/functions_help.php
@@ -6,14 +6,13 @@
  * @version $Id: DrByte 2019 May 26 Modified in v1.5.6b $
  */
 
- function page_has_help($help_page) {
+ function page_has_help() {
    global $PHP_SELF;
 
    $page = basename($PHP_SELF, ".php");
-   // This list will be built out in the final version
 
    $pagelist = array(
-
+     FILENAME_DEFAULT => "https://docs.zen-cart.com/user/admin_pages/admin_dashboard/",
      FILENAME_CONFIGURATION => "https://docs.zen-cart.com/user/admin_pages/configuration/",
      FILENAME_CATEGORIES => "https://docs.zen-cart.com/user/admin_pages/catalog/categories/", 
      FILENAME_CATEGORY_PRODUCT_LISTING => "https://docs.zen-cart.com/user/admin_pages/catalog/categories_products/", 

--- a/admin/includes/header_navigation.php
+++ b/admin/includes/header_navigation.php
@@ -43,7 +43,7 @@ $menuTitles = zen_get_menu_titles();
     </ul>
   </div><!-- /.navbar-collapse -->
 </nav>
-<?php if ($url = page_has_help($help_page)) { ?>
+<?php if ($url = page_has_help()) { ?>
 <div align="right">
   <div class="btn-group">
     <a href="<?php echo $url; ?>" target="_blank" class="btn btn-sm btn-default btn-help" role="button" title="Help">


### PR DESCRIPTION
Fixes notice about `help_page` parameter reported by @torvista.