### PR TITLE
Check coupon_name instead of shipping_method

### DIFF
--- a/zc_install/includes/systemChecks.yml
+++ b/zc_install/includes/systemChecks.yml
@@ -303,10 +303,10 @@ systemChecks:
             fieldCheck: Type
             expectedResult: 'VARCHAR(255)'
           - checkType: fieldSchema
-            tableName: orders
-            fieldName: shipping_method
+            tableName: coupons_description
+            fieldName: coupon_name
             fieldCheck: Type
-            expectedResult: 'VARCHAR(255)'
+            expectedResult: 'VARCHAR(64)'
           - checkType: configValue
             fieldName: CURRENCY_SERVER_PRIMARY
             expectedResult: 'Currency Exchange Rate: Primary Source'


### PR DESCRIPTION
Checking shipping_method causes upgrade issues for users of the popular Advanced Shipper mod.  Changing to another field gives the same level of validation without the issues. 