### PR TITLE
Bug fix to prior PR: wrong value_id value in options_values_manager.php

### DIFF
--- a/admin/options_values_manager.php
+++ b/admin/options_values_manager.php
@@ -812,11 +812,11 @@ if (zen_not_null($action)) {
                     <?php } ?>
                     <?php
                   }
-                  $max_values_id_values = $db->Execute("SELECT MAX(products_options_values_id) + 1 AS next_id
-                                                        FROM " . TABLE_PRODUCTS_OPTIONS_VALUES);
-
-                  $next_id = $max_values_id_values->fields['next_id'];
                 }
+                $max_values_id_values = $db->Execute("SELECT MAX(products_options_values_id) + 1 AS next_id
+                                                      FROM " . TABLE_PRODUCTS_OPTIONS_VALUES);
+
+                $next_id = $max_values_id_values->fields['next_id'];
                 ?>
               </tr>
               <?php if ($action != 'update_option_value') { ?>


### PR DESCRIPTION
As reported in #2973 This fixes a bug in the options_values_manager.php

This happen on creating a new value when selecting an option from the filter dropdown that contains no values first.

The problem is that the ```$value_id``` sits inside a ```foreach``` that is never fired on empty options. 
Moving the query that sets ```$value_id``` outside the ```foreach``` fixed the error on pressing insert
@torvista : This is the fix we talked about through email