### PR TITLE
Change from document.write of JQuery to forced CDN load

### DIFF
--- a/includes/templates/responsive_classic/common/html_header.php
+++ b/includes/templates/responsive_classic/common/html_header.php
@@ -136,7 +136,7 @@ if (count($lng->catalog_languages) > 1) {
 
 /** CDN for jQuery core **/
 ?>
-
+<script src="https://code.jquery.com/jquery-3.5.0.min.js" integrity="sha256-xNzN2a4ltkB44Mc/Jz3pT4iU1cmeR0FkXs4pru/JxaQ=" crossorigin="anonymous"></script>
 <?php if (file_exists(DIR_WS_TEMPLATE . "jscript/jquery.min.js")) { ?>
 <script type="text/javascript">window.jQuery || document.write(unescape('%3Cscript type="text/javascript" src="<?php echo $template->get_template_dir('.js',DIR_WS_TEMPLATE, $current_page_base,'jscript'); ?>/jquery.min.js"%3E%3C/script%3E'));</script>
 <?php } ?>

--- a/includes/templates/responsive_classic/common/html_header.php
+++ b/includes/templates/responsive_classic/common/html_header.php
@@ -137,7 +137,6 @@ if (count($lng->catalog_languages) > 1) {
 /** CDN for jQuery core **/
 ?>
 
-<script type="text/javascript">window.jQuery || document.write(unescape('%3Cscript type="text/javascript" src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"%3E%3C/script%3E'));</script>
 <?php if (file_exists(DIR_WS_TEMPLATE . "jscript/jquery.min.js")) { ?>
 <script type="text/javascript">window.jQuery || document.write(unescape('%3Cscript type="text/javascript" src="<?php echo $template->get_template_dir('.js',DIR_WS_TEMPLATE, $current_page_base,'jscript'); ?>/jquery.min.js"%3E%3C/script%3E'));</script>
 <?php } ?>


### PR DESCRIPTION
There are so many versions of JQuery flloating around and this one causes...
***************************
index.php?main_page=product_info&cPath=81_1_3&products_id=1:22 A parser-blocking, cross site (i.e. different eTLD+1) script, https://code.jquery.com/jquery-3.3.1.min.js, is invoked via document.write. The network request for this script MAY be blocked by the browser in this or a future page load due to poor network connectivity. If blocked in this page load, it will be confirmed in a subsequent console message. See https://www.chromestatus.com/feature/5718547946799104 for more details.
*************************
removing  original line 140 solves this problem for our sites.