### PR TITLE
Default to https URLs in installer

### DIFF
--- a/zc_install/includes/functions/general.php
+++ b/zc_install/includes/functions/general.php
@@ -191,14 +191,14 @@ function zen_get_select_options($optionList, $setDefault)
     global $request_type;
     if (isset($_POST['adminDir'])) $adminDir = zen_output_string_protected($_POST['adminDir']);
     $documentRoot = zen_get_document_root();
-    $url = ($request_type == 'SSL' ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'] . str_replace('/zc_install/index.php', '', $_SERVER['SCRIPT_NAME']);
+    $proto = ($request_type == 'SSL' ? 'https://' : 'http://'); 
+    $url = $proto . $_SERVER['HTTP_HOST'] . str_replace('/zc_install/index.php', '', $_SERVER['SCRIPT_NAME']);
     $httpServer = zen_parse_url($url, 'host', true);
-    $adminServer = ($request_type == 'SSL') ? 'https://' : 'http://';
-    $adminServer .= $httpServer;
-    $catalogHttpServer = 'http://' . $httpServer;
-    $catalogHttpUrl = 'http://' . $httpServer . '/' . zen_parse_url($url, 'path', true);
-    $catalogHttpsServer = 'https://' . $httpServer;
-    $catalogHttpsUrl = 'https://' . $httpServer . '/' . zen_parse_url($url, 'path', true);
+    $adminServer = $proto . $httpServer;
+    $catalogHttpServer = $proto . $httpServer;
+    $catalogHttpUrl = $proto . $httpServer . '/' . zen_parse_url($url, 'path', true);
+    $catalogHttpsServer = $proto . $httpServer;
+    $catalogHttpsUrl = $proto . $httpServer . '/' . zen_parse_url($url, 'path', true);
     $dir_ws_http_catalog = str_replace($catalogHttpServer, '', $catalogHttpUrl) .'/';
     $dir_ws_https_catalog = str_replace($catalogHttpsServer, '', $catalogHttpsUrl) . '/';
 


### PR DESCRIPTION
Fixes #3269

Also preserves ability for people testing in a local environment to use http without having to edit URLs. 