### PR TITLE
Reverts #2775 - wrongly specifying "missing_file" when saving attributes

### DIFF
--- a/admin/attributes_controller.php
+++ b/admin/attributes_controller.php
@@ -337,12 +337,6 @@ if (zen_not_null($action)) {
             $products_attributes_maxdays = (int)$_POST['products_attributes_maxdays'];
             $products_attributes_maxcount = (int)$_POST['products_attributes_maxcount'];
 
-            // check to see if it's a file missing a name
-            if ($options_id === 1) {
-              if (empty($products_attributes_filename)) {
-                $products_attributes_filename = 'missing_file';
-              }
-            }
             if (!empty($products_attributes_filename)) {
               $db->Execute("INSERT INTO " . TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD . " (products_attributes_id, products_attributes_filename, products_attributes_maxdays, products_attributes_maxcount)
                             VALUES (" . (int)$products_attributes_id . ",


### PR DESCRIPTION
Fixes #2927  