### PR TITLE
[zc_install] Respect line if field exists and table is being modified

### DIFF
--- a/zc_install/includes/classes/class.zcDatabaseInstaller.php
+++ b/zc_install/includes/classes/class.zcDatabaseInstaller.php
@@ -337,9 +337,8 @@ class zcDatabaseInstaller
                 // Do nothing (no checks at this time)
                 break;
               default:
-                // No known item added, MySQL defaults to column definition
-                $exists = $this->tableColumnExists($this->lineSplit[2], $this->lineSplit[4]);
-                $exists = (strtoupper($this->lineSplit[3]) == 'DROP') ? !$exists : $exists);
+                // No known item added, MySQL defaults to column definition unless the action is to drop the item, then it is the reverse.
+                $exists = (strtoupper($this->lineSplit[3]) != 'DROP') == $this->tableColumnExists($this->lineSplit[2], $this->lineSplit[4]);
             }
             // Ignore this line if the column / index already exists
             if($exists) $this->ignoreLine = true;

--- a/zc_install/includes/classes/class.zcDatabaseInstaller.php
+++ b/zc_install/includes/classes/class.zcDatabaseInstaller.php
@@ -339,6 +339,7 @@ class zcDatabaseInstaller
               default:
                 // No known item added, MySQL defaults to column definition
                 $exists = $this->tableColumnExists($this->lineSplit[2], $this->lineSplit[4]);
+                $exists = (strtoupper($this->lineSplit[3]) == 'DROP') ? !$exists : $exists);
             }
             // Ignore this line if the column / index already exists
             if($exists) $this->ignoreLine = true;


### PR DESCRIPTION
Fixes #3278.

While not every possible combination was researched, the SQL statement provided in #3278 is very specific and results in executing the default portion of the function evaluation.  An earlier consideration was to swap the sequence of the `ADD` and `DROP` such that if `DROP` occurred, then the result was the reverse of the field existing in the table so that the function resolved to allow the line to be executed.  This though directly resolves the condition that led to finding the problem...