### PR TITLE
zc_install - Sync SQL updates (tested back to 1.5.1)

### DIFF
--- a/zc_install/sql/install/mysql_zencart.sql
+++ b/zc_install/sql/install/mysql_zencart.sql
@@ -1718,7 +1718,7 @@ CREATE TABLE products_options (
   products_options_sort_order int(11) NOT NULL default '0',
   products_options_type int(5) NOT NULL default '0',
   products_options_length smallint(2) NOT NULL default '32',
-  products_options_comment varchar(255) default NULL,
+  products_options_comment varchar(256) default NULL,
   products_options_size smallint(2) NOT NULL default '32',
   products_options_images_per_row int(2) default '5',
   products_options_images_style int(1) default '0',

--- a/zc_install/sql/updates/mysql_upgrade_zencart_156.sql
+++ b/zc_install/sql/updates/mysql_upgrade_zencart_156.sql
@@ -176,7 +176,8 @@ VALUES ('categoriesProductListing', 'BOX_CATALOG_CATEGORIES_PRODUCTS', 'FILENAME
 
 DELETE FROM admin_pages WHERE page_key = 'linkpointReview';
 
-ALTER TABLE customers_basket DROP final_price;
+# This was moved to the 1.5.7 upgrade; DROP did not work in 1.5.6
+# ALTER TABLE customers_basket DROP final_price;
 
 ## add support for multi lingual ezpages
 #NEXT_X_ROWS_AS_ONE_COMMAND:8
@@ -194,7 +195,11 @@ INSERT IGNORE INTO ezpages_content (pages_id, languages_id, pages_title, pages_h
 SELECT e.pages_id, l.languages_id, e.pages_title, e.pages_html_text
 FROM ezpages e
 LEFT JOIN languages l ON 1;
-ALTER TABLE ezpages DROP languages_id, DROP pages_title, DROP pages_html_text;
+
+# This was moved to the 1.5.7 upgrade; DROP did not work in 1.5.6
+# Note that these should have been done on separate lines
+# ALTER TABLE ezpages DROP languages_id, DROP pages_title, DROP pages_html_text;
+
 ALTER TABLE ezpages ADD status_visible int(1) NOT NULL default '0';
 ## support for utf8mb4 index limitations in MySQL 5.5-5.6
 ALTER TABLE admin_menus MODIFY menu_key VARCHAR(191) NOT NULL DEFAULT '';

--- a/zc_install/sql/updates/mysql_upgrade_zencart_157.sql
+++ b/zc_install/sql/updates/mysql_upgrade_zencart_157.sql
@@ -77,7 +77,7 @@ UPDATE product_type_layout SET configuration_title = 'Product page &lt;title&gt;
 UPDATE product_type_layout SET configuration_title = 'Product page &lt;title&gt; tag - default: use SITE_TAGLINE', configuration_description = 'Default setting for a new product (can be modified per product).<br>Show the defined constant "SITE_TAGLINE" in the page &lt;title&gt; tag.' WHERE configuration_key = 'SHOW_PRODUCT_FREE_SHIPPING_INFO_METATAGS_TITLE_TAGLINE_STATUS';
 
 # Repair ez-pages table field that was too short in v156
-ALTER TABLE ezpages_content MODIFY pages_html_text mediumtext NOT NULL;
+ALTER TABLE ezpages_content MODIFY pages_html_text mediumtext; 
 
 # Enable Products to Categories as a menu option
 UPDATE admin_pages SET display_on_menu = 'Y' WHERE page_key = 'productsToCategories';
@@ -223,6 +223,17 @@ ALTER TABLE admin_activity_log MODIFY attention MEDIUMTEXT;
 ALTER TABLE upgrade_exceptions MODIFY sql_file varchar(128) default NULL; 
 ALTER TABLE upgrade_exceptions MODIFY reason TEXT;
 ALTER TABLE upgrade_exceptions MODIFY errordate datetime default NULL; 
+
+# ZC 156 upgrade did these operations, which did not work. 
+# Adding for people who upgraded to 1.5.6, and are now upgrading again
+ALTER TABLE customers_basket DROP final_price;
+ALTER TABLE ezpages DROP languages_id; 
+ALTER TABLE ezpages DROP pages_title; 
+ALTER TABLE ezpages DROP pages_html_text;
+
+# ZC 155 upgrade missed these operations
+ALTER TABLE admin_activity_log ADD logmessage mediumtext NOT NULL;
+ALTER TABLE admin_activity_log ADD severity varchar(9) NOT NULL DEFAULT 'info';
 
 
 # New Plugin tables


### PR DESCRIPTION
As @mc12345678 figured out, DROP wasn't working in prior versions of the upgrade software, so the Zen Cart 1.5.6 drop of the final_price field wasn't actually working. 

Now that that bug has been fixed (in #3282), we can correctly update the schema.  I have removed the DROP from 1.5.6 so upgraders in the future won't do it twice. 

Fixes (truly fixes!) #3278 