### PR TITLE
Streamlining css buttons

### DIFF
--- a/includes/functions/html_output.php
+++ b/includes/functions/html_output.php
@@ -325,11 +325,8 @@ function zen_catalog_href_link($page = '', $parameters = '', $connection = 'NONS
     if (empty($sec_class)) $sec_class = $button_name;
     if(!empty($sec_class)) $sec_class = ' ' . $sec_class;
     if(!empty($parameters))$parameters = ' ' . $parameters;
-    $mouse_out_class  = 'cssButton ' . (($type == 'submit') ? 'submit_button button ' : 'normal_button button ') . $sec_class;
-    $mouse_over_class = 'cssButtonHover ' . (($type == 'button') ? 'normal_button button ' : '') . $sec_class . $sec_class . 'Hover';
-    // javascript to set different classes on mouseover and mouseout: enables hover effect on the buttons
-    // (pure css hovers on non link elements do work work in every browser)
-    $css_button_js =  'onmouseover="this.className=\''. $mouse_over_class . '\'" onmouseout="this.className=\'' . $mouse_out_class . '\'"';
+    $button_class  = 'cssButton ' . (($type == 'submit') ? 'submit_button' : 'normal_button') . $sec_class;
+    
 
     if (defined('CSS_BUTTON_POPUPS_IS_ARRAY') && CSS_BUTTON_POPUPS_IS_ARRAY == 'true') {
       $popuptext = (!empty($css_button_text[$button_name])) ? $css_button_text[$button_name] : ($button_name . CSSBUTTONS_CATALOG_POPUPS_SHOW_BUTTON_NAMES_TEXT);
@@ -368,7 +365,7 @@ function zen_catalog_href_link($page = '', $parameters = '', $connection = 'NONS
             $css_button
       );
       if ($css_button == '') {
-        $css_button = '<input class="' . $mouse_out_class . '" ' . $css_button_js . ' type="submit" value="' . $text . '"' . $tooltip . $parameters . ' />';
+        $css_button = '<input class="' . $button_class . '" '. ' type="submit" value="' . $text . '"' . $tooltip . $parameters . ' />';
       }
     }
 
@@ -390,7 +387,7 @@ function zen_catalog_href_link($page = '', $parameters = '', $connection = 'NONS
             $css_button
       );
       if ($css_button == '') {
-        $css_button = '<span class="' . $mouse_out_class . '" ' . $css_button_js . $tooltip . $parameters . '>&nbsp;' . $text . '&nbsp;</span>';
+        $css_button = '<span class="' . $button_class . '" '. $tooltip . $parameters . '>&nbsp;' . $text . '&nbsp;</span>';
       }
     }
     return $css_button;

--- a/includes/templates/classic/css/stylesheet_css_buttons.css
+++ b/includes/templates/classic/css/stylesheet_css_buttons.css
@@ -1,8 +1,4 @@
-/* This imageless css button is based on the button that was generated initially by CSSButtonGenerator.com */
-.buttonRow a {
-  text-decoration: none;
-}
-.button, input.button, input.cssButtonHover {
+.cssButton {
   -moz-border-radius:6px;
   -webkit-border-radius:6px;
   border-radius:6px;
@@ -24,7 +20,7 @@ input.submit_button {
   padding: 3px 8px;
   color: #404040;  /* Text color for submit buttons */
 }
-input.submit_button:hover, input.cssButtonHover {
+input.submit_button:hover {
   background-color:#ffdc9c;  /* Hover color for the submit buttons */
   border: 1px solid #638263;  /* Submit button border color */
   cursor: pointer;

--- a/includes/templates/responsive_classic/css/stylesheet_css_buttons.css
+++ b/includes/templates/responsive_classic/css/stylesheet_css_buttons.css
@@ -1,22 +1,19 @@
-.buttonRow a {text-decoration:none;}
-.button, input.button, input.cssButtonHover {display:inline-block;font-size:1.3em;margin:0;padding:8px 20px;text-decoration:none;}
-input.submit_button {border:none !important;font-size: 1.2em;display: inline-block;margin:0;padding: 12px 30px 30px 30px;}
-input.submit_button:hover {border:none !important;font-size: 1.2em;display: inline-block;margin:0;padding: 12px 30px 30px 30px !important;}
-input.cssButtonHover {border:none;cursor: pointer;border:none;font-size: 1.2em;display: inline-block;margin:0;padding: 12px 30px 30px 30px !important;}
-span.normal_button {}
-span.normal_button:hover {}
-span.cssButton.normal_button.button.button_more_reviews, .button_more_reviews:hover, span.cssButton.normal_button.button.button_read_reviews, .button_read_reviews:hover{display:block;text-align:center;}
-span.cssButton.normal_button.button.button_write_review, .button_write_review, span.cssButton.normal_button.button.button_in_cart{display:block;text-align:center;font-size:130%;padding:12px 20px !important;}
-#indexBody span.cssButton.normal_button.button.button_in_cart, #indexBody .button_in_cart:hover{display:inline-block;}
-span.cssButton.normal_button.button.button_goto_prod_details{background:#000;}
-.button_goto_prod_details:hover{background:#05a5cb !important;}
-input.cssButton.submit_button.button.button_search, .button_search:hover{padding:8px 20px !important;font-size:1.0em;line-height:18px;}
-#advSearchDefault input.cssButton.submit_button.button.button_search, #advSearchDefault .button_search:hover{font-size:1.3em;}
+.buttonRow a { text-decoration: none; }
+.cssButton {display:inline-block;font-size:1.3em;margin:0;padding:8px 20px;text-decoration:none;}
+input.submit_button {border:none;font-size: 1.2em;display: inline-block;margin:0;padding: 12px 30px 30px 30px;}
+input.submit_button:hover {border:none;font-size: 1.2em;display: inline-block;margin:0;padding: 12px 30px 30px 30px;}
+input.cssButtonHover {border:none;cursor: pointer;border:none;font-size: 1.2em;display: inline-block;margin:0;padding: 12px 30px 30px 30px;}
+span.cssButton.normal_button.button_more_reviews, .button_more_reviews:hover, span.cssButton.normal_button.button.button_read_reviews, .button_read_reviews:hover{display:block;text-align:center;}
+span.cssButton.normal_button.button_write_review, .button_write_review, span.cssButton.normal_button.button_in_cart{display:block;text-align:center;padding:12px 20px;}
+#indexBody span.cssButton.normal_button.button_in_cart, #indexBody .button_in_cart:hover{display:inline-block;}
+span.cssButton.normal_button.bbutton_goto_prod_details{background:#000;}
+.button_goto_prod_details:hover{background:#05a5cb;}
+input.cssButton.submit_button.button_search, .button_search:hover{padding:8px 20px !important;font-size:1.0em;line-height:18px;}
+#advSearchDefault input.cssButton.submit_button.button_search, #advSearchDefault .button_search:hover{font-size:1.3em;}
 .button-left{margin-right:10px;}
 .button-right{margin-left:10px;}
-span.cssButton.normal_button.button.button_checkout, .button_checkout:hover{display:block;padding:15px 30px;display:block;}
-span.cssButton.normal_button.button.button_continue_shopping, .button_continue_shopping:hover, span.cssButton.normal_button.button.button_shipping_estimator, .button_shipping_estimator:hover, span.cssButton.normal_button.button.button_back, .button_back:hover{}
-#reviewsInfoDefault span.cssButton.normal_button.button.button_in_cart, #reviewsInfoDefault .button_in_cart:hover{display:block;text-align:center;padding:12px 20px !important;}
-#reviewsInfoDefault .button_in_cart:hover, #reviewsDefault .button_in_cart:hover{display:block !important;}
+span.cssButton.normal_button.button_checkout, .button_checkout:hover{display:block;padding:15px 30px;display:block;}
+#reviewsInfoDefault span.cssButton.normal_button.button_in_cart, #reviewsInfoDefault .button_in_cart:hover{display:block;text-align:center;padding:12px 20px;}
+#reviewsInfoDefault .button_in_cart:hover, #reviewsDefault .button_in_cart:hover{display:block;}
 #reviewsDefault .button_in_cart:hover{text-align:center;padding:12px 20px;}
-span.cssButton.normal_button.button.button_logoff, span.cssButton.normal_button.button.small_edit{background:#666;}
+span.cssButton.normal_button.button_logoff, span.cssButton.normal_button.button.small_edit{background:#666;}


### PR DESCRIPTION
Removing unused button code in html_output.php and updating the Classic and Responsive Classic stylesheet_css_buttons.css. This "streamlining" chose to use the cssButton class as default and removed the duplication of the button class. The remaining css in the classic template is as cleaned up and as efficient as possible for css buttons. Neither css actually uses the button class but the way the responsive is done did require removing the button from the code like span.cssButton.normal_button.button.button_checkout >pan.cssButton.normal_button.button_checkout. If someone has based their css on the responsive, they would have to edit that file due to these changes.