### PR TITLE
Change styling on admin help button

### DIFF
--- a/admin/includes/header_navigation.php
+++ b/admin/includes/header_navigation.php
@@ -44,7 +44,7 @@ $menuTitles = zen_get_menu_titles();
   </div><!-- /.navbar-collapse -->
 </nav>
 <?php if ($url = page_has_help()) { ?>
-<div style="float: right;">
+<div class="pull-right">
   <a href="<?php echo $url; ?>" target="_blank" class="btn btn-sm btn-default btn-help" role="button" title="Help">
     <i class="fa fa-question fa-lg" aria-hidden="true"></i>
   </a>


### PR DESCRIPTION
Why use an inline style when a Bootstrap helper class is available