### PR TITLE
Fix admin keepalive legacy pages

### DIFF
--- a/admin/includes/header_navigation.php
+++ b/admin/includes/header_navigation.php
@@ -44,7 +44,7 @@ $menuTitles = zen_get_menu_titles();
   </div><!-- /.navbar-collapse -->
 </nav>
 <?php if ($url = page_has_help()) { ?>
-<div style="float: right;">
+<div class="pull-right">
   <a href="<?php echo $url; ?>" target="_blank" class="btn btn-sm btn-default btn-help" role="button" title="Help">
     <i class="fa fa-question fa-lg" aria-hidden="true"></i>
   </a>

--- a/admin/includes/stylesheet.css
+++ b/admin/includes/stylesheet.css
@@ -14,3 +14,4 @@
 @import url("css/font-awesome.min.css");
 @import url("https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css");
 @import url(css/stylesheet.css);
+@import url(css/jAlert.css);


### PR DESCRIPTION
I found the keepalive "broken" on legacy pages because jAlert.css was not being loaded.