### PR TITLE
fix keepalive alert for legacy pages

### DIFF
--- a/admin/includes/stylesheet.css
+++ b/admin/includes/stylesheet.css
@@ -14,3 +14,4 @@
 @import url("css/font-awesome.min.css");
 @import url("https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css");
 @import url(css/stylesheet.css);
+@import url(css/jAlert.css);


### PR DESCRIPTION
I found the keepalive "broken" on legacy pages because jAlert.css was not being loaded.