### PR TITLE
ShoppingCart: Skip loop through products if db query is empty.

### DIFF
--- a/includes/classes/shopping_cart.php
+++ b/includes/classes/shopping_cart.php
@@ -1171,7 +1171,8 @@ class shoppingCart extends base {
                            AND pd.products_id = p.products_id
                            AND pd.language_id = " . (int)$_SESSION['languages_id'] . " LIMIT 1";
 
-      if ($products = $db->Execute($products_query)) {
+      $products = $db->Execute($products_query);
+      if (!$products->EOF) {
         $this->notify('NOTIFY_CART_GET_PRODUCTS_NEXT', $products_id, $products->fields);
 
         $prid = $products->fields['products_id'];


### PR DESCRIPTION
`shopping_cart::get_products()`:
When the db query is customized to check only for products which match certain criteria, not aborting this loop will cause incorrect empty entries in the resulting array, and will trigger numerous "index not found" notices.
Checking for validity allows skipping the unnecessary processing of this large section of code and avoids false entries.