### PR TITLE
Update old tutorials links to docs site

### DIFF
--- a/docs/0.about_zen_cart.html
+++ b/docs/0.about_zen_cart.html
@@ -196,7 +196,7 @@
     <div>
         <h1>Zen Cart&reg; Requirements</h1>
         <ul>
-            <li>For up-to-date requirements, see: <a href="https://www.zen-cart.com/content.php?48-what-are-the-server-requirements-to-run-zen-cart" target="_blank"> Zen Cart&reg; Server Requirements</a></li>
+            <li>For up-to-date requirements, see: <a href="https://docs.zen-cart.com/user/first_steps/server_requirements/" target="_blank"> Zen Cart&reg; Server Requirements</a></li>
             <li>Apache must be configured with AllowOverride set to either "All" or at least both "Limit" and "Indexes" parameters, and preferably the "Options" parameter as well.</li>
             <li>PHP must be configured to support CURL with OpenSSL</li>
         </ul>
@@ -207,7 +207,7 @@
     <div>
         <h1>Zen Cart&reg; Support</h1>
         <p>
-            For additional help and support, visit the <a href="https://www.zen-cart.com/tutorials" target="_blank">Zen Cart&reg; FAQ</a> and the <a href="https://www.zen-cart.com/forum.php" target="_blank">Zen Cart&reg; Support Forum</a>.
+            For additional help and support, visit the <a href="https://docs.zen-cart.com/" target="_blank">Zen Cart&reg; Documentation</a> and the <a href="https://www.zen-cart.com/forum.php" target="_blank">Zen Cart&reg; Support Forum</a>.
         </p>
     </div>
 

--- a/docs/1.readme_installation.html
+++ b/docs/1.readme_installation.html
@@ -64,7 +64,7 @@
         <div>
             <h1>Zen Cart&reg; Requirements</h1>
             <ul>
-                <li>For up-to-date requirements, see: <a href="https://www.zen-cart.com/content.php?48-what-are-the-server-requirements-to-run-zen-cart" target="_blank"> Zen Cart&reg; Server Requirements</a></li>
+                <li>For up-to-date requirements, see: <a href="https://docs.zen-cart.com/user/first_steps/server_requirements/" target="_blank"> Zen Cart&reg; Server Requirements</a></li>
                 <li>Apache must be configured with AllowOverride set to either "All" or at least both "Limit" and "Indexes" parameters, and preferably the "Options" parameter as well.</li>
                 <li>PHP must be configured to support CURL with OpenSSL</li>
             </ul>
@@ -514,7 +514,7 @@
                     If you do not have an SSL certificate yet, <em>do not</em> enable this feature now. It can be changed at a later date. 
                 </p>
                 <p> 
-                    See the <a href="https://www.zen-cart.com/content.php?56" target="_blank">Enabling SSL Tutorial</a> for detailed instructions.
+                    See the <a href="https://docs.zen-cart.com/user/installing/enable_ssl/" target="_blank">Enabling SSL Tutorial</a> for detailed instructions.
                 </p>
             </div> <!-- End systemSetupStep //-->
             
@@ -633,7 +633,7 @@
         <div>
             <h1>Next Steps</h1>
             <p>
-                To set up your online store, see the Zen Cart&reg; Wiki entry outlining a <em><a href="https://www.zen-cart.com/wiki/index.php/Basic_Checklist" target="_blank">Basic Checklist</a></em>
+                To set up your online store, see the Zen Cart&reg; documentation entry outlining a <em><a href="https://docs.zen-cart.com/user/first_steps/basic_checklist/" target="_blank">Basic Checklist</a></em>
             </p>
             <ul class="noStyle">
                 Familiarize yourself with the Zen Cart&reg; Developers Toolkit
@@ -645,10 +645,7 @@
                 </li>
             </ul>
             <ul class="noStyle">
-                Review the Zen Cart&reg; <a href="important_site_security_recommendations.html">Site Security Recommendations</a> to be sure your site is not vulnerable to hackers
-                <li class="no-left-margin small-string">
-                    The most up-to-date version of the security recommendations can be found on the <a href="https://www.zen-cart.com/wiki/index.php/Important_Site_Security_Recommendations" target="_blank">Zen Cart&reg; Wiki</a>
-                </li>
+                Review the Zen Cart&reg; <a href="https://docs.zen-cart.com/user/security/security_recommendations/">Site Security Recommendations</a> to be sure your site is not vulnerable to hackers
             </ul>
         </div>
         <br>
@@ -661,7 +658,7 @@
         <div>
             <h1>Help and Support</h1>
             <p>
-                For additional help and support, visit the <a href="https://www.zen-cart.com/tutorials" target="_blank">Zen Cart&reg; FAQ</a> and the <a href="https://www.zen-cart.com/forum.php" target="_blank">Zen Cart&reg; Support Forum</a>.
+                For additional help and support, visit the <a href="https://docs.zen-cart.com/" target="_blank">Zen Cart&reg; Documentation site</a> and the <a href="https://www.zen-cart.com/forum.php" target="_blank">Zen Cart&reg; Support Forum</a>.
             </p>
         </div>
     </section> <!-- End helpSupport //-->

--- a/docs/2.readme_how_to_upgrade.html
+++ b/docs/2.readme_how_to_upgrade.html
@@ -64,7 +64,7 @@
         <div>
             <h1>Zen Cart&reg; Requirements</h1>
             <ul>
-                <li>For up-to-date requirements, see: <a href="https://www.zen-cart.com/content.php?48-what-are-the-server-requirements-to-run-zen-cart" target="_blank"> Zen Cart&reg; Server Requirements</a></li>
+                <li>For up-to-date requirements, see: <a href="https://docs.zen-cart.com/user/first_steps/server_requirements/" target="_blank"> Zen Cart&reg; Server Requirements</a></li>
                 <li>Apache must be configured with AllowOverride set to either "All" or at least both "Limit" and "Indexes" parameters, and preferably the "Options" parameter as well.</li>
                 <li>PHP must be configured to support CURL with OpenSSL</li>
             </ul>
@@ -287,7 +287,7 @@
                         As you make a list of changes, you may want to move things into the Zen Cart&reg; template override system     
                         <ul class="noteList noStyle">
                             <li class="no-left-margin small-string">
-                                See the Zen Cart&reg; site for <a href="https://www.zen-cart.com/content.php?27-template-customization-building-overrides" target="_blank">Template System FAQ</a>.
+                                See the Zen Cart&reg; site for <a href="https://docs.zen-cart.com/user/template/template_overrides/" target="_blank">Template System FAQ</a>.
                             </li>
                         </ul>
                     </li>

--- a/docs/important_site_security_recommendations.html
+++ b/docs/important_site_security_recommendations.html
@@ -68,7 +68,7 @@
                 The Zen Cart&reg; Team, along with Zen Cart&reg; Users and Contributors, regularly update security recommendations on the Zen Cart&reg; Website.
             </p>
             <p>
-                You may wish to also consult recommendations posted on the <a href="https://www.zen-cart.com/content.php?115-how-can-i-protect-my-site-from-malicious-attack-plus-security-recommendations">Zen Cart&reg; Website</a>. 
+                You may wish to also consult recommendations posted on the <a href="https://docs.zen-cart.com/user/security/security_recommendations/">Zen Cart&reg; Website</a>. 
             </p>
         </div>
         <div>


### PR DESCRIPTION
Note: The file docs/important_site_security_recommendations.html should really be removed and replaced with an htaccess redirect to the new location, 

https://docs.zen-cart.com/user/security/security_recommendations/ 

Alternately, the file content could be removed and a simple link could be left in, redirecting the user to this new location. 