### PR TITLE
fixes count error

### DIFF
--- a/includes/modules/pages/checkout_success/header_php.php
+++ b/includes/modules/pages/checkout_success/header_php.php
@@ -103,6 +103,7 @@ if ($flag_global_notifications != '1') {
   $products_query = $db->bindVars($products_query, ':ordersID', $orders_id, 'integer');
   $products = $db->Execute($products_query);
 
+  $notificationsArray = [];
   foreach ($products as $product) {
     $notificationsArray[] = array('counter'=>$counter,
                                   'products_id'=>$product['products_id'],


### PR DESCRIPTION
turn on global notifications for products and not have any products to be notified on your account_notifications page.  you get a countable error:

`PHP Warning: sizeof(): Parameter must be an array or an object that implements Countable in /var/www/includes/modules/pages/checkout_success/header_php.php on line 114.`

i like properly initializing the array as a solution.