### PR TITLE
Remove convert string to integer in query.

### DIFF
--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -32,7 +32,7 @@
     global $db;
     $customers_values = $db->Execute("SELECT customers_firstname, customers_lastname
                                FROM " . TABLE_CUSTOMERS . "
-                               WHERE customers_id = '" . (int)$customers_id . "'");
+                               WHERE customers_id = " . (int)$customers_id);
     if ($customers_values->EOF) return '';
     return $customers_values->fields['customers_firstname'] . ' ' . $customers_values->fields['customers_lastname'];
   }
@@ -208,8 +208,8 @@
     if ($include_itself) {
       $category = $db->Execute("SELECT cd.categories_name
                                 FROM " . TABLE_CATEGORIES_DESCRIPTION . " cd
-                                WHERE cd.language_id = '" . (int)$_SESSION['languages_id'] . "'
-                                AND cd.categories_id = '" . (int)$parent_id . "'");
+                                WHERE cd.language_id = " . (int)$_SESSION['languages_id'] . "
+                                AND cd.categories_id = " . (int)$parent_id);
 
       $category_tree_array[] = array('id' => $parent_id, 'text' => $category->fields['categories_name']);
     }
@@ -217,9 +217,9 @@
     $categories = $db->Execute("SELECT c.categories_id, cd.categories_name, c.parent_id
                                 FROM " . TABLE_CATEGORIES . " c, " . TABLE_CATEGORIES_DESCRIPTION . " cd
                                 WHERE c.categories_id = cd.categories_id
-                                AND cd.language_id = '" . (int)$_SESSION['languages_id'] . "'
-                                and c.parent_id = '" . (int)$parent_id . "'
-                                order by c.sort_order, cd.categories_name");
+                                AND cd.language_id = " . (int)$_SESSION['languages_id'] . "
+                                AND c.parent_id = " . (int)$parent_id . "
+                                ORDER BY c.sort_order, cd.categories_name");
 
     while (!$categories->EOF) {
       if ($category_has_products == true and zen_products_in_category_count($categories->fields['categories_id'], '', false, true) >= 1) {
@@ -265,7 +265,7 @@
                                 LEFT JOIN " . TABLE_PRODUCTS_TO_CATEGORIES . " ptc ON ptc.products_id = p.products_id, " .
                                 TABLE_PRODUCTS_DESCRIPTION . " pd
                                 where p.products_id = pd.products_id
-                                and pd.language_id = '" . (int)$_SESSION['languages_id'] . "'
+                                and pd.language_id = " . (int)$_SESSION['languages_id'] . "
                                 and ptc.categories_id = " . (int)$current_category_id .
                                 $order_by);
     } else {
@@ -299,8 +299,8 @@
 
     $options_values = $db->Execute("SELECT products_options_name
                                     FROM " . TABLE_PRODUCTS_OPTIONS . "
-                                    WHERE products_options_id = '" . (int)$options_id . "'
-                                    AND language_id = '" . (int)$_SESSION['languages_id'] . "'");
+                                    WHERE products_options_id = " . (int)$options_id . "
+                                    AND language_id = " . (int)$_SESSION['languages_id']);
     if ($options_values->EOF) return '';
     return $options_values->fields['products_options_name'];
   }
@@ -311,8 +311,8 @@
 
     $values_values = $db->Execute("SELECT products_options_values_name
                                    FROM " . TABLE_PRODUCTS_OPTIONS_VALUES . "
-                                   WHERE products_options_values_id = '" . (int)$values_id . "'
-                                   AND language_id = '" . (int)$_SESSION['languages_id'] . "'");
+                                   WHERE products_options_values_id = " . (int)$values_id . "
+                                   AND language_id = " . (int)$_SESSION['languages_id']);
     if ($values_values->EOF) return '';
     return $values_values->fields['products_options_values_name'];
   }
@@ -333,7 +333,7 @@
     global $db;
     $country = $db->Execute("SELECT countries_name
                              FROM " . TABLE_COUNTRIES . "
-                             WHERE countries_id = '" . (int)$country_id . "'");
+                             WHERE countries_id = " . (int)$country_id);
 
     if ($country->RecordCount() < 1) {
       return $country_id;
@@ -347,7 +347,7 @@
     global $db;
     $country = $db->Execute("SELECT countries_name
                              FROM " . TABLE_COUNTRIES . "
-                             WHERE countries_id = '" . (int)$country_id . "'");
+                             WHERE countries_id = " . (int)$country_id);
 
     if ($country->RecordCount() < 1) {
       return $country_id;
@@ -361,8 +361,8 @@
     global $db;
     $zone = $db->Execute("SELECT zone_name
                                 FROM " . TABLE_ZONES . "
-                                WHERE zone_country_id = '" . (int)$country_id . "'
-                                AND zone_id = '" . (int)$zone_id . "'");
+                                WHERE zone_country_id = " . (int)$country_id . "
+                                AND zone_id = " . (int)$zone_id);
 
     if ($zone->RecordCount() > 0) {
       return $zone->fields['zone_name'];
@@ -419,7 +419,7 @@
     global $db;
     $zones = $db->Execute("SELECT geo_zone_name
                            FROM " . TABLE_GEO_ZONES . "
-                           WHERE geo_zone_id = '" . (int)$geo_zone_id . "'");
+                           WHERE geo_zone_id = " . (int)$geo_zone_id);
 
     if ($zones->RecordCount() < 1) {
       $geo_zone_name = $geo_zone_id;
@@ -448,8 +448,8 @@
     global $db;
     $zone_query = "SELECT zone_code
                    FROM " . TABLE_ZONES . "
-                   WHERE zone_country_id = '" . (int)$country_id . "'
-                   AND zone_id = '" . (int)$zone_id . "'";
+                   WHERE zone_country_id = " . (int)$country_id . "
+                   AND zone_id = " . (int)$zone_id;
 
     $zone = $db->Execute($zone_query);
 
@@ -482,8 +482,8 @@
     global $db;
     $category = $db->Execute("SELECT categories_name
                               FROM " . TABLE_CATEGORIES_DESCRIPTION . "
-                              WHERE categories_id = '" . (int)$category_id . "'
-                              AND language_id = '" . (int)$language_id . "'");
+                              WHERE categories_id = " . (int)$category_id . "
+                              AND language_id = " . (int)$language_id);
     if ($category->EOF) return '';
     return $category->fields['categories_name'];
   }
@@ -493,8 +493,8 @@
     global $db;
     $category = $db->Execute("SELECT categories_description
                               FROM " . TABLE_CATEGORIES_DESCRIPTION . "
-                              WHERE categories_id = '" . (int)$category_id . "'
-                              AND language_id = '" . (int)$language_id . "'");
+                              WHERE categories_id = " . (int)$category_id . "
+                              AND language_id = " . (int)$language_id);
     if ($category->EOF) return '';
     return $category->fields['categories_description'];
   }
@@ -506,8 +506,8 @@
     if (!$language_id) $language_id = $_SESSION['languages_id'];
     $orders_status = $db->Execute("SELECT orders_status_name
                                    FROM " . TABLE_ORDERS_STATUS . "
-                                   WHERE orders_status_id = '" . (int)$orders_status_id . "'
-                                   AND language_id = '" . (int)$language_id . "'");
+                                   WHERE orders_status_id = " . (int)$orders_status_id . "
+                                   AND language_id = " . (int)$language_id);
     if ($orders_status->EOF) return '';
     return $orders_status->fields['orders_status_name'];
   }
@@ -519,7 +519,7 @@
     $orders_status_array = array();
     $orders_status = $db->Execute("SELECT orders_status_id, orders_status_name
                                    FROM " . TABLE_ORDERS_STATUS . "
-                                   WHERE language_id = '" . (int)$_SESSION['languages_id'] . "'
+                                   WHERE language_id = " . (int)$_SESSION['languages_id'] . "
                                    ORDER BY orders_status_id");
 
     while (!$orders_status->EOF) {
@@ -538,8 +538,8 @@
     if ($language_id == 0) $language_id = $_SESSION['languages_id'];
     $product = $db->Execute("SELECT products_name
                              FROM " . TABLE_PRODUCTS_DESCRIPTION . "
-                             WHERE products_id = '" . (int)$product_id . "'
-                             AND language_id = '" . (int)$language_id . "'");
+                             WHERE products_id = " . (int)$product_id . "
+                             AND language_id = " . (int)$language_id);
     if ($product->EOF) return '';
     return $product->fields['products_name'];
   }
@@ -549,8 +549,8 @@
     global $db;
     $product = $db->Execute("SELECT products_description
                              FROM " . TABLE_PRODUCTS_DESCRIPTION . "
-                             WHERE products_id = '" . (int)$product_id . "'
-                             AND language_id = '" . (int)$language_id . "'");
+                             WHERE products_id = " . (int)$product_id . "
+                             AND language_id = " . (int)$language_id);
     if ($product->EOF) return '';
     return $product->fields['products_description'];
   }
@@ -560,8 +560,8 @@
     global $db;
     $product = $db->Execute("SELECT products_url
                              FROM " . TABLE_PRODUCTS_DESCRIPTION . "
-                             WHERE products_id = '" . (int)$product_id . "'
-                             AND language_id = '" . (int)$language_id . "'");
+                             WHERE products_id = " . (int)$product_id . "
+                             AND language_id = " . (int)$language_id);
     if ($product->EOF) return '';
     return $product->fields['products_url'];
   }
@@ -574,8 +574,8 @@
     global $db;
     $manufacturer = $db->Execute("SELECT manufacturers_url
                                   FROM " . TABLE_MANUFACTURERS_INFO . "
-                                  WHERE manufacturers_id = '" . (int)$manufacturer_id . "'
-                                  and languages_id = '" . (int)$language_id . "'");
+                                  WHERE manufacturers_id = " . (int)$manufacturer_id . "
+                                  AND languages_id = " . (int)$language_id);
     if ($manufacturer->EOF) return '';
     return $manufacturer->fields['manufacturers_url'];
   }
@@ -599,13 +599,13 @@
       $products = $db->Execute("SELECT COUNT(*) AS total
                                 FROM " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_TO_CATEGORIES . " p2c
                                 WHERE p.products_id = p2c.products_id
-                                AND p2c.categories_id = '" . (int)$categories_id . "'" . $limit_count);
+                                AND p2c.categories_id = " . (int)$categories_id . $limit_count);
     } else {
       $products = $db->Execute("SELECT COUNT(*) AS total
                                 FROM " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_TO_CATEGORIES . " p2c
                                 WHERE p.products_id = p2c.products_id
                                 AND p.products_status = 1
-                                and p2c.categories_id = '" . (int)$categories_id . "'" . $limit_count);
+                                AND p2c.categories_id = " . (int)$categories_id . $limit_count);
 
     }
 
@@ -613,7 +613,7 @@
 
     if ($include_child) {
       $childs = $db->Execute("SELECT categories_id FROM " . TABLE_CATEGORIES . "
-                              WHERE parent_id = '" . (int)$categories_id . "'");
+                              WHERE parent_id = " . (int)$categories_id);
       if ($childs->RecordCount() > 0 ) {
         while (!$childs->EOF) {
           $products_count += zen_products_in_category_count($childs->fields['categories_id'], $include_deactivated);
@@ -634,7 +634,7 @@
 
     $categories = $db->Execute("SELECT categories_id
                                 FROM " . TABLE_CATEGORIES . "
-                                WHERE parent_id = '" . (int)$categories_id . "'");
+                                WHERE parent_id = " . (int)$categories_id);
 
     while (!$categories->EOF) {
       $categories_count++;
@@ -679,7 +679,7 @@
     $zones_array = array();
     $zones = $db->Execute("SELECT zone_id, zone_name
                            FROM " . TABLE_ZONES . "
-                           WHERE zone_country_id = '" . (int)$country_id . "'
+                           WHERE zone_country_id = " . (int)$country_id . "
                            ORDER BY zone_name");
 
     while (!$zones->EOF) {
@@ -741,7 +741,7 @@
     global $db;
     $coupon_array = array();
     $name = (($key) ? 'configuration[' . $key . ']' : 'configuration_value');
-    $coupons = $db->execute("SELECT cd.coupon_name, c.coupon_id FROM " . TABLE_COUPONS ." c, ". TABLE_COUPONS_DESCRIPTION . " cd WHERE cd.coupon_id = c.coupon_id AND cd.language_id = '" . (int)$_SESSION['languages_id'] . "'");
+    $coupons = $db->execute("SELECT cd.coupon_name, c.coupon_id FROM " . TABLE_COUPONS ." c, ". TABLE_COUPONS_DESCRIPTION . " cd WHERE cd.coupon_id = c.coupon_id AND cd.language_id = " . (int)$_SESSION['languages_id']);
     $coupon_array[] = array('id' => '0',
                             'text' => 'None');
 
@@ -817,7 +817,7 @@
     global $db;
     $zone = $db->Execute("SELECT zone_name
                           FROM " . TABLE_ZONES . "
-                          WHERE zone_id = '" . (int)$zone_id . "'");
+                          WHERE zone_id = " . (int)$zone_id);
 
     if ($zone->RecordCount() < 1) {
       return $zone_id;
@@ -1024,7 +1024,7 @@ function zen_set_product_status($products_id, $status)
     if ($from == 'product') {
       $categories = $db->Execute("select categories_id
                                   from " . TABLE_PRODUCTS_TO_CATEGORIES . "
-                                  where products_id = '" . (int)$id . "'");
+                                  where products_id = " . (int)$id);
 
       while (!$categories->EOF) {
         if ($categories->fields['categories_id'] == '0') {
@@ -1032,9 +1032,9 @@ function zen_set_product_status($products_id, $status)
         } else {
           $category = $db->Execute("select cd.categories_name, c.parent_id
                                     from " . TABLE_CATEGORIES . " c, " . TABLE_CATEGORIES_DESCRIPTION . " cd
-                                    where c.categories_id = '" . (int)$categories->fields['categories_id'] . "'
+                                    where c.categories_id = " . (int)$categories->fields['categories_id'] . "
                                     and c.categories_id = cd.categories_id
-                                    and cd.language_id = '" . (int)$_SESSION['languages_id'] . "'");
+                                    and cd.language_id = " . (int)$_SESSION['languages_id']);
 
           $categories_array[$index][] = array('id' => $categories->fields['categories_id'], 'text' => $category->fields['categories_name']);
           if ( (zen_not_null($category->fields['parent_id'])) && ($category->fields['parent_id'] != '0') ) $categories_array = zen_generate_category_path($category->fields['parent_id'], 'category', $categories_array, $index);
@@ -1046,9 +1046,9 @@ function zen_set_product_status($products_id, $status)
     } elseif ($from == 'category') {
       $category = $db->Execute("select cd.categories_name, c.parent_id
                                 from " . TABLE_CATEGORIES . " c, " . TABLE_CATEGORIES_DESCRIPTION . " cd
-                                where c.categories_id = '" . (int)$id . "'
+                                where c.categories_id = " . (int)$id . "
                                 and c.categories_id = cd.categories_id
-                                and cd.language_id = '" . (int)$_SESSION['languages_id'] . "'");
+                                and cd.language_id = " . (int)$_SESSION['languages_id']);
       if (!$category->EOF) {
         $categories_array[$index][] = array('id' => $id, 'text' => $category->fields['categories_name']);
         if ( (zen_not_null($category->fields['parent_id'])) && ($category->fields['parent_id'] != '0') ) $categories_array = zen_generate_category_path($category->fields['parent_id'], 'category', $categories_array, $index);
@@ -1109,7 +1109,7 @@ function zen_set_product_status($products_id, $status)
     // delete from salemaker - sale_categories_selected
     $chk_sale_categories_selected = $db->Execute("select * from " . TABLE_SALEMAKER_SALES . "
     WHERE
-    sale_categories_selected = '" . (int)$category_id . "'
+    sale_categories_selected = " . (int)$category_id . "
     OR sale_categories_selected LIKE '%," . (int)$category_id . ",%'
     OR sale_categories_selected LIKE '%," . (int)$category_id . "'
     OR sale_categories_selected LIKE '" . (int)$category_id . ",%'");
@@ -1117,7 +1117,7 @@ function zen_set_product_status($products_id, $status)
     // delete from salemaker - sale_categories_all
     $chk_sale_categories_all = $db->Execute("select * from " . TABLE_SALEMAKER_SALES . "
     WHERE
-    sale_categories_all = '" . (int)$category_id . "'
+    sale_categories_all = " . (int)$category_id . "
     OR sale_categories_all LIKE '%," . (int)$category_id . ",%'
     OR sale_categories_all LIKE '%," . (int)$category_id . "'
     OR sale_categories_all LIKE '" . (int)$category_id . ",%'");
@@ -1133,7 +1133,7 @@ while (!$chk_sale_categories_selected->EOF) {
 //echo 'A: I should delete this record sale_id: ' . $chk_sale_categories_selected->fields['sale_id'] . '<br><br>';
     $skip_cats = true;
     $skip_sale_id = $chk_sale_categories_selected->fields['sale_id'];
-    $salemakerdelete = "DELETE from " . TABLE_SALEMAKER_SALES . " WHERE sale_id='"  . $skip_sale_id . "'";
+    $salemakerdelete = "DELETE from " . TABLE_SALEMAKER_SALES . " WHERE sale_id='"  . (int)$skip_sale_id;
   }
 
   // if in the front - remove 9,
@@ -1168,7 +1168,7 @@ while (!$chk_sale_categories_selected->EOF) {
     $salemakerupdate =
     "UPDATE " . TABLE_SALEMAKER_SALES . "
     SET sale_categories_selected='" . $new_sale_categories_selected . "'
-    WHERE sale_id = '" . $chk_sale_categories_selected->fields['sale_id'] . "'";
+    WHERE sale_id = " . (int)$chk_sale_categories_selected->fields['sale_id'];
 //echo 'Update new_sale_categories_selected: ' . $salemakerupdate . '<br>';
     $db->Execute($salemakerupdate);
   } else {
@@ -1220,7 +1220,7 @@ while (!$chk_sale_categories_all->EOF) {
     echo 'D: new_sale_categories_all: ' . $new_sale_categories_all. '<br><br>';
   }
 */
-      $salemakerupdate = "UPDATE " . TABLE_SALEMAKER_SALES . " SET sale_categories_all='" . $new_sale_categories_all . "' WHERE sale_id = '" . $chk_sale_categories_all->fields['sale_id'] . "'";
+      $salemakerupdate = "UPDATE " . TABLE_SALEMAKER_SALES . " SET sale_categories_all='" . $new_sale_categories_all . "' WHERE sale_id = " . (int)$chk_sale_categories_all->fields['sale_id'];
 
 //echo 'Update sale_categories_all: ' . $salemakerupdate . '<br>';
 
@@ -1233,7 +1233,7 @@ while (!$chk_sale_categories_all->EOF) {
 
     $category_image = $db->Execute("select categories_image
                                     from " . TABLE_CATEGORIES . "
-                                    where categories_id = '" . (int)$category_id . "'");
+                                    where categories_id = " . (int)$category_id);
 
     $duplicate_image = $db->Execute("select count(*) as total
                                      from " . TABLE_CATEGORIES . "
@@ -1246,19 +1246,19 @@ while (!$chk_sale_categories_all->EOF) {
     }
 
     $db->Execute("delete from " . TABLE_CATEGORIES . "
-                  where categories_id = '" . (int)$category_id . "'");
+                  where categories_id = " . (int)$category_id);
 
     $db->Execute("delete from " . TABLE_CATEGORIES_DESCRIPTION . "
-                  where categories_id = '" . (int)$category_id . "'");
+                  where categories_id = " . (int)$category_id);
 
     $db->Execute("delete from " . TABLE_PRODUCTS_TO_CATEGORIES . "
-                  where categories_id = '" . (int)$category_id . "'");
+                  where categories_id = " . (int)$category_id);
 
     $db->Execute("delete from " . TABLE_METATAGS_CATEGORIES_DESCRIPTION . "
-                  where categories_id = '" . (int)$category_id . "'");
+                  where categories_id = " . (int)$category_id);
 
     $db->Execute("delete from " . TABLE_COUPON_RESTRICT . "
-                  where category_id = '" . (int)$category_id . "'");
+                  where category_id = " . (int)$category_id);
 
     zen_record_admin_activity('Deleted category ' . (int)$category_id . ' from database via admin console.', 'warning');
   }
@@ -1269,7 +1269,7 @@ while (!$chk_sale_categories_all->EOF) {
 
     $product_image = $db->Execute("select products_image
                                    from " . TABLE_PRODUCTS . "
-                                   where products_id = '" . (int)$product_id . "'");
+                                   where products_id = " . (int)$product_id);
 
     $duplicate_image = $db->Execute("select count(*) as total
                                      from " . TABLE_PRODUCTS . "
@@ -1295,57 +1295,57 @@ while (!$chk_sale_categories_all->EOF) {
     }
 
     $db->Execute("delete from " . TABLE_SPECIALS . "
-                  where products_id = '" . (int)$product_id . "'");
+                  where products_id = " . (int)$product_id);
 
     $db->Execute("delete from " . TABLE_PRODUCTS . "
-                  where products_id = '" . (int)$product_id . "'");
+                  where products_id = " . (int)$product_id);
 
 //    if ($ptc == 'true') {
       $db->Execute("delete from " . TABLE_PRODUCTS_TO_CATEGORIES . "
-                    where products_id = '" . (int)$product_id . "'");
+                    where products_id = " . (int)$product_id);
 //    }
 
     $db->Execute("delete from " . TABLE_PRODUCTS_DESCRIPTION . "
-                  where products_id = '" . (int)$product_id . "'");
+                  where products_id = " . (int)$product_id);
 
     $db->Execute("delete from " . TABLE_META_TAGS_PRODUCTS_DESCRIPTION . "
-                  where products_id = '" . (int)$product_id . "'");
+                  where products_id = " . (int)$product_id);
 
     zen_products_attributes_download_delete($product_id);
 
     $db->Execute("delete from " . TABLE_PRODUCTS_ATTRIBUTES . "
-                  where products_id = '" . (int)$product_id . "'");
+                  where products_id = " . (int)$product_id);
 
     $db->Execute("delete from " . TABLE_CUSTOMERS_BASKET . "
-                  where products_id = '" . (int)$product_id . "'");
+                  where products_id = " . (int)$product_id);
 
     $db->Execute("delete from " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . "
-                  where products_id = '" . (int)$product_id . "'");
+                  where products_id = " . (int)$product_id);
 
 
     $product_reviews = $db->Execute("select reviews_id
                                      from " . TABLE_REVIEWS . "
-                                     where products_id = '" . (int)$product_id . "'");
+                                     where products_id = " . (int)$product_id);
 
     while (!$product_reviews->EOF) {
       $db->Execute("delete from " . TABLE_REVIEWS_DESCRIPTION . "
-                    where reviews_id = '" . (int)$product_reviews->fields['reviews_id'] . "'");
+                    where reviews_id = " . (int)$product_reviews->fields['reviews_id']);
       $product_reviews->MoveNext();
     }
     $db->Execute("delete from " . TABLE_REVIEWS . "
-                  where products_id = '" . (int)$product_id . "'");
+                  where products_id = " . (int)$product_id);
 
     $db->Execute("delete from " . TABLE_FEATURED . "
-                  where products_id = '" . (int)$product_id . "'");
+                  where products_id = " . (int)$product_id);
 
     $db->Execute("delete from " . TABLE_PRODUCTS_DISCOUNT_QUANTITY . "
-                  where products_id = '" . (int)$product_id . "'");
+                  where products_id = " . (int)$product_id);
 
     $db->Execute("delete from " . TABLE_COUPON_RESTRICT . "
-                  where product_id = '" . (int)$product_id . "'");
+                  where product_id = " . (int)$product_id);
 
     $db->Execute("delete from " . TABLE_PRODUCTS_NOTIFICATIONS . "
-                  where products_id = '" . (int)$product_id . "'");
+                  where products_id = " . (int)$product_id);
 
     zen_record_admin_activity('Deleted product ' . (int)$product_id . ' from database via admin console.', 'warning');
   }
@@ -1355,9 +1355,9 @@ while (!$chk_sale_categories_all->EOF) {
     $zco_notifier->notify('NOTIFIER_ADMIN_ZEN_PRODUCTS_ATTRIBUTES_DOWNLOAD_DELETE', array(), $product_id);
 
   // remove downloads if they exist
-    $remove_downloads= $db->Execute("select products_attributes_id from " . TABLE_PRODUCTS_ATTRIBUTES . " where products_id= '" . (int)$product_id . "'");
+    $remove_downloads= $db->Execute("select products_attributes_id from " . TABLE_PRODUCTS_ATTRIBUTES . " where products_id= " . (int)$product_id);
     while (!$remove_downloads->EOF) {
-      $db->Execute("delete from " . TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD . " where products_attributes_id= '" . $remove_downloads->fields['products_attributes_id'] . "'");
+      $db->Execute("delete from " . TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD . " where products_attributes_id= " . (int)$remove_downloads->fields['products_attributes_id']);
       $remove_downloads->MoveNext();
     }
   }
@@ -1368,33 +1368,33 @@ while (!$chk_sale_categories_all->EOF) {
     if ($restock == 'on') {
       $order = $db->Execute("select products_id, products_quantity
                              from " . TABLE_ORDERS_PRODUCTS . "
-                             where orders_id = '" . (int)$order_id . "'");
+                             where orders_id = " . (int)$order_id);
 
       while (!$order->EOF) {
         $db->Execute("update " . TABLE_PRODUCTS . "
-                      set products_quantity = products_quantity + " . $order->fields['products_quantity'] . ", products_ordered = products_ordered - " . $order->fields['products_quantity'] . " where products_id = '" . (int)$order->fields['products_id'] . "'");
+                      set products_quantity = products_quantity + " . $order->fields['products_quantity'] . ", products_ordered = products_ordered - " . $order->fields['products_quantity'] . " where products_id = " . (int)$order->fields['products_id']);
         $order->MoveNext();
       }
     }
 
-    $db->Execute("delete from " . TABLE_ORDERS . " where orders_id = '" . (int)$order_id . "'");
+    $db->Execute("delete from " . TABLE_ORDERS . " where orders_id = " . (int)$order_id);
     $db->Execute("delete from " . TABLE_ORDERS_PRODUCTS . "
-                  where orders_id = '" . (int)$order_id . "'");
+                  where orders_id = " . (int)$order_id);
 
     $db->Execute("delete from " . TABLE_ORDERS_PRODUCTS_ATTRIBUTES . "
-                  where orders_id = '" . (int)$order_id . "'");
+                  where orders_id = " . (int)$order_id);
 
     $db->Execute("delete from " . TABLE_ORDERS_PRODUCTS_DOWNLOAD . "
-                  where orders_id = '" . (int)$order_id . "'");
+                  where orders_id = " . (int)$order_id);
 
     $db->Execute("delete from " . TABLE_ORDERS_STATUS_HISTORY . "
-                  where orders_id = '" . (int)$order_id . "'");
+                  where orders_id = " . (int)$order_id);
 
     $db->Execute("delete from " . TABLE_ORDERS_TOTAL . "
-                  where orders_id = '" . (int)$order_id . "'");
+                  where orders_id = " . (int)$order_id);
 
     $db->Execute("delete from " . TABLE_COUPON_GV_QUEUE . "
-                  where order_id = '" . (int)$order_id . "' and release_flag = 'N'");
+                  where order_id = " . (int)$order_id . " and release_flag = 'N'");
 
     zen_record_admin_activity('Deleted order ' . (int)$order_id . ' from database via admin console.', 'warning');
   }
@@ -1521,7 +1521,7 @@ while (!$chk_sale_categories_all->EOF) {
     } else {
       $classes = $db->Execute("select tax_class_title
                                from " . TABLE_TAX_CLASS . "
-                               where tax_class_id = '" . (int)$tax_class_id . "'");
+                               where tax_class_id = " . (int)$tax_class_id);
       if ($classes->EOF) return '';
       return $classes->fields['tax_class_title'];
     }
@@ -1610,10 +1610,10 @@ while (!$chk_sale_categories_all->EOF) {
                          left join " . TABLE_GEO_ZONES . " tz ON tz.geo_zone_id = tr.tax_zone_id )
                          WHERE (za.zone_country_id IS NULL
                          OR za.zone_country_id = 0
-                         OR za.zone_country_id = '" . (int)$country_id . "')
+                         OR za.zone_country_id = " . (int)$country_id . ")
                          AND (za.zone_id IS NULL OR za.zone_id = 0
-                         OR za.zone_id = '" . (int)$zone_id . "')
-                         AND tr.tax_class_id = '" . (int)$class_id . "'
+                         OR za.zone_id = " . (int)$zone_id . ")
+                         AND tr.tax_class_id = " . (int)$class_id . "
                          GROUP BY tr.tax_priority");
 
     if ($tax->RecordCount() > 0) {
@@ -1651,7 +1651,7 @@ while (!$chk_sale_categories_all->EOF) {
     } else {
       $classes = $db->Execute("select geo_zone_name
                                from " . TABLE_GEO_ZONES . "
-                               where geo_zone_id = '" . (int)$zone_class_id . "'");
+                               where geo_zone_id = " . (int)$zone_class_id);
       if ($classes->EOF) return '';
       return $classes->fields['geo_zone_name'];
     }
@@ -1717,8 +1717,8 @@ while (!$chk_sale_categories_all->EOF) {
 
     $status = $db->Execute("select orders_status_name
                             from " . TABLE_ORDERS_STATUS . "
-                            where orders_status_id = '" . (int)$order_status_id . "'
-                            and language_id = '" . (int)$language_id . "'");
+                            where orders_status_id = " . (int)$order_status_id . "
+                            and language_id = " . (int)$language_id);
     if ($status->EOF) return 'ERROR: INVALID STATUS ID: ' . (int)$order_status_id;
     return $status->fields['orders_status_name'] . ' [' . (int)$order_status_id . ']';
   }
@@ -1822,19 +1822,19 @@ while (!$chk_sale_categories_all->EOF) {
     global $db;
     $customer_gv = $db->Execute("select amount
                                  from " . TABLE_COUPON_GV_CUSTOMER . "
-                                 where customer_id = '" . (int)$customer_id . "'");
+                                 where customer_id = " . (int)$customer_id);
 
     $coupon_gv = $db->Execute("select coupon_amount
                                from " . TABLE_COUPONS . "
-                               where coupon_id = '" . (int)$gv_id . "'");
+                               where coupon_id = " . (int)$gv_id);
 
     if ($customer_gv->RecordCount() > 0) {
       $new_gv_amount = $customer_gv->fields['amount'] + $coupon_gv->fields['coupon_amount'];
       $gv_query = $db->Execute("update " . TABLE_COUPON_GV_CUSTOMER . "
                                 set amount = '" . $new_gv_amount . "'
-                                where customer_id = '" . (int)$customer_id . "'");
+                                where customer_id = " . (int)$customer_id);
     } else {
-      $db->Execute("insert into " . TABLE_COUPON_GV_CUSTOMER . " (customer_id, amount) values ('" . (int)$customer_id . "', '" . $coupon_gv->fields['coupon_amount'] . "')");
+      $db->Execute("insert into " . TABLE_COUPON_GV_CUSTOMER . " (customer_id, amount) values (" . (int)$customer_id . ", '" . $coupon_gv->fields['coupon_amount'] . "')");
     }
   }
 
@@ -1890,9 +1890,9 @@ while (!$chk_sale_categories_all->EOF) {
     global $db;
     $check_options_to_values_query= $db->Execute("select products_options_id
                                                   from " . TABLE_PRODUCTS_OPTIONS_VALUES_TO_PRODUCTS_OPTIONS . "
-                                                  where products_options_id= '" . (int)$products_options_id . "'
-                                                  and products_options_values_id='" . (int)$products_options_values_id .
-                                                  "' limit 1");
+                                                  where products_options_id= " . (int)$products_options_id . "
+                                                  and products_options_values_id=" . (int)$products_options_values_id .
+                                                  " limit 1");
 
     if ($check_options_to_values_query->RecordCount() != 1) {
       return false;
@@ -1913,13 +1913,13 @@ while (!$chk_sale_categories_all->EOF) {
 
     $check_options_to_values = $db->Execute("select products_options_id
                     from " . TABLE_PRODUCTS_OPTIONS_VALUES_TO_PRODUCTS_OPTIONS . "
-                    where products_options_values_id='" . (int)$lookup . "'");
+                    where products_options_values_id=" . (int)$lookup);
     if ($check_options_to_values->EOF) return '';
 
     $check_options = $db->Execute("select products_options_name
                       from " . TABLE_PRODUCTS_OPTIONS . "
-                      where products_options_id='" . (int)$check_options_to_values->fields['products_options_id']
-                      . "' and language_id='" . (int)$_SESSION['languages_id'] . "'");
+                      where products_options_id=" . (int)$check_options_to_values->fields['products_options_id']
+                      . " and language_id=" . (int)$_SESSION['languages_id']);
     if ($check_options->EOF) return '';
     return $check_options->fields['products_options_name'];
   }
@@ -1932,7 +1932,7 @@ while (!$chk_sale_categories_all->EOF) {
     global $db;
     $check = $db->Execute("select products_model
                     from " . TABLE_PRODUCTS . "
-                    where products_id='" . (int)$products_id . "'");
+                    where products_id=" . (int)$products_id);
     if ($check->EOF) return '';
     return $check->fields['products_model'];
   }
@@ -1944,7 +1944,7 @@ while (!$chk_sale_categories_all->EOF) {
     global $db;
     $attributes = $db->Execute("select count(*) as count
                          from " . TABLE_PRODUCTS_ATTRIBUTES . "
-                         where products_id = '" . (int)$products_id . "'");
+                         where products_id = " . (int)$products_id);
 
     if ($attributes->fields['count'] > 0) {
       return true;
@@ -1963,12 +1963,12 @@ while (!$chk_sale_categories_all->EOF) {
       // don't include READONLY attributes to determine if attributes must be selected to add to cart
       $attributes_query = "select pa.products_attributes_id
                            from " . TABLE_PRODUCTS_ATTRIBUTES . " pa left join " . TABLE_PRODUCTS_OPTIONS . " po on pa.options_id = po.products_options_id
-                           where pa.products_id = '" . (int)$products_id . "' and po.products_options_type != '" . PRODUCTS_OPTIONS_TYPE_READONLY . "' limit 1";
+                           where pa.products_id = " . (int)$products_id . " and po.products_options_type != '" . PRODUCTS_OPTIONS_TYPE_READONLY . "' limit 1";
     } else {
       // regardless of READONLY attributes no add to cart buttons
       $attributes_query = "select pa.products_attributes_id
                            from " . TABLE_PRODUCTS_ATTRIBUTES . " pa
-                           where pa.products_id = '" . (int)$products_id . "' limit 1";
+                           where pa.products_id = " . (int)$products_id . " limit 1";
     }
 
     $attributes = $db->Execute($attributes_query);
@@ -1983,7 +1983,7 @@ while (!$chk_sale_categories_all->EOF) {
     global $db;
     $products_valid_query = "select count(*) as count
                          from " . TABLE_PRODUCTS . "
-                         where products_id = '" . (int)$products_id . "'";
+                         where products_id = " . (int)$products_id;
 
     $products_valid = $db->Execute($products_valid_query);
 
@@ -2065,7 +2065,7 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
     if ($copy_attributes_delete_first=='1' and $already_has_attributes == true) {
       // delete all attributes first from products_id_to
       zen_products_attributes_download_delete($products_id_to);
-      $db->Execute("delete from " . TABLE_PRODUCTS_ATTRIBUTES . " where products_id = '" . (int)$products_id_to . "'");
+      $db->Execute("delete from " . TABLE_PRODUCTS_ATTRIBUTES . " where products_id = " . (int)$products_id_to);
       
       // -----
       // Notify that attributes have been deleted for the product.
@@ -2074,16 +2074,16 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
     }
 
     // get attributes to copy from
-    $products_copy_from= $db->Execute("select * from " . TABLE_PRODUCTS_ATTRIBUTES . " where products_id='" . (int)$products_id_from . "'" . " order by products_attributes_id");
+    $products_copy_from= $db->Execute("select * from " . TABLE_PRODUCTS_ATTRIBUTES . " where products_id=" . (int)$products_id_from . " order by products_attributes_id");
 
     while ( !$products_copy_from->EOF ) {
       $update_attribute = false;
       $add_attribute = true;
 
       $check_duplicate = $db->Execute("select * from " . TABLE_PRODUCTS_ATTRIBUTES . " 
-          where products_id='" . (int)$products_id_to . "'" . " 
-          and options_id= '" . (int)$products_copy_from->fields['options_id'] . "' 
-          and options_values_id='" . (int)$products_copy_from->fields['options_values_id'] .  "'"
+          where products_id=" . (int)$products_id_to . "
+          and options_id= " . (int)$products_copy_from->fields['options_id'] . "
+          and options_values_id=" . (int)$products_copy_from->fields['options_values_id'] .  "'"
       );
 
       if ($already_has_attributes == true) {
@@ -2120,7 +2120,7 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
               attributes_price_factor_onetime_offset, attributes_qty_prices, attributes_qty_prices_onetime, 
               attributes_price_words, attributes_price_words_free, attributes_price_letters, attributes_price_letters_free, 
               attributes_required)
-              VALUES ('" . (int)$products_id_to . "',
+              VALUES (" . (int)$products_id_to . ",
               '" . $products_copy_from->fields['options_id'] . "',
               '" . $products_copy_from->fields['options_values_id'] . "',
               '" . $products_copy_from->fields['options_values_price'] . "',
@@ -2182,8 +2182,8 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
               attributes_price_letters_free='" . $products_copy_from->fields['attributes_price_letters_free'] . "',
               attributes_required='" . $products_copy_from->fields['attributes_required'] . "
               WHERE products_id=" . (int)$products_id_to . "
-               AND options_id= '" . $products_copy_from->fields['options_id'] . "' 
-               AND options_values_id='" . $products_copy_from->fields['options_values_id'] . "'"
+               AND options_id= " . (int)$products_copy_from->fields['options_id'] . "
+               AND options_values_id=" . (int)$products_copy_from->fields['options_values_id']
 // and attributes_image='" . $products_copy_from->fields['attributes_image'] . "'
 // and attributes_price_base_included=" . $products_copy_from->fields['attributes_price_base_included']
           );
@@ -2235,7 +2235,7 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
  */
   function zen_get_language_icon($lookup) {
     global $db;
-    $languages_icon = $db->Execute("select directory, image from " . TABLE_LANGUAGES . " where languages_id = '" . zen_db_input($lookup) . "'");
+    $languages_icon = $db->Execute("select directory, image from " . TABLE_LANGUAGES . " where languages_id = " . (int)$lookup);
     if ($languages_icon->EOF) return '';
     $icon= zen_image(DIR_WS_CATALOG_LANGUAGES . $languages_icon->fields['directory'] . '/images/' . $languages_icon->fields['image'], $languages_icon->fields['directory']);
     return $icon;
@@ -2246,7 +2246,7 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
  */
   function zen_get_option_name_language($option, $language) {
     global $db;
-    $lookup = $db->Execute("select products_options_id, products_options_name from " . TABLE_PRODUCTS_OPTIONS . " where products_options_id= '" . (int)$option . "' and language_id = '" . (int)$language . "'");
+    $lookup = $db->Execute("select products_options_id, products_options_name from " . TABLE_PRODUCTS_OPTIONS . " where products_options_id= " . (int)$option . " and language_id = " . (int)$language);
     if ($lookup->EOF) return '';
     return $lookup->fields['products_options_name'];
   }
@@ -2256,7 +2256,7 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
  */
   function zen_get_option_name_language_sort_order($option, $language) {
     global $db;
-    $lookup = $db->Execute("select products_options_id, products_options_name, products_options_sort_order from " . TABLE_PRODUCTS_OPTIONS . " where products_options_id= '" . (int)$option . "' and language_id = '" . (int)$language . "'");
+    $lookup = $db->Execute("select products_options_id, products_options_name, products_options_sort_order from " . TABLE_PRODUCTS_OPTIONS . " where products_options_id= " . (int)$option . " and language_id = " . (int)$language);
     if ($lookup->EOF) return '';
     return $lookup->fields['products_options_sort_order'];
   }
@@ -2266,7 +2266,7 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
  */
   function zen_get_language_name($lookup) {
     global $db;
-    $check_language= $db->Execute("select directory from " . TABLE_LANGUAGES . " where languages_id = '" . (int)$lookup . "'");
+    $check_language= $db->Execute("select directory from " . TABLE_LANGUAGES . " where languages_id = " . (int)$lookup);
     if ($check_language->EOF) return '';
     return $check_language->fields['directory'];
   }
@@ -2280,13 +2280,13 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
     $zco_notifier->notify('NOTIFIER_ADMIN_ZEN_DELETE_PRODUCTS_ATTRIBUTES', array(), $delete_product_id);
 
     // first delete associated downloads
-    $products_delete_from = $db->Execute("select pa.products_id, pad.products_attributes_id from " . TABLE_PRODUCTS_ATTRIBUTES . " pa, " . TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD . " pad  where pa.products_id='" . (int)$delete_product_id . "' and pad.products_attributes_id= pa.products_attributes_id");
+    $products_delete_from = $db->Execute("select pa.products_id, pad.products_attributes_id from " . TABLE_PRODUCTS_ATTRIBUTES . " pa, " . TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD . " pad  where pa.products_id=" . (int)$delete_product_id . " and pad.products_attributes_id= pa.products_attributes_id");
     while (!$products_delete_from->EOF) {
-      $db->Execute("delete from " . TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD . " where products_attributes_id = '" . $products_delete_from->fields['products_attributes_id'] . "'");
+      $db->Execute("delete from " . TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD . " where products_attributes_id = " . (int)$products_delete_from->fields['products_attributes_id']);
       $products_delete_from->MoveNext();
     }
 
-    $db->Execute("delete from " . TABLE_PRODUCTS_ATTRIBUTES . " where products_id = '" . (int)$delete_product_id . "'");
+    $db->Execute("delete from " . TABLE_PRODUCTS_ATTRIBUTES . " where products_id = " . (int)$delete_product_id);
 }
 
 /**
@@ -2294,9 +2294,9 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
  */
   function zen_update_attributes_products_option_values_sort_order($products_id) {
     global $db;
-    $attributes_sort_order = $db->Execute("select distinct pa.products_attributes_id, pa.options_id, pa.options_values_id, pa.products_options_sort_order, pov.products_options_values_sort_order from " . TABLE_PRODUCTS_ATTRIBUTES . " pa, " . TABLE_PRODUCTS_OPTIONS_VALUES . " pov where pa.products_id = '" . (int)$products_id . "' and pa.options_values_id = pov.products_options_values_id");
+    $attributes_sort_order = $db->Execute("select distinct pa.products_attributes_id, pa.options_id, pa.options_values_id, pa.products_options_sort_order, pov.products_options_values_sort_order from " . TABLE_PRODUCTS_ATTRIBUTES . " pa, " . TABLE_PRODUCTS_OPTIONS_VALUES . " pov where pa.products_id = " . (int)$products_id . " and pa.options_values_id = pov.products_options_values_id");
     while (!$attributes_sort_order->EOF) {
-      $db->Execute("update " . TABLE_PRODUCTS_ATTRIBUTES . " set products_options_sort_order = '" . $attributes_sort_order->fields['products_options_values_sort_order'] . "' where products_id = '" . (int)$products_id . "' and products_attributes_id = '" . $attributes_sort_order->fields['products_attributes_id'] . "'");
+      $db->Execute("update " . TABLE_PRODUCTS_ATTRIBUTES . " set products_options_sort_order = '" . $attributes_sort_order->fields['products_options_values_sort_order'] . "' where products_id = " . (int)$products_id . " and products_attributes_id = " . (int)$attributes_sort_order->fields['products_attributes_id']);
       $attributes_sort_order->MoveNext();
     }
   }
@@ -2325,7 +2325,7 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
         " from " . TABLE_PRODUCTS . " p, " .
         TABLE_PRODUCTS_DESCRIPTION . " pd, " .
         TABLE_PRODUCTS_ATTRIBUTES . " pa " .
-        " where p.products_id= pa.products_id and p.products_id = pd.products_id and pd.language_id = '" . (int)$_SESSION['languages_id'] . "' order by products_name");
+        " where p.products_id= pa.products_id and p.products_id = pd.products_id and pd.language_id = " . (int)$_SESSION['languages_id'] . " order by products_name");
 
     while (!$products->EOF) {
       if (!in_array($products->fields['products_id'], $exclude)) {
@@ -2363,7 +2363,7 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
         " from " . TABLE_CATEGORIES . " c, " .
         TABLE_CATEGORIES_DESCRIPTION . " cd, " .
         TABLE_PRODUCTS_TO_CATEGORIES . " ptoc " .
-        " where ptoc.categories_id = c.categories_id and c.categories_id = cd.categories_id and cd.language_id = '" . (int)$_SESSION['languages_id'] . "' order by categories_name");
+        " where ptoc.categories_id = c.categories_id and c.categories_id = cd.categories_id and cd.language_id = " . (int)$_SESSION['languages_id'] . " order by categories_name");
 
     while (!$categories->EOF) {
       if (!in_array($categories->fields['categories_id'], $exclude)) {
@@ -2408,7 +2408,7 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
         TABLE_CATEGORIES_DESCRIPTION . " cd, " .
         TABLE_PRODUCTS_TO_CATEGORIES . " ptoc, " .
         TABLE_PRODUCTS_ATTRIBUTES . " pa " .
-        " where pa.products_id= ptoc.products_id and ptoc.categories_id= c.categories_id and c.categories_id = cd.categories_id and cd.language_id = '" . (int)$_SESSION['languages_id'] . "' order by categories_name");
+        " where pa.products_id= ptoc.products_id and ptoc.categories_id= c.categories_id and c.categories_id = cd.categories_id and cd.language_id = " . (int)$_SESSION['languages_id'] . " order by categories_name");
     while (!$categories->EOF) {
       if (!in_array($categories->fields['categories_id'], $exclude)) {
         $select_string .= '<option value="' . $categories->fields['categories_id'] . '">' . $categories->fields['categories_name'] . '</option>';
@@ -2426,7 +2426,7 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
     if (DOWNLOAD_ENABLED == 'true') {
       $download_display_query_raw ="select pa.products_attributes_id, pad.products_attributes_filename
                                     from " . TABLE_PRODUCTS_ATTRIBUTES . " pa, " . TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD . " pad
-                                    where pa.products_id='" . (int)$products_id . "'
+                                    where pa.products_id=" . (int)$products_id . "
                                       and pad.products_attributes_id= pa.products_attributes_id";
       $download_display = $db->Execute($download_display_query_raw);
       if ($check_valid == true) {
@@ -2483,14 +2483,14 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
 /*
     $category_query = "select p2c.categories_id
                        from " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_TO_CATEGORIES . " p2c
-                       where p.products_id = '" . (int)$products_id . "' " .
+                       where p.products_id = " . (int)$products_id . " " .
                        ($status_override == 1 ? " and p.products_status = 1 " : '') . "
                        and p.products_id = p2c.products_id limit 1";
 */
 
     $category_query = "select p.products_id, p.master_categories_id
                        from " . TABLE_PRODUCTS . " p
-                       where p.products_id = '" . (int)$products_id . "' limit 1";
+                       where p.products_id = " . (int)$products_id . " limit 1";
 
 
     $category = $db->Execute($category_query);
@@ -2519,7 +2519,7 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
     global $db;
     $parent_categories_query = "select parent_id
                                 from " . TABLE_CATEGORIES . "
-                                where categories_id = '" . (int)$categories_id . "'";
+                                where categories_id = " . (int)$categories_id;
 
     $parent_categories = $db->Execute($parent_categories_query);
 
@@ -2540,7 +2540,7 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
   function zen_get_products_category_id($products_id) {
     global $db;
 
-    $the_products_category_query = "select products_id, master_categories_id from " . TABLE_PRODUCTS . " where products_id = '" . (int)$products_id . "'";
+    $the_products_category_query = "select products_id, master_categories_id from " . TABLE_PRODUCTS . " where products_id = " . (int)$products_id;
     $the_products_category = $db->Execute($the_products_category_query);
     if ($the_products_category->EOF) return '';
     return $the_products_category->fields['master_categories_id'];
@@ -2557,7 +2557,7 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
 
     $categories_lookup = $db->Execute("select parent_id
                                 from " . TABLE_CATEGORIES . "
-                                where categories_id = '" . (int)$categories_id . "'");
+                                where categories_id = " . (int)$categories_id);
 
     $parent_name = zen_get_category_name($categories_lookup->fields['parent_id'], (int)$_SESSION['languages_id']);
 
@@ -2580,7 +2580,7 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
 
   function zen_get_configuration_group_value($lookup) {
     global $db;
-    $configuration_query= $db->Execute("select configuration_group_title from " . TABLE_CONFIGURATION_GROUP . " where configuration_group_id ='" . (int)$lookup . "'");
+    $configuration_query= $db->Execute("select configuration_group_title from " . TABLE_CONFIGURATION_GROUP . " where configuration_group_id =" . (int)$lookup);
     if ( $configuration_query->RecordCount() == 0 ) {
       return (int)$lookup;
     }
@@ -2641,7 +2641,7 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
   function zen_get_handler_from_type($product_type) {
     global $db;
 
-    $sql = "select type_handler from " . TABLE_PRODUCT_TYPES . " where type_id = '" . (int)$product_type . "'";
+    $sql = "select type_handler from " . TABLE_PRODUCT_TYPES . " where type_id = " . (int)$product_type;
     $handler = $db->Execute($sql);
     if ($handler->EOF) return 'ERROR: Invalid type_handler. Your product_type settings are wrong, incomplete, or damaged.';
     return $handler->fields['type_handler'];
@@ -2655,12 +2655,12 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
     if ($status == '1') {
       return $db->Execute("update " . TABLE_FEATURED . "
                            set status = '1', expires_date = NULL, date_status_change = NULL
-                           where featured_id = '" . (int)$featured_id . "'");
+                           where featured_id = " . (int)$featured_id);
 
     } elseif ($status == '0') {
       return $db->Execute("update " . TABLE_FEATURED . "
                            set status = '0', date_status_change = now()
-                           where featured_id = '" . (int)$featured_id . "'");
+                           where featured_id = " . (int)$featured_id);
 
     } else {
       return -1;
@@ -2676,12 +2676,12 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
     if ($status == '1') {
       return $db->Execute("update " . TABLE_REVIEWS . "
                            set status = 1
-                           where reviews_id = '" . (int)$review_id . "'");
+                           where reviews_id = " . (int)$review_id);
 
     } elseif ($status == '0') {
       return $db->Execute("update " . TABLE_REVIEWS . "
                            set status = 0
-                           where reviews_id = '" . (int)$review_id . "'");
+                           where reviews_id = " . (int)$review_id);
 
     } else {
       return -1;
@@ -2697,7 +2697,7 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
     $products_price_sorter = zen_get_products_actual_price($product_id);
     $db->Execute("update " . TABLE_PRODUCTS . " set
          products_price_sorter='" . zen_db_prepare_input($products_price_sorter) . "'
-         where products_id='" . (int)$product_id . "'");
+         where products_id=" . (int)$product_id);
   }
 
 /**
@@ -2705,7 +2705,7 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
  */
   function zen_get_configuration_key_value_layout($lookup, $type=1) {
     global $db;
-    $configuration_query= $db->Execute("select configuration_value from " . TABLE_PRODUCT_TYPE_LAYOUT . " where configuration_key='" . zen_db_input($lookup) . "' and product_type_id='". (int)$type . "'");
+    $configuration_query= $db->Execute("select configuration_value from " . TABLE_PRODUCT_TYPE_LAYOUT . " where configuration_key='" . zen_db_input($lookup) . "' and product_type_id='". (int)$type);
     if ($configuration_query->EOF) return '';
     $lookup_value= $configuration_query->fields['configuration_value'];
     if ( !($lookup_value) ) {
@@ -2722,7 +2722,7 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
     global $db;
     $child_category_query = "select count(*) as count
                              from " . TABLE_CATEGORIES . "
-                             where parent_id = '" . (int)$category_id . "'";
+                             where parent_id = " . (int)$category_id;
 
     $child_category = $db->Execute($child_category_query);
 
@@ -2837,7 +2837,7 @@ function zen_get_categories($categories_array = array(), $parent_id = '0', $inde
     $cat_products_query = "select count(if (p.products_status=1,1,NULL)) as pr_on, count(*) as total
                            from " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_TO_CATEGORIES . " p2c
                            where p.products_id = p2c.products_id
-                           and p2c.categories_id = '" . (int)$category_id . "'";
+                           and p2c.categories_id = " . (int)$category_id;
 
     $pr_count = $db->Execute($cat_products_query);
 //    echo $pr_count->RecordCount();
@@ -2846,7 +2846,7 @@ function zen_get_categories($categories_array = array(), $parent_id = '0', $inde
 
     $cat_child_categories_query = "select categories_id
                                from " . TABLE_CATEGORIES . "
-                               where parent_id = '" . (int)$category_id . "'";
+                               where parent_id = " . (int)$category_id;
 
     $cat_child_categories = $db->Execute($cat_child_categories_query);
 
@@ -2880,13 +2880,13 @@ function zen_get_categories($categories_array = array(), $parent_id = '0', $inde
         $cat_products_query = "select count(*) as total
                            from " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_TO_CATEGORIES . " p2c
                            where p.products_id = p2c.products_id
-                           and p2c.categories_id = '" . (int)$category_id . "'";
+                           and p2c.categories_id = " . (int)$category_id;
         break;
         case ('products_active'):
         $cat_products_query = "select p.products_id
                            from " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_TO_CATEGORIES . " p2c
                            where p.products_id = p2c.products_id
-                           and p2c.categories_id = '" . (int)$category_id . "'";
+                           and p2c.categories_id = " . (int)$category_id;
         break;
       }
 
@@ -2897,14 +2897,14 @@ function zen_get_categories($categories_array = array(), $parent_id = '0', $inde
                              from " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_TO_CATEGORIES . " p2c
                              where p.products_id = p2c.products_id
                              and p.products_status = 1
-                             and p2c.categories_id = '" . (int)$category_id . "'";
+                             and p2c.categories_id = " . (int)$category_id;
         break;
         case ('products_active'):
           $cat_products_query = "select p.products_id
                              from " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_TO_CATEGORIES . " p2c
                              where p.products_id = p2c.products_id
                              and p.products_status = 1
-                             and p2c.categories_id = '" . (int)$category_id . "'";
+                             and p2c.categories_id = " . (int)$category_id;
         break;
       }
     }
@@ -2925,7 +2925,7 @@ function zen_get_categories($categories_array = array(), $parent_id = '0', $inde
 
     $cat_child_categories_query = "select categories_id
                                from " . TABLE_CATEGORIES . "
-                               where parent_id = '" . (int)$category_id . "'";
+                               where parent_id = " . (int)$category_id;
 
     $cat_child_categories = $db->Execute($cat_child_categories_query);
 
@@ -2989,7 +2989,7 @@ function zen_get_master_categories_pulldown($product_id, $fullpath = false)
   function zen_get_products_type($product_id) {
     global $db;
 
-    $check_products_type = $db->Execute("select products_type from " . TABLE_PRODUCTS . " where products_id='" . (int)$product_id . "'");
+    $check_products_type = $db->Execute("select products_type from " . TABLE_PRODUCTS . " where products_id=" . (int)$product_id);
     if ($check_products_type->EOF) return '';
     return $check_products_type->fields['products_type'];
   }
@@ -3016,7 +3016,7 @@ function zen_get_master_categories_pulldown($product_id, $fullpath = false)
     global $db;
     $product_image = $db->Execute("select products_image
                                    from " . TABLE_PRODUCTS . "
-                                   where products_id = '" . (int)$product_id . "'");
+                                   where products_id = " . (int)$product_id);
     if ($product_image->EOF) return '';
     return $product_image->fields['products_image'];
   }
@@ -3075,12 +3075,12 @@ function zen_get_master_categories_pulldown($product_id, $fullpath = false)
  */
   function zen_restrict_sub_categories($zf_cat_id, $zf_type) {
     global $db;
-    $zp_sql = "select categories_id from " . TABLE_CATEGORIES . " where parent_id = '" . (int)$zf_cat_id . "'";
+    $zp_sql = "select categories_id from " . TABLE_CATEGORIES . " where parent_id = " . (int)$zf_cat_id;
     $zq_sub_cats = $db->Execute($zp_sql);
     while (!$zq_sub_cats->EOF) {
       $zp_sql = "select * from " . TABLE_PRODUCT_TYPES_TO_CATEGORY . "
-                         where category_id = '" . (int)$zq_sub_cats->fields['categories_id'] . "'
-                         and product_type_id = '" . (int)$zf_type . "'";
+                         where category_id = " . (int)$zq_sub_cats->fields['categories_id'] . "
+                         and product_type_id = " . (int)$zf_type;
 
       $zq_type_to_cat = $db->Execute($zp_sql);
 
@@ -3100,12 +3100,12 @@ function zen_get_master_categories_pulldown($product_id, $fullpath = false)
  */
   function zen_remove_restrict_sub_categories($zf_cat_id, $zf_type) {
     global $db;
-    $zp_sql = "select categories_id from " . TABLE_CATEGORIES . " where parent_id = '" . (int)$zf_cat_id . "'";
+    $zp_sql = "select categories_id from " . TABLE_CATEGORIES . " where parent_id = " . (int)$zf_cat_id;
     $zq_sub_cats = $db->Execute($zp_sql);
     while (!$zq_sub_cats->EOF) {
         $sql = "delete from " .  TABLE_PRODUCT_TYPES_TO_CATEGORY . "
-                where category_id = '" . (int)$zq_sub_cats->fields['categories_id'] . "'
-                and product_type_id = '" . (int)$zf_type . "'";
+                where category_id = " . (int)$zq_sub_cats->fields['categories_id'] . "
+                and product_type_id = " . (int)$zf_type;
 
         $db->Execute($sql);
       zen_remove_restrict_sub_categories($zq_sub_cats->fields['categories_id'], $zf_type);
@@ -3147,11 +3147,11 @@ function zen_get_master_categories_pulldown($product_id, $fullpath = false)
       global $db;
       $type_lookup = 0;
       $type_handler = '';
-      $sql = "select products_type from " . TABLE_PRODUCTS . " where products_id='" . (int)$lookup . "'";
+      $sql = "select products_type from " . TABLE_PRODUCTS . " where products_id=" . (int)$lookup;
       $result = $db->Execute($sql);
       if (!$result->EOF) $type_lookup = $result->fields['products_type'];
 
-      $sql = "select type_handler from " . TABLE_PRODUCT_TYPES . " where type_id = '" . (int)$type_lookup . "'";
+      $sql = "select type_handler from " . TABLE_PRODUCT_TYPES . " where type_id = " . (int)$type_lookup;
       $result = $db->Execute($sql);
       if (!$result->EOF) $type_handler = $result->fields['type_handler'];
       $zv_key = strtoupper($prefix . $type_handler . $suffix . $field_prefix . $field . $field_suffix);
@@ -3245,12 +3245,12 @@ function zen_get_master_categories_pulldown($product_id, $fullpath = false)
  */
   function zen_update_salemaker_product_prices($salemaker_id) {
     global $db;
-    $zv_categories = $db->Execute("select sale_categories_selected from " . TABLE_SALEMAKER_SALES . " where sale_id = '" . (int)$salemaker_id . "'");
+    $zv_categories = $db->Execute("select sale_categories_selected from " . TABLE_SALEMAKER_SALES . " where sale_id = " . (int)$salemaker_id);
     if ($zv_categories->EOF) return FALSE;
     $za_salemaker_categories = zen_parse_salemaker_categories($zv_categories->fields['sale_categories_selected']);
     $n = sizeof($za_salemaker_categories);
     for ($i=0; $i<$n; $i++) {
-      $update_products_price = $db->Execute("select products_id from " . TABLE_PRODUCTS_TO_CATEGORIES . " where categories_id='" . (int)$za_salemaker_categories[$i] . "'");
+      $update_products_price = $db->Execute("select products_id from " . TABLE_PRODUCTS_TO_CATEGORIES . " where categories_id=" . (int)$za_salemaker_categories[$i]);
       while (!$update_products_price->EOF) {
         zen_update_products_price_sorter($update_products_price->fields['products_id']);
         $update_products_price->MoveNext();
@@ -3264,7 +3264,7 @@ function zen_get_master_categories_pulldown($product_id, $fullpath = false)
   function zen_has_product_discounts($look_up) {
     global $db;
 
-    $check_discount_query = "select products_id from " . TABLE_PRODUCTS_DISCOUNT_QUANTITY . " where products_id='" . (int)$look_up . "'";
+    $check_discount_query = "select products_id from " . TABLE_PRODUCTS_DISCOUNT_QUANTITY . " where products_id=" . (int)$look_up;
     $check_discount = $db->Execute($check_discount_query);
 
     if ($check_discount->RecordCount() > 0) {
@@ -3280,19 +3280,19 @@ function zen_get_master_categories_pulldown($product_id, $fullpath = false)
   function zen_copy_discounts_to_product($copy_from, $copy_to) {
     global $db;
 
-    $check_discount_type_query = "select products_discount_type, products_discount_type_from, products_mixed_discount_quantity from " . TABLE_PRODUCTS . " where products_id='" . (int)$copy_from . "'";
+    $check_discount_type_query = "select products_discount_type, products_discount_type_from, products_mixed_discount_quantity from " . TABLE_PRODUCTS . " where products_id=" . (int)$copy_from;
     $check_discount_type = $db->Execute($check_discount_type_query);
     if ($check_discount_type->EOF) return FALSE;
 
-    $db->Execute("update " . TABLE_PRODUCTS . " set products_discount_type='" . $check_discount_type->fields['products_discount_type'] . "', products_discount_type_from='" . $check_discount_type->fields['products_discount_type_from'] . "', products_mixed_discount_quantity='" . $check_discount_type->fields['products_mixed_discount_quantity'] . "' where products_id='" . (int)$copy_to . "'");
+    $db->Execute("update " . TABLE_PRODUCTS . " set products_discount_type='" . $check_discount_type->fields['products_discount_type'] . "', products_discount_type_from='" . $check_discount_type->fields['products_discount_type_from'] . "', products_mixed_discount_quantity='" . $check_discount_type->fields['products_mixed_discount_quantity'] . "' where products_id=" . (int)$copy_to);
 
-    $check_discount_query = "select * from " . TABLE_PRODUCTS_DISCOUNT_QUANTITY . " where products_id='" . (int)$copy_from . "' order by discount_id";
+    $check_discount_query = "select * from " . TABLE_PRODUCTS_DISCOUNT_QUANTITY . " where products_id=" . (int)$copy_from . " order by discount_id";
     $check_discount = $db->Execute($check_discount_query);
     $cnt_discount=1;
     while (!$check_discount->EOF) {
       $db->Execute("insert into " . TABLE_PRODUCTS_DISCOUNT_QUANTITY . "
                   (discount_id, products_id, discount_qty, discount_price )
-                  values ('" . (int)$cnt_discount . "', '" . (int)$copy_to . "', '" . $check_discount->fields['discount_qty'] . "', '" . $check_discount->fields['discount_price'] . "')");
+                  values (" . (int)$cnt_discount . ", " . (int)$copy_to . ", '" . $check_discount->fields['discount_qty'] . "', '" . $check_discount->fields['discount_price'] . "')");
       $cnt_discount++;
       $check_discount->MoveNext();
     }
@@ -3308,7 +3308,7 @@ function zen_get_master_categories_pulldown($product_id, $fullpath = false)
 
     $categories_lookup = $db->Execute("select master_categories_id
                                 from " . TABLE_PRODUCTS . "
-                                where products_id = '" . (int)$product_id . "'");
+                                where products_id = " . (int)$product_id);
     if ($categories_lookup->EOF) return '';
     return $categories_lookup->fields['master_categories_id'];
   }
@@ -3391,13 +3391,13 @@ function zen_get_master_categories_pulldown($product_id, $fullpath = false)
       $products = $db->Execute("select p.products_id
                                 from " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_TO_CATEGORIES . " p2c
                                 where p.products_id = p2c.products_id
-                                and p2c.categories_id = '" . (int)$categories_id . "'");
+                                and p2c.categories_id = " . (int)$categories_id);
     } else {
       $products = $db->Execute("select p.products_id
                                 from " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_TO_CATEGORIES . " p2c
                                 where p.products_id = p2c.products_id
                                 and p.products_status = '1'
-                                and p2c.categories_id = '" . (int)$categories_id . "'");
+                                and p2c.categories_id = " . (int)$categories_id);
     }
 
     while (!$products->EOF) {
@@ -3409,7 +3409,7 @@ function zen_get_master_categories_pulldown($product_id, $fullpath = false)
 
     if ($include_child) {
       $childs = $db->Execute("select categories_id from " . TABLE_CATEGORIES . "
-                              where parent_id = '" . (int)$categories_id . "'");
+                              where parent_id = " . (int)$categories_id);
       if ($childs->RecordCount() > 0 ) {
         while (!$childs->EOF) {
           zen_get_categories_products_list($childs->fields['categories_id'], $include_deactivated);
@@ -3454,7 +3454,7 @@ function zen_get_master_categories_pulldown($product_id, $fullpath = false)
     $customer_address_book_count_query = "SELECT c.*, ab.* from " .
                                           TABLE_CUSTOMERS . " c
                                           left join " . TABLE_ADDRESS_BOOK . " ab on c.customers_id = ab.customers_id
-                                          WHERE c.customers_id = '" . (int)$customer_id . "'";
+                                          WHERE c.customers_id = " . (int)$customer_id;
 
     $customer_address_book_count = $db->Execute($customer_address_book_count_query);
     return $customer_address_book_count;
@@ -3467,7 +3467,7 @@ function zen_get_master_categories_pulldown($product_id, $fullpath = false)
     global $db;
     $orders_comments_query = "SELECT osh.comments from " .
                               TABLE_ORDERS_STATUS_HISTORY . " osh
-                              where osh.orders_id = '" . (int)$orders_id . "'
+                              where osh.orders_id = " . (int)$orders_id . "
                               order by osh.orders_status_history_id
                               limit 1";
     $orders_comments = $db->Execute($orders_comments_query);
@@ -3484,7 +3484,7 @@ function zen_get_master_categories_pulldown($product_id, $fullpath = false)
     $product_query = "select m.manufacturers_name
                       from " . TABLE_PRODUCTS . " p, " .
                             TABLE_MANUFACTURERS . " m
-                      where p.products_id = '" . (int)$product_id . "'
+                      where p.products_id = " . (int)$product_id . "
                       and p.manufacturers_id = m.manufacturers_id";
     $product = $db->Execute($product_query);
 
@@ -3493,7 +3493,7 @@ function zen_get_master_categories_pulldown($product_id, $fullpath = false)
 
   function zen_user_has_gv_balance($c_id) {
     global $db;
-      $gv_result = $db->Execute("select amount from " . TABLE_COUPON_GV_CUSTOMER . " where customer_id = '" . (int)$c_id . "'");
+      $gv_result = $db->Execute("select amount from " . TABLE_COUPON_GV_CUSTOMER . " where customer_id = " . (int)$c_id);
       if ($gv_result->RecordCount() > 0) {
         if ($gv_result->fields['amount'] > 0) {
           return $gv_result->fields['amount'];
@@ -3726,10 +3726,10 @@ function get_logs_data($maxToList = 'count') {
   global $db;
     if ($status == '1') {
       zen_record_admin_activity('EZ-Page ID ' . (int)$pages_id . ' [' . $status_field . '] changed to 0', 'info');
-      return $db->Execute("update " . TABLE_EZPAGES . " set " . zen_db_input($status_field) . " = '0'  where pages_id = '" . (int)$pages_id . "'");
+      return $db->Execute("update " . TABLE_EZPAGES . " set " . zen_db_input($status_field) . " = '0'  where pages_id = " . (int)$pages_id);
     } elseif ($status == '0') {
       zen_record_admin_activity('EZ-Page ID ' . (int)$pages_id . ' [' . $status_field . '] changed to 1', 'info');
-      return $db->Execute("update " . TABLE_EZPAGES . " set " . zen_db_input($status_field) . " = '1'  where pages_id = '" . (int)$pages_id . "'");
+      return $db->Execute("update " . TABLE_EZPAGES . " set " . zen_db_input($status_field) . " = '1'  where pages_id = " . (int)$pages_id);
     } else {
       return -1;
     }


### PR DESCRIPTION
Where values in a SQL statement are expected to be an integer,
the value is cast to an integer, and was previously surrounded
by single quotes, the additional quotes have been removed and
in a few cases, the value is now cast to `int` and in a few other
cases the `zen_db_input` function sanitization was replaced with
casting to `int`.

There may still be some efficiencies to be gained within a function
to where the original value would be cast to an integer one time
and then used throughout instead of cast to int on each access.

I did not fully touch conversion of SQL statements to use all
capital letters for words such as `SELECT`, `UPDATE`, `SET`, etc...