### PR TITLE
Restore footer position to original.

### DIFF
--- a/admin/options_name_manager.php
+++ b/admin/options_name_manager.php
@@ -909,11 +909,11 @@ function translate_type_to_name($opt_type)
           </div>
         <?php } // show copier features ?>
       </div>
-      <!-- body_text_eof //-->
-      <!-- footer //-->
-      <?php require DIR_WS_INCLUDES . 'footer.php'; ?>
-      <!-- footer_eof //-->
     </div>
+    <!-- body_text_eof //-->
+    <!-- footer //-->
+    <?php require(DIR_WS_INCLUDES . 'footer.php'); ?>
+    <!-- footer_eof //-->
   </body>
 </html>
 <?php require DIR_WS_INCLUDES . 'application_bottom.php'; ?>


### PR DESCRIPTION
No reason has been provided for moving the footer to within
the divider.  Without reason it should not be moved as may/will
cause additional work for coders that affect this page through
use of the footer's notifier.

If there is a reason, then it should be made known public for
incorporation/consideration of use.