### PR TITLE
Remove conversion from integer cast variables

### DIFF
--- a/includes/classes/shopping_cart.php
+++ b/includes/classes/shopping_cart.php
@@ -106,7 +106,7 @@ class shoppingCart extends base {
         $qty = $this->contents[$products_id]['qty'];
         $product_query = "SELECT products_id
                             FROM " . TABLE_CUSTOMERS_BASKET . "
-                            WHERE customers_id = '" . (int)$_SESSION['customer_id'] . "'
+                            WHERE customers_id = " . (int)$_SESSION['customer_id'] . "
                             AND products_id = '" . zen_db_input($products_id) . "'";
 
         $product = $db->Execute($product_query);
@@ -115,7 +115,7 @@ class shoppingCart extends base {
           $sql = "INSERT INTO " . TABLE_CUSTOMERS_BASKET . "
                                 (customers_id, products_id, customers_basket_quantity,
                                  customers_basket_date_added)
-                                 VALUES ('" . (int)$_SESSION['customer_id'] . "', '" . zen_db_input($products_id) . "', '" .
+                                 VALUES (" . (int)$_SESSION['customer_id'] . ", '" . zen_db_input($products_id) . "', '" .
           $qty . "', '" . date('Ymd') . "')";
 
           $db->Execute($sql);
@@ -133,7 +133,7 @@ class shoppingCart extends base {
               $sql = "INSERT INTO " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . "
                       (customers_id, products_id, products_options_id,
                        products_options_value_id, products_options_value_text, products_options_sort_order)
-                       VALUES ('" . (int)$_SESSION['customer_id'] . "', '" . zen_db_input($products_id) . "', '" .
+                       VALUES (" . (int)$_SESSION['customer_id'] . ", '" . zen_db_input($products_id) . "', '" .
                        $option . "', '" . $value . "', '" . $attr_value . "', '" . $products_options_sort_order . "')";
 
               $db->Execute($sql);
@@ -142,7 +142,7 @@ class shoppingCart extends base {
         } else {
           $sql = "UPDATE " . TABLE_CUSTOMERS_BASKET . "
                   SET customers_basket_quantity = '" . $qty . "'
-                  WHERE customers_id = '" . (int)$_SESSION['customer_id'] . "'
+                  WHERE customers_id = " . (int)$_SESSION['customer_id'] . "
                   AND products_id = '" . zen_db_input($products_id) . "'";
           $db->Execute($sql);
 
@@ -167,7 +167,7 @@ class shoppingCart extends base {
 
       $attributes = $db->Execute("SELECT products_options_id, products_options_value_id, products_options_value_text
                              FROM " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . "
-                             WHERE customers_id = '" . (int)$_SESSION['customer_id'] . "'
+                             WHERE customers_id = " . (int)$_SESSION['customer_id'] . "
                              AND products_id = '" . zen_db_input($products->fields['products_id']) . "' " . $order_by);
 
       while (!$attributes->EOF) {
@@ -262,7 +262,7 @@ class shoppingCart extends base {
         $sql = "INSERT INTO " . TABLE_CUSTOMERS_BASKET . "
                 (customers_id, products_id, customers_basket_quantity,
                 customers_basket_date_added)
-                VALUES ('" . (int)$_SESSION['customer_id'] . "', '" . zen_db_input($products_id) . "', '" .
+                VALUES (" . (int)$_SESSION['customer_id'] . ", '" . zen_db_input($products_id) . "', '" .
                 $qty . "', '" . date('Ymd') . "')";
         $db->Execute($sql);
       }
@@ -308,7 +308,7 @@ class shoppingCart extends base {
                   $products_options_sort_order= zen_get_attributes_options_sort_order(zen_get_prid($products_id), $option, $opt);
                   $sql = "INSERT INTO " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . "
                           (customers_id, products_id, products_options_id, products_options_value_id, products_options_sort_order)
-                          VALUES ('" . (int)$_SESSION['customer_id'] . "', '" . zen_db_input($products_id) . "', '" .
+                          VALUES (" . (int)$_SESSION['customer_id'] . ", '" . zen_db_input($products_id) . "', '" .
                           (int)$option.'_chk'. (int)$val . "', '" . (int)$val . "',  '" . $products_options_sort_order . "')";
                   $db->Execute($sql);
                 }
@@ -319,7 +319,7 @@ class shoppingCart extends base {
                 $products_options_sort_order= zen_get_attributes_options_sort_order(zen_get_prid($products_id), $option, $value);
                 $sql = "INSERT INTO " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . "
                         (customers_id, products_id, products_options_id, products_options_value_id, products_options_value_text, products_options_sort_order)
-                        VALUES ('" . (int)$_SESSION['customer_id'] . "', '" . zen_db_input($products_id) . "', '" .
+                        VALUES (" . (int)$_SESSION['customer_id'] . ", '" . zen_db_input($products_id) . "', '" .
                         (int)$option . "', '" . (int)$value . "', '" . $attr_value . "', '" . $products_options_sort_order . "')";
                 $db->Execute($sql);
               }
@@ -373,7 +373,7 @@ class shoppingCart extends base {
     if (zen_is_logged_in() && !zen_in_guest_checkout()) {
       $sql = "UPDATE " . TABLE_CUSTOMERS_BASKET . "
               SET customers_basket_quantity = '" . (float)$quantity . "'
-              WHERE customers_id = '" . (int)$_SESSION['customer_id'] . "'
+              WHERE customers_id = " . (int)$_SESSION['customer_id'] . "
               AND products_id = '" . zen_db_input($products_id) . "'";
       $db->Execute($sql);
     }
@@ -414,17 +414,17 @@ class shoppingCart extends base {
                   $products_options_sort_order= zen_get_attributes_options_sort_order(zen_get_prid($products_id), $option, $opt);
                   $sql = "UPDATE " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . "
                           SET products_options_value_id = '" . (int)$val . "'
-                          WHERE customers_id = '" . (int)$_SESSION['customer_id'] . "'
+                          WHERE customers_id = " . (int)$_SESSION['customer_id'] . "
                           AND products_id = '" . zen_db_input($products_id) . "'
                           AND products_options_id = '" . (int)$option.'_chk'.(int)$val . "'";
                   $db->Execute($sql);
                 }
               } else {
                   $sql = "UPDATE " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . "
-                          SET products_options_value_id = '" . (int)$value . "', products_options_value_text = '" . $attr_value . "'
-                          WHERE customers_id = '" . (int)$_SESSION['customer_id'] . "'
+                          SET products_options_value_id = " . (int)$value . ", products_options_value_text = '" . $attr_value . "'
+                          WHERE customers_id = " . (int)$_SESSION['customer_id'] . "
                           AND products_id = '" . zen_db_input($products_id) . "'
-                          AND products_options_id = '" . (int)$option . "'";
+                          AND products_options_id = " . (int)$option;
                   $db->Execute($sql);
               }
           }
@@ -453,12 +453,12 @@ class shoppingCart extends base {
 
         if (zen_is_logged_in() && !zen_in_guest_checkout()) {
           $sql = "DELETE FROM " . TABLE_CUSTOMERS_BASKET . "
-                  WHERE customers_id = '" . (int)$_SESSION['customer_id'] . "'
+                  WHERE customers_id = " . (int)$_SESSION['customer_id'] . "
                   AND products_id = '" . $key . "'";
           $db->Execute($sql);
 
           $sql = "DELETE FROM " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . "
-                  WHERE customers_id = '" . (int)$_SESSION['customer_id'] . "'
+                  WHERE customers_id = " . (int)$_SESSION['customer_id'] . "
                   AND products_id = '" . $key . "'";
           $db->Execute($sql);
         }
@@ -537,12 +537,12 @@ class shoppingCart extends base {
     // remove from database
     if (zen_is_logged_in() && !zen_in_guest_checkout()) {
       $sql = "DELETE FROM " . TABLE_CUSTOMERS_BASKET . "
-              WHERE customers_id = '" . (int)$_SESSION['customer_id'] . "'
+              WHERE customers_id = " . (int)$_SESSION['customer_id'] . "
               AND products_id = '" . zen_db_input($products_id) . "'";
       $db->Execute($sql);
 
       $sql = "DELETE FROM " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . "
-              WHERE customers_id = '" . (int)$_SESSION['customer_id'] . "'
+              WHERE customers_id = " . (int)$_SESSION['customer_id'] . "
               AND products_id = '" . zen_db_input($products_id) . "'";
       $db->Execute($sql);
     }
@@ -608,7 +608,7 @@ class shoppingCart extends base {
                           products_priced_by_attribute, product_is_always_free_shipping, products_discount_type, products_discount_type_from,
                           products_virtual, products_model
                           FROM " . TABLE_PRODUCTS . "
-                          WHERE products_id = '" . (int)$products_id . "'";
+                          WHERE products_id = " . (int)$products_id;
 
       if ($product = $db->Execute($product_query)) {
         $prid = $product->fields['products_id'];
@@ -683,9 +683,9 @@ class shoppingCart extends base {
 
           $attribute_price_query = "SELECT *
                                       FROM " . TABLE_PRODUCTS_ATTRIBUTES . "
-                                      WHERE products_id = '" . (int)$prid . "'
-                                      AND options_id = '" . (int)$option . "'
-                                      AND options_values_id = '" . (int)$value . "'";
+                                      WHERE products_id = " . (int)$prid . "
+                                      AND options_id = " . (int)$option . "
+                                      AND options_values_id = " . (int)$value;
 
           $attribute_price = $db->Execute($attribute_price_query);
 
@@ -743,7 +743,7 @@ class shoppingCart extends base {
               $check_attribute = $attribute_price->fields['products_attributes_id'];
               $sql = "SELECT products_attributes_id
                       FROM " . TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD . "
-                      WHERE products_attributes_id = '" . $check_attribute . "'";
+                      WHERE products_attributes_id = " . (int)$check_attribute;
               $check_download = $db->Execute($sql);
               if ($check_download->RecordCount()) {
             // count number of downloads
@@ -846,9 +846,9 @@ class shoppingCart extends base {
         foreach($this->contents[$products_id]['attributes'] as $option => $value) {
           $attribute_weight_query = "SELECT products_attributes_weight, products_attributes_weight_prefix
                                        FROM " . TABLE_PRODUCTS_ATTRIBUTES . "
-                                       WHERE products_id = '" . (int)$prid . "'
-                                       AND options_id = '" . (int)$option . "'
-                                       AND options_values_id = '" . (int)$value . "'";
+                                       WHERE products_id = " . (int)$prid . "
+                                       AND options_id = " . (int)$option . "
+                                       AND options_values_id = " . (int)$value;
 
           $attribute_weight = $db->Execute($attribute_weight_query);
 
@@ -932,9 +932,9 @@ class shoppingCart extends base {
         $attributes_price = 0;
         $attribute_price_query = "SELECT *
                                     FROM " . TABLE_PRODUCTS_ATTRIBUTES . "
-                                    WHERE products_id = '" . (int)$products_id . "'
-                                    AND options_id = '" . (int)$option . "'
-                                    AND options_values_id = '" . (int)$value . "'";
+                                    WHERE products_id = " . (int)$products_id . "
+                                    AND options_id = " . (int)$option . "
+                                    AND options_values_id = " . (int)$value;
 
         $attribute_price = $db->Execute($attribute_price_query);
 
@@ -1040,9 +1040,9 @@ class shoppingCart extends base {
 
         $attribute_price_query = "SELECT *
                                     FROM " . TABLE_PRODUCTS_ATTRIBUTES . "
-                                    WHERE products_id = '" . (int)$products_id . "'
-                                    AND options_id = '" . (int)$option . "'
-                                    AND options_values_id = '" . (int)$value . "'";
+                                    WHERE products_id = " . (int)$products_id . "
+                                    AND options_id = " . (int)$option . "
+                                    AND options_values_id = " . (int)$value;
 
         $attribute_price = $db->Execute($attribute_price_query);
 
@@ -1116,9 +1116,9 @@ class shoppingCart extends base {
       foreach($this->contents[$products_id]['attributes'] as $option => $value) {
         $attribute_weight_query = "SELECT products_attributes_weight, products_attributes_weight_prefix
                                     FROM " . TABLE_PRODUCTS_ATTRIBUTES . "
-                                    WHERE products_id = '" . (int)$products_id . "'
-                                    AND options_id = '" . (int)$option . "'
-                                    AND options_values_id = '" . (int)$value . "'";
+                                    WHERE products_id = " . (int)$products_id . "
+                                    AND options_id = " . (int)$option . "
+                                    AND options_values_id = " . (int)$value;
 
         $attribute_weight_info = $db->Execute($attribute_weight_query);
 
@@ -1131,7 +1131,7 @@ class shoppingCart extends base {
         // adjusted count for free shipping
         $product = $db->Execute("SELECT products_id, product_is_always_free_shipping
                           FROM " . TABLE_PRODUCTS . "
-                          WHERE products_id = '" . (int)$products_id . "'");
+                          WHERE products_id = " . (int)$products_id);
 
         if ($product->fields['product_is_always_free_shipping'] != 1) {
           $new_attributes_weight = $attribute_weight_info->fields['products_attributes_weight'];
@@ -1228,15 +1228,15 @@ class shoppingCart extends base {
                 $chkcount ++;
                 $chk_attributes_exist_query = "SELECT products_id
                                           FROM " . TABLE_PRODUCTS_ATTRIBUTES . " pa
-                                          WHERE pa.products_id = '" . (int)$products_id . "'
-                                          AND pa.options_values_id = '" . (int)$value . "'";
+                                          WHERE pa.products_id = " . (int)$products_id . "
+                                          AND pa.options_values_id = " . (int)$value;
 
                 $chk_attributes_exist = $db->Execute($chk_attributes_exist_query);
 //echo 'what is it: ' . ' : ' . $products_id . ' - ' . $value . ' records: ' . $chk_attributes_exist->RecordCount() . ' vs ' . print_r($this->contents[$products_id]) . '<br>';
                 if ($chk_attributes_exist->EOF) {
                   $fix_once ++;
                   $_SESSION['valid_to_checkout'] = false;
-                  $chk_product_attributes = $db->Execute("SELECT products_status FROM " . TABLE_PRODUCTS . " WHERE products_status = 1 AND products_id = '" . $products->fields["products_id"] . "' LIMIT 1");
+                  $chk_product_attributes = $db->Execute("SELECT products_status FROM " . TABLE_PRODUCTS . " WHERE products_status = 1 AND products_id = " . (int)$products->fields["products_id"] . " LIMIT 1");
                   if (!$chk_product_attributes->EOF && $chk_product_attributes->fields['products_status'] == 1) {
                     $chk_products_link = '<a href="' . zen_href_link(zen_get_info_page($products->fields["products_id"]), 'cPath=' . zen_get_generated_category_path_rev($products->fields["master_categories_id"]) . '&products_id=' . $products->fields["products_id"]) . '">' . $products->fields['products_name'] . '</a>';
                   } else {
@@ -1399,7 +1399,7 @@ class shoppingCart extends base {
 
     if ( $this->count_contents() > 0 ) {
       foreach($this->contents as $products_id => $data) {
-        $free_ship_check = $db->Execute("SELECT products_virtual, products_model, products_price, product_is_always_free_shipping FROM " . TABLE_PRODUCTS . " WHERE products_id = '" . zen_get_prid($products_id) . "'");
+        $free_ship_check = $db->Execute("SELECT products_virtual, products_model, products_price, product_is_always_free_shipping FROM " . TABLE_PRODUCTS . " WHERE products_id = " . (int)$products_id);
         $virtual_check = false;
         if (preg_match('/^GIFT/', addslashes($free_ship_check->fields['products_model']))) {
 // @TODO - fix GIFT price in cart special/attribute
@@ -1419,8 +1419,8 @@ class shoppingCart extends base {
             $virtual_check_query = "SELECT COUNT(*) as total
                                       FROM " . TABLE_PRODUCTS_ATTRIBUTES . " pa, "
                                       . TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD . " pad
-                                      WHERE pa.products_id = '" . (int)$products_id . "'
-                                      AND pa.options_values_id = '" . (int)$value . "'
+                                      WHERE pa.products_id = " . (int)$products_id . "
+                                      AND pa.options_values_id = " . (int)$value . "
                                       AND pa.products_attributes_id = pad.products_attributes_id";
 
             $virtual_check = $db->Execute($virtual_check_query);
@@ -1544,7 +1544,7 @@ class shoppingCart extends base {
     if (!is_array($this->contents)) return 0;
 
     // check if mixed is on
-    $product = $db->Execute("SELECT products_id, products_quantity_mixed FROM " . TABLE_PRODUCTS . " WHERE products_id='" . zen_get_prid($products_id) . "' limit 1");
+    $product = $db->Execute("SELECT products_id, products_quantity_mixed FROM " . TABLE_PRODUCTS . " WHERE products_id=" . (int)$products_id . " limit 1");
 
     // if mixed attributes is off return qty for current attribute selection
     if ($product->fields['products_quantity_mixed'] == '0') {
@@ -1584,7 +1584,7 @@ class shoppingCart extends base {
 
     // check if mixed is on
     //      $product = $db->Execute("select products_id, products_mixed_discount_quantity from " . TABLE_PRODUCTS . " where products_id='" . (int)$products_id . "' limit 1");
-    $product = $db->Execute("SELECT products_id, products_mixed_discount_quantity FROM " . TABLE_PRODUCTS . " WHERE products_id='" . zen_get_prid($products_id) . "' limit 1");
+    $product = $db->Execute("SELECT products_id, products_mixed_discount_quantity FROM " . TABLE_PRODUCTS . " WHERE products_id=" . (int)$products_id . " limit 1");
 
     // if mixed attributes is off return qty for current attribute selection
     if ($product->fields['products_mixed_discount_quantity'] == '0') {
@@ -1626,7 +1626,7 @@ class shoppingCart extends base {
     foreach($this->contents as $products_id => $data) {
       $testing_id = zen_get_prid($products_id);
       // check if field it true
-      $product_check = $db->Execute("SELECT " . $check_what . " AS check_it FROM " . TABLE_PRODUCTS . " WHERE products_id='" . $testing_id . "' LIMIT 1");
+      $product_check = $db->Execute("SELECT " . $check_what . " AS check_it FROM " . TABLE_PRODUCTS . " WHERE products_id=" . (int)$testing_id . " LIMIT 1");
       if ($product_check->fields['check_it'] == $check_value) {
         $in_cart_check_qty += $this->contents[$products_id]['qty'];
       }
@@ -1909,7 +1909,7 @@ class shoppingCart extends base {
                 if ($products_options_file->parse(TEXT_PREFIX . $_POST[UPLOAD_PREFIX . $i])) {
                   $products_image_extension = substr($products_options_file->filename, strrpos($products_options_file->filename, '.'));
                   if (zen_is_logged_in()) {
-                    $db->Execute("INSERT INTO " . TABLE_FILES_UPLOADED . " (sesskey, customers_id, files_uploaded_name) VALUES ('" . zen_session_id() . "', '" . $_SESSION['customer_id'] . "', '" . zen_db_input($products_options_file->filename) . "')");
+                    $db->Execute("INSERT INTO " . TABLE_FILES_UPLOADED . " (sesskey, customers_id, files_uploaded_name) VALUES ('" . zen_session_id() . "', " . (int)$_SESSION['customer_id'] . ", '" . zen_db_input($products_options_file->filename) . "')");
                   } else {
                     $db->Execute("INSERT INTO " . TABLE_FILES_UPLOADED . " (sesskey, files_uploaded_name) VALUES ('" . zen_session_id() . "', '" . zen_db_input($products_options_file->filename) . "')");
                   }
@@ -2478,7 +2478,7 @@ class shoppingCart extends base {
     $pr_id = zen_get_prid($product_id);
 
     // check if mixed is on
-    $product = $db->Execute("SELECT products_id, products_quantity_mixed FROM " . TABLE_PRODUCTS . " WHERE products_id=" . $pr_id . " limit 1");
+    $product = $db->Execute("SELECT products_id, products_quantity_mixed FROM " . TABLE_PRODUCTS . " WHERE products_id=" . (int)$pr_id . " limit 1");
 
     // if mixed attributes is off identify that this product is the last of its kind (which is also the first of its kind).
     if ($product->fields['products_quantity_mixed'] == '0') {


### PR DESCRIPTION
This removes the excess quotes (string casting) from around
variables that are cast to integers and expected to be stored
in the database as integers.  Previous result was value
(potentially a string) was cast to an integer, then encapsulated
into quotes which makes database treat as a string that then
is to be stored into an integer type datatype so requiring
additional conversion by the database to int. This reduces
the additional two conversions though only one was really
processing related (conversion of string back to integer).