### PR TITLE
Correct type-conversion error during low-stock check

### DIFF
--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -774,9 +774,10 @@ class order extends base {
 
           // Will work with only one option for downloadable products
           // otherwise, we have to build the query dynamically with a loop
+          // NOTE: Need the (int) cast on the option_id, since checkbox-type attributes' are formatted like '46_chk887'. 
           if (!empty($this->products[$i]['attributes']) && is_array($this->products[$i]['attributes'])) {
             $products_attributes = $this->products[$i]['attributes'];
-            $stock_query_raw .= " AND pa.options_id = " . $products_attributes[0]['option_id'] . " AND pa.options_values_id = " . $products_attributes[0]['value_id'];
+            $stock_query_raw .= " AND pa.options_id = " . (int)$products_attributes[0]['option_id'] . " AND pa.options_values_id = " . $products_attributes[0]['value_id'];
           }
           $stock_values = $db->ExecuteNoCache($stock_query_raw . ' LIMIT 1');
         } else {


### PR DESCRIPTION
If a product's first (or only) attribute is a checkbox-type one, the low-stock check on order completion fails since the associated options_id value is formatted similar to '45_chk21'.