### PR TITLE
empty() should not be used for defined constants

### DIFF
--- a/includes/functions/plugin_support.php
+++ b/includes/functions/plugin_support.php
@@ -59,7 +59,7 @@ function plugin_version_check_for_updates($plugin_file_id = 0, $version_string_t
     if (strcmp($data[0]['latest_plugin_version'], $version_string_to_compare) > 0) $new_version_available = true;
 
     // check whether present ZC version is compatible with the latest available plugin version
-    if (!defined('PLUGIN_VERSION_CHECK_MATCHING_OVERRIDE') || empty(PLUGIN_VERSION_CHECK_MATCHING_OVERRIDE)) {
+    if (!defined('PLUGIN_VERSION_CHECK_MATCHING_OVERRIDE') || PLUGIN_VERSION_CHECK_MATCHING_OVERRIDE == '') {
         $zc_version = PROJECT_VERSION_MAJOR . '.' . preg_replace('/[^0-9.]/', '', PROJECT_VERSION_MINOR);
         if ($strict_zc_version_compare) $zc_version = PROJECT_VERSION_MAJOR . '.' . PROJECT_VERSION_MINOR;
         if (!in_array('v' . $zc_version, $data[0]['zcversions'], false)) $new_version_available = false;


### PR DESCRIPTION
empty is for variables, not defined constants.  

