### PR TITLE
Coupon admin page shows empty brackets in sidebar if no coupons

### DIFF
--- a/admin/coupon_admin.php
+++ b/admin/coupon_admin.php
@@ -1408,7 +1408,11 @@ function check_form(form_name) {
       $contents[] = array('text' => '<br />' . COUPON_USES_COUPON . '<br />' . zen_draw_input_field('voucher_number_of'));
       break;
     default:
-      $heading[] = array('text'=>'['.$cInfo->coupon_id.']  '.$cInfo->coupon_code . ($cInfo->coupon_id == '' ? ' - (' . (!empty($_GET['cid']) ? $_GET['cid'] : 0) . ')' : ''));
+      if ($cc_list->RecordCount() > 0) {
+        $heading[] = array('text'=>'['.$cInfo->coupon_id.']  '.$cInfo->coupon_code . ($cInfo->coupon_id == '' ? ' - (' . (!empty($_GET['cid']) ? $_GET['cid'] : 0) . ')' : ''));
+      } else {
+        $heading[] = array('text'=>ERROR_NO_COUPONS);
+      }
       $amount = $cInfo->coupon_amount;
       if ($cInfo->coupon_type == 'P' || $cInfo->coupon_type == 'E') {
         $amount .= '%';

--- a/admin/includes/languages/english/coupon_admin.php
+++ b/admin/includes/languages/english/coupon_admin.php
@@ -149,3 +149,4 @@ define('TEXT_CONFIRM_REACTIVATE', 'Are you sure you want to restore this Coupon?
 define('SUCCESS_COUPON_FOUND', 'Discount Coupon found!');
 define('ERROR_COUPON_NOT_FOUND', 'Discount Coupon not found!');
 define('ERROR_NO_COUPON_CODE', 'Discount Coupon coupon code not entered!');
+define('ERROR_NO_COUPONS', 'No coupons'); 


### PR DESCRIPTION
<img width="393" alt="coupon_admin_when_empty" src="https://user-images.githubusercontent.com/4391638/80607063-07494a00-8a03-11ea-9d23-781f5af4fb8a.png">
