### PR TITLE
installer language: add return array

### DIFF
--- a/zc_install/includes/classes/LanguageManager.php
+++ b/zc_install/includes/classes/LanguageManager.php
@@ -20,6 +20,7 @@ class LanguageManager
             $infoData = require(DIR_FS_INSTALL . $this->langPath . $infoFile);
             $this->languagesInstalled = array_merge($this->languagesInstalled, $infoData);
         }
+	return $this->languagesInstalled;
     }
 
     public function loadLanguageDefines($lng, $currentPage, $fallback = 'en_us')


### PR DESCRIPTION
fixes non-display of language select drop down
https://github.com/zencart/zencart/pull/3355#issuecomment-621050003

