### PR TITLE
admin: splitPageResults hide PREV when on page 1

### DIFF
--- a/admin/includes/classes/split_page_results.php
+++ b/admin/includes/classes/split_page_results.php
@@ -77,7 +77,7 @@ class splitPageResults
         if ($current_page_number > 1) {
           $display_links .= '<a href="' . zen_href_link(basename($PHP_SELF), $parameters . $page_name . '=' . ($current_page_number - 1), 'NONSSL') . '" class="splitPageLink">' . PREVNEXT_BUTTON_PREV . '</a>&nbsp;&nbsp;';
         } else {
-          $display_links .= PREVNEXT_BUTTON_PREV . '&nbsp;&nbsp;';
+          $display_links .= '<span style="display:none;">'. PREVNEXT_BUTTON_PREV . '&nbsp;&nbsp;</span>';
         }
 
         $display_links .= sprintf(TEXT_RESULT_PAGE, zen_draw_pull_down_menu($page_name, $pages_array, $current_page_number, 'onChange="this.form.submit();"'), $num_pages);

--- a/admin/includes/classes/split_page_results.php
+++ b/admin/includes/classes/split_page_results.php
@@ -77,7 +77,7 @@ class splitPageResults
         if ($current_page_number > 1) {
           $display_links .= '<a href="' . zen_href_link(basename($PHP_SELF), $parameters . $page_name . '=' . ($current_page_number - 1), 'NONSSL') . '" class="splitPageLink">' . PREVNEXT_BUTTON_PREV . '</a>&nbsp;&nbsp;';
         } else {
-          $display_links .= '<span style="display:none;">'. PREVNEXT_BUTTON_PREV . '&nbsp;&nbsp;</span>';
+          $display_links .= '<span style="visibility:hidden;">'. PREVNEXT_BUTTON_PREV . '&nbsp;&nbsp;</span>';
         }
 
         $display_links .= sprintf(TEXT_RESULT_PAGE, zen_draw_pull_down_menu($page_name, $pages_array, $current_page_number, 'onChange="this.form.submit();"'), $num_pages);
@@ -85,7 +85,7 @@ class splitPageResults
         if (($current_page_number < $num_pages) && ($num_pages != 1)) {
           $display_links .= '&nbsp;&nbsp;<a href="' . zen_href_link(basename($PHP_SELF), $parameters . $page_name . '=' . ($current_page_number + 1), 'NONSSL') . '" class="splitPageLink">' . PREVNEXT_BUTTON_NEXT . '</a>';
         } else {
-          $display_links .= '&nbsp;&nbsp;' . PREVNEXT_BUTTON_NEXT;
+          $display_links .= '<span style="visibility:hidden;">&nbsp;&nbsp;' . PREVNEXT_BUTTON_NEXT . '</span>';
         }
 
         if ($parameters != '') {


### PR DESCRIPTION
Hide Prev on page 1 and Next on last page
I decided to hide them rather than not use them, to preserve spacing, maybe.
fixes https://github.com/zencart/zencart/issues/3381

I note that the IDE is complaining that the filename is not the same as the classname....