### PR TITLE
Add back TEXT_SEE_ORDERS which is used by older templates

### DIFF
--- a/includes/languages/english/checkout_success.php
+++ b/includes/languages/english/checkout_success.php
@@ -15,6 +15,7 @@ define('HEADING_TITLE', 'Thank You! We Appreciate your Business!');
 define('TEXT_SUCCESS', '');
 define('TEXT_NOTIFY_PRODUCTS', 'Please notify me of updates to these products');
 // Still used by some older templates
+define('TEXT_SEE_ORDERS', 'You can view your order history by going to the <a href="' . zen_href_link(FILENAME_ACCOUNT, '', 'SSL') . '" name="linkMyAccount">My Account</a> page and by clicking on "View All Orders".');
 define('TEXT_CONTACT_STORE_OWNER', 'Please direct any questions to customer service.');
 define('TEXT_THANKS_FOR_SHOPPING', 'Thanks for shopping with us online!');
 


### PR DESCRIPTION
This define should not have been removed in the cull of #3209.  It is not currently used by the vanilla distribution but is still used by popular older templates. 