### PR TITLE
Make Admin category/products and orders table rows clickable again

### DIFF
--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -572,7 +572,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
 
           $show_prod_labels = ($search_result || $categories->EOF) ? true : false;
           ?>
-          <table class="table table-striped">
+          <table id="categories-products-table" class="table table-striped">
             <thead>
               <tr>
                 <th class="text-right shrink"><?php echo TABLE_HEADING_ID; ?></th>
@@ -610,7 +610,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
                 $cInfo = new objectInfo($category);
               }
               ?>
-              <tr>
+              <tr class="category-listing-row" data-cid="<?php echo $category['categories_id']; ?>">
                 <td class="text-right"><?php echo $category['categories_id']; ?></td>
                 <td>
                   <a href="<?php echo zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING, zen_get_path($category['categories_id'])); ?>" class="folder"><i class="fa fa-lg fa-folder"></i>&nbsp;<strong><?php echo $category['categories_name']; ?></strong></a>
@@ -631,7 +631,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
                     ?>
                   </td>
                 <?php } ?>
-                <td class="text-right hidden-sm hidden-xs">
+                <td class="text-right hidden-sm hidden-xs dataTableButtonCell">
                   <?php if (SHOW_CATEGORY_PRODUCTS_LINKED_STATUS == 'true' && zen_get_products_to_categories($category['categories_id'], true, 'products_active') == 'true') { ?>
                     <i class="fa fa-square fa-lg txt-linked" aria-hidden="true" title="<?php echo IMAGE_ICON_LINKED; ?>"></i>
                   <?php } ?>
@@ -645,7 +645,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
                 if ($action == '') {
                   ?>
                   <td class="text-right hidden-sm hidden-xs"><?php echo $category['sort_order']; ?></td>
-                  <td class="text-right">
+                  <td class="text-right dataTableButtonCell">
                     <div class="btn-group">
                       <a href="<?php echo zen_href_link(FILENAME_CATEGORIES, 'cPath=' . $cPath . '&cID=' . $category['categories_id'] . '&action=edit_category' . ($search_result ? '&search=' . $_GET['search'] : '')); ?>" class="btn btn-sm btn-default btn-edit" role="button" title="<?php echo ICON_EDIT; ?>">
                         <i class="fa fa-pencil fa-lg" aria-hidden="true"></i>
@@ -785,13 +785,13 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
 
               $type_handler = $zc_products->get_handler($product['products_type']);
               ?>
-              <tr>
+              <tr class="product-listing-row" data-pid="<?php echo $product['products_id']; ?>">
                 <td class="text-right"><?php echo $product['products_id']; ?></td>
                 <td><a href="<?php echo zen_catalog_href_link($type_handler . '_info', 'cPath=' . $cPath . '&products_id=' . $product['products_id'] . '&language=' . $_SESSION['languages_code'] . '&product_type=' . $product['products_type']); ?>" target="_blank"><?php echo zen_image(DIR_WS_ICONS . 'preview.gif', ICON_PREVIEW); ?></a>&nbsp;<a href="<?php echo zen_href_link(FILENAME_PRODUCT, 'cPath=' . $cPath . '&product_type=' . $product['products_type'] . '&pID=' . $product['products_id'] . '&action=new_product' . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')); ?>" title="<?php echo IMAGE_EDIT; ?>" style="text-decoration: none"><?php echo $product['products_name']; ?></a></td>
                 <td class="hidden-sm hidden-xs"><?php echo $product['products_model']; ?></td>
                 <td class="text-right hidden-sm hidden-xs"><?php echo zen_get_products_display_price($product['products_id']); ?></td>
                 <td class="text-right hidden-sm hidden-xs"><?php echo $product['products_quantity']; ?></td>
-                <td class="text-right hidden-sm hidden-xs text-nowrap">
+                <td class="text-right hidden-sm hidden-xs text-nowrap dataTableButtonCell">
                   <?php
                   $additional_icons = '';
                   $zco_notifier->notify('NOTIFY_ADMIN_PROD_LISTING_ADD_ICON', $product, $additional_icons);
@@ -816,7 +816,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
                 </td>
                 <?php if ($action == '') { ?>
                   <td class="text-right hidden-sm hidden-xs"><?php echo $product['products_sort_order']; ?></td>
-                  <td class="text-right">
+                  <td class="text-right dataTableButtonCell">
                     <div class="btn-group">
                       <a href="<?php echo zen_href_link(FILENAME_PRODUCT, 'cPath=' . $cPath . '&product_type=' . $product['products_type'] . '&pID=' . $product['products_id'] . '&action=new_product' . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')); ?>" class="btn btn-sm btn-default btn-edit" role="button" title="<?php echo IMAGE_EDIT_PRODUCT; ?>">
                         <i class="fa fa-pencil fa-lg" aria-hidden="true"></i>
@@ -1110,6 +1110,23 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
         </div>
       <?php } ?>
     </div>
+    <!--  enable on-page script tools -->
+    <script>
+        <?php
+        $categorySelectLink = str_replace('&amp;', '&', zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING, zen_get_all_get_params(array('cPath', 'action')) . "cPath=[*]"));
+        $productEditLink = str_replace('&amp;', '&', zen_href_link(FILENAME_PRODUCT, zen_get_all_get_params(array('pID', 'action')) . "pID=[*]&action=new_product"));
+        ?>
+        jQuery(function () {
+            const categorySelectlink = '<?php echo $categorySelectLink; ?>';
+            const productEditLink = '<?php echo $productEditLink; ?>';
+            jQuery("tr.category-listing-row td").not('.dataTableButtonCell').on('click', (function() {
+                window.location.href = categorySelectlink.replace('[*]', jQuery(this).parent().attr('data-cid'));
+            }));
+            jQuery("tr.product-listing-row td").not('.dataTableButtonCell').on('click', (function() {
+                window.location.href = productEditLink.replace('[*]', jQuery(this).parent().attr('data-pid'));
+            }));
+        })
+    </script>
     <!-- footer //-->
     <?php require DIR_WS_INCLUDES . 'footer.php'; ?>
     <!-- footer_eof //-->

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -30,7 +30,7 @@ if (!isset($_GET['list_order'])) $_GET['list_order'] = '';
 if (!isset($_GET['page'])) $_GET['page'] = '';
 
 include DIR_FS_CATALOG . DIR_WS_CLASSES . 'order.php';
-$show_including_tax = (DISPLAY_PRICE_WITH_TAX == 'true'); 
+$show_including_tax = (DISPLAY_PRICE_WITH_TAX == 'true');
 // prepare order-status look-up list
 $orders_status_array = array();
 $orders_status = $db->Execute("SELECT orders_status_id, orders_status_name
@@ -1042,7 +1042,7 @@ if (zen_not_null($action) && $order_exists == true) {
         <div class="row"><?php echo TEXT_LEGEND . ' ' . zen_image(DIR_WS_IMAGES . 'icon_status_red.gif', TEXT_BILLING_SHIPPING_MISMATCH, 10, 10) . ' ' . TEXT_BILLING_SHIPPING_MISMATCH . $extra_legends; ?></div>
         <div class="row">
           <div class="col-xs-12 col-sm-12 col-md-9 col-lg-9 configurationColumnLeft">
-            <table class="table table-hover">
+            <table id="orders-table" class="table table-hover">
               <thead>
                 <tr class="dataTableHeadingRow">
                     <?php
@@ -1185,9 +1185,9 @@ if (zen_not_null($action) && $order_exists == true) {
                     }
 
                     if (isset($oInfo) && is_object($oInfo) && ($orders->fields['orders_id'] == $oInfo->orders_id)) {
-                      echo '<tr id="defaultSelected" class="dataTableRowSelected">' . "\n";
+                      echo '<tr id="defaultSelected" class="dataTableRowSelected order-listing-row" data-oid="' . $orders->fields['orders_id'] . '">' . "\n";
                     } else {
-                      echo '<tr class="dataTableRow">' . "\n";
+                      echo '<tr class="dataTableRow order-listing-row" data-oid="' . $orders->fields['orders_id'] . '">' . "\n";
                     }
 
                     $show_difference = '';
@@ -1207,7 +1207,7 @@ if (zen_not_null($action) && $order_exists == true) {
                 <td class="dataTableContent"><?php echo $show_payment_type; ?></td>
                 <td class="dataTableContent"><?php echo '<a href="' . zen_href_link(FILENAME_CUSTOMERS, 'cID=' . $orders->fields['customers_id'], 'NONSSL') . '">' . zen_image(DIR_WS_ICONS . 'preview.gif', ICON_PREVIEW . ' ' . TABLE_HEADING_CUSTOMERS) . '</a>&nbsp;' . $orders->fields['customers_name'] . ($orders->fields['customers_company'] != '' ? '<br>' . $orders->fields['customers_company'] : ''); ?></td>
                 <td class="dataTableContent text-right"><?php echo strip_tags($orders->fields['order_total']); ?></td>
-                <td class="dataTableContent text-right">
+                <td class="dataTableContent text-right dataTableButtonCell">
                     <?php
                     $sql = "SELECT op.products_quantity AS qty, op.products_name AS name, op.products_model AS model, opa.products_options AS product_option, opa.products_options_values AS product_value 
                             FROM " . TABLE_ORDERS_PRODUCTS . " op 
@@ -1264,7 +1264,12 @@ if (zen_not_null($action) && $order_exists == true) {
   }
 ?>
 
-                <td class="dataTableContent noprint text-right"><?php echo '<a href="' . zen_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('oID', 'action')) . 'oID=' . $orders->fields['orders_id'] . '&action=edit', 'NONSSL') . '">' . zen_image(DIR_WS_IMAGES . 'icon_edit.gif', ICON_EDIT) . '</a>' . $extra_action_icons; ?>&nbsp;<?php
+                <td class="dataTableContent noprint text-right dataTableButtonCell">
+                    <?php
+                    echo '<a href="' . zen_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('oID', 'action')) . 'oID=' . $orders->fields['orders_id'] . '&action=edit', 'NONSSL') . '">' . zen_image(DIR_WS_IMAGES . 'icon_edit.gif', ICON_EDIT) . '</a>' . $extra_action_icons;
+                    ?>
+                    &nbsp;
+                    <?php
                     if (isset($oInfo) && is_object($oInfo) && ($orders->fields['orders_id'] == $oInfo->orders_id)) {
                       echo zen_image(DIR_WS_IMAGES . 'icon_arrow_right.gif', '');
                     } else {
@@ -1398,10 +1403,17 @@ if (zen_not_null($action) && $order_exists == true) {
     </div>
     <!-- body_eof //-->
 
-    <!--  enable popovers-->
+    <!--  enable on-page script tools -->
     <script>
+        <?php
+        $order_link = str_replace('&amp;', '&', zen_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('oID', 'action')) . "oID=[*]"));
+        ?>
         jQuery(function () {
-            jQuery('[data-toggle="popover"]').popover({html:true,sanitize: true})
+            const orderLink = '<?php echo $order_link; ?>';
+            jQuery("tr.order-listing-row td").not('.dataTableButtonCell').on('click', (function() {
+                window.location.href = orderLink.replace('[*]', jQuery(this).parent().attr('data-oid'));
+            }));
+            jQuery('[data-toggle="popover"]').popover({html:true,sanitize: true});
         })
     </script>
 


### PR DESCRIPTION
Fixes #3304

This uses the on-page action ideas offered by @lat9 in #3304, with some variations to use named classes for excluded columns.

Closes #3377 
Closes #3378 