### PR TITLE
Admin - order status update - send email in order language

### DIFF
--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -2231,15 +2231,24 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
 
 
 /**
- * Lookup Languages Icon
+ * Lookup Languages Icon by id or code
+ * @param $lookup
+ * @param bool $code
+ * @return bool|string
  */
-  function zen_get_language_icon($lookup) {
+function zen_get_language_icon($lookup, $code = false)
+{
     global $db;
-    $languages_icon = $db->Execute("select directory, image from " . TABLE_LANGUAGES . " where languages_id = " . (int)$lookup);
-    if ($languages_icon->EOF) return '';
-    $icon= zen_image(DIR_WS_CATALOG_LANGUAGES . $languages_icon->fields['directory'] . '/images/' . $languages_icon->fields['image'], $languages_icon->fields['directory']);
-    return $icon;
-  }
+    if ($code) { // 157: use code
+        $languages_icon = $db->Execute("SELECT directory, image from " . TABLE_LANGUAGES . " WHERE code = '" . zen_db_input($lookup) . "' LIMIT 1");
+    } else { // legacy: use id
+        $languages_icon = $db->Execute("SELECT directory, image from " . TABLE_LANGUAGES . " where languages_id = " . (int)$lookup . " LIMIT 1");
+    }
+    if ($languages_icon->EOF) {
+        return '';
+    }
+    return zen_image(DIR_WS_CATALOG_LANGUAGES . $languages_icon->fields['directory'] . '/images/' . $languages_icon->fields['image'], $languages_icon->fields['directory']);
+}
 
 /**
  * Get the Option Name for a particular language
@@ -2262,12 +2271,21 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
   }
 
 /**
- * lookup language dir from id
+ * lookup language directory name by id or code
+ * @param $lookup
+ * @param bool $code
+ * @return mixed|string
  */
-  function zen_get_language_name($lookup) {
+  function zen_get_language_name($lookup, $code = false) {
     global $db;
-    $check_language= $db->Execute("select directory from " . TABLE_LANGUAGES . " where languages_id = " . (int)$lookup);
-    if ($check_language->EOF) return '';
+    if ($code){ // 157: by code
+        $check_language= $db->Execute("SELECT directory FROM " . TABLE_LANGUAGES . " WHERE code = '" . zen_db_input($lookup) . "' LIMIT 1");
+    } else { // legacy: by id
+        $check_language= $db->Execute("SELECT directory FROM " . TABLE_LANGUAGES . " WHERE languages_id = " . (int)$lookup . " LIMIT 1");
+    }
+    if ($check_language->EOF) {
+        return '';
+    }
     return $check_language->fields['directory'];
   }
 

--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -2233,17 +2233,17 @@ function zen_copy_products_attributes($products_id_from, $products_id_to) {
 /**
  * Lookup Languages Icon by id or code
  * @param $lookup
- * @param bool $code
  * @return bool|string
  */
-function zen_get_language_icon($lookup, $code = false)
+function zen_get_language_icon($lookup)
 {
     global $db;
-    if ($code) { // 157: use code
-        $languages_icon = $db->Execute("SELECT directory, image from " . TABLE_LANGUAGES . " WHERE code = '" . zen_db_input($lookup) . "' LIMIT 1");
-    } else { // legacy: use id
-        $languages_icon = $db->Execute("SELECT directory, image from " . TABLE_LANGUAGES . " where languages_id = " . (int)$lookup . " LIMIT 1");
-    }
+    $languages_icon = $db->Execute("SELECT directory, image FROM " . TABLE_LANGUAGES . " 
+        WHERE 
+        languages_id = " . (int)$lookup . " 
+        OR
+        code = '" . zen_db_input($lookup) . "' 
+        LIMIT 1");
     if ($languages_icon->EOF) {
         return '';
     }
@@ -2273,22 +2273,23 @@ function zen_get_language_icon($lookup, $code = false)
 /**
  * lookup language directory name by id or code
  * @param $lookup
- * @param bool $code
  * @return mixed|string
  */
-  function zen_get_language_name($lookup, $code = false) {
+function zen_get_language_name($lookup)
+{
     global $db;
-    if ($code){ // 157: by code
-        $check_language= $db->Execute("SELECT directory FROM " . TABLE_LANGUAGES . " WHERE code = '" . zen_db_input($lookup) . "' LIMIT 1");
-    } else { // legacy: by id
-        $check_language= $db->Execute("SELECT directory FROM " . TABLE_LANGUAGES . " WHERE languages_id = " . (int)$lookup . " LIMIT 1");
-    }
+    $check_language = $db->Execute("SELECT directory FROM " . TABLE_LANGUAGES . " 
+        WHERE 
+        languages_id = " . (int)$lookup . " 
+        OR
+        code = '" . zen_db_input($lookup) . "' 
+        LIMIT 1");
+
     if ($check_language->EOF) {
         return '';
     }
     return $check_language->fields['directory'];
-  }
-
+}
 
 /**
  * Delete all product attributes

--- a/admin/includes/languages/english/orders.php
+++ b/admin/includes/languages/english/orders.php
@@ -130,3 +130,5 @@ define('TEXT_MAP_CUSTOMER_ADDRESS', 'Map Customer Address');
 define('TEXT_MAP_SHIPPING_ADDRESS', 'Map Shipping Address');
 define('TEXT_MAP_BILLING_ADDRESS', 'Map Billing Address');
 
+define('TEXT_EMAIL_LANGUAGE', 'order language: %s');
+define('SUCCESS_EMAIL_SENT', 'Email %s sent to customer');

--- a/admin/includes/languages/english/orders.php
+++ b/admin/includes/languages/english/orders.php
@@ -130,5 +130,5 @@ define('TEXT_MAP_CUSTOMER_ADDRESS', 'Map Customer Address');
 define('TEXT_MAP_SHIPPING_ADDRESS', 'Map Shipping Address');
 define('TEXT_MAP_BILLING_ADDRESS', 'Map Billing Address');
 
-define('TEXT_EMAIL_LANGUAGE', 'order language: %s');
+define('TEXT_EMAIL_LANGUAGE', 'Order Language: %s');
 define('SUCCESS_EMAIL_SENT', 'Email %s sent to customer');

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -947,7 +947,7 @@ if (zen_not_null($action) && $order_exists == true) {
                   <?php echo zen_draw_textarea_field('comments', 'soft', '60', '5', '', 'id="comments" class="form-control"');
                   // remind admin user of the order/customer language in case of writing a comment.
                   if (count(zen_get_languages()) > 1) {
-                      echo '<br>' . zen_get_language_icon($order->info['language_code'], true) . ' <strong>' . sprintf(TEXT_EMAIL_LANGUAGE, zen_get_language_name($order->info['language_code'], true)) . '</strong>';
+                      echo '<br>' . zen_get_language_icon($order->info['language_code']) . ' <strong>' . sprintf(TEXT_EMAIL_LANGUAGE, zen_get_language_name($order->info['language_code'])) . '</strong>';
                      echo zen_draw_hidden_field('admin_language', $_SESSION['languages_code']);
                   } ?>
               </div>

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -1351,9 +1351,6 @@ if (zen_not_null($action) && $order_exists == true) {
                         '</fieldset></form>' . "\n"];
 
                     $contents[] = array('text' => '<br>' . TEXT_DATE_ORDER_CREATED . ' ' . zen_date_short($oInfo->date_purchased));
-                    if ($_SESSION['languages_code'] !== $oInfo->language_code) {
-                        $contents[] = array('text' => zen_get_language_icon($oInfo->language_code, true) . ' ' . sprintf(TEXT_EMAIL_LANGUAGE, zen_get_language_name($oInfo->language_code, true)));
-}
                     $contents[] = array('text' => '<br>' . $oInfo->customers_email_address);
                     $contents[] = array('text' => TEXT_INFO_IP_ADDRESS . ' ' . $oInfo->ip_address);
                     if (zen_not_null($oInfo->last_modified)) {

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -954,7 +954,7 @@ if (zen_not_null($action) && $order_exists == true) {
                       <?php echo zen_draw_textarea_field('comments', 'soft', '60', '5', '', 'id="comments" class="editorHook form-control"');
                       // remind admin user of the order/customer language in case of writing a comment.
                       if (count(zen_get_languages()) > 1) {
-                          echo '<br>' . zen_get_language_icon($order->info['language_code']) . ' <strong>' . sprintf(TEXT_EMAIL_LANGUAGE, zen_get_language_name($order->info['language_code'])) . '</strong>';
+                          echo '<br>' . zen_get_language_icon($order->info['language_code']) . ' <strong>' . sprintf(TEXT_EMAIL_LANGUAGE, ucfirst(zen_get_language_name($order->info['language_code']))) . '</strong>';
                           echo zen_draw_hidden_field('admin_language', $_SESSION['languages_code']);
                       } ?>
                   </div>

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -1342,11 +1342,13 @@ if (zen_not_null($action) && $order_exists == true) {
                     // each contents array is drawn in a div, so this form block must be a single array element.
                     $contents[] = ['text' =>
                         zen_draw_form('statusUpdate', FILENAME_ORDERS, zen_get_all_get_params(['action','language']) . 'action=update_order' . (!isset($_GET['oID']) ? '&oID=' . $oInfo->orders_id : '') . '&language=' . $oInfo->language_code, 'post', '', true) . // form action uses the order language to change the session language on the update. On initial page load (from another page), $_GET['oID'] is not set, hence clause in form action
-                        zen_draw_hidden_field('listing', '1') . // identify that this form was submitted from infoBox/listing page and not the order details page (for the redirect to this same page)
+                        '<fieldset style="border:solid thin slategray;padding:5px"><legend style="width:inherit;">&nbsp;' . IMAGE_UPDATE . '&nbsp;</legend>' .
+                        zen_draw_hidden_field('listing', '1') . // identify that this form was submitted from the infoBox/listing page and not the Order Details page (to redirect to this same page)
                         ($oInfo->language_code !== $_SESSION['languages_code'] ? zen_draw_hidden_field('admin_language', $_SESSION['languages_code']) : '') . // if the order language is different to the current admin language, record the admin language, to restore it in the redirect after the status update email has been sent
-                        '<label class="form-group" style="margin:8px 0">' . BOX_TOOLS_MAIL . zen_draw_checkbox_field('notify', '1', $notify_email, '', 'style="vertical-align: middle;"') . '</label>' . "<br>\n" .
-                        '<label class="form-group" for="status">' . HEADING_TITLE_STATUS . '</label>' . zen_draw_order_status_dropdown('status', $oInfo->orders_status, '', 'onChange="this.form.submit();" id="status"') . "\n" .
-                        '</form>' . "\n"];
+                        '<label class="control-label" for="notify">' . BOX_TOOLS_MAIL . '</label> ' .
+                        zen_draw_checkbox_field('notify', '1', $notify_email, '', 'class="checkbox-inline" id="notify"') . "<br>\n" .
+                        '<label class="control-label" for="status">' . HEADING_TITLE_STATUS . '</label>' . zen_draw_order_status_dropdown('status', $oInfo->orders_status, '', 'onChange="this.form.submit();" id="status" class="form-control"') . "\n" .
+                        '</fieldset></form>' . "\n"];
 
                     $contents[] = array('text' => '<br>' . TEXT_DATE_ORDER_CREATED . ' ' . zen_date_short($oInfo->date_purchased));
                     if ($_SESSION['languages_code'] !== $oInfo->language_code) {

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -232,7 +232,7 @@ if (zen_not_null($action) && $order_exists == true) {
       break;
     case 'update_order':
       $oID = zen_db_prepare_input($_GET['oID']);
-      $comments = zen_db_prepare_input($_POST['comments']);
+      $comments = !empty($_POST['comments']) ? zen_db_prepare_input($_POST['comments']) : '';
       $admin_language = zen_db_prepare_input(isset($_POST['admin_language']) ? $_POST['admin_language'] : $_SESSION['languages_code']);
       $status = (int)$_POST['status'];
       if ($status < 1) {

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -320,10 +320,11 @@ if (zen_not_null($action) && $order_exists == true) {
         $messageStack->add_session(WARNING_ORDER_NOT_UPDATED, 'warning');
       }
 
+        $redirect = zen_href_link(FILENAME_ORDERS, zen_get_all_get_params(['action', 'language']) . ($admin_language !== $_SESSION['languages_code'] ? '&language=' . $admin_language : ''), 'NONSSL');
         if (isset($_POST['camefrom']) && $_POST['camefrom'] === 'orderEdit') {
-            zen_redirect(zen_href_link(FILENAME_ORDERS, zen_get_all_get_params(['action', 'language']) . 'action=edit' . ($admin_language !== $_SESSION['languages_code'] ? '&language=' . $admin_language : ''), 'NONSSL'));
+            $redirect .= '&action=edit';
         }
-        zen_redirect(zen_href_link(FILENAME_ORDERS, zen_get_all_get_params(['action', 'language']) . ($admin_language !== $_SESSION['languages_code'] ? 'language=' . $admin_language : ''), 'NONSSL'));
+        zen_redirect($redirect);
       break;
 
     case 'deleteconfirm':

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -1345,9 +1345,9 @@ if (zen_not_null($action) && $order_exists == true) {
                         '<fieldset style="border:solid thin slategray;padding:5px"><legend style="width:inherit;">&nbsp;' . IMAGE_UPDATE . '&nbsp;</legend>' .
                         zen_draw_hidden_field('listing', '1') . // identify that this form was submitted from the infoBox/listing page and not the Order Details page (to redirect to this same page)
                         ($oInfo->language_code !== $_SESSION['languages_code'] ? zen_draw_hidden_field('admin_language', $_SESSION['languages_code']) : '') . // if the order language is different to the current admin language, record the admin language, to restore it in the redirect after the status update email has been sent
-                        '<label class="control-label" for="notify">' . BOX_TOOLS_MAIL . '</label> ' .
+                        '<label class="control-label" for="notify">' . IMAGE_SEND_EMAIL . '</label> ' .
                         zen_draw_checkbox_field('notify', '1', $notify_email, '', 'class="checkbox-inline" id="notify"') . "<br>\n" .
-                        '<label class="control-label" for="status">' . HEADING_TITLE_STATUS . '</label>' . zen_draw_order_status_dropdown('status', $oInfo->orders_status, '', 'onChange="this.form.submit();" id="status" class="form-control"') . "\n" .
+                        '<label class="control-label" for="status">' . ENTRY_STATUS . '</label>' . zen_draw_order_status_dropdown('status', $oInfo->orders_status, '', 'onChange="this.form.submit();" id="status" class="form-control"') . "\n" .
                         '</fieldset></form>' . "\n"];
 
                     $contents[] = array('text' => '<br>' . TEXT_DATE_ORDER_CREATED . ' ' . zen_date_short($oInfo->date_purchased));

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -439,6 +439,11 @@ if (zen_not_null($action) && $order_exists == true) {
           window.open(url, 'popupWindow', 'toolbar=no,location=no,directories=no,status=no,menu bar=no,scrollbars=yes,resizable=yes,copyhistory=no,width=450,height=280,screenX=150,screenY=150,top=150,left=150')
       }
     </script>
+      <?php
+      if ($action === 'edit' && $editor_handler !== '') {
+          include ($editor_handler);
+      }
+      ?>
   </head>
   <body onLoad = "init()">
     <!-- header //-->
@@ -946,7 +951,7 @@ if (zen_not_null($action) && $order_exists == true) {
               <div class="form-group">
                   <?php echo zen_draw_label(TABLE_HEADING_COMMENTS, 'comments', 'class="col-sm-3 control-label"'); ?>
                   <div class="col-sm-9">
-                      <?php echo zen_draw_textarea_field('comments', 'soft', '60', '5', '', 'id="comments" class="form-control editorHook"');
+                      <?php echo zen_draw_textarea_field('comments', 'soft', '60', '5', '', 'id="comments" class="editorHook form-control"');
                       // remind admin user of the order/customer language in case of writing a comment.
                       if (count(zen_get_languages()) > 1) {
                           echo '<br>' . zen_get_language_icon($order->info['language_code']) . ' <strong>' . sprintf(TEXT_EMAIL_LANGUAGE, zen_get_language_name($order->info['language_code'])) . '</strong>';


### PR DESCRIPTION
I've been using a dirtier version of this for many moons, but based on language id, not code.
So while I've been pre-update modifying it to use language_code, I decided to put it out for persusal, while it's fresh in my mind. Maybe it's not ideal, but it works for me.

Two birds killed with this one, the infobox is modified to allow sending emails directly from it. Stolen from Quick Status Update long ago.

The form action includes the language parameter, and so 
if the admin language is different to the order language, the admin language is changed to the order language for the update/email sending, and restored back to the admin language on the redirect.
Single language sites should see nothing apart from the email option in the infoBox.

I modified the language lookups to allow lookup by code in addition to by id.

Also the email language is indicated by the comments box on the details page to remind the admin user to write in the correct language. This is surprisingly necessary for us!