### PR TITLE
Disable products_viewed tracking by default

### DIFF
--- a/includes/extra_datafiles/products_viewed_counter.php
+++ b/includes/extra_datafiles/products_viewed_counter.php
@@ -12,5 +12,5 @@
  * 'on' - triggers the default counter for products_viewed
  * 'off' - the default counter functionality is bypassed
  */
-  define('LEGACY_PRODUCTS_VIEWED_COUNTER', 'on');
+  define('LEGACY_PRODUCTS_VIEWED_COUNTER', 'off');
 


### PR DESCRIPTION
This will speed up db-internal caching and help improve performance on busy sites.
Caveat: the (rarely-used) products-viewed report in the Admin will not have any counter data to display.
Alternative: 3rd party analytics tracking tool is more beneficial.

Root cause: db schema deficiency causes race condition: when a product-page is visited, the record in the products table gets its viewed-counter updated, which makes the db's cache for that row no longer valid, which means it must redo its lookup of that record on the next visit instead of loading it from the db's internal cache. A schema change to put the field in another relational table would prevent the race condition. 
But an external analytics tool can track all this and much more, so better to use that instead.