### PR TITLE
Use Ask a Question for call for price

### DIFF
--- a/includes/functions/functions_general.php
+++ b/includes/functions/functions_general.php
@@ -865,7 +865,7 @@
       return $additional_link;
       break;
     case ($button_check->fields['product_is_call'] == '1'):
-      $return_button = '<a href="' . zen_href_link(FILENAME_CONTACT_US, '', 'SSL') . '">' . TEXT_CALL_FOR_PRICE . '</a>';
+      $return_button = '<a href="' . zen_href_link(FILENAME_ASK_A_QUESTION, 'products_id='.(int)$product_id, 'SSL') . '">' . TEXT_CALL_FOR_PRICE . '</a>';
       break;
     case ($button_check->fields['products_quantity'] <= 0 and SHOW_PRODUCTS_SOLD_OUT_IMAGE == '1'):
       if ($_GET['main_page'] == zen_get_info_page($product_id)) {


### PR DESCRIPTION
Instead of redirecting to the contact us page, redirect to the now built-in Ask a Question page, since the product information is available and can be used to save a step in this transaction.

Fixes #3341 

