### PR TITLE
php notice shipping estimate when no modules enabled

### DIFF
--- a/includes/templates/template_default/templates/tpl_modules_shipping_estimator.php
+++ b/includes/templates/template_default/templates/tpl_modules_shipping_estimator.php
@@ -11,7 +11,9 @@
 ?>
 <div id="shippingEstimatorContent">
 <?php echo zen_draw_form('estimator', zen_href_link($show_in . '#view', '', $request_type), 'post'); ?>
-<?php echo zen_draw_hidden_field('scid', $selected_shipping['id']); ?>
+<?php if (is_array($selected_shipping)) {
+    zen_draw_hidden_field('scid', $selected_shipping['id']);
+} ?>
 <?php echo zen_draw_hidden_field('action', 'submit'); ?>
 <?php
   if($_SESSION['cart']->count_contents()) {


### PR DESCRIPTION
fix for php notice when no shipping module selected/available: check existence of array first.
fixes #3433 