### PR TITLE
Force template column widths to use px units.

### DIFF
--- a/includes/templates/responsive_classic/common/tpl_main_page.php
+++ b/includes/templates/responsive_classic/common/tpl_main_page.php
@@ -53,7 +53,10 @@ if (!defined('IS_ADMIN_FLAG')) {
 
 
 
-// the following IF statement can be duplicated/modified as needed to set additional flags
+// the following statements can be modified as needed to set additional flags
+if (in_array($current_page_base,explode(",",'list_pages_to_skip_all_left_sideboxes_on_here,separated_by_commas,and_no_spaces')) ) {
+  $flag_disable_left = true;
+}
 if (in_array($current_page_base,explode(",",'list_pages_to_skip_all_right_sideboxes_on_here,separated_by_commas,and_no_spaces')) ) {
   $flag_disable_right = true;
 }

--- a/includes/templates/template_default/common/tpl_box_default_left.php
+++ b/includes/templates/template_default/common/tpl_box_default_left.php
@@ -16,7 +16,7 @@
 //
 ?>
 <!--// bof: <?php echo $box_id; ?> //-->
-<div class="leftBoxContainer" id="<?php echo str_replace('_', '-', $box_id ); ?>" style="width: <?php echo $column_width; ?>">
+<div class="leftBoxContainer" id="<?php echo str_replace('_', '-', $box_id ); ?>" style="width: <?php echo $column_width; ?>px">
 <h3 class="leftBoxHeading" id="<?php echo str_replace('_', '-', $box_id) . 'Heading'; ?>"><?php echo $title; ?></h3>
 <?php echo $content; ?>
 </div>

--- a/includes/templates/template_default/common/tpl_box_default_right.php
+++ b/includes/templates/template_default/common/tpl_box_default_right.php
@@ -16,7 +16,7 @@
 //
 ?>
 <!--// bof: <?php echo $box_id; ?> //-->
-<div class="rightBoxContainer" id="<?php echo str_replace('_', '-', $box_id ); ?>" style="width: <?php echo $column_width; ?>">
+<div class="rightBoxContainer" id="<?php echo str_replace('_', '-', $box_id ); ?>" style="width: <?php echo $column_width; ?>px">
 <h3 class="rightBoxHeading" id="<?php echo str_replace('_', '-', $box_id) . 'Heading'; ?>"><?php echo $title; ?></h3>
 <?php echo $content; ?>
 </div>

--- a/includes/templates/template_default/common/tpl_box_default_single.php
+++ b/includes/templates/template_default/common/tpl_box_default_single.php
@@ -16,7 +16,7 @@
 //
 ?>
 <!--// bof: <?php echo $box_id; ?> //-->
-<div class="singleBoxContainer" id="<?php echo str_replace('_', '-', $box_id ); ?>" style="width: <?php echo $column_width; ?>">
+<div class="singleBoxContainer" id="<?php echo str_replace('_', '-', $box_id ); ?>" style="width: <?php echo $column_width; ?>px">
 <h3 class="singleBoxHeading" id="<?php echo str_replace('_', '-', $box_id) . 'Heading'; ?>"><?php echo $title; ?></h3>
 <?php echo $content; ?>
 </div>

--- a/includes/templates/template_default/common/tpl_main_page.php
+++ b/includes/templates/template_default/common/tpl_main_page.php
@@ -97,14 +97,14 @@ if (COLUMN_LEFT_STATUS == 0 || (CUSTOMERS_APPROVAL == '1' and !zen_is_logged_in(
 if (!isset($flag_disable_left) || !$flag_disable_left) {
 ?>
 
- <td id="navColumnOne" class="columnLeft" style="width: <?php echo COLUMN_WIDTH_LEFT; ?>">
+ <td id="navColumnOne" class="columnLeft" style="width: <?php echo (int)COLUMN_WIDTH_LEFT; ?>px">
 <?php
  /**
   * prepares and displays left column sideboxes
   *
   */
 ?>
-<div id="navColumnOneWrapper" style="width: <?php echo BOX_WIDTH_LEFT; ?>"><?php require(DIR_WS_MODULES . zen_get_module_directory('column_left.php')); ?></div></td>
+<div id="navColumnOneWrapper" style="width: <?php echo (int)BOX_WIDTH_LEFT; ?>px"><?php require(DIR_WS_MODULES . zen_get_module_directory('column_left.php')); ?></div></td>
 <?php
 }
 ?>
@@ -154,14 +154,14 @@ if (COLUMN_RIGHT_STATUS == 0 || (CUSTOMERS_APPROVAL == '1' and !zen_is_logged_in
 }
 if (!isset($flag_disable_right) || !$flag_disable_right) {
 ?>
-<td id="navColumnTwo" class="columnRight" style="width: <?php echo COLUMN_WIDTH_RIGHT; ?>">
+<td id="navColumnTwo" class="columnRight" style="width: <?php echo (int)COLUMN_WIDTH_RIGHT; ?>"px>
 <?php
  /**
   * prepares and displays right column sideboxes
   *
   */
 ?>
-<div id="navColumnTwoWrapper" style="width: <?php echo BOX_WIDTH_RIGHT; ?>"><?php require(DIR_WS_MODULES . zen_get_module_directory('column_right.php')); ?></div></td>
+<div id="navColumnTwoWrapper" style="width: <?php echo (int)BOX_WIDTH_RIGHT; ?>"px><?php require(DIR_WS_MODULES . zen_get_module_directory('column_right.php')); ?></div></td>
 <?php
 }
 ?>


### PR DESCRIPTION
This avoids invalid contents due to tampering.
Templates that rely on different units can change the units if needed directly in their own template code that's already being heavily customized.