### PR TITLE
Add count_key for splitpageresults notifier

### DIFF
--- a/includes/modules/pages/featured_products/header_php.php
+++ b/includes/modules/pages/featured_products/header_php.php
@@ -34,10 +34,10 @@ $order_by;
 
 $featured_products_query_raw = $db->bindVars($featured_products_query_raw, ':languagesID', $_SESSION['languages_id'], 'integer');
 
-// Notifier Point
-$zco_notifier->notify('NOTIFY_FEATURED_PRODUCTS_SQL_STRING', array(), $featured_products_query_raw);
+$count_key = '*';
+$zco_notifier->notify('NOTIFY_FEATURED_PRODUCTS_SQL_STRING', array(), $featured_products_query_raw, $count_key);
 
-$featured_products_split = new splitPageResults($featured_products_query_raw, MAX_DISPLAY_PRODUCTS_FEATURED_PRODUCTS);
+$featured_products_split = new splitPageResults($featured_products_query_raw, MAX_DISPLAY_PRODUCTS_FEATURED_PRODUCTS, $count_key);
 
 //check to see if we are in normal mode ... not showcase, not maintenance, etc
 $show_submit = zen_run_normal();

--- a/includes/modules/pages/specials/main_template_vars.php
+++ b/includes/modules/pages/specials/main_template_vars.php
@@ -22,9 +22,10 @@ if (MAX_DISPLAY_SPECIAL_PRODUCTS > 0 ) {
 
   $specials_query_raw = $db->bindVars($specials_query_raw, ':languagesID', $_SESSION['languages_id'], 'integer');
   
-  $zco_notifier->notify('NOTIFY_SPECIALS_MAIN_TEMPLATE_VARS_SQL_STRING', array(), $specials_query_raw);
+  $count_key = '*';
+  $zco_notifier->notify('NOTIFY_SPECIALS_MAIN_TEMPLATE_VARS_SQL_STRING', array(), $specials_query_raw, $count_key);
   
-  $specials_split = new splitPageResults($specials_query_raw, MAX_DISPLAY_SPECIAL_PRODUCTS);
+  $specials_split = new splitPageResults($specials_query_raw, MAX_DISPLAY_SPECIAL_PRODUCTS, $count_key);
   $specials = $db->Execute($specials_split->sql_query);
   $row = 0;
   $col = 0;


### PR DESCRIPTION
There are some queries that require providing a specific field or set of fields when splitting the page results.  While this edit does not add all available parameters of the `splitPageResults` class, it does add the next one.  At this time, the parameters to the class are: `$query, $max_rows, $count_key = '*', $page_holder = 'page', $debug = false, $countQuery = ""` with the first two already considered in the previous code.