### PR TITLE
Rename $_SESSION['check_valid'] and switch to boolean

### DIFF
--- a/includes/init_includes/init_sanitize.php
+++ b/includes/init_includes/init_sanitize.php
@@ -138,19 +138,19 @@
 /**
  * validate products_id for search engines and bookmarks, etc.
  */
-  if (isset($_GET['products_id']) && (!isset($_SESSION['check_valid']) || $_SESSION['check_valid'] != 'false')) {
+  if (isset($_GET['products_id']) && (!isset($_SESSION['check_valid_prod']) || $_SESSION['check_valid_prod'] != false)) {
     $check_valid = zen_products_id_valid($_GET['products_id']) && !empty($_GET['main_page']);
     if (!$check_valid) {
       $_GET['main_page'] = zen_get_info_page($_GET['products_id']);
       /**
        * do not recheck redirect
        */
-      $_SESSION['check_valid'] = 'false';
+      $_SESSION['check_valid_prod'] = false;
       zen_redirect(zen_href_link($_GET['main_page'], 'products_id=' . $_GET['products_id']));
     }
   }
  
-  $_SESSION['check_valid'] = 'true';
+  $_SESSION['check_valid_prod'] = true;
 /**
  * We do some checks here to ensure $_GET['main_page'] has a sane value
  */


### PR DESCRIPTION
There's no need for these to be strings.

Caveat: upgraders who have written custom code which relies on this variable will get false positives until they change their code to refer to the new variable name and check for boolean.

Two plugins affected: `FAQ Manager` and `360 view`