### PR TITLE
Fix Color Contrast in Responsive_Classic

### DIFF
--- a/includes/templates/responsive_classic/css/stylesheet_colors.css
+++ b/includes/templates/responsive_classic/css/stylesheet_colors.css
@@ -1,17 +1,17 @@
 /*bof font colors*/
 body, .messageStackSuccess, .messageStackCaution, #tagline, #productQuantityDiscounts table, .categoryListBoxContents a, h2.greeting a {color:#000000;}
-a:link, #navEZPagesTOC ul li a, a:hover, #navEZPagesTOC ul li a:hover, #navMain ul li a:hover, #navSupp ul li a:hover, .sideBoxContent a:visited, fieldset fieldset legend, #navBreadCrumb a:visited, #siteinfoLegal a, h3.rightBoxHeading a:hover, h3.leftBoxHeading a:hover, .cartTotalDisplay, .cartOldItem, .specialsListBoxContents, .centerBoxContentsSpecials, .centerBoxContentsAlsoPurch, .centerBoxContentsFeatured, .centerBoxContentsNew, .list-price, .itemTitle a, h2.greeting, #icon, h1, .header .fa-bars {color:#05a5cb;}
+a:link, #navEZPagesTOC ul li a, a:hover, #navEZPagesTOC ul li a:hover, #navMain ul li a:hover, #navSupp ul li a:hover, .sideBoxContent a:visited, fieldset fieldset legend, #navBreadCrumb a:visited, #siteinfoLegal a, h3.rightBoxHeading a:hover, h3.leftBoxHeading a:hover, .cartTotalDisplay, .cartOldItem, .specialsListBoxContents, .centerBoxContentsSpecials, .centerBoxContentsAlsoPurch, .centerBoxContentsFeatured, .centerBoxContentsNew, .list-price, .itemTitle a, h2.greeting, #icon, h1, .header .fa-bars {color:#364fb5;}
 a:visited, .cat-count, .itemTitle a:hover, h2.greeting a:hover {color:#666;}
 a:active {color:#0000ff;}
-h2, h3, .cartAttribsList, #cart-box {color:#444;}
-.blue{color:#05a5cb !important;}
+h2, h3, .cartAttribsList, #cart-box {color:#000000;}
+.blue{color:#364fb5 !important;}
 .blue:hover{color:#036f89 !important;}
 .alert {color: #8b0000;}
 legend, .specialsListBoxContents a, .centerBoxContentsAlsoPurch a, .centerBoxContentsFeatured a, .centerBoxContentsSpecials a, .centerBoxContentsNew a, .productPriceDiscount{color:#333;}
 .messageStackWarning, .messageStackError, #navMainWrapper, #navMain ul li a, #navCatTabsWrapper, #navCatTabs li a, #navCatTabs li a:hover, #navCatTabs li:hover, #navEZPagesTop, #navEZPagesTop li a, .pagination li a, #navSuppWrapper, #navSupp li a, #siteinfoIP, #siteinfoLegal, #bannerSix, #siteinfoLegal a:hover, h2.centerBoxHeading, h3.rightBoxHeading, h3.leftBoxHeading, h3.rightBoxHeading a, h3.leftBoxHeading a, .seDisplayedAddressLabel, TR.tableHeading, #shippingEstimatorContent h2, #shippingEstimatorContent th, #checkoutConfirmDefault .cartTableHeading, #filter-wrapper, .navSplitPagesLinks a, .current, .productListing-rowheading a, .productListing-rowheading a, .prod-list-wrap, #productQuantityDiscounts table tr:first-child td, #reviewsWriteHeading, #sendSpendWrapper h2, #accountDefault #sendSpendWrapper h2, #gvFaqDefaultSubHeading, #checkoutPayAddressDefaultAddress, #checkoutShipAddressDefaultAddress, #accountLinksWrapper h2, h2#addressBookDefaultPrimary, #myAccountPaymentInfo h3, #myAccountShipInfo h3, #myAccountPaymentInfo h4, #myAccountShipInfo h4, input.submit_button, input.submit_button:hover, input.cssButtonHover, span.normal_button{color: #ffffff;}
 .cartNewItem {color:#33cc33;}
-.productSpecialPrice, .productSalePrice, .productSpecialPriceSale, .productPriceDiscount {color:#ff0000;}
-.categoryListBoxContents a:hover, .categoryListBoxContents:hover a{color:#05a5bc;}
+.productSpecialPrice, .productSalePrice, .productSpecialPriceSale, .productPriceDiscount {color:#900404;}
+.categoryListBoxContents a:hover, .categoryListBoxContents:hover a{color:#364fb5;}
 .list-more{color:#fff !important;}
 
 /*bof background colors*/
@@ -31,9 +31,9 @@ span.cssButton.normal_button.button.button_logoff, span.cssButton.normal_button.
 .messageStackWarning, .messageStackError {background-color:#8b0000;}
 .messageStackSuccess {background-color:#99ff99;}
 #shippingEstimatorContent th, .navSplitPagesLinks a:hover, .productListing-rowheading, #productQuantityDiscounts table tr:first-child td{background:#999;}
-#navCatTabsWrapper, .current, .productListing-rowheading a, .list-more:hover, input.submit_button, span.normal_button {background:#05a5cb;}
+#navCatTabsWrapper, .current, .productListing-rowheading a, .list-more:hover, input.submit_button, span.normal_button {background:#364fb5;}
 .button_goto_prod_details:hover{background:#05a5cb !important;}
-#navCatTabs li a:hover, input.submit_button:hover, input.cssButtonHover {background:#028fba;}
+#navCatTabs li a:hover, input.submit_button:hover, input.cssButtonHover {background:#666666;}
 #filter-wrapper, span.normal_button:hover, span.cssButton.normal_button.button.button_goto_prod_details{background:#000;}
 #docGeneralDisplay #pinfo-right, #popupShippingEstimator, #popupSearchHelp, #popupAdditionalImage, #popupImage, #popupCVVHelp, #popupCouponHelp, #popupAtrribsQuantityPricesHelp, #infoShoppingCart{background:none;}
 
@@ -58,4 +58,4 @@ ol.list-links li{border-bottom:1px solid #ddd;}
 /*bof placeholders*/
 ::-moz-placeholder, :-moz-placeholder, ::-webkit-input-placeholder, :-ms-input-placeholder, :placeholder-shown {color: #D01;}
 
-
+#siteinfoLegal a{color:#ffffff;}


### PR DESCRIPTION
The colors for the present responsive_classic stylesheets_colors.css do not meet the standards for readability in accessibility tests.
An example of where it stood can be seen by going to //webaim.org/resources/contrastchecker/.  Enter #FFFFFF on the right and #05A5CB on the left.  The contrast ratio is 2.89:1 which fails all five situations.  Changing #05A5CB to #364fb5 results in a 7.13:1 ratio and passes all situations in which the font might be used.
Also, changing the hover color for the navCatTabs menu is required to up the contrast during a hover over that menu.
There are other colors affected as well.  One would think that red on white would not be a problem.   Yet, replace the #364fb5 with #FF0000 (red), and the ratio is 3.99:1.  Another fail.  Thus, the standard for specials and special pricing actually makes it difficult for some folks to read the text/price.
This PR is not meant to "cure" anything but the color contrast and therefore only affects includes/templates/responsive_classic/css/stylesheet_colors.css.
It is meant to provide anyone wishing to use the template to have no color contrast hits in accessibility and SEO.

<img width="1430" alt="Screen Shot 2020-05-17 at 2 28 02 PM" src="https://user-images.githubusercontent.com/404472/82156682-adda7b00-984a-11ea-948e-b6871f963fcb.png">
