### PR TITLE
Admin-template select: revision for clarifications

### DIFF
--- a/admin/includes/languages/english/template_select.php
+++ b/admin/includes/languages/english/template_select.php
@@ -1,45 +1,41 @@
 <?php
-//
-// +----------------------------------------------------------------------+
-// |zen-cart Open Source E-commerce                                       |
-// +----------------------------------------------------------------------+
-// | Copyright (c) 2003 The zen-cart developers                           |
-// |                                                                      |
-// | http://www.zen-cart.com/index.php                                    |
-// |                                                                      |
-// | Portions Copyright (c) 2003 osCommerce                               |
-// +----------------------------------------------------------------------+
-// | This source file is subject to version 2.0 of the GPL license,       |
-// | that is bundled with this package in the file LICENSE, and is        |
-// | available through the world-wide-web at the following url:           |
-// | http://www.zen-cart.com/license/2_0.txt.                             |
-// | If you did not receive a copy of the zen-cart license and are unable |
-// | to obtain it through the world-wide-web, please send a note to       |
-// | license@zen-cart.com so we can mail you a copy immediately.          |
-// +----------------------------------------------------------------------+
-//  $Id: template_select.php 1105 2005-04-04 22:05:35Z birdbrain $
-//
+/**
+ * @package admin
+ * @copyright Copyright 2003-2020 Zen Cart Development Team
+ * @copyright Portions Copyright 2003 osCommerce
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id:  Modified in v1.5.7 $
+ */
 
 define('HEADING_TITLE', 'Template Selection');
+define('TEXT_TEMPLATE_SELECT_INFO', '<p>A different template may be assigned to each of the installed languages.<br>The default template is used when there is no template assigned to that language.</p>
+<p>It is possible to view a template in a <em>private</em> session, for example when testing a new template:</p>
+<ol>
+<li>Assign the current/active template to <strong>all</strong> of the installed languages.</li>
+<li>Assign the new template as the Default.</li>
+<li>Add your (admin) IP address to <a href="index.php?cmd=configuration&gID=20&cID=458&action=edit">Configuration->Website Maintenance->Down For Maintenance (exclude this IP-Address)</a>.</li>
+<li>When viewing the shop front, to override the template display, add "&amp;t=new_template_directory_name" to the page url. This override will persist for the duration of the session. Use private browsing/incognito tabs to create separate sessions/use different templates.</li>
+<li>Add "&amp;t=off" to the page url to cancel the session override.</li>
+</ol></ul>');
 
 define('TABLE_HEADING_LANGUAGE', 'Template Language');
 define('TABLE_HEADING_NAME', 'Template Name');
 define('TABLE_HEADING_DIRECTORY', 'Template Directory');
 define('TABLE_HEADING_ACTION', 'Action');
 
+define('TEXT_INFO_HEADING_LANGUAGE', 'Language');
 define('TEXT_INFO_DEFAULT_LANGUAGE', 'Default (any)');
+define('TEXT_INFO_DEFAULT_TEMPLATE', 'This template is used by default / when an installed language does not have an assigned template.');
 define('TEXT_INFO_HEADING_EDIT_TEMPLATE', 'Edit Template Settings');
 define('TEXT_INFO_HEADING_DELETE_TEMPLATE', 'Delete Template association');
-define('TEXT_INFO_EDIT_INTRO', 'Change the template');
-define('TEXT_INFO_DELETE_INTRO', 'Delete this association');
+define('TEXT_INFO_EDIT_INTRO', 'Change the Template');
+define('TEXT_INFO_DELETE_INTRO', 'Delete this template-language association');
 define('TEXT_INFO_TEMPLATE_NAME', 'Template Name');
 define('TEXT_INFO_LANGUAGE_NAME', 'Language Name');
-define('TEXT_INFO_TEMPLATE_VERSION', 'Template Version : ');
-define('TEXT_INFO_TEMPLATE_AUTHOR', 'Template Author : ');
-define('TEXT_INFO_TEMPLATE_DESCRIPTION', 'Template Description');
-define('TEXT_INFO_TEMPLATE_INSTALLED', 'Templates Installed');
-define('TEXT_INFO_HEADING_NEW_TEMPLATE', 'Associate Template with language');
+define('TEXT_INFO_TEMPLATE_VERSION', 'Template Version: ');
+define('TEXT_INFO_TEMPLATE_AUTHOR', 'Template Author: ');
+define('TEXT_INFO_TEMPLATE_DESCRIPTION', 'Template Description:');
+define('TEXT_INFO_TEMPLATE_INSTALLED', 'Templates Available');
+define('TEXT_INFO_HEADING_NEW_TEMPLATE', 'Associate Template with a language');
 define('TEXT_INFO_INSERT_INTRO', 'Choose below to associate a template with a language');
 define('IMAGE_NEW_TEMPLATE', 'Create a new template/language association');
-
-?>

--- a/admin/includes/languages/english/template_select.php
+++ b/admin/includes/languages/english/template_select.php
@@ -8,14 +8,14 @@
  */
 
 define('HEADING_TITLE', 'Template Selection');
-define('TEXT_TEMPLATE_SELECT_INFO', '<p>Here you may change the template used to format the Shopfront.</p><p>A different template may be assigned to each of the installed languages. The default template is used when there is no specific template assigned to a language.</p><p>It is possible to view a template in a <em>private</em> session, for example when testing a new template: see the online Help <strong>?</strong>.</p>');
+define('TEXT_INFO_DEFAULT_LANGUAGE', 'Default (all)');
+define('TEXT_TEMPLATE_SELECT_INFO', '<p>Here you may change the template used to format the storefront.</p><p>The "' . TEXT_INFO_DEFAULT_LANGUAGE . '" template is normally used for <strong>all</strong> the installed languages (although a different template may optionally be assigned).</p><p>It is possible to view a template in a <em>private</em> session, for example when testing a new template: see the online Help <strong>?</strong></p>');
 define('TABLE_HEADING_LANGUAGE', 'Template Language');
 define('TABLE_HEADING_NAME', 'Template Name');
 define('TABLE_HEADING_DIRECTORY', 'Template Directory');
 define('TABLE_HEADING_ACTION', 'Action');
 
 define('TEXT_INFO_HEADING_LANGUAGE', 'Language');
-define('TEXT_INFO_DEFAULT_LANGUAGE', 'Default (any)');
 define('TEXT_INFO_DEFAULT_TEMPLATE', 'This template is used by default / when an installed language does not have an assigned template.');
 define('TEXT_INFO_HEADING_EDIT_TEMPLATE', 'Edit Template Settings');
 define('TEXT_INFO_HEADING_DELETE_TEMPLATE', 'Delete Template association');

--- a/admin/includes/languages/english/template_select.php
+++ b/admin/includes/languages/english/template_select.php
@@ -9,7 +9,7 @@
 
 define('HEADING_TITLE', 'Template Selection');
 define('TEXT_INFO_DEFAULT_LANGUAGE', 'Default (all)');
-define('TEXT_TEMPLATE_SELECT_INFO', '<p>Here you may change the template used to format the storefront.</p><p>The "' . TEXT_INFO_DEFAULT_LANGUAGE . '" template is normally used for <strong>all</strong> the installed languages (although a different template may optionally be assigned).</p><p>It is possible to view a template in a <em>private</em> session, for example when testing a new template: see the online Help <strong>?</strong></p>');
+define('TEXT_TEMPLATE_SELECT_INFO', '<p>Here you may change the template used to display the storefront.</p><p>The default template is normally used for <strong>all</strong> languages. Adding template-to-language assignments is typically only useful when supporting RTL languages alongside LTR languages.</p><p>It is possible to view a template in a <em>private</em> session, for example when testing a new template: see the online Help <strong>?</strong></p>');
 define('TABLE_HEADING_LANGUAGE', 'Template Language');
 define('TABLE_HEADING_NAME', 'Template Name');
 define('TABLE_HEADING_DIRECTORY', 'Template Directory');

--- a/admin/includes/languages/english/template_select.php
+++ b/admin/includes/languages/english/template_select.php
@@ -27,6 +27,7 @@ define('TABLE_HEADING_NAME', 'Template Name');
 define('TABLE_HEADING_DIRECTORY', 'Template Directory');
 define('TABLE_HEADING_ACTION', 'Action');
 
+define('TEXT_INFO_DEFAULT_LANGUAGE', 'Default (any)');
 define('TEXT_INFO_HEADING_EDIT_TEMPLATE', 'Edit Template Settings');
 define('TEXT_INFO_HEADING_DELETE_TEMPLATE', 'Delete Template association');
 define('TEXT_INFO_EDIT_INTRO', 'Change the template');

--- a/admin/includes/languages/english/template_select.php
+++ b/admin/includes/languages/english/template_select.php
@@ -8,16 +8,8 @@
  */
 
 define('HEADING_TITLE', 'Template Selection');
-define('TEXT_TEMPLATE_SELECT_INFO', '<p>A different template may be assigned to each of the installed languages.<br>The default template is used when there is no template assigned to that language.</p>
-<p>It is possible to view a template in a <em>private</em> session, for example when testing a new template:</p>
-<ol>
-<li>Assign the current/active template to <strong>all</strong> of the installed languages.</li>
-<li>Assign the new template as the Default.</li>
-<li>Add your (admin) IP address to <a href="index.php?cmd=configuration&gID=20&cID=458&action=edit">Configuration->Website Maintenance->Down For Maintenance (exclude this IP-Address)</a>.</li>
-<li>When viewing the shop front, to override the template display, add "&amp;t=new_template_directory_name" to the page url. This override will persist for the duration of the session. Use private browsing/incognito tabs to create separate sessions/use different templates.</li>
-<li>Add "&amp;t=off" to the page url to cancel the session override.</li>
-</ol></ul>');
-
+define('TEXT_TEMPLATE_SELECT_INFO', '<p>A different template may be assigned to each of the installed languages.<br>The default template is used when there is no template assigned to that language.</p><p>It is possible to view a template in a <em>private</em> session, for example when testing a new template:</p>
+<ol><li>Assign the current/active template to <strong>all</strong> of the installed languages.</li><li>Assign the new template as the Default.</li><li>Add your (admin) IP address to Configuration->Website Maintenance->Down For Maintenance (exclude this IP-Address).</li><li>When viewing the shop front, to override the template display, add "&amp;t=new_template_directory_name" to the page url. This override will persist for the duration of the session. Use private browsing/incognito tabs to create separate sessions/use different templates.</li> <li>Add "&amp;t=off" to the page url to cancel the session override.</li> </ol></ul>');
 define('TABLE_HEADING_LANGUAGE', 'Template Language');
 define('TABLE_HEADING_NAME', 'Template Name');
 define('TABLE_HEADING_DIRECTORY', 'Template Directory');

--- a/admin/includes/languages/english/template_select.php
+++ b/admin/includes/languages/english/template_select.php
@@ -8,8 +8,7 @@
  */
 
 define('HEADING_TITLE', 'Template Selection');
-define('TEXT_TEMPLATE_SELECT_INFO', '<p>A different template may be assigned to each of the installed languages.<br>The default template is used when there is no template assigned to that language.</p><p>It is possible to view a template in a <em>private</em> session, for example when testing a new template:</p>
-<ol><li>Assign the current/active template to <strong>all</strong> of the installed languages.</li><li>Assign the new template as the Default.</li><li>Add your (admin) IP address to Configuration->Website Maintenance->Down For Maintenance (exclude this IP-Address).</li><li>When viewing the shop front, to override the template display, add "&amp;t=new_template_directory_name" to the page url. This override will persist for the duration of the session. Use private browsing/incognito tabs to create separate sessions/use different templates.</li> <li>Add "&amp;t=off" to the page url to cancel the session override.</li> </ol></ul>');
+define('TEXT_TEMPLATE_SELECT_INFO', '<p>Here you may change the template used to format the Shopfront.</p><p>A different template may be assigned to each of the installed languages. The default template is used when there is no specific template assigned to a language.</p><p>It is possible to view a template in a <em>private</em> session, for example when testing a new template: see the online Help <strong>?</strong>.</p>');
 define('TABLE_HEADING_LANGUAGE', 'Template Language');
 define('TABLE_HEADING_NAME', 'Template Name');
 define('TABLE_HEADING_DIRECTORY', 'Template Directory');

--- a/admin/template_select.php
+++ b/admin/template_select.php
@@ -145,6 +145,10 @@ if (zen_not_null($action)) {
             ?>
             </tbody>
           </table>
+            <div class="row">
+                <div><?php echo $template_split->display_count($template_query_numrows, MAX_DISPLAY_SEARCH_RESULTS, $_GET['page'], TEXT_DISPLAY_NUMBER_OF_TEMPLATES); ?></div>
+                <div class="text-right"><?php echo $template_split->display_links($template_query_numrows, MAX_DISPLAY_SEARCH_RESULTS, MAX_DISPLAY_PAGE_LINKS, $_GET['page']); ?></div>
+            </div>
         </div>
         <div class="col-xs-12 col-sm-12 col-md-3 col-lg-3 configurationColumnRight">
             <?php
@@ -229,13 +233,6 @@ if (zen_not_null($action)) {
             }
             ?>
         </div>
-      </div>
-      <div class="row">
-        <table class="table">
-          <tr>
-            <td><?php echo $template_split->display_count($template_query_numrows, MAX_DISPLAY_SEARCH_RESULTS, $_GET['page'], TEXT_DISPLAY_NUMBER_OF_TEMPLATES); ?></td>
-            <td class="text-right"><?php echo $template_split->display_links($template_query_numrows, MAX_DISPLAY_SEARCH_RESULTS, MAX_DISPLAY_PAGE_LINKS, $_GET['page']); ?></td>
-          </tr>
           <?php
           if (empty($action)) {
             ?>

--- a/admin/template_select.php
+++ b/admin/template_select.php
@@ -174,8 +174,7 @@ if (zen_not_null($action)) {
                     'id' => $key,
                     'text' => $value['name']];
                 }
-                $lns = $db->Execute("SELECT name, languages_id
-                                     FROM " . TABLE_LANGUAGES);
+                $lns = $db->Execute("SELECT lng.name, lng.languages_id FROM " . TABLE_LANGUAGES . " lng WHERE lng.languages_id NOT IN (SELECT tms.template_language FROM " . TABLE_TEMPLATE_SELECT . " tms)");
                 foreach ($lns as $ln) {
                   $language_array[] = [
                     'text' => $ln['name'],

--- a/admin/template_select.php
+++ b/admin/template_select.php
@@ -181,8 +181,8 @@ if (zen_not_null($action)) {
                     'text' => $ln['name'],
                     'id' => $ln['languages_id']];
                 }
-                $contents[] = ['text' => '<br>' . zen_draw_label(TEXT_INFO_TEMPLATE_NAME, 'ln', 'class="control-label"') . zen_draw_pull_down_menu('ln', $template_array, '', 'class="form-control"')];
-                $contents[] = ['text' => '<br>' . zen_draw_label(TEXT_INFO_LANGUAGE_NAME, 'lang', 'class="control-label"') . zen_draw_pull_down_menu('lang', $language_array, '', 'class="form-control"')];
+                $contents[] = ['text' => zen_draw_label(TEXT_INFO_TEMPLATE_NAME, 'ln', 'class="control-label"') . zen_draw_pull_down_menu('ln', $template_array, '', 'class="form-control" id="ln"')];
+                $contents[] = ['text' => zen_draw_label(TEXT_INFO_LANGUAGE_NAME, 'lang', 'class="control-label"') . zen_draw_pull_down_menu('lang', $language_array, '', 'class="form-control" id="lang"')];
                 $contents[] = ['align' => 'text-center', 'text' => '<br><button type="submit" class="btn btn-primary">' . IMAGE_INSERT . '</button> <a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page']) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>'];
                 break;
 
@@ -194,7 +194,7 @@ if (zen_not_null($action)) {
                 foreach($template_info as $key => $value) {
                   $template_array[] = ['id' => $key, 'text' => $value['name']];
                 }
-                $contents[] = ['text' => '<br>' . zen_draw_label(TEXT_INFO_TEMPLATE_NAME, 'ln', 'class="control-label"') . zen_draw_pull_down_menu('ln', $template_array, $templates->fields['template_dir'], 'class="form-control"')];
+                $contents[] = ['text' => zen_draw_label(TEXT_INFO_TEMPLATE_NAME, 'ln', 'class="control-label"') . zen_draw_pull_down_menu('ln', $template_array, $templates->fields['template_dir'], 'class="form-control" id="ln"')];
                 $contents[] = ['align' => 'text-center', 'text' => '<br><button type="submit" class="btn btn-primary">' . IMAGE_UPDATE . '</button> <a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>'];
                 break;
 

--- a/admin/template_select.php
+++ b/admin/template_select.php
@@ -120,11 +120,15 @@ if (zen_not_null($action)) {
                     $tInfo = new objectInfo($template);
                   }
 
-                  if (isset($tInfo) && is_object($tInfo) && ($template['template_id'] == $tInfo->template_id)) {
-                    echo '              <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href=\'' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id . '&action=edit') . '\'" role="button">' . "\n";
-                  } else {
-                    echo '              <tr class="dataTableRow" onclick="document.location.href=\'' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $template['template_id']) . '\'" role="button">' . "\n";
-                  }
+                    if (isset($tInfo) && is_object($tInfo) && ($template['template_id'] == $tInfo->template_id)) {
+                        if ($action === 'edit') { ?>
+                            <tr id="defaultSelected" class="dataTableRowSelected">
+                        <?php } else { ?>
+                            <tr id="defaultSelected" class="dataTableRowSelected" style="cursor:pointer" onclick="document.location.href='<?php echo zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id . '&action=edit'); ?>'">
+                        <?php }
+                    } else { ?>
+                        <tr class="dataTableRow" style="cursor:pointer" onclick="document.location.href='<?php echo zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $template['template_id']); ?>'">
+                    <?php }
                   if ($template['template_language'] == 0) {
                     $template_language = "Default(All)";
                   } else {

--- a/admin/template_select.php
+++ b/admin/template_select.php
@@ -85,6 +85,7 @@ if (zen_not_null($action)) {
     <!-- body //-->
     <div class="container-fluid">
       <h1><?php echo HEADING_TITLE; ?></h1>
+      <div class="row"><?php echo TEXT_TEMPLATE_SELECT_INFO;?></div>
       <div class="row">
         <!-- body_text //-->
         <div class="col-xs-12 col-sm-12 col-md-9 col-lg-9 configurationColumnLeft">
@@ -147,6 +148,14 @@ if (zen_not_null($action)) {
         </div>
         <div class="col-xs-12 col-sm-12 col-md-3 col-lg-3 configurationColumnRight">
             <?php
+            if (isset($tInfo) && is_object($tInfo)) {
+                if ($tInfo->template_language == '0') {
+                    $template_language = TEXT_INFO_DEFAULT_LANGUAGE;
+                } else {
+                    $ln = $db->Execute("SELECT name FROM " . TABLE_LANGUAGES . " WHERE languages_id = " . (int)$tInfo->template_language);
+                    $template_language = $ln->fields['name'];
+                }
+            }
             $heading = [];
             $contents = [];
 
@@ -174,7 +183,7 @@ if (zen_not_null($action)) {
                 break;
 
               case 'edit':
-                $heading[] = ['text' => '<h4>' . TEXT_INFO_HEADING_EDIT_TEMPLATE . '</h4>'];
+                $heading[] = ['text' => '<h4>' . TABLE_HEADING_LANGUAGE . ': '  . $template_language . '</h4>'];
 
                 $contents = ['form' => zen_draw_form('templateselect', FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id . '&action=save', 'post', 'class="form-horizontal"')];
                 $contents[] = ['text' => TEXT_INFO_EDIT_INTRO];
@@ -186,7 +195,7 @@ if (zen_not_null($action)) {
                 break;
 
               case 'delete':
-                $heading[] = ['text' => '<h4>' . TEXT_INFO_HEADING_DELETE_TEMPLATE . '</h4>'];
+                $heading[] = ['text' => '<h4>' . TABLE_HEADING_LANGUAGE . ': '  . $template_language . '</h4>'];
 
                 $contents = ['form' => zen_draw_form('zones', FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&action=deleteconfirm') . zen_draw_hidden_field('tID', $tInfo->template_id)];
                 $contents[] = ['text' => TEXT_INFO_DELETE_INTRO];
@@ -196,7 +205,7 @@ if (zen_not_null($action)) {
 
               default:
                 if (isset($tInfo) && is_object($tInfo)) {
-                  $heading[] = ['text' => '<h4>' . $template_info[$tInfo->template_dir]['name'] . '</h4>'];
+                 $heading[] = ['text' => '<h4>' . TABLE_HEADING_LANGUAGE . ': '  . $template_language . '</h4>'];
 
                   if ($tInfo->template_language == 0) {
                     $contents[] = ['align' => 'text-center', 'text' => '<a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id . '&action=edit') . '" class="btn btn-primary" role="button">' . IMAGE_EDIT . '</a>'];

--- a/admin/template_select.php
+++ b/admin/template_select.php
@@ -118,7 +118,7 @@ if (zen_not_null($action)) {
                         <tr class="dataTableRow" style="cursor:pointer" onclick="document.location.href='<?php echo zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $template['template_id']); ?>'">
                     <?php }
                   if ($template['template_language'] == '0') {
-                    $template_language = "Default(All)";
+                    $template_language = TEXT_INFO_DEFAULT_LANGUAGE;
                   } else {
                     $ln = $db->Execute("SELECT name
                                         FROM " . TABLE_LANGUAGES . "

--- a/admin/template_select.php
+++ b/admin/template_select.php
@@ -74,23 +74,9 @@ if (zen_not_null($action)) {
 <!doctype html>
 <html <?php echo HTML_PARAMS; ?>>
   <head>
-    <meta charset="<?php echo CHARSET; ?>">
-    <title><?php echo TITLE; ?></title>
-    <link rel="stylesheet" type="text/css" href="includes/stylesheet.css">
-    <link rel="stylesheet" type="text/css" href="includes/cssjsmenuhover.css" media="all" id="hoverJS">
-    <script src="includes/menu.js"></script>
-    <script src="includes/general.js"></script>
-    <script>
-      function init() {
-          cssjsmenu('navbar');
-          if (document.getElementById) {
-              var kill = document.getElementById('hoverJS');
-              kill.disabled = true;
-          }
-      }
-    </script>
+      <?php require DIR_WS_INCLUDES . 'admin_html_head.php'; ?>
   </head>
-  <body onLoad="init()">
+  <body>
     <!-- header //-->
     <?php require(DIR_WS_INCLUDES . 'header.php'); ?>
     <!-- header_eof //-->

--- a/admin/template_select.php
+++ b/admin/template_select.php
@@ -183,7 +183,7 @@ if (zen_not_null($action)) {
                 }
                 $contents[] = ['text' => zen_draw_label(TEXT_INFO_TEMPLATE_NAME, 'ln', 'class="control-label"') . zen_draw_pull_down_menu('ln', $template_array, '', 'class="form-control" id="ln"')];
                 $contents[] = ['text' => zen_draw_label(TEXT_INFO_LANGUAGE_NAME, 'lang', 'class="control-label"') . zen_draw_pull_down_menu('lang', $language_array, '', 'class="form-control" id="lang"')];
-                $contents[] = ['align' => 'text-center', 'text' => '<br><button type="submit" class="btn btn-primary">' . IMAGE_INSERT . '</button> <a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page']) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>'];
+                $contents[] = ['align' => 'text-center', 'text' => '<button type="submit" class="btn btn-primary">' . IMAGE_INSERT . '</button> <a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page']) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>'];
                 break;
 
               case 'edit':
@@ -195,7 +195,7 @@ if (zen_not_null($action)) {
                   $template_array[] = ['id' => $key, 'text' => $value['name']];
                 }
                 $contents[] = ['text' => zen_draw_label(TEXT_INFO_TEMPLATE_NAME, 'ln', 'class="control-label"') . zen_draw_pull_down_menu('ln', $template_array, $templates->fields['template_dir'], 'class="form-control" id="ln"')];
-                $contents[] = ['align' => 'text-center', 'text' => '<br><button type="submit" class="btn btn-primary">' . IMAGE_UPDATE . '</button> <a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>'];
+                $contents[] = ['align' => 'text-center', 'text' => '<button type="submit" class="btn btn-primary">' . IMAGE_UPDATE . '</button> <a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>'];
                 break;
 
               case 'delete':
@@ -203,23 +203,25 @@ if (zen_not_null($action)) {
 
                 $contents = ['form' => zen_draw_form('zones', FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&action=deleteconfirm') . zen_draw_hidden_field('tID', $tInfo->template_id)];
                 $contents[] = ['text' => TEXT_INFO_DELETE_INTRO];
-                $contents[] = ['text' => '<br><b>' . $template_info[$tInfo->template_dir]['name'] . '</b>'];
-                $contents[] = ['align' => 'text-center', 'text' => '<br><button type="submit" class="btn btn-danger">' . IMAGE_DELETE . '</button> <a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>'];
+                $contents[] = ['text' => '<b>' . $template_info[$tInfo->template_dir]['name'] . '</b>'];
+                $contents[] = ['align' => 'text-center', 'text' => '<button type="submit" class="btn btn-danger">' . IMAGE_DELETE . '</button> <a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>'];
                 break;
 
               default:
                 if (isset($tInfo) && is_object($tInfo)) {
                  $heading[] = ['text' => '<h4>' . TABLE_HEADING_LANGUAGE . ': '  . $template_language . '</h4>'];
 
-                  if ($tInfo->template_language == 0) {
-                    $contents[] = ['align' => 'text-center', 'text' => '<a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id . '&action=edit') . '" class="btn btn-primary" role="button">' . IMAGE_EDIT . '</a>'];
-                  } else {
-                    $contents[] = ['align' => 'text-center', 'text' => '<a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id . '&action=edit') . '" class="btn btn-primary" role="button">' . IMAGE_EDIT . '</a> <a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id . '&action=delete') . '" class="btn btn-warning" role="button">' . IMAGE_DELETE . '</a>'];
-                  }
-                  $contents[] = ['text' => '<br>' . TEXT_INFO_TEMPLATE_AUTHOR . $template_info[$tInfo->template_dir]['author']];
-                  $contents[] = ['text' => '<br>' . TEXT_INFO_TEMPLATE_VERSION . $template_info[$tInfo->template_dir]['version']];
-                  $contents[] = ['text' => '<br>' . TEXT_INFO_TEMPLATE_DESCRIPTION . '<br />' . $template_info[$tInfo->template_dir]['description']];
-                  $contents[] = ['text' => '<br>' . TEXT_INFO_TEMPLATE_INSTALLED . '<br />'];
+                    if ($tInfo->template_language == '0') {
+                        $contents[] = ['text' => '<h5>' . TEXT_INFO_DEFAULT_TEMPLATE . '</h5>'];
+                    }
+                 $contents[] = ['text' => TEXT_INFO_TEMPLATE_NAME . ': <strong>"' . $template_info[$tInfo->template_dir]['name'] . '</strong>"'];
+                 $contents[] = ['text' => TEXT_INFO_TEMPLATE_AUTHOR . $template_info[$tInfo->template_dir]['author']];
+                 $contents[] = ['text' => TEXT_INFO_TEMPLATE_VERSION . $template_info[$tInfo->template_dir]['version']];
+                 $contents[] = ['text' => TEXT_INFO_TEMPLATE_DESCRIPTION . '<br>' . $template_info[$tInfo->template_dir]['description']];
+                 $contents[] = ['align' => 'text-center',
+                    'text' => '<a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id . '&action=edit') . '" class="btn btn-primary" role="button">' . TEXT_INFO_EDIT_INTRO . '</a>' . ($tInfo->template_language != '0' ? ' <a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id . '&action=delete') . '" class="btn btn-warning" role="button">' . IMAGE_DELETE . '</a>' : '')];
+                  $contents[] = ['text' => '<hr>'];
+                  $contents[] = ['text' => TEXT_INFO_TEMPLATE_INSTALLED];
                   foreach($template_info as $key => $value) {
                     $contents[] = ['text' => '<a href="' . DIR_WS_CATALOG_TEMPLATE . $key . '/images/' . $value['screenshot'] . '" target = "_blank" class="btn btn-info" role="button">' . IMAGE_PREVIEW . '</a>&nbsp;&nbsp;' . $value['name']];
                   }

--- a/admin/template_select.php
+++ b/admin/template_select.php
@@ -146,8 +146,8 @@ if (zen_not_null($action)) {
             </tbody>
           </table>
             <div class="row">
-                <div><?php echo $template_split->display_count($template_query_numrows, MAX_DISPLAY_SEARCH_RESULTS, $_GET['page'], TEXT_DISPLAY_NUMBER_OF_TEMPLATES); ?></div>
-                <div class="text-right"><?php echo $template_split->display_links($template_query_numrows, MAX_DISPLAY_SEARCH_RESULTS, MAX_DISPLAY_PAGE_LINKS, $_GET['page']); ?></div>
+                <div class="col-xs-6"><?php echo $template_split->display_count($template_query_numrows, MAX_DISPLAY_SEARCH_RESULTS, $_GET['page'], TEXT_DISPLAY_NUMBER_OF_TEMPLATES); ?></div>
+                <div class="col-xs-6 text-right"><?php echo $template_split->display_links($template_query_numrows, MAX_DISPLAY_SEARCH_RESULTS, MAX_DISPLAY_PAGE_LINKS, $_GET['page']); ?></div>
             </div>
         </div>
         <div class="col-xs-12 col-sm-12 col-md-3 col-lg-3 configurationColumnRight">

--- a/admin/template_select.php
+++ b/admin/template_select.php
@@ -48,6 +48,7 @@ if (zen_not_null($action)) {
       }
       $action = '';
       break;
+
     case 'save':
       $sql = "UPDATE " . TABLE_TEMPLATE_SELECT . "
               SET template_dir = :tpl:
@@ -57,11 +58,12 @@ if (zen_not_null($action)) {
       $db->Execute($sql);
       zen_redirect(zen_href_link(FILENAME_TEMPLATE_SELECT, zen_get_all_get_params(['action'])));
       break;
+
     case 'deleteconfirm':
       $check_query = $db->Execute("SELECT template_language
                                    FROM " . TABLE_TEMPLATE_SELECT . "
                                    WHERE template_id = " . (int)$_POST['tID']);
-      if ($check_query->fields['template_language'] != 0) {
+      if ($check_query->fields['template_language'] != '0') {
         $db->Execute("DELETE FROM " . TABLE_TEMPLATE_SELECT . "
                       WHERE template_id = " . (int)$_POST['tID']);
         zen_redirect(zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page']));
@@ -115,7 +117,7 @@ if (zen_not_null($action)) {
                     } else { ?>
                         <tr class="dataTableRow" style="cursor:pointer" onclick="document.location.href='<?php echo zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $template['template_id']); ?>'">
                     <?php }
-                  if ($template['template_language'] == 0) {
+                  if ($template['template_language'] == '0') {
                     $template_language = "Default(All)";
                   } else {
                     $ln = $db->Execute("SELECT name
@@ -170,6 +172,7 @@ if (zen_not_null($action)) {
                 $contents[] = ['text' => '<br>' . zen_draw_label(TEXT_INFO_LANGUAGE_NAME, 'lang', 'class="control-label"') . zen_draw_pull_down_menu('lang', $language_array, '', 'class="form-control"')];
                 $contents[] = ['align' => 'text-center', 'text' => '<br><button type="submit" class="btn btn-primary">' . IMAGE_INSERT . '</button> <a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page']) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>'];
                 break;
+
               case 'edit':
                 $heading[] = ['text' => '<h4>' . TEXT_INFO_HEADING_EDIT_TEMPLATE . '</h4>'];
 
@@ -181,6 +184,7 @@ if (zen_not_null($action)) {
                 $contents[] = ['text' => '<br>' . zen_draw_label(TEXT_INFO_TEMPLATE_NAME, 'ln', 'class="control-label"') . zen_draw_pull_down_menu('ln', $template_array, $templates->fields['template_dir'], 'class="form-control"')];
                 $contents[] = ['align' => 'text-center', 'text' => '<br><button type="submit" class="btn btn-primary">' . IMAGE_UPDATE . '</button> <a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>'];
                 break;
+
               case 'delete':
                 $heading[] = ['text' => '<h4>' . TEXT_INFO_HEADING_DELETE_TEMPLATE . '</h4>'];
 
@@ -189,9 +193,11 @@ if (zen_not_null($action)) {
                 $contents[] = ['text' => '<br><b>' . $template_info[$tInfo->template_dir]['name'] . '</b>'];
                 $contents[] = ['align' => 'text-center', 'text' => '<br><button type="submit" class="btn btn-danger">' . IMAGE_DELETE . '</button> <a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>'];
                 break;
+
               default:
                 if (isset($tInfo) && is_object($tInfo)) {
                   $heading[] = ['text' => '<h4>' . $template_info[$tInfo->template_dir]['name'] . '</h4>'];
+
                   if ($tInfo->template_language == 0) {
                     $contents[] = ['align' => 'text-center', 'text' => '<a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id . '&action=edit') . '" class="btn btn-primary" role="button">' . IMAGE_EDIT . '</a>'];
                   } else {

--- a/admin/template_select.php
+++ b/admin/template_select.php
@@ -223,7 +223,7 @@ if (zen_not_null($action)) {
                   $contents[] = ['text' => '<hr>'];
                   $contents[] = ['text' => TEXT_INFO_TEMPLATE_INSTALLED];
                   foreach($template_info as $key => $value) {
-                    $contents[] = ['text' => '<a href="' . DIR_WS_CATALOG_TEMPLATE . $key . '/images/' . $value['screenshot'] . '" target = "_blank" class="btn btn-info" role="button">' . IMAGE_PREVIEW . '</a>&nbsp;&nbsp;' . $value['name']];
+                    $contents[] = array('text' => '<a href="' . DIR_WS_CATALOG_TEMPLATE . $key . '/images/' . $value['screenshot'] . '" rel="noreferrer noopener" target = "_blank" class="btn btn-info" role="button">' . IMAGE_PREVIEW . '</a>&nbsp;&nbsp;' . $value['name']);
                   }
                 }
                 break;

--- a/admin/template_select.php
+++ b/admin/template_select.php
@@ -16,12 +16,12 @@ while ($file = $dir->read()) {
   if (is_dir(DIR_FS_CATALOG_TEMPLATES . $file) && $file != 'template_default') {
     if (file_exists(DIR_FS_CATALOG_TEMPLATES . $file . '/template_info.php')) {
       require(DIR_FS_CATALOG_TEMPLATES . $file . '/template_info.php');
-      $template_info[$file] = array(
+      $template_info[$file] = [
         'name' => $template_name,
         'version' => $template_version,
         'author' => $template_author,
         'description' => $template_description,
-        'screenshot' => $template_screenshot);
+        'screenshot' => $template_screenshot];
     }
   }
 }
@@ -44,7 +44,7 @@ if (zen_not_null($action)) {
         $sql = $db->bindVars($sql, ':tpl:', $_POST['ln'], 'string');
         $sql = $db->bindVars($sql, ':lang:', $_POST['lang'], 'string');
         $db->Execute($sql);
-        $_GET['tID'] = $db->Insert_ID();
+        $_GET['tID'] = $db->insert_ID();
       }
       $action = '';
       break;
@@ -55,7 +55,7 @@ if (zen_not_null($action)) {
       $sql = $db->bindVars($sql, ':tpl:', $_POST['ln'], 'string');
       $sql = $db->bindVars($sql, ':id:', $_GET['tID'], 'integer');
       $db->Execute($sql);
-      zen_redirect(zen_href_link(FILENAME_TEMPLATE_SELECT, zen_get_all_get_params(array('action'))));
+      zen_redirect(zen_href_link(FILENAME_TEMPLATE_SELECT, zen_get_all_get_params(['action'])));
       break;
     case 'deleteconfirm':
       $check_query = $db->Execute("SELECT template_language
@@ -159,71 +159,71 @@ if (zen_not_null($action)) {
         </div>
         <div class="col-xs-12 col-sm-12 col-md-3 col-lg-3 configurationColumnRight">
             <?php
-            $heading = array();
-            $contents = array();
+            $heading = [];
+            $contents = [];
 
             switch ($action) {
               case 'new':
-                $heading[] = array('text' => '<h4>' . TEXT_INFO_HEADING_NEW_TEMPLATE . '</h4>');
+                $heading[] = ['text' => '<h4>' . TEXT_INFO_HEADING_NEW_TEMPLATE . '</h4>'];
 
-                $contents = array('form' => zen_draw_form('zones', FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&action=insert', 'post', 'class="form-horizontal"'));
-                $contents[] = array('text' => TEXT_INFO_INSERT_INTRO);
+                $contents = ['form' => zen_draw_form('zones', FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&action=insert', 'post', 'class="form-horizontal"')];
+                $contents[] = ['text' => TEXT_INFO_INSERT_INTRO];
                 foreach($template_info as $key => $value) {
-                  $template_array[] = array(
+                  $template_array[] = [
                     'id' => $key,
-                    'text' => $value['name']);
+                    'text' => $value['name']];
                 }
                 $lns = $db->Execute("SELECT name, languages_id
                                      FROM " . TABLE_LANGUAGES);
                 foreach ($lns as $ln) {
-                  $language_array[] = array(
+                  $language_array[] = [
                     'text' => $ln['name'],
-                    'id' => $ln['languages_id']);
+                    'id' => $ln['languages_id']];
                 }
-                $contents[] = array('text' => '<br>' . zen_draw_label(TEXT_INFO_TEMPLATE_NAME, 'ln', 'class="control-label"') . zen_draw_pull_down_menu('ln', $template_array, '', 'class="form-control"'));
-                $contents[] = array('text' => '<br>' . zen_draw_label(TEXT_INFO_LANGUAGE_NAME, 'lang', 'class="control-label"') . zen_draw_pull_down_menu('lang', $language_array, '', 'class="form-control"'));
-                $contents[] = array('align' => 'text-center', 'text' => '<br><button type="submit" class="btn btn-primary">' . IMAGE_INSERT . '</button> <a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page']) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>');
+                $contents[] = ['text' => '<br>' . zen_draw_label(TEXT_INFO_TEMPLATE_NAME, 'ln', 'class="control-label"') . zen_draw_pull_down_menu('ln', $template_array, '', 'class="form-control"')];
+                $contents[] = ['text' => '<br>' . zen_draw_label(TEXT_INFO_LANGUAGE_NAME, 'lang', 'class="control-label"') . zen_draw_pull_down_menu('lang', $language_array, '', 'class="form-control"')];
+                $contents[] = ['align' => 'text-center', 'text' => '<br><button type="submit" class="btn btn-primary">' . IMAGE_INSERT . '</button> <a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page']) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>'];
                 break;
               case 'edit':
-                $heading[] = array('text' => '<h4>' . TEXT_INFO_HEADING_EDIT_TEMPLATE . '</h4>');
+                $heading[] = ['text' => '<h4>' . TEXT_INFO_HEADING_EDIT_TEMPLATE . '</h4>'];
 
-                $contents = array('form' => zen_draw_form('templateselect', FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id . '&action=save', 'post', 'class="form-horizontal"'));
-                $contents[] = array('text' => TEXT_INFO_EDIT_INTRO);
+                $contents = ['form' => zen_draw_form('templateselect', FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id . '&action=save', 'post', 'class="form-horizontal"')];
+                $contents[] = ['text' => TEXT_INFO_EDIT_INTRO];
                 foreach($template_info as $key => $value) {
-                  $template_array[] = array('id' => $key, 'text' => $value['name']);
+                  $template_array[] = ['id' => $key, 'text' => $value['name']];
                 }
-                $contents[] = array('text' => '<br>' . zen_draw_label(TEXT_INFO_TEMPLATE_NAME, 'ln', 'class="control-label"') . zen_draw_pull_down_menu('ln', $template_array, $templates->fields['template_dir'], 'class="form-control"'));
-                $contents[] = array('align' => 'text-center', 'text' => '<br><button type="submit" class="btn btn-primary">' . IMAGE_UPDATE . '</button> <a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>');
+                $contents[] = ['text' => '<br>' . zen_draw_label(TEXT_INFO_TEMPLATE_NAME, 'ln', 'class="control-label"') . zen_draw_pull_down_menu('ln', $template_array, $templates->fields['template_dir'], 'class="form-control"')];
+                $contents[] = ['align' => 'text-center', 'text' => '<br><button type="submit" class="btn btn-primary">' . IMAGE_UPDATE . '</button> <a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>'];
                 break;
               case 'delete':
-                $heading[] = array('text' => '<h4>' . TEXT_INFO_HEADING_DELETE_TEMPLATE . '</h4>');
+                $heading[] = ['text' => '<h4>' . TEXT_INFO_HEADING_DELETE_TEMPLATE . '</h4>'];
 
-                $contents = array('form' => zen_draw_form('zones', FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&action=deleteconfirm') . zen_draw_hidden_field('tID', $tInfo->template_id));
-                $contents[] = array('text' => TEXT_INFO_DELETE_INTRO);
-                $contents[] = array('text' => '<br><b>' . $template_info[$tInfo->template_dir]['name'] . '</b>');
-                $contents[] = array('align' => 'text-center', 'text' => '<br><button type="submit" class="btn btn-danger">' . IMAGE_DELETE . '</button> <a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>');
+                $contents = ['form' => zen_draw_form('zones', FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&action=deleteconfirm') . zen_draw_hidden_field('tID', $tInfo->template_id)];
+                $contents[] = ['text' => TEXT_INFO_DELETE_INTRO];
+                $contents[] = ['text' => '<br><b>' . $template_info[$tInfo->template_dir]['name'] . '</b>'];
+                $contents[] = ['align' => 'text-center', 'text' => '<br><button type="submit" class="btn btn-danger">' . IMAGE_DELETE . '</button> <a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>'];
                 break;
               default:
                 if (isset($tInfo) && is_object($tInfo)) {
-                  $heading[] = array('text' => '<h4>' . $template_info[$tInfo->template_dir]['name'] . '</h4>');
+                  $heading[] = ['text' => '<h4>' . $template_info[$tInfo->template_dir]['name'] . '</h4>'];
                   if ($tInfo->template_language == 0) {
-                    $contents[] = array('align' => 'text-center', 'text' => '<a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id . '&action=edit') . '" class="btn btn-primary" role="button">' . IMAGE_EDIT . '</a>');
+                    $contents[] = ['align' => 'text-center', 'text' => '<a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id . '&action=edit') . '" class="btn btn-primary" role="button">' . IMAGE_EDIT . '</a>'];
                   } else {
-                    $contents[] = array('align' => 'text-center', 'text' => '<a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id . '&action=edit') . '" class="btn btn-primary" role="button">' . IMAGE_EDIT . '</a> <a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id . '&action=delete') . '" class="btn btn-warning" role="button">' . IMAGE_DELETE . '</a>');
+                    $contents[] = ['align' => 'text-center', 'text' => '<a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id . '&action=edit') . '" class="btn btn-primary" role="button">' . IMAGE_EDIT . '</a> <a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id . '&action=delete') . '" class="btn btn-warning" role="button">' . IMAGE_DELETE . '</a>'];
                   }
-                  $contents[] = array('text' => '<br>' . TEXT_INFO_TEMPLATE_AUTHOR . $template_info[$tInfo->template_dir]['author']);
-                  $contents[] = array('text' => '<br>' . TEXT_INFO_TEMPLATE_VERSION . $template_info[$tInfo->template_dir]['version']);
-                  $contents[] = array('text' => '<br>' . TEXT_INFO_TEMPLATE_DESCRIPTION . '<br />' . $template_info[$tInfo->template_dir]['description']);
-                  $contents[] = array('text' => '<br>' . TEXT_INFO_TEMPLATE_INSTALLED . '<br />');
+                  $contents[] = ['text' => '<br>' . TEXT_INFO_TEMPLATE_AUTHOR . $template_info[$tInfo->template_dir]['author']];
+                  $contents[] = ['text' => '<br>' . TEXT_INFO_TEMPLATE_VERSION . $template_info[$tInfo->template_dir]['version']];
+                  $contents[] = ['text' => '<br>' . TEXT_INFO_TEMPLATE_DESCRIPTION . '<br />' . $template_info[$tInfo->template_dir]['description']];
+                  $contents[] = ['text' => '<br>' . TEXT_INFO_TEMPLATE_INSTALLED . '<br />'];
                   foreach($template_info as $key => $value) {
-                    $contents[] = array('text' => '<a href="' . DIR_WS_CATALOG_TEMPLATE . $key . '/images/' . $value['screenshot'] . '" target = "_blank" class="btn btn-info" role="button">' . IMAGE_PREVIEW . '</a>&nbsp;&nbsp;' . $value['name']);
+                    $contents[] = ['text' => '<a href="' . DIR_WS_CATALOG_TEMPLATE . $key . '/images/' . $value['screenshot'] . '" target = "_blank" class="btn btn-info" role="button">' . IMAGE_PREVIEW . '</a>&nbsp;&nbsp;' . $value['name']];
                   }
                 }
                 break;
             }
 
             if ((zen_not_null($heading)) && (zen_not_null($contents))) {
-              $box = new box;
+              $box = new box();
               echo $box->infoBox($heading, $contents);
             }
             ?>

--- a/admin/template_select.php
+++ b/admin/template_select.php
@@ -236,14 +236,18 @@ if (zen_not_null($action)) {
         </div>
           <?php
           if (empty($action)) {
-            ?>
-            <tr>
-              <td colspan="2" class="text-right"><a href="<?php echo zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&action=new'); ?>" class="btn btn-primary" role="button"><?php echo IMAGE_NEW_TEMPLATE; ?></a></td>
-            </tr>
-            <?php
+              $template_languages = [];
+              foreach ($templates as $template) {
+                  $template_languages[] = $template['template_language'];
+              }
+              foreach ($languages as $language) {
+                  if (!in_array($language['id'], $template_languages)) { ?>
+                      <div class="row text-right"><a href="<?php echo zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&action=new'); ?>" class="btn btn-primary" role="button"><?php echo IMAGE_NEW_TEMPLATE; ?></a></div>
+                      <?php break;
+                  }
+              }
           }
           ?>
-        </table>
       </div>
       <!-- body_text_eof //-->
     </div>

--- a/admin/template_select.php
+++ b/admin/template_select.php
@@ -218,7 +218,8 @@ if (zen_not_null($action)) {
                  $contents[] = ['text' => TEXT_INFO_TEMPLATE_VERSION . $template_info[$tInfo->template_dir]['version']];
                  $contents[] = ['text' => TEXT_INFO_TEMPLATE_DESCRIPTION . '<br>' . $template_info[$tInfo->template_dir]['description']];
                  $contents[] = ['align' => 'text-center',
-                    'text' => '<a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id . '&action=edit') . '" class="btn btn-primary" role="button">' . TEXT_INFO_EDIT_INTRO . '</a>' . ($tInfo->template_language != '0' ? ' <a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id . '&action=delete') . '" class="btn btn-warning" role="button">' . IMAGE_DELETE . '</a>' : '')];
+                    'text' => '<a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id . '&action=edit') . '" class="btn btn-primary" role="button">' . TEXT_INFO_EDIT_INTRO . '</a>' .
+                        ($tInfo->template_language != '0' ? ' <a href="' . zen_href_link(FILENAME_TEMPLATE_SELECT, 'page=' . $_GET['page'] . '&tID=' . $tInfo->template_id . '&action=delete') . '" class="btn btn-warning" role="button">' . IMAGE_DELETE . '</a>' : '')];
                   $contents[] = ['text' => '<hr>'];
                   $contents[] = ['text' => TEXT_INFO_TEMPLATE_INSTALLED];
                   foreach($template_info as $key => $value) {

--- a/includes/init_includes/init_templates.php
+++ b/includes/init_includes/init_templates.php
@@ -40,6 +40,9 @@ if (false !== strpos(EXCLUDE_ADMIN_IP_FOR_MAINTENANCE, $_SERVER['REMOTE_ADDR']))
     if (isset($_GET['t']) && in_array($_GET['t'], $templates, true) && file_exists(DIR_WS_TEMPLATES . $_GET['t'])) {
         $_SESSION['tpl_override'] = $_GET['t'];
     }
+    if (isset($_GET['t']) && $_GET['t'] === 'off') {
+        unset($_SESSION['tpl_override']);
+    }
     if (isset($_SESSION['tpl_override'])) $template_dir = $_SESSION['tpl_override'];
     unset($templates, $row);
 }


### PR DESCRIPTION
This revising was instigated by my confusion at not understanding the process of using t=template for admin/development use.
This has been resolved by renaming the infoboxes to better reflect their function and adding extra information.
Also:
Associations can only be added when there are un-associated languages still to be added.
An option to remove the t=override was added.

Usual html cleanups.
