### PR TITLE
Fix function signatures so "no required after optional"

### DIFF
--- a/admin/includes/functions/functions_prices.php
+++ b/admin/includes/functions/functions_prices.php
@@ -1072,12 +1072,12 @@ If a special exist * 10+9
 
 ////
 // attributes final price onetime
-  function zen_get_attributes_price_final_onetime($attribute, $qty= 1, $pre_selected_onetime) {
+  function zen_get_attributes_price_final_onetime($attribute, $qty= 1, $pre_selected_onetime = null) {
     global $db;
 
     $attributes_price_final_onetime = 0.0;
 
-    if ($pre_selected_onetime == '' or $attribute != $pre_selected_onetime->fields["products_attributes_id"]) {
+    if (empty($pre_selected_onetime) || $attribute != $pre_selected_onetime->fields["products_attributes_id"]) {
       $pre_selected_onetime = $db->Execute("select pa.* from " . TABLE_PRODUCTS_ATTRIBUTES . " pa where pa.products_attributes_id= '" . (int)$attribute . "'");
     } else {
       // use existing select
@@ -1131,7 +1131,7 @@ If a special exist * 10+9
 
 ////
 // calculate words price
-  function zen_get_word_count_price($string, $free=0, $price) {
+  function zen_get_word_count_price($string, $free = 0, $price = 0) {
     $word_count = zen_get_word_count($string, $free);
     if ($word_count >= 1) {
       return ($word_count * $price);
@@ -1162,7 +1162,7 @@ If a special exist * 10+9
 
 ////
 // calculate letters price
-  function zen_get_letters_count_price($string, $free=0, $price) {
+  function zen_get_letters_count_price($string, $free = 0, $price = 0) {
       $letters_price = zen_get_letters_count($string, $free) * $price;
       if ($letters_price <= 0) {
         return 0;

--- a/includes/functions/functions_general.php
+++ b/includes/functions/functions_general.php
@@ -191,8 +191,8 @@
   }
 
 ////
-// Parse search string into indivual objects
-  function zen_parse_search_string($search_str = '', &$objects) {
+// Parse search string into individual objects
+  function zen_parse_search_string($search_str = '', &$objects = array()) {
     $search_str = trim(strtolower($search_str));
 
 // Break up $search_str on whitespace; quoted string will be reconstructed later

--- a/includes/functions/functions_prices.php
+++ b/includes/functions/functions_prices.php
@@ -1289,10 +1289,10 @@ If a special exist * 10
 
 ////
 // attributes final price onetime
-  function zen_get_attributes_price_final_onetime($attribute, $qty= 1, $pre_selected_onetime) {
+  function zen_get_attributes_price_final_onetime($attribute, $qty= 1, $pre_selected_onetime = null) {
     global $db;
 
-    if ($pre_selected_onetime == '' or $attribute != $pre_selected_onetime->fields["products_attributes_id"]) {
+    if (empty($pre_selected_onetime) || $attribute != $pre_selected_onetime->fields["products_attributes_id"]) {
       $pre_selected_onetime = $db->Execute("select pa.* from " . TABLE_PRODUCTS_ATTRIBUTES . " pa where pa.products_attributes_id= '" . (int)$attribute . "'");
     } else {
       // use existing select
@@ -1346,7 +1346,7 @@ If a special exist * 10
 
 ////
 // calculate words price
-  function zen_get_word_count_price($string, $free=0, $price) {
+  function zen_get_word_count_price($string, $free = 0, $price = 0) {
     $word_count = zen_get_word_count($string, $free);
     if ($word_count >= 1) {
       return ($word_count * $price);
@@ -1377,7 +1377,7 @@ If a special exist * 10
 
 ////
 // calculate letters price
-  function zen_get_letters_count_price($string, $free=0, $price) {
+  function zen_get_letters_count_price($string, $free = 0, $price = 0) {
 
     $letters_price = zen_get_letters_count($string, $free) * $price;
     if ($letters_price <= 0) {

--- a/includes/modules/payment/paypal/paypal_curl.php
+++ b/includes/modules/payment/paypal/paypal_curl.php
@@ -366,7 +366,7 @@ class paypal_curl extends base {
    *
    * Used to read data from PayPal for specified transaction criteria
    */
-  function TransactionSearch($startdate, $txnID = '', $email = '', $options) {
+  function TransactionSearch($startdate, $txnID = '', $email = '', $options = null) {
     if ($this->_mode == 'payflow') {
       $values['CUSTREF'] = $txnID;
       $values['TENDER'] = 'C';

--- a/includes/modules/payment/paypal/paypal_functions.php
+++ b/includes/modules/payment/paypal/paypal_functions.php
@@ -640,7 +640,7 @@
 /**
  * Write order-history update to ZC tables denoting the update supplied by the IPN
  */
-  function ipn_update_orders_status_and_history($ordersID, $new_status = 1, $txn_type) {
+  function ipn_update_orders_status_and_history($ordersID, $new_status = 1, $txn_type = '') {
     global $db;
     
     ipn_debug_email('IPN NOTICE :: Updating order #' . (int)$ordersID . ' to status: ' . (int)$new_status . ' (txn_type: ' . $txn_type . ')');


### PR DESCRIPTION
This in preparation for PHP 8 compatibility:

```
Declaring a required parameter after an optional one is deprecated. 
```