### PR TITLE
Fix admin whos-online logging-out the administrator

### DIFF
--- a/admin/whos_online.php
+++ b/admin/whos_online.php
@@ -317,7 +317,8 @@ $listingURL = FILENAME_WHOS_ONLINE . '.php?' . zen_get_all_get_params(['q', 't',
             $cart = isset($whos_online[$selectedSession]['cart']) ? $whos_online[$selectedSession]['cart'] : null;
 
             if ($cart !== null) {
-                $contents[] = ['text' => $item['full_name'] . ' - ' . $item['ip_address'] . '<br>' . $selectedSession];
+                $contents[] = ['text' => $whos_online[$selectedSession]['full_name'] . ' - ' . $whos_online[$selectedSession]['ip_address'] . '<br>' . $selectedSession];
+
                 foreach ($cart['products'] as $product) {
                   $contents[] = ['text' => $product['quantity'] . ' x ' . '<a href="' . zen_href_link(FILENAME_PRODUCT, 'cPath=' . zen_get_product_path($product['id']) . '&pID=' . $product['id']) . '">' . $product['name'] . '</a>'];
                 }


### PR DESCRIPTION
When inspecting cart of a not-logged-in user it could logout the admin due to session content mismatching due to customizations of catalog session variables.

Fixes #3491

No plans to backport to prior versions.
(While this isn't directly backportable to older versions because it's done in a different file, the concept can probably be replicated easily if it were needed.)
