### PR TITLE
Color Contrast in #navMain

### DIFF
--- a/includes/templates/responsive_classic/css/stylesheet_colors.css
+++ b/includes/templates/responsive_classic/css/stylesheet_colors.css
@@ -4,8 +4,7 @@ a:link, #navEZPagesTOC ul li a, a:hover, #navEZPagesTOC ul li a:hover, #navMain 
 a:visited, .cat-count, .itemTitle a:hover, h2.greeting a:hover {color:#666;}
 a:active {color:#0000ff;}
 h2, h3, .cartAttribsList, #cart-box {color:#000000;}
-.blue{color:#364fb5 !important;}
-.blue:hover{color:#036f89 !important;}
+#navMain ul li a:hover{color:#03a5ce;}
 .alert {color: #8b0000;}
 legend, .specialsListBoxContents a, .centerBoxContentsAlsoPurch a, .centerBoxContentsFeatured a, .centerBoxContentsSpecials a, .centerBoxContentsNew a, .productPriceDiscount{color:#333;}
 .messageStackWarning, .messageStackError, #navMainWrapper, #navMain ul li a, #navCatTabsWrapper, #navCatTabs li a, #navCatTabs li a:hover, #navCatTabs li:hover, #navEZPagesTop, #navEZPagesTop li a, .pagination li a, #navSuppWrapper, #navSupp li a, #siteinfoIP, #siteinfoLegal, #bannerSix, #siteinfoLegal a:hover, h2.centerBoxHeading, h3.rightBoxHeading, h3.leftBoxHeading, h3.rightBoxHeading a, h3.leftBoxHeading a, .seDisplayedAddressLabel, TR.tableHeading, #shippingEstimatorContent h2, #shippingEstimatorContent th, #checkoutConfirmDefault .cartTableHeading, #filter-wrapper, .navSplitPagesLinks a, .current, .productListing-rowheading a, .productListing-rowheading a, .prod-list-wrap, #productQuantityDiscounts table tr:first-child td, #reviewsWriteHeading, #sendSpendWrapper h2, #accountDefault #sendSpendWrapper h2, #gvFaqDefaultSubHeading, #checkoutPayAddressDefaultAddress, #checkoutShipAddressDefaultAddress, #accountLinksWrapper h2, h2#addressBookDefaultPrimary, #myAccountPaymentInfo h3, #myAccountShipInfo h3, #myAccountPaymentInfo h4, #myAccountShipInfo h4, input.submit_button, input.submit_button:hover, input.cssButtonHover, span.normal_button{color: #ffffff;}


### PR DESCRIPTION
took color call out of  includes/templates/responsive_classic/templates/common/tpl_header.php and added the proper calls in includes/templates/responsive_classic/css/stylesheet_colors.css for the #navMain link hovers.