### PR TITLE
V157 enable error logging static

### DIFF
--- a/includes/extra_configures/enable_error_logging.php
+++ b/includes/extra_configures/enable_error_logging.php
@@ -21,8 +21,9 @@ function zen_debug_error_handler($errno, $errstr, $errfile, $errline)
         return;
     }
 
+    static $last_log_suffix;
     if (!isset($last_log_suffix)) {
-        static $last_log_suffix = '.log';
+        $last_log_suffix = '.log';
     }
     $ignore_dups = false;
     if (IS_ADMIN_FLAG === true) {


### PR DESCRIPTION
Two items here, one is discussed: https://github.com/zencart/zencart/commit/e87391bbf17368be5f4c0d64518c193d9a35434a#r39297222

The other is a result of seeing how this works and making it possible for the operation to remain as it was for those interested.  Kept the default the same as has been provided (to split out the files), but made it admin controllable to be able to make sense of the data in a logical sequence rather than by some sort of file convention.