### PR TITLE
Admin - Load localized CSS overrides if present

### DIFF
--- a/admin/includes/admin_html_head.php
+++ b/admin/includes/admin_html_head.php
@@ -14,9 +14,21 @@ if (!defined('IS_ADMIN_FLAG')) {
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title><?php echo TITLE; ?></title>
+<?php if (file_exists($file = 'includes/css/bootstrap.min.css')) { ?>
+    <link rel="stylesheet" href="<?php echo $file; ?>">
+<?php } else { ?>
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
+<?php } ?>
+<?php if (file_exists($file = 'includes/css/font-awesome.min.css')) { ?>
+    <link rel="stylesheet" href="<?php echo $file; ?>">
+<?php } else { ?>
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
+<?php } ?>
+<?php if (file_exists($file = 'includes/css/jquery-ui.css')) { ?>
+    <link rel="stylesheet" href="<?php echo $file; ?>">
+<?php } else { ?>
     <link rel="stylesheet" href="https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
+<?php } ?>
     <link rel="stylesheet" href="includes/css/jAlert.css">
     <link rel="stylesheet" href="includes/css/menu.css">
     <link rel="stylesheet" href="includes/css/stylesheet.css">

--- a/admin/includes/stylesheet.css
+++ b/admin/includes/stylesheet.css
@@ -9,10 +9,10 @@
 /*
  * Left here for legacy pages that do not use the new admin_html_head.php file
  */
-@import url("https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css");
-/*@import url("css/bootstrap.min.css");*/
-@import url("https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css");
-/*@import url("css/font-awesome.min.css");*/
+/*@import url("https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css");*/
+@import url("css/bootstrap.min.css");
+/*@import url("https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css");*/
+@import url("css/font-awesome.min.css");
 @import url("https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css");
 /*@import url("css/jquery-ui.css");*/
 @import url("css/jAlert.css");


### PR DESCRIPTION
This allows one to "drop in" a Bootstrap 3 theme replacement (`bootstrap.min.css` file) from one of the many 3rd party theming sites.

One can also delete the local file if CDN loading is preferred.
