### PR TITLE
Remove Link from Store Name in Footer.

### DIFF
--- a/includes/languages/english.php
+++ b/includes/languages/english.php
@@ -13,7 +13,7 @@
 //define('CUSTOM_KEYWORDS', 'ecommerce, open source, shop, online shopping');
 // END: moved to meta_tags.php
 
-  define('FOOTER_TEXT_BODY', 'Copyright &copy; ' . date('Y') . ' <a href="' . zen_href_link(FILENAME_DEFAULT) . '" rel="noopener" target="_blank">' . STORE_NAME . '</a>. Powered by <a href="https://www.zen-cart.com" rel="noopener" target="_blank">Zen Cart</a>');
+  define('FOOTER_TEXT_BODY', 'Copyright &copy; ' . date('Y') . ' ' . STORE_NAME . ' - Powered by <a href="https://www.zen-cart.com" rel="noopener" target="_blank">Zen Cart</a>');
 
 // look in your $PATH_LOCALE/locale directory for available locales..
   $locales = ['en_US', 'en_US.utf8', 'en', 'English_United States.1252'];


### PR DESCRIPTION
Not only does the target="blank" set off accessibility alarms, I'm wondering why we would need for a customer to go to our site when they're already on it.   Much less, going where they already are in a new window!