### PR TITLE
Adding noreferrer to Offsite Links

### DIFF
--- a/includes/functions/banner.php
+++ b/includes/functions/banner.php
@@ -145,7 +145,7 @@
       } else {
         $target = '';
         if ($banner->fields['banners_open_new_windows'] == '1') {
-          $target = ' rel="noopener" target="_blank"';
+          $target = ' rel="noopener noreferrer" target="_blank"';
         }
         $banner_string = '<a href="' . zen_href_link(FILENAME_REDIRECT, 'action=banner&goto=' . $banner->fields['banners_id']) . '"' . $target . '>' . zen_image(DIR_WS_IMAGES . $banner->fields['banners_image'], $banner->fields['banners_title']) . '</a>';
       }


### PR DESCRIPTION
While the noopener is sufficient for our purposes, adding the noreferrer makes the offsite link compatible with accessibility standards.
Otherwise we would need to warn folks that they are going to a site that might be insecure.
It's known as a (reverse) tabnabbing form of phishing.
This will need to be done in several offsite links with target="_blank" but I'm not familiar with how to do more than one file at a time on github.