### PR TITLE
music-product noreferrer for 508 target="_blank"

### DIFF
--- a/includes/modules/pages/product_music_info/main_template_vars_product_type.php
+++ b/includes/modules/pages/product_music_info/main_template_vars_product_type.php
@@ -65,8 +65,8 @@
   $products_record_company_name = !empty($record_company->fields['record_company_name']) ? $record_company->fields['record_company_name'] : '';
   $products_record_company_url = !empty($record_company_info->fields['record_company_url']) ? $record_company_info->fields['record_company_url'] : '';
   $products_music_genre_name = !empty($music_genre->fields['music_genre_name']) ? $music_genre->fields['music_genre_name'] : '';
-  if (!empty($products_artist_url)) $products_artist_name = '<a href="' . zen_href_link(FILENAME_REDIRECT, 'action=music_arist&artists_id=' . zen_output_string_protected($music_extras->fields['artists_id']), 'NONSSL', true, false) . '" rel="noopener" target="_blank">'.$products_artist_name.'</a>';
-  if (!empty($products_record_company_url)) $products_record_company_name = '<a href="' . zen_href_link(FILENAME_REDIRECT, 'action=music_record_company&record_company_id=' . zen_output_string_protected($music_extras->fields['record_company_id']), 'NONSSL', true, false) . '" rel="noopener" target="_blank">'.$products_record_company_name.'</a>';
+  if (!empty($products_artist_url)) $products_artist_name = '<a href="' . zen_href_link(FILENAME_REDIRECT, 'action=music_arist&artists_id=' . zen_output_string_protected($music_extras->fields['artists_id']), 'NONSSL', true, false) . '" rel="noopener noreferrer" target="_blank">'.$products_artist_name.'</a>';
+  if (!empty($products_record_company_url)) $products_record_company_name = '<a href="' . zen_href_link(FILENAME_REDIRECT, 'action=music_record_company&record_company_id=' . zen_output_string_protected($music_extras->fields['record_company_id']), 'NONSSL', true, false) . '" rel="noopener noreferrer" target="_blank">'.$products_record_company_name.'</a>';
 
   // This should be last line of the script:
   $zco_notifier->notify('NOTIFY_PRODUCT_TYPE_VARS_END_PRODUCT_MUSIC_INFO');


### PR DESCRIPTION
This makes links in the current distribution using target="_blank" ether use the noreferrer or point to "acceptable risk/known" sites.