### PR TITLE
Set unique-index on admin profile names

### DIFF
--- a/zc_install/sql/install/mysql_zencart.sql
+++ b/zc_install/sql/install/mysql_zencart.sql
@@ -188,8 +188,9 @@ CREATE TABLE admin_pages (
 DROP TABLE IF EXISTS admin_profiles;
 CREATE TABLE admin_profiles (
   profile_id int(11) NOT NULL AUTO_INCREMENT,
-  profile_name varchar(255) NOT NULL default '',
-  PRIMARY KEY (profile_id)
+  profile_name varchar(191) NOT NULL default '',
+  PRIMARY KEY (profile_id),
+  UNIQUE KEY idx_profile_name_zen (profile_name)
 ) ENGINE=MyISAM;
 
 # --------------------------------------------------------

--- a/zc_install/sql/updates/mysql_upgrade_zencart_157.sql
+++ b/zc_install/sql/updates/mysql_upgrade_zencart_157.sql
@@ -234,6 +234,8 @@ CREATE TABLE IF NOT EXISTS count_product_views (
 ) ENGINE=MyISAM;
 
 
+ALTER TABLE admin_profiles MODIFY profile_name varchar(191) NOT NULL default '';
+ALTER TABLE admin_profiles ADD UNIQUE idx_profile_name_zen (profile_name);
 
 ALTER TABLE admin_activity_log MODIFY attention MEDIUMTEXT;
 


### PR DESCRIPTION
There's no "unique" index on the admin_profiles table.
This means someone can insert multiple entries of the same name, but have different controls associated with them.

Adding a unique index to the table solves the problem of potential ambiguity.



Closes #3540