### PR TITLE
Base Font Size Too Small for Readability

### DIFF
--- a/includes/templates/responsive_classic/css/stylesheet.css
+++ b/includes/templates/responsive_classic/css/stylesheet.css
@@ -9,7 +9,7 @@
  */
 
 /*bof basic elements*/
-body {margin:0;font-family:verdana, arial, helvetica, sans-serif;font-size:72.5%;line-height:140%;}
+body {margin:0;font-family:verdana, arial, helvetica, sans-serif;font-size:80%;line-height:140%;}
 /*general link styles*/
 a img {border:none;}
 a:link, #navEZPagesTOC ul li a {text-decoration:underline;}


### PR DESCRIPTION
While there is no specific written standard for font-size, it is considered to be 12pt or 16px.  At the original 72.5% and the fact that most alerts and small text are set to em (some as low as .5em), readability is taking a big hit on the mobiles and things like the site legal info.
Making the setting 80% at least gets us to 10pt and triggers no errors for font too small while still not overpowering the screen.