### PR TITLE
Prevent Non-Secure Link on Main Page

### DIFF
--- a/includes/languages/english/html_includes/define_main_page.php
+++ b/includes/languages/english/html_includes/define_main_page.php
@@ -1,4 +1,4 @@
-<a href="http://www.zen-cart.com/book"><img src="images/large/e-start-book.gif" alt="get your manual today" title="Have you got yours yet? Join the 1000's of Zen Cart users that have bought the only comprehensive owners manual !" /></a>
+<a href="//zen-cart.com/book"><img src="images/large/e-start-book.gif" alt="get your manual today" title="Have you got yours yet? Join the 1000's of Zen Cart users that have bought the only comprehensive owners manual !" /></a>
 <p>This content is located in the file at: <code> /languages/english/html_includes/YOUR_TEMPLATE/define_main_page.php</code></p>
 <p>You can quickly edit this content via Admin->Tools->Define Pages Editor, and select define_main_page from the pulldown.</p>
 <p><strong>NOTE: Always backup the files in<code> /languages/english/html_includes/your_template</code></strong></p>


### PR DESCRIPTION
The use of // versus http://www. allows the link to be presented in the settings of the remote site.
Stops the browser warnings for mixed content.