### PR TITLE
Improve admin pwd resets when duplicate emails exist

### DIFF
--- a/admin/includes/languages/english/password_forgotten.php
+++ b/admin/includes/languages/english/password_forgotten.php
@@ -9,15 +9,19 @@
 
 define('HEADING_TITLE', 'Reset Password');
 
-define('TEXT_ADMIN_EMAIL', 'Admin Email Address: ');
+define('TEXT_ADMIN_EMAIL', 'Admin Email Address');
+define('TEXT_ADMIN_USERNAME', 'Admin Username');
 define('TEXT_BUTTON_REQUEST_RESET', 'Request Reset');
 define('TEXT_BUTTON_LOGIN', 'Login');
 define('TEXT_BUTTON_CANCEL', 'Cancel');
 
 define('ERROR_WRONG_EMAIL', 'You entered the wrong email address.');
 define('ERROR_WRONG_EMAIL_NULL', 'Go away gooberbrain :-P');
-define('MESSAGE_PASSWORD_SENT', 'Thank you. If the email address you entered matches an admin account in our database, then a new password will be sent to that email address.<br />Please read that email and then click "login" below to login with the new temporary password.');
+define('MESSAGE_PASSWORD_SENT', 'Thank you. If the email address and username you entered matches an admin account in our database, then a new password will be sent to that email address.<br>Please read that email and then click "login" to use the new temporary password.');
 
 define('TEXT_EMAIL_SUBJECT_PWD_RESET', 'Your Requested change');
 define('TEXT_EMAIL_MESSAGE_PWD_RESET', 'A new password was requested from %s.' . "\n\n" . 'Your new temporary password is:' . "\n\n   %s\n\nYou will be asked to choose a new password before logging in.\n\nThis temporary password expires in 24 hours.\n\n\n");
+
+define('TEXT_EMAIL_SUBJECT_PWD_FAILED_RESET', 'Access Alert!');
+define('TEXT_EMAIL_MESSAGE_PWD_FAILED_RESET', "Failed attempts for admin password resets have been received from %s\n\nInvalid email and/or username supplied.\n\nIf you have admin accounts sharing the same email address you should consider assigning unique email addresses to them, to make resets easier.");
 

--- a/admin/password_forgotten.php
+++ b/admin/password_forgotten.php
@@ -22,35 +22,61 @@ $error = false;
 $resetToken = '';
 $email_message = '';
 if (isset($_POST['action']) && $_POST['action'] == 'update') {
-  if (!$_POST['admin_email']) {
-    $error = true;
-    $email_message = ERROR_WRONG_EMAIL_NULL;
-  }
-  $admin_email = zen_db_prepare_input($_POST['admin_email']);
-  $sql = "SELECT admin_id, admin_name, admin_email, admin_pass, lockout_expires
-          FROM " . TABLE_ADMIN . "
-          WHERE admin_email = :admEmail:
-          LIMIT 1";
-  $sql = $db->bindVars($sql, ':admEmail:', $admin_email, 'string');
-  $result = $db->Execute($sql);
-  if (!($admin_email == $result->fields['admin_email'])) {
-    $error = true;
-    $email_message = MESSAGE_PASSWORD_SENT;
-    $resetToken = 'bad';
-  } else if ($result->fields['lockout_expires'] != 0) {
-    header('HTTP/1.1 406 Not Acceptable');
-    exit(0);
-  }
+    if (empty($_POST['admin_email'])) {
+        $error = true;
+        $email_message = ERROR_WRONG_EMAIL_NULL;
+    }
+    $sql = "SELECT admin_id, admin_name, admin_email, admin_pass, lockout_expires
+            FROM " . TABLE_ADMIN . "
+            WHERE admin_email = :admEmail:";
+    $sql = $db->bindVars($sql, ':admEmail:', $_POST['admin_email'], 'string');
+    $emailResult = $db->Execute($sql);
+
+    if (!empty($_POST['admin_username'])) {
+        $sql = "SELECT admin_id, admin_name, admin_email, admin_pass, lockout_expires
+                FROM " . TABLE_ADMIN . "
+                WHERE admin_email = :admEmail: AND admin_name = :admUsername: LIMIT 1";
+        $sql = $db->bindVars($sql, ':admEmail:', $_POST['admin_email'], 'string');
+        $sql = $db->bindVars($sql, ':admUsername:', $_POST['admin_username'], 'string');
+        $usernameResult = $db->Execute($sql);
+    }
+
+    // no matching email addresses
+    if ($emailResult->RecordCount() === 0) {
+        $error = true;
+        $email_message = MESSAGE_PASSWORD_SENT;
+        $resetToken = 'bad';
+    }
+
+    // multiple matching email addresses
+    if ($emailResult->RecordCount() > 1) {
+        if (empty($_POST['admin_username']) || $usernameResult->RecordCount() === 0) {
+            $error = true;
+            $email_message = MESSAGE_PASSWORD_SENT;
+            $resetToken = 'bad';
+        } else {
+            $result = $usernameResult;
+        }
+    } else {
+        $result = $emailResult;
+    }
+
+
+    if ($error === false && $result->fields['lockout_expires'] != 0) {
+        header('HTTP/1.1 406 Not Acceptable');
+        exit(0);
+    }
+
 
   // BEGIN SLAM PREVENTION
-  if ($_POST['admin_email'] != '') {
+  if (empty($_POST['admin_email'])) {
     if (!isset($_SESSION['login_attempt'])) {
       $_SESSION['login_attempt'] = 0;
     }
     $_SESSION['login_attempt']++;
   } // END SLAM PREVENTION
 
-  if ($error == false) {
+  if ($error === false) {
     $new_password = zen_create_PADSS_password((int)ADMIN_PASSWORD_MIN_LENGTH < 7 ? 7 : (int)ADMIN_PASSWORD_MIN_LENGTH);
     $resetToken = (time() + ADMIN_PWD_TOKEN_DURATION) . '}' . zen_encrypt_password($new_password);
     $sql = "UPDATE " . TABLE_ADMIN . "
@@ -62,8 +88,16 @@ if (isset($_POST['action']) && $_POST['action'] == 'update') {
     $html_msg['EMAIL_MESSAGE_HTML'] = sprintf(TEXT_EMAIL_MESSAGE_PWD_RESET, $_SERVER['REMOTE_ADDR'], $new_password);
     zen_mail($result->fields['admin_name'], $result->fields['admin_email'], TEXT_EMAIL_SUBJECT_PWD_RESET, sprintf(TEXT_EMAIL_MESSAGE_PWD_RESET, $_SERVER['REMOTE_ADDR'], $new_password), STORE_NAME, EMAIL_FROM, $html_msg, 'password_forgotten_admin');
     $email_message = MESSAGE_PASSWORD_SENT;
+  } else {
+    $html_msg['EMAIL_MESSAGE_HTML'] = sprintf(TEXT_EMAIL_MESSAGE_PWD_FAILED_RESET, $_SERVER['REMOTE_ADDR']);
+    zen_mail(STORE_NAME, STORE_OWNER_EMAIL_ADDRESS, TEXT_EMAIL_SUBJECT_PWD_FAILED_RESET, sprintf(TEXT_EMAIL_MESSAGE_PWD_FAILED_RESET, $_SERVER['REMOTE_ADDR']), STORE_NAME, EMAIL_FROM, $html_msg, 'password_forgotten_admin');
+    $email_message = MESSAGE_PASSWORD_SENT;
   }
 }
+
+$sql = "SELECT admin_email FROM " . TABLE_ADMIN . " GROUP BY admin_email HAVING COUNT(admin_email) > 1";
+$result = $db->Execute($sql);
+$has_duplicate_admin_emails = ($result->RecordCount() > 0);
 ?>
 <!DOCTYPE html>
 <html <?php echo HTML_PARAMS; ?>>
@@ -91,9 +125,19 @@ if (isset($_POST['action']) && $_POST['action'] == 'update') {
                   <span class="input-group-addon">
                     <i class="fa fa-lg fa-at"></i>
                   </span>
-                  <?php echo zen_draw_input_field('admin_email', '', 'class="form-control input-lg" id="admin_email" autocapitalize="none" spellcheck="false" autocomplete="off" autofocus placeholder="' . TEXT_ADMIN_EMAIL . '"') . PHP_EOL; ?>
+                  <?php echo zen_draw_input_field('admin_email', '', 'class="form-control input-lg" id="admin_email" autocapitalize="none" spellcheck="false" autocomplete="off" autofocus required placeholder="' . TEXT_ADMIN_EMAIL . '" aria-label="' . TEXT_ADMIN_EMAIL . '"', false, 'email') . PHP_EOL; ?>
                 </div>
               </div>
+                <?php if ($has_duplicate_admin_emails) { ?>
+              <div class="form-group">
+                <div class="input-group">
+                  <span class="input-group-addon">
+                    <i class="fa fa-lg fa-user"></i>
+                  </span>
+                  <?php echo zen_draw_input_field('admin_username', '', 'class="form-control input-lg" id="admin_username" autocapitalize="none" spellcheck="false" autocomplete="off" placeholder="' . TEXT_ADMIN_USERNAME . '" aria-label="' . TEXT_ADMIN_USERNAME . '"', false, 'text') . PHP_EOL; ?>
+                </div>
+              </div>
+                <?php } ?>
               <?php echo zen_draw_hidden_field('action', 'update') . PHP_EOL; ?>
               <div class="form-group">
                 <button type="submit" class="btn btn-primary btn-lg"><?php echo TEXT_BUTTON_REQUEST_RESET; ?></button>


### PR DESCRIPTION
If multiple email addresses exist in admin user accounts, users will be prompted to also provide the username in order to request a reset.

Also, now when failed resets happen an email alert is sent.

Fixes #3546


Default display:
<img width="454" alt="Screen Shot 2020-06-09 at 1 31 13 PM" src="https://user-images.githubusercontent.com/404472/84180512-9e1f1280-aa55-11ea-97b9-7fe8a3186f55.png">

Updated display if duplicate emails exist:
<img width="453" alt="Screen Shot 2020-06-09 at 1 31 46 PM" src="https://user-images.githubusercontent.com/404472/84180549-af681f00-aa55-11ea-8582-ee2550a5a058.png">
