### PR TITLE
Fix to allow admin pwd to work while reset token exists

### DIFF
--- a/admin/includes/functions/admin_access.php
+++ b/admin/includes/functions/admin_access.php
@@ -348,6 +348,8 @@ function zen_validate_user_login($admin_name, $admin_pass)
           $message = ERROR_WRONG_LOGIN;
           zen_record_admin_activity(sprintf(TEXT_ERROR_FAILED_ADMIN_LOGIN_FOR_USER) . ' ' . $admin_name, 'warning');
         }
+      } else {
+        $error = false;
       }
     }
     // BEGIN 2-factor authentication


### PR DESCRIPTION
Fixes #3572 :
If an admin user requests a password reset,
a temporary password is generated with an expiry token and emailed to them.
The new password can be used until the token expires,
but the old password no longer works ... until the reset token expires.

This `else ... $error = false` resets the `$error = true` triggered earlier when the login attempt is being made against a non-expired reset token: when logging in with the "old" pwd the login against the reset-token fails and is recorded as an error, thus this reset is necessary when the login passes against the original token.
All this becomes moot once the reset-token expires, as it falls back to only checking against the original token.