### PR TITLE
Update library loader code to remove google jsapi

### DIFF
--- a/admin/includes/modules/dashboard_widgets/SalesReportDashboardWidget.php
+++ b/admin/includes/modules/dashboard_widgets/SalesReportDashboardWidget.php
@@ -41,9 +41,9 @@ $currencies = new currencies();
   var data;
   var chart;
   // Load the Visualization API and the piechart package.
-  google.load('visualization', '1', {'packages': ['corechart']});
+  google.charts.load('current', {packages: ['corechart']});
   // Set a callback to run when the Google Visualization API is loaded.
-  google.setOnLoadCallback(drawSalesGraph);
+  google.charts.setOnLoadCallback(drawSalesGraph);
 
   function drawSalesGraph() {
       data = new google.visualization.DataTable();

--- a/admin/includes/modules/dashboard_widgets/TrafficDashboardWidget.php
+++ b/admin/includes/modules/dashboard_widgets/TrafficDashboardWidget.php
@@ -64,9 +64,9 @@ foreach ($visits as $data) {
   var data;
   var chart;
   // Load the Visualization API and the piechart package.
-  google.load('visualization', '1', {'packages': ['corechart']});
+  google.charts.load('current', {packages: ['corechart']});
   // Set a callback to run when the Google Visualization API is loaded.
-  google.setOnLoadCallback(drawTrafficChart);
+  google.charts.setOnLoadCallback(drawTrafficChart);
 
   // Callback that creates and populates a data table,
   // instantiates the pie chart, passes in the data and draws it.

--- a/admin/index_dashboard.php
+++ b/admin/index_dashboard.php
@@ -15,27 +15,9 @@ if (empty($currencies)) {
 <!doctype html>
 <html <?php echo HTML_PARAMS; ?>>
   <head>
-    <meta charset="<?php echo CHARSET; ?>">
-    <title><?php echo TITLE; ?></title>
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-    <meta name="robots" content="noindex, nofollow">
-    <link href="includes/stylesheet.css" rel="stylesheet">
-    <link rel="stylesheet" href="includes/cssjsmenuhover.css" media="all" id="hoverJS">
-    <script src="includes/menu.js" title="menu"></script>
-    <script title="menu_init">
-      function init() {
-          cssjsmenu('navbar');
-          if (document.getElementById) {
-              var kill = document.getElementById('hoverJS');
-              kill.disabled = true;
-          }
-      }
-    </script>
-
+    <?php require DIR_WS_INCLUDES . 'admin_html_head.php'; ?>
     <!--Load the AJAX API FOR GOOGLE GRAPHS -->
-    <script src="https://www.google.com/jsapi" title="google_graphs_api"></script>
-
-
+    <script src="https://www.gstatic.com/charts/loader.js" title="google_graphs_api"></script>
     <style>
       /* #coltwo div.row span.left { float: left; text-align: left; width: 50%; white-space: nowrap; }*/
       #colthree div.row span.left { float: left; text-align: left; width: 50%; white-space: nowrap; }
@@ -44,7 +26,6 @@ if (empty($currencies)) {
       div.first { float: left; width: 90px; }
       div.col { float: left; width: 18%; }
     </style>
-
   </head>
   <body class="indexDashboard" onLoad="init()">
     <!-- header //-->

--- a/admin/index_dashboard.php
+++ b/admin/index_dashboard.php
@@ -27,7 +27,7 @@ if (empty($currencies)) {
       div.col { float: left; width: 18%; }
     </style>
   </head>
-  <body class="indexDashboard" onLoad="init()">
+  <body class="indexDashboard">
     <!-- header //-->
     <?php require(DIR_WS_INCLUDES . 'header.php'); ?>
     <!-- header_eof //-->

--- a/admin/stats_sales_report_graphs.php
+++ b/admin/stats_sales_report_graphs.php
@@ -82,27 +82,14 @@ if (strlen($sales_report_filter) == 0) {
   <head>
     <meta charset="<?php echo CHARSET; ?>">
     <title><?php echo TITLE; ?></title>
-    <link rel="stylesheet" href="includes/stylesheet.css">
-    <link rel="stylesheet" media="print" href="includes/css/stylesheet_print.css">
-    <link rel="stylesheet" href="includes/cssjsmenuhover.css" media="all" id="hoverJS">
-    <script src="includes/menu.js"></script>
-    <script src="includes/general.js"></script>
-    <script src="https://www.google.com/jsapi"></script>
-    <script title="menu_init">
-      function init() {
-          cssjsmenu('navbar');
-          if (document.getElementById) {
-              var kill = document.getElementById('hoverJS');
-              kill.disabled = true;
-          }
-      }
-    </script>
+    <?php require 'includes/admin_html_head.php'; ?>
+    <script src="https://www.gstatic.com/charts/loader.js"></script>
     <script title="build_graphs">
       // Load the Visualization API and the piechart package.
-      google.load('visualization', '1.0', {'packages': ['corechart']});
+      google.charts.load('current', {packages: ['corechart']});
 
       // Set a callback to run when the Google Visualization API is loaded.
-      google.setOnLoadCallback(drawChart);
+      google.charts.setOnLoadCallback(drawChart);
 
       function drawChart() {
 
@@ -170,7 +157,7 @@ for ($i = 0; $i < $report->size; $i++) {
       }
     </script>
   </head>
-  <body onload="init()">
+  <body>
     <!-- header //-->
     <?php require(DIR_WS_INCLUDES . 'header.php'); ?>
     <!-- header_eof //-->


### PR DESCRIPTION
As mentioned here (https://developers.google.com/chart/interactive/docs/basic_load_libs#updateloader), the code loading the chart scripts should be updated.

And while updating I also updated the html head.
More Updates queued for ZC1.5.8