### PR TITLE
Add developer-mode array of configs to override on new installs

### DIFF
--- a/zc_install/includes/classes/class.zcDatabaseInstaller.php
+++ b/zc_install/includes/classes/class.zcDatabaseInstaller.php
@@ -495,6 +495,16 @@ class zcDatabaseInstaller
                 : ", reset_token = '" . (time() + (72 * 60 * 60)) . "}" . zen_encrypt_password($options['admin_password']) . "'") . " where admin_id = 1";
         $this->db->Execute($sql);
 
+        if (DEVELOPER_MODE === true && defined('DEVELOPER_CONFIGS') && is_array(DEVELOPER_CONFIGS)) {
+            foreach (DEVELOPER_CONFIGS as $key) {
+                if (defined($key)) {
+                    $value = constant($key);
+                    if (null === $value) continue;
+                    $sql = "update " . $this->dbPrefix . "configuration set configuration_value = '" . $this->db->prepareInput($value) . "' where configuration_key = '" . $this->db->prepareInput($key) . "'";
+                    $this->db->Execute($sql);
+                }
+            }
+        }
     }
 
     private function camelize($parseString)

--- a/zc_install/includes/localConfig.php
+++ b/zc_install/includes/localConfig.php
@@ -32,3 +32,12 @@ define('DEVELOPER_DBNAME_DEFAULT', $dev_db_default_name);
 define('DEVELOPER_DBUSER_DEFAULT', 'root');
 define('DEVELOPER_DBPASSWORD_DEFAULT', '');
 define('DEVELOPER_INSTALL_DEMO_DATA', true);
+
+// optional configuration table keys to override on new installs when DEVELOPER_MODE===true
+define('DEVELOPER_CONFIGS', [
+    'EMAIL_SMTPAUTH_MAILBOX' => 'Zen Cart',
+    'EMAIL_SMTPAUTH_PASSWORD' => '',
+    'EMAIL_SMTPAUTH_MAIL_SERVER' => 'localhost',
+    'EMAIL_SMTPAUTH_MAIL_SERVER_PORT' => '2525',
+    'EMAIL_TRANSPORT' => 'smtpauth',
+]);


### PR DESCRIPTION
When doing local dev sometimes it's helpful to override some default configuration table settings, without having to use custom .sql files.
This offers the ability to set those when developer mode is on. For new installs only.