### PR TITLE
Fix Non-static method base::getStaticProperty() should not be called statically

### DIFF
--- a/includes/classes/class.base.php
+++ b/includes/classes/class.base.php
@@ -75,7 +75,7 @@ class base
     {
         $this->logNotifier($eventID, $param1, $param2, $param3, $param4, $param5, $param6, $param7, $param8, $param9);
 
-        $observers = &self::getStaticObserver();
+        $observers = &$this->getStaticObserver();
         if (is_null($observers)) {
             return;
         }

--- a/includes/classes/traits/EventManager.php
+++ b/includes/classes/traits/EventManager.php
@@ -18,7 +18,7 @@ trait EventManager
     {
         $this->logNotifier($eventID, $param1, $param2, $param3, $param4, $param5, $param6, $param7, $param8, $param9);
 
-        $observers = &self::getStaticObserver();
+        $observers = &$this->getStaticObserver();
         if (is_null($observers)) {
             return;
         }
@@ -69,7 +69,7 @@ trait EventManager
     }
 
     protected function & getStaticObserver() {
-        return \base::getStaticProperty('observer');
+        return (new \base)->getStaticProperty('observer');
     }
 
     protected function & getStaticProperty($var)


### PR DESCRIPTION

```
1) ObserverAliasingTest::testObserverAliasing
Non-static method base::getStaticProperty() should not be called statically
```