### PR TITLE
Include zen_cfg_read_only configuration-helper function

### DIFF
--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -3101,15 +3101,13 @@ function zen_get_master_categories_pulldown($product_id, $fullpath = false)
     $string .= zen_draw_hidden_field($name, '--none--');
     return $string;
   }
-  
+
 /**
- * Function for configuration values that are read-only, e.g. a plugin's version
- * number.  Adapted from the like-named function in the Sitemap XML plugin, provided
- * by AndrewBerezin (rip).
+ * Function for configuration values that are read-only, e.g. a plugin's version number
  */
 function zen_cfg_read_only($text, $key = '') 
 {
-    $name = ((!empty($key)) ? 'configuration[' . $key . ']' : 'configuration_value');
+    $name = (!empty($key)) ? 'configuration[' . $key . ']' : 'configuration_value';
     $text = htmlspecialchars_decode($text);
 
     return $text . zen_draw_hidden_field($name, $text);

--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -3101,6 +3101,19 @@ function zen_get_master_categories_pulldown($product_id, $fullpath = false)
     $string .= zen_draw_hidden_field($name, '--none--');
     return $string;
   }
+  
+/**
+ * Function for configuration values that are read-only, e.g. a plugin's version
+ * number.  Adapted from the like-named function in the Sitemap XML plugin, provided
+ * by AndrewBerezin (rip).
+ */
+function zen_cfg_read_only($text, $key = '') 
+{
+    $name = ((!empty($key)) ? 'configuration[' . $key . ']' : 'configuration_value');
+    $text = htmlspecialchars_decode($text);
+
+    return $text . zen_draw_hidden_field($name, $text);
+}
 
 /**
  * get products image


### PR DESCRIPTION
... as distributed in various plugins currently, e.g. Sitemap XML.  Credit given to Andrew Berezin (rip).