### PR TITLE
Fixes default attribute issues

### DIFF
--- a/zc_install/sql/demo/README.txt
+++ b/zc_install/sql/demo/README.txt
@@ -1,4 +1,13 @@
-The demo_cleanup.sql script deletes ALL of records in the 
+Notes on Demo Data:
+
+mysql_demo.sql can be rerun after demo_cleanup.sql is used if you are
+tweaking the demo data and want to reload each time (without going through a
+full re-install). 
+
+Note that mysql_demo.sql should be used from the command line only, 
+not from Admin > Tools > MySQL Patches (the lines are too long). 
+
+demo_cleanup.sql deletes ALL of records in the 
 tables listed below.  It is intended for developers of demo data only.
 In particular, it should not be used if you have begun adding real
 data on top of demo data, because it removes data indiscriminately. 
@@ -37,5 +46,4 @@ reviews
 reviews_description 
 salemaker_sales 
 specials 
-
 

--- a/zc_install/sql/demo/mysql_demo.sql
+++ b/zc_install/sql/demo/mysql_demo.sql
@@ -980,7 +980,8 @@ INSERT INTO products_attributes_download (products_attributes_id, products_attri
 (1093, 'test.zip', 7, 5),
 (1094, 'test2.zip', 7, 5),
 (1100, 'ms_word_sample.zip', 7, 5),
-(1103, 'pdf_sample.zip', 7, 5);
+(1103, 'pdf_sample.zip', 7, 5),
+(1105, 'pdf_sample.zip', 7, 5);
 
 #
 # Dumping data for table `products_description`


### PR DESCRIPTION
- Correct test data set to ensure single product single attribute product has an associated file download
- Update documentation on data set
- Update shopping cart: 
  - build attributes array for defaultable attributes products added from listing page.
  - correct in cart quantity in that situation.
  - permit add from listing page when Buy Now button is used (vs Multiple Products Qty Box). 

Fixes #3626 