### PR TITLE
Add missing message

### DIFF
--- a/admin/includes/languages/english/category_product_listing.php
+++ b/admin/includes/languages/english/category_product_listing.php
@@ -85,3 +85,4 @@ define('TEXT_SUBCATEGORIES_STATUS_NOCHANGE', 'Unchanged');
 define('WARNING_PRODUCTS_IN_TOP_INFO', 'WARNING: You have Products in the Top Level Category. This will cause pricing to not work properly in the Catalog. Products found: ');
 
 define('TEXT_COPY_MEDIA_MANAGER', 'Copy media?');
+define('SUCCESS_ATTRIBUTES_DELETED','Attributes successfully deleted');


### PR DESCRIPTION
This message is used in the following workflow: 
-  from the product listing screen, click the A icon on a product with attributes
- click the Delete button next to Delete ALL Product Attributes for.