### PR TITLE
V157 admin product avail datepicker vs empty or malformed dates

### DIFF
--- a/admin/includes/modules/product_music/update_product.php
+++ b/admin/includes/modules/product_music/update_product.php
@@ -16,10 +16,13 @@ if (isset($_POST['edit']) && $_POST['edit'] == 'edit') {
   $action = 'new_product';
 } elseif ((isset($_POST['products_model']) ? $_POST['products_model'] : '') . (isset($_POST['products_url']) ? implode('', $_POST['products_url']) : '') . (isset($_POST['products_name']) ? implode('', $_POST['products_name']) : '') . (isset($_POST['products_description']) ? implode('', $_POST['products_description']) : '') != '') {
   $products_date_available = zen_db_prepare_input($_POST['products_date_available']);
-  if (DATE_FORMAT_DATE_PICKER != 'yy-mm-dd') {
+  if (DATE_FORMAT_DATE_PICKER != 'yy-mm-dd' && !empty($products_date_available)) {
     $local_fmt = zen_datepicker_format_fordate(); 
-    $dt = DateTime::createFromFormat($local_fmt, $products_date_available); 
-    $products_date_available = $dt->format('Y-m-d'); 
+    $dt = DateTime::createFromFormat($local_fmt, $products_date_available);
+      $products_date_available = 'null';
+      if (!empty($dt)) {
+        $products_date_available = $dt->format('Y-m-d'); 
+      }
   }
   $products_date_available = (date('Y-m-d') < $products_date_available) ? $products_date_available : 'null';
 

--- a/admin/includes/modules/update_product.php
+++ b/admin/includes/modules/update_product.php
@@ -16,10 +16,13 @@ if (isset($_POST['edit']) && $_POST['edit'] == 'edit') {
   $action = 'new_product';
 } elseif ((isset($_POST['products_model']) ? $_POST['products_model'] : '') . (isset($_POST['products_url']) ? implode('', $_POST['products_url']) : '') . (isset($_POST['products_name']) ? implode('', $_POST['products_name']) : '') . (isset($_POST['products_description']) ? implode('', $_POST['products_description']) : '') != '') {
   $products_date_available = zen_db_prepare_input($_POST['products_date_available']);
-  if (DATE_FORMAT_DATE_PICKER != 'yy-mm-dd') {
+  if (DATE_FORMAT_DATE_PICKER != 'yy-mm-dd' && !empty($products_date_available)) {
     $local_fmt = zen_datepicker_format_fordate(); 
-    $dt = DateTime::createFromFormat($local_fmt, $products_date_available); 
-    $products_date_available = $dt->format('Y-m-d'); 
+    $dt = DateTime::createFromFormat($local_fmt, $products_date_available);
+    $products_date_available = 'null';
+    if (!empty($dt)) {
+      $products_date_available = $dt->format('Y-m-d'); 
+    }
   }
   $products_date_available = (date('Y-m-d') < $products_date_available) ? $products_date_available : 'null';
 


### PR DESCRIPTION
Support product update if incorrectly formatted date provided 
Addresses: https://www.zen-cart.com/showthread.php?226900-v157-DATE_FORMAT_DATE_PICKER-error-if-date-format-change-and-update-product&p=1370184#post1370184
When storing a product without an available date and using a format other than `yy-mm-dd`, the update action failed because `$dt===false` and `false->format` doesn't exist.

Alternative solutions considered: testing against the existence of the method `format` of the variable `$dt` as part of this resolution, providing admin feedback (likely in the preview area or as a redirect here when such a failure occurs.

The same problem appears to occur if an invalid date format is provided: E.g. if using `dd-mm-yy` for `DATE_FORMAT_DATE_PICKER` and a date is entered as `dd/mm/yy` then `$dt` will be set to false and the same problem would occur as otherwise found for an empty date and a modified format.