### PR TITLE
For "required" input fields, use browser validation instead of just text indicator

### DIFF
--- a/admin/includes/functions/html_output.php
+++ b/admin/includes/functions/html_output.php
@@ -263,11 +263,12 @@ function zen_image_submit($image, $alt = '', $parameters = '')
 
     if (zen_not_null($parameters)) $field .= ' ' . $parameters;
 
+    if ($required && strpos($parameters, 'required') === false) {
+        $field .= ' required';
+    }
+
     $field .= ' />';
 
-    if ($required && !empty(TEXT_FIELD_REQUIRED)) {
-      $field .= '&nbsp;<span class="alert">' . TEXT_FIELD_REQUIRED . '</span>';
-    }
     return $field;
   }
 
@@ -371,11 +372,14 @@ function zen_image_submit($image, $alt = '', $parameters = '')
  * @return string
  */
   function zen_draw_pull_down_menu($name, $values, $default = '', $parameters = '', $required = false) {
-  //    $field = '<select name="' . zen_output_string($name) . '"';
     $field = '<select rel="dropdown" name="' . zen_output_string($name) . '"';
 
     if (zen_not_null($parameters)) {
       $field .= ' ' . $parameters;
+    }
+
+    if ($required && strpos($parameters, 'required') === false) {
+          $field .= ' required';
     }
 
     $field .= '>' . "\n";
@@ -393,10 +397,6 @@ function zen_image_submit($image, $alt = '', $parameters = '')
       $field .= '>' . zen_output_string($value['text'], array('"' => '&quot;', '\'' => '&#039;', '<' => '&lt;', '>' => '&gt;')) . '</option>' . "\n";
     }
     $field .= '</select>' . "\n";
-
-    if ($required == true) {
-      $field .= TEXT_FIELD_REQUIRED;
-    }
 
     return $field;
   }


### PR DESCRIPTION
`<span class="alert">*</span>` creates layout messes, and still doesn't enforce required entry in fields.

Passing the `required` attribute tells the browser to alert when the field is left empty, and skipping the `<span>` prevents the layout issues.