### PR TITLE
check page strip of .php suffix done on wrong side

### DIFF
--- a/admin/includes/functions/admin_access.php
+++ b/admin/includes/functions/admin_access.php
@@ -36,7 +36,7 @@ function check_page($page, $params) {
   $result = $db->Execute($sql);
   $retVal = FALSE;
   while (!$result->EOF) {
-    if ($result->fields['main_page'] != '' && defined($result->fields['main_page']) && (constant($result->fields['main_page']) == $page || basename(constant($result->fields['main_page']), '.php') == $page) && $result->fields['page_params'] == $page_params) {
+    if ($result->fields['main_page'] != '' && defined($result->fields['main_page']) && basename(constant($result->fields['main_page']), '.php') == $page && $result->fields['page_params'] == $page_params) {
       $retVal = TRUE;
     }
     $result->MoveNext();

--- a/admin/includes/functions/admin_access.php
+++ b/admin/includes/functions/admin_access.php
@@ -36,7 +36,7 @@ function check_page($page, $params) {
   $result = $db->Execute($sql);
   $retVal = FALSE;
   while (!$result->EOF) {
-    if ($result->fields['main_page'] != '' && defined($result->fields['main_page']) && (constant($result->fields['main_page']) == $page || constant($result->fields['main_page']) . '.php' == $page) && $result->fields['page_params'] == $page_params) {
+    if ($result->fields['main_page'] != '' && defined($result->fields['main_page']) && (constant($result->fields['main_page']) == $page || basename(constant($result->fields['main_page']), '.php') == $page) && $result->fields['page_params'] == $page_params) {
       $retVal = TRUE;
     }
     $result->MoveNext();
@@ -966,8 +966,8 @@ function zen_admin_authorized_to_place_order()
         if (count($profile_list) != 0) {
             $profile_clause = ' AND admin_profile IN (' . implode(',', $profile_list) . ')';
             $emp_sql =
-                "SELECT admin_profile, admin_pass 
-                   FROM " . TABLE_ADMIN . " 
+                "SELECT admin_profile, admin_pass
+                   FROM " . TABLE_ADMIN . "
                   WHERE admin_id = :adminId:$profile_clause
                   LIMIT 1";
             $emp_sql = $db->bindVars($emp_sql, ':adminId:', $_SESSION['admin_id'], 'integer');


### PR DESCRIPTION
looks like comparison is done on the wrong side.

8 years ago, ```$page``` was defined as without extension:

https://github.com/zencart/zencart/blob/8e14368e080b910a120f6e2ec3d8a8c7dc1b9f11/admin/includes/init_includes/init_admin_auth.php#L55

7 years ago, a fix was implemented to address those `modders` who included the '.php' in their filename:

https://www.zen-cart.com/showthread.php?207650-Antibugging-in-admin-function-check_page%28%29

only problem is that the constant is the one that has the .php at the end.  so now the comparison is for ```filename.php.php == filename```

this PR fixes that.  and allows ```modders``` to continue to mess up with '.php' in their filenames without unintended negative consequences.