### PR TITLE
Allow observer to be executed from multiple files

### DIFF
--- a/includes/classes/class.base.php
+++ b/includes/classes/class.base.php
@@ -116,7 +116,7 @@ class base
             foreach($methodsToCheck as $method) {
                 if (method_exists($obs['obs'], $method)) {
                     $obs['obs']->{$method}($this, $actualEventId, $param1, $param2, $param3, $param4, $param5, $param6, $param7, $param8, $param9);
-                    return;
+                    continue 2;
                 }
             }
             // If no update handler method exists then trigger an error so the problem is logged


### PR DESCRIPTION
While I can not seem to find this as an equivalent operation
for ZC 1.5.8 (too rushed?), I discovered this bug where
if a notifier was observed by more than one observer, then it
seems that either a secondary observer was not executing or
if it was, data was lost... This allows the notifier to be
executed through multiple observers and not lose the data that
was originally transferred.

Issue was seen with installation of both stock by attributes
and products with attributes image swap.  Both were listening
to the notifier: `NOTIFY_ATTRIBUTES_MODULE_START_OPTION` but
only SBA's version was execute while attribute image swap was
not executing and in strict mode there were notices thrown that
variables were not defined/declared...

I'll continue to try to find the ZC 1.5.8 version of this
code section, but not sure if it will/does suffer the same
issue as it has been moved into using namespace type execution.