### PR TITLE
define TOPMOST_CATEGORY_PARENT_ID = 0

### DIFF
--- a/admin/categories.php
+++ b/admin/categories.php
@@ -112,6 +112,7 @@ if (zen_not_null($action)) {
                 WHERE categories_id = '" . (int)$categories_id . "'";
 
         $parent_cat = $db->Execute($sql);
+        // @TODO - should this be checking against TOPMOST_CATEGORY_PARENT_ID?
         if ($parent_cat->fields['parent_id'] != '0') {
           $sql = "SELECT *
                   FROM " . TABLE_PRODUCT_TYPES_TO_CATEGORY . "

--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -130,11 +130,11 @@ if (zen_not_null($action)) {
       }
 
       // delete category and products
-      if (isset($_POST['categories_id']) && $_POST['categories_id'] != '' && is_numeric($_POST['categories_id']) && $_POST['categories_id'] != 0) {
+      if (!empty($_POST['categories_id']) && is_numeric($_POST['categories_id']) && $_POST['categories_id'] != TOPMOST_CATEGORY_PARENT_ID) {
         $categories_id = zen_db_prepare_input($_POST['categories_id']);
 
         // create list of any subcategories in the selected category,
-        $categories = zen_get_category_tree($categories_id, '', '0', '', true);
+        $categories = zen_get_category_tree($categories_id, '', TOPMOST_CATEGORY_PARENT_ID, [], true);
 
         zen_set_time_limit(600);
 
@@ -1069,11 +1069,11 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
         <div class="row text-center alert">
           <?php
           // warning if products are in top level categories
-          $check_products_top_categories = $db->Execute("SELECT COUNT(*) AS products_errors
+          $check_products_top_categories = $db->Execute("SELECT COUNT(*) AS products_in_top_level_error
                                                              FROM " . TABLE_PRODUCTS_TO_CATEGORIES . "
-                                                             WHERE categories_id = 0");
-          if ($check_products_top_categories->fields['products_errors'] > 0) {
-            echo WARNING_PRODUCTS_IN_TOP_INFO . $check_products_top_categories->fields['products_errors'] . '<br>';
+                                                             WHERE categories_id = " . (int)TOPMOST_CATEGORY_PARENT_ID);
+          if ($check_products_top_categories->fields['products_in_top_level_error'] > 0) {
+            echo WARNING_PRODUCTS_IN_TOP_INFO . $check_products_top_categories->fields['products_in_top_level_error'] . '<br>';
           }
           ?>
         </div>

--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -751,7 +751,7 @@ function zen_set_product_status($products_id, $status)
 
 
   function zen_remove_category($category_id) {
-    if ((int)$category_id == 0) return;
+    if ((int)$category_id == TOPMOST_CATEGORY_PARENT_ID) return;
     global $db, $zco_notifier;
     $zco_notifier->notify('NOTIFIER_ADMIN_ZEN_REMOVE_CATEGORY', array(), $category_id);
 
@@ -2029,7 +2029,6 @@ function zen_get_language_name($lookup)
 /**
  * Count how many subcategories exist in a category
  * TABLES: categories
- * old v1.2 name zen_get_parent_category_name
  */
   function zen_get_products_master_categories_name($categories_id) {
     global $db;

--- a/admin/includes/init_includes/init_category_path.php
+++ b/admin/includes/init_includes/init_category_path.php
@@ -10,6 +10,8 @@ if (!defined('IS_ADMIN_FLAG')) {
     die('Illegal Access');
 }
 
+define('TOPMOST_CATEGORY_PARENT_ID', '0');
+
 // calculate category path
 if (isset($_POST['cPath'])) {
     $cPath = $_POST['cPath'];
@@ -25,7 +27,7 @@ if (zen_not_null($cPath)) {
     $current_category_id = $cPath_array[(count($cPath_array) - 1)];
 } else {
     $cPath_array = [];
-    $current_category_id = 0;
+    $current_category_id = TOPMOST_CATEGORY_PARENT_ID;
 }
 
 // default open navigation box

--- a/admin/products_to_categories.php
+++ b/admin/products_to_categories.php
@@ -14,10 +14,10 @@ require('includes/application_top.php');
  * validate the user-entered categories from the Global Tools
  * @param int $ref_category_id
  * @param int $target_category_id
- * @param bool $reset_master_category
+ * @param bool $reset_master_category set to true if using this function when resetting master_category_id
  * @return bool
  */
-function zen_validate_categories($ref_category_id, $target_category_id = 0, $reset_master_category = false)
+function zen_validate_categories($ref_category_id, $target_category_id = TOPMOST_CATEGORY_PARENT_ID, $reset_master_category = false)
 {
     global $db, $messageStack;
 
@@ -62,7 +62,7 @@ function zen_validate_categories($ref_category_id, $target_category_id = 0, $res
  * @param string $category_path_string The full path of the names of all the parent categories being included in the path for the (sub)categories info being generated.
  * @return void
  */
-function zen_get_categories_info($parent_id = 0, $category_path_string = '')
+function zen_get_categories_info($parent_id = TOPMOST_CATEGORY_PARENT_ID, $category_path_string = '')
 {
     global $db, $categories_info;
 
@@ -100,7 +100,7 @@ function zen_get_categories_info($parent_id = 0, $category_path_string = '')
  * @param string $type category or product: to determine the array structure
  * @return array
  */
-function zen_get_target_categories_products($parent_id = 0, $spacing = '', $category_product_tree_array = [], $type = 'category')
+function zen_get_target_categories_products($parent_id = TOPMOST_CATEGORY_PARENT_ID, $spacing = '', $category_product_tree_array = [], $type = 'category')
 {
     global $db, $products_filter;
     $categories = $db->Execute("SELECT cd.categories_id, cd.categories_name, c.parent_id
@@ -228,7 +228,7 @@ if ($products_filter === '' && !empty($current_category_id)) { // when prev-next
     }
 
 } elseif ($products_filter === '' && empty($current_category_id)) {// on first entry into page from Admin menu
-    $reset_categories_id = zen_get_category_tree('', '', '0', '', '', true);
+    $reset_categories_id = zen_get_category_tree('', '', TOPMOST_CATEGORY_PARENT_ID, '', '', true);
     $current_category_id = (int)$reset_categories_id[0]['id'];
     $new_product_query = $db->Execute("SELECT ptc.products_id FROM " . TABLE_PRODUCTS_TO_CATEGORIES . " ptc WHERE ptc.categories_id = " . $current_category_id . " LIMIT 1");
     $products_filter = (!$new_product_query->EOF) ? $new_product_query->fields['products_id'] : '';// Empty if category has no products/has subcategories
@@ -481,7 +481,7 @@ if (zen_not_null($action)) {
 
             $category_id_as_master = (int)$_POST['category_id_as_master'];
 
-            if (!zen_validate_categories($category_id_as_master, 0, true)) {
+            if (!zen_validate_categories($category_id_as_master, TOPMOST_CATEGORY_PARENT_ID, true)) {
                 zen_redirect(zen_href_link(FILENAME_PRODUCTS_TO_CATEGORIES, 'products_filter=' . $products_filter . '&current_category_id=' . $current_category_id));
             }
             // if either category was invalid nothing processes below
@@ -821,11 +821,11 @@ if ($target_subcategory_count > $max_input_vars) { //warning when in excess of P
                     echo zen_draw_form('set_target_category_form', FILENAME_PRODUCTS_TO_CATEGORIES, 'action=set_target_category' . '&products_filter=' . $products_filter . '&current_category_id=' . $current_category_id, 'post');
                     $select_all_categories_option = [
                         [
-                            'id' => 0,
+                            'id' => TOPMOST_CATEGORY_PARENT_ID,
                             'text' => TEXT_TOP
                         ]
                     ];
-                    $category_select_values = zen_get_target_categories_products(0, '&nbsp;&nbsp;&nbsp;', $select_all_categories_option);
+                    $category_select_values = zen_get_target_categories_products(TOPMOST_CATEGORY_PARENT_ID, '&nbsp;&nbsp;&nbsp;', $select_all_categories_option);
                     ?>
                     <label><?php echo TEXT_LABEL_CATEGORY_DISPLAY_ROOT . zen_draw_pull_down_menu('target_category_id', $category_select_values, $target_category_id, 'onChange="this.form.submit();"'); ?></label>
                     <?php
@@ -967,7 +967,7 @@ if ($target_subcategory_count > $max_input_vars) { //warning when in excess of P
                         'id' => '',
                         'text' => TEXT_OPTION_LINKED_CATEGORIES
                     ];
-                    $category_product_tree_array = zen_get_target_categories_products(0, '', $category_product_tree_array, 'product');
+                    $category_product_tree_array = zen_get_target_categories_products(TOPMOST_CATEGORY_PARENT_ID, '', $category_product_tree_array, 'product');
                     ?>
                     <div class="form-group-row">
                         <div class="col-lg-8">

--- a/includes/classes/categories_ul_generator.php
+++ b/includes/classes/categories_ul_generator.php
@@ -22,7 +22,7 @@
 //
 
 class zen_categories_ul_generator {
-    var $root_category_id = 0,
+    var $root_category_id = TOPMOST_CATEGORY_PARENT_ID,
     $max_level = 0,
     $data = array(),
     $parent_group_start_string = '<ul%s>',
@@ -55,6 +55,7 @@ class zen_categories_ul_generator {
 
     function buildBranch($parent_id, $level = 0, $submenu=true, $parent_link='')
     {
+        $parent_id = (int)$parent_id;
         $level = (int)$level;
         $result = sprintf($this->parent_group_start_string, ($submenu==true) ? ' class="level'. ($level+1) . '"' : '' );
 

--- a/includes/classes/category_tree.php
+++ b/includes/classes/category_tree.php
@@ -29,7 +29,7 @@ class category_tree extends base {
     if ($product_type == 'all') {
       $categories_query = "select c.categories_id, cd.categories_name, c.parent_id, c.categories_image
                              from " . TABLE_CATEGORIES . " c, " . TABLE_CATEGORIES_DESCRIPTION . " cd
-                             where c.parent_id = 0
+                             where c.parent_id = " . (int)TOPMOST_CATEGORY_PARENT_ID . "
                              and c.categories_id = cd.categories_id
                              and cd.language_id='" . (int)$_SESSION['languages_id'] . "'
                              and c.categories_status= 1
@@ -37,7 +37,7 @@ class category_tree extends base {
     } else {
       $categories_query = "select ptc.category_id as categories_id, cd.categories_name, c.parent_id, c.categories_image
                              from " . TABLE_CATEGORIES . " c, " . TABLE_CATEGORIES_DESCRIPTION . " cd, " . TABLE_PRODUCT_TYPES_TO_CATEGORY . " ptc
-                             where c.parent_id = 0
+                             where c.parent_id = " . (int)TOPMOST_CATEGORY_PARENT_ID . "
                              and ptc.category_id = cd.categories_id
                              and ptc.product_type_id = " . $master_type . "
                              and c.categories_id = ptc.category_id
@@ -146,13 +146,13 @@ class category_tree extends base {
     $this->categories_string = "";
 
     for ($i=0; $i<$this->tree[$counter]['level']; $i++) {
-      if ($this->tree[$counter]['parent'] != 0) {
+      if ($this->tree[$counter]['parent'] != TOPMOST_CATEGORY_PARENT_ID) {
         $this->categories_string .= CATEGORIES_SUBCATEGORIES_INDENT;
       }
     }
 
 
-    if ($this->tree[$counter]['parent'] == 0) {
+    if ($this->tree[$counter]['parent'] == TOPMOST_CATEGORY_PARENT_ID) {
       $cPath_new = 'cPath=' . $counter;
       $this->box_categories_array[$ii]['top'] = 'true';
     } else {

--- a/includes/classes/site_map.php
+++ b/includes/classes/site_map.php
@@ -17,7 +17,7 @@ if (!defined('IS_ADMIN_FLAG')) {
  * @package general
  */
  class zen_SiteMapTree {
-   var $root_category_id = 0,
+   var $root_category_id = TOPMOST_CATEGORY_PARENT_ID,
        $max_level = 0,
        $data = array(),
        $root_start_string = '',

--- a/includes/init_includes/init_category_path.php
+++ b/includes/init_includes/init_category_path.php
@@ -13,6 +13,8 @@ if (!defined('IS_ADMIN_FLAG')) {
     die('Illegal Access');
 }
 
+define('TOPMOST_CATEGORY_PARENT_ID', '0');
+
 $show_welcome = false;
 if (isset($_GET['cPath'])) {
     $cPath = $_GET['cPath'];
@@ -32,7 +34,7 @@ if (zen_not_null($cPath)) {
     $cPath = implode('_', $cPath_array);
     $current_category_id = $cPath_array[(count($cPath_array) - 1)];
 } else {
-    $current_category_id = 0;
+    $current_category_id = TOPMOST_CATEGORY_PARENT_ID;
     $cPath_array = [];
 }
 

--- a/includes/modules/categories_tabs.php
+++ b/includes/modules/categories_tabs.php
@@ -13,11 +13,14 @@ if (!defined('IS_ADMIN_FLAG')) {
 }
 $order_by = " order by c.sort_order, cd.categories_name ";
 
-$categories_tab_query = "select c.sort_order, c.categories_id, cd.categories_name from " .
-TABLE_CATEGORIES . " c, " . TABLE_CATEGORIES_DESCRIPTION . " cd
-                          where c.categories_id=cd.categories_id and c.parent_id= '0' and cd.language_id='" . (int)$_SESSION['languages_id'] . "' and c.categories_status='1'" .
-$order_by;
-$categories_tab = $db->Execute($categories_tab_query);
+$sql = "SELECT c.sort_order, c.categories_id, cd.categories_name
+        FROM " . TABLE_CATEGORIES . " c
+        LEFT JOIN " . TABLE_CATEGORIES_DESCRIPTION . " cd USING (categories_id)
+        WHERE c.parent_id= " . (int)TOPMOST_CATEGORY_PARENT_ID . "
+        AND cd.language_id=" . (int)$_SESSION['languages_id'] . "
+        AND c.categories_status=1 " .
+        $order_by;
+$categories_tab = $db->Execute($sql);
 
 $links_list = array();
 while (!$categories_tab->EOF) {


### PR DESCRIPTION
Instead of using `'0'` to denote the "top"/root/parent category, use the `TOPMOST_CATEGORY_PARENT_ID` constant.

This will improve clarity in code when checking whether a `category_id == '0'` vs being 0 for some other reason.
It also allows, in theory, for a different parent/root to be set for other reasons (such as an MPTT category structure, or nested sub-groupings .... neither of which are planned/forecasted on any roadmaps).