### PR TITLE
Force conversion to float

### DIFF
--- a/includes/modules/payment/paypalwpp.php
+++ b/includes/modules/payment/paypalwpp.php
@@ -533,7 +533,7 @@ if (false) { // disabled until clarification is received about coupons in PayPal
                           'mc_gross' => (float)$this->amt,
                           'mc_fee' => (float)urldecode($this->feeamt),
                           'mc_currency' => $this->responsedata['PAYMENTINFO_0_CURRENCYCODE'],
-                          'settle_amount' => (float)(isset($this->responsedata['PAYMENTINFO_0_SETTLEAMT'])) ? $this->urldecode($this->responsedata['PAYMENTINFO_0_SETTLEAMT']) : $this->amt,
+                          'settle_amount' => (float)(isset($this->responsedata['PAYMENTINFO_0_SETTLEAMT']) ? $this->urldecode($this->responsedata['PAYMENTINFO_0_SETTLEAMT']) : $this->amt),
                           'settle_currency' => $this->responsedata['PAYMENTINFO_0_CURRENCYCODE'],
                           'exchange_rate' => (isset($this->responsedata['PAYMENTINFO_0_EXCHANGERATE']) && urldecode($this->responsedata['PAYMENTINFO_0_EXCHANGERATE']) > 0) ? urldecode($this->responsedata['PAYMENTINFO_0_EXCHANGERATE']) : 1.0,
                           'notify_version' => '0',


### PR DESCRIPTION
Using MySQL 5.7, the cast to float was not being applied to the result of the if statement, but instead basically to the if test and a fatal error to be logged (and possibly/eventually a duplicate order number to be generated). This corrects the casting to apply to whatever result is to be used for `settle_amount`.

Applies to ZC 1.5.6 also...