### PR TITLE
Remove excess $this->

### DIFF
--- a/includes/modules/payment/paypalwpp.php
+++ b/includes/modules/payment/paypalwpp.php
@@ -533,7 +533,7 @@ if (false) { // disabled until clarification is received about coupons in PayPal
                           'mc_gross' => (float)$this->amt,
                           'mc_fee' => (float)urldecode($this->feeamt),
                           'mc_currency' => $this->responsedata['PAYMENTINFO_0_CURRENCYCODE'],
-                          'settle_amount' => (float)(isset($this->responsedata['PAYMENTINFO_0_SETTLEAMT']) ? $this->urldecode($this->responsedata['PAYMENTINFO_0_SETTLEAMT']) : $this->amt),
+                          'settle_amount' => (float)(isset($this->responsedata['PAYMENTINFO_0_SETTLEAMT']) ? urldecode($this->responsedata['PAYMENTINFO_0_SETTLEAMT']) : $this->amt),
                           'settle_currency' => $this->responsedata['PAYMENTINFO_0_CURRENCYCODE'],
                           'exchange_rate' => (isset($this->responsedata['PAYMENTINFO_0_EXCHANGERATE']) && urldecode($this->responsedata['PAYMENTINFO_0_EXCHANGERATE']) > 0) ? urldecode($this->responsedata['PAYMENTINFO_0_EXCHANGERATE']) : 1.0,
                           'notify_version' => '0',


### PR DESCRIPTION
Closes #3693 

Finally figured it out... There were a series of commits made for ZC 1.5.7 to add some "functionality" (processing/storage of `$this->amt` when `$this->responsedata['PAYMENTINFO_0_SETTLEAMT']` is not available). In making the commits, there was one mistake made (absence of `$this->` from `$this->responsedata['PAYMENTINFO_0_SETTLEAMT']`; however, it had been accidentally added to `urldecode` in the original commit (https://github.com/zencart/zencart/commit/03bb26ba50d7fecd472ccda0f1affe55e3ad4f37). When this discrepancy was identified (the absence of `$this->` from `$this->responsedata['PAYMENTINFO_0_SETTLEAMT']`), it was corrected with another commit (https://github.com/zencart/zencart/commit/75bb26f76d75753b7c3d70d5e4bc4b19b5becf2a#diff-1b7e5e4f394173368732a571b5c8a0d5R539); however, the additional `$this->` on `urldecode` was not noticed/corrected.  Then along comes stricter processing/code evaluation where it was desired to cast either of those two results to a float, which seems to happen automatically in "earlier" MySQL default server installations (can be made possible in more recent versions by relaxing some of the default settings).  A separate commit was issued to address the float casting: https://github.com/zencart/zencart/pull/3692/commits/b781a1b92e7f934f8582b58a3595a11e419bd053 where in one of the comments the changes of this commit are discussed... Now having reviewed the history of this line, the change of this commit appears to be the correct "solution" assuming that the value of `$this->responsedata['PAYMENTINFO_0_SETTLEAMT']` still is "available" and of any importance such that it would still go through `urldecode` because it would be set...

Oye…

This is applicable to ZC 1.5.6 as well...