### PR TITLE
catalog language loading and plugin support 

### DIFF
--- a/admin/includes/application_bottom.php
+++ b/admin/includes/application_bottom.php
@@ -8,6 +8,28 @@
 if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
 }
-// print_r($languageLoader->getLanguageFilesLoaded());
+//  @todo icwtodo Development debug code
+// do not remove for now
+if (defined('DEV_SHOW_APPLICATION_BOTTOM_DEBUG') && DEV_SHOW_APPLICATION_BOTTOM_DEBUG == true) {
+    $langLoaded = $languageLoader->getLanguageFilesLoaded();
+    dump($langLoaded);
+    $files = get_included_files();
+    $langFiles = [];
+    $pattern = '~^' . DIR_FS_CATALOG . DIR_WS_LANGUAGES . '~';
+    foreach ($files as $file) {
+        $shortFile = str_replace(DIR_FS_CATALOG, '', $file);
+        if (in_array($shortFile, $langLoaded['legacy']) || in_array($file, $langLoaded['legacy'])) {
+            continue;
+        }
+        if (in_array($shortFile, $langLoaded['arrays']) || in_array($file, $langLoaded['arrays'])) {
+            continue;
+        }
+        if (preg_match($pattern, $file)) {
+            $langFiles[] = $file;
+        }
+    }
+    dump($langFiles);
+//dump($_SESSION);
+}
 // close session (store variables)
   session_write_close();

--- a/app/Console/Commands/MakeDefinesCommand.php
+++ b/app/Console/Commands/MakeDefinesCommand.php
@@ -1,0 +1,294 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Symfony\Component\Console\Exception\InvalidOptionException;
+
+class MakeDefinesCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'make:defines {--f=} {--d=} {--c=}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Creates array type language files from legacy define files';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->fs = new Filesystem();
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        try {
+            $this->validateInputOptions();
+        } catch (InvalidOptionException $e) {
+            $this->error($e->getMessage());
+            exit(1);
+        }
+        try {
+            $this->processFilesFromInput();
+        } catch (InvalidOptionException $e) {
+            $this->error($e->getMessage());
+            exit(1);
+        }
+        return 0;
+    }
+
+    protected function processFilesFromInput()
+    {
+        $file = $this->option('f');
+        $dir = $this->option('d');
+        $config = $this->option('c');
+        try {
+            if (isset($file)) {
+                $this->processSingleFile($file);
+            }
+            if (isset($dir)) {
+                $this->processDirectory($dir);
+            }
+            if (isset($config)) {
+                $this->processConfigFile($config);
+            }
+        } catch (InvalidOptionException $e) {
+            throw new InvalidOptionException($e->getMessage());
+        }
+    }
+
+    private function validateInputOptions()
+    {
+        $file = $this->option('f');
+        $dir = $this->option('d');
+        $config = $this->option('c');
+        if (!isset($file) && !isset($dir) && !isset($config)) {
+            throw new InvalidOptionException('Seems you didn\'t pass any options');
+        }
+        $this->validateConfigFile($config);
+        $this->validateFile($file);
+        $this->validateDirectory($dir);
+
+    }
+    protected function validateConfigFile($configFile)
+    {
+        if (!isset($configFile)) {
+            return;
+        }
+        if (!is_file($configFile)) {
+            throw new InvalidOptionException('Invalid file for config option');
+        }
+    }
+
+    protected function validateFile($file)
+    {
+        if (!isset($file)) {
+            return;
+        }
+        if (!is_file($file)) {
+            throw new InvalidOptionException('Invalid file for file option:' . $file);
+        }
+    }
+
+    protected function validateDirectory($directory)
+    {
+        if (!isset($directory)) {
+            return;
+        }
+        if (!is_dir($directory)) {
+            throw new InvalidOptionException('Invalid directory for dir option: ' . $directory);
+        }
+    }
+    protected function processSingleFile($fileToConvert)
+    {
+        $pathInfo = pathinfo($fileToConvert);
+        $originalFile = $pathInfo['dirname'] . '/' . $pathInfo['filename'] . '.' . $pathInfo['extension'];
+        $destinationFile = $pathInfo['dirname'] . '/' . 'lang.' . $pathInfo['filename'] . '.' . $pathInfo['extension'];
+        $tokenized = $this->tokenizeData($originalFile);
+        $parsed = $this->parseTokenizedData($tokenized);
+        $outputData = $this->buildOutputData($parsed);
+        if (count($outputData) == 0) {
+            throw new InvalidOptionException($fileToConvert . ' does not appear to be a define file');
+        }
+        $this->writeOutputFile($destinationFile, $outputData);
+    }
+
+    protected function processDirectory($directory)
+    {
+        $this->output->writeln('processing directory ' . $directory);
+        $fileList = $this->fs->files($directory);
+        foreach ($fileList as $file) {
+            if (!preg_match('~(.*)\.php$~', $file->getFilename())) continue;
+            if (preg_match('~^lang\.~', $file->getFilename())) continue;
+            try {
+                $this->processSingleFile($file->getPathname());
+                $this->doVerboseOutput('processing file ' . $file->getPathname());
+            } catch (InvalidOptionException $e) {
+                $this->doVerboseOutput('Invalid file :' . $file->getPathname());
+            }
+        }
+    }
+
+    protected function processConfigFile($configFile)
+    {
+        $configDetails = require $configFile;
+        if (!isset($configDetails['files']) && !isset($configDetails['directories'])) {
+            throw new InvalidOptionException('config file does not appear to be valid');
+        }
+        $this->processConfigFileFiles($configDetails);
+        $this->processConfigFileDirectories($configDetails);
+    }
+
+    protected function processConfigFileFiles($configDetails)
+    {
+        if (!isset($configDetails['files'])) {
+            return;
+        }
+        foreach ($configDetails['files'] as $file) {
+            $this->validateFile($file);
+            $this->processSingleFile($file);
+        }
+    }
+
+    protected function processConfigFileDirectories($configDetails)
+    {
+        if (!isset($configDetails['directories'])) {
+            return;
+        }
+        foreach ($configDetails['directories'] as $directory) {
+            $this->validateDirectory($directory);
+            $this->processDirectory($directory);
+        }
+    }
+
+    protected function tokenizeData($originalFile)
+    {
+        $data = file_get_contents($originalFile);
+        $tokenizedData = token_get_all($data);
+        return $tokenizedData;
+    }
+
+    protected function parseTokenizedData($tokenizedData)
+    {
+        $currentLineNumber = -1;
+        $currentLine = [];
+        $builtLines = [];
+
+        foreach ($tokenizedData as $token) {
+            if ($this->canSkipCurrentToken($token)) continue;
+            $lineNumber = $token[2];
+            if ($currentLineNumber != $lineNumber) {
+                $currentLineNumber = $lineNumber;
+                $builtLines[] = $currentLine;
+                $currentLine = [];
+            }
+            $currentLine[] = $token;
+        }
+        $builtLines[] = $currentLine;
+        return $builtLines;
+    }
+
+    protected function canSkipCurrentToken($token)
+    {
+        if (!is_array($token)) return true;
+        if (count($token) < 3) return true;
+        return false;
+    }
+
+    public function buildOutputData($builtLines)
+    {
+        $outputData = [];
+        foreach ($builtLines as $tokens) {
+            $pointer = $this->skipLeadingWhiteSpace($tokens);
+            if ($pointer == -1) continue;
+            if (!isset($tokens[$pointer])) continue;
+            if ($tokens[$pointer][1] != 'define') continue;
+            $pointer++;
+            $pointer = $this->skipLeadingWhiteSpace($tokens, $pointer);
+            $defineKey = $tokens[$pointer][1];
+            $pointer++;
+            $pointer = $this->skipLeadingWhiteSpace($tokens, $pointer);
+            $defineValue = $this->buildDefineValue($tokens, $pointer);
+            $outputData[] = [$defineKey, $defineValue];
+        }
+        return $outputData;
+    }
+
+    protected function skipLeadingWhiteSpace($tokens, $start = 0)
+    {
+        if (!isset($tokens[$start])) return false;
+        if (!isset($tokens[$start][0])) return false;
+        foreach ($tokens as $tokenPointer => $token) {
+            $pointer = -1;
+            if ($tokenPointer < $start) continue;
+            if ($token[0] === T_WHITESPACE) continue;
+            $pointer = $tokenPointer;
+            break;
+        }
+        return $pointer;
+    }
+
+    protected function buildDefineValue($tokens, $pointer)
+    {
+        $completed = false;
+        $defineValue = '';
+        $allowedTokens = [T_STRING, T_CONSTANT_ENCAPSED_STRING, T_LNUMBER];
+        while ($completed == false) {
+            if (in_array($tokens[$pointer][0], $allowedTokens)) {
+                $defineValue .= $tokens[$pointer][1] . ' . ';
+            }
+            $pointer++;
+            if ($pointer >= count($tokens)) {
+                $defineValue = rtrim($defineValue, ' . ');
+                $completed = true;
+            }
+        }
+        return $defineValue;
+    }
+
+    public function writeOutputFile($destinationFile, $outputData)
+    {
+        $this->doVerboseOutput('Writing Destination ' . $destinationFile);
+        $fp = fopen($destinationFile, 'w');
+        fwrite($fp, '<?php' . "\n");
+        fwrite($fp, '/**' . "\n");
+        fwrite($fp, ' * @copyright Copyright 2003-' . date('Y') . ' Zen Cart Development Team' . "\n");
+        fwrite($fp, ' * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0' . "\n");
+        fwrite($fp, ' * @version $Id:' . "\n");
+        fwrite($fp, '*/' . "\n\n");
+        fwrite($fp, '$define = [' . "\n");
+        foreach ($outputData as $definevalue) {
+            fwrite($fp, '    ' . $definevalue[0] . " => ");
+            fwrite($fp, $definevalue[1]);
+            fwrite($fp, ",\n");
+        }
+        fwrite($fp, '];' . "\n\n");
+        fwrite($fp, 'return $define;' . "\n");
+        fclose($fp);
+    }
+    protected function doVerboseOutput($output)
+    {
+        if (!$this->getOutput()->isVerbose()) {
+            return;
+        }
+        $this->info($output);
+    }
+}

--- a/app/Models/PluginControl.php
+++ b/app/Models/PluginControl.php
@@ -16,4 +16,6 @@ class PluginControl extends Eloquent
     protected $keyType = 'string';
     public $incrementing = false;
     public $timestamps = false;
+    protected $fillable = ['infs'];
+    protected $guarded = [];
 }

--- a/app/Models/PluginControlVersion.php
+++ b/app/Models/PluginControlVersion.php
@@ -16,4 +16,5 @@ class PluginControlVersion extends Eloquent
     protected $keyType = 'string';
     public $incrementing = false;
     public $timestamps = false;
+    protected $guarded = [];
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -46,6 +46,8 @@ class AppServiceProvider extends ServiceProvider
         } else {
             error_reporting(0);
         }
+        if ($this->app->runningInConsole()) return;
+
         $pluginManager = new PluginManager(new PluginControl, new PluginControlVersion);
         $installedPlugins = $pluginManager->getInstalledPlugins();
         $this->app->instance('installedPlugins', $installedPlugins);

--- a/app/artisan
+++ b/app/artisan
@@ -37,7 +37,8 @@ $app = require_once __DIR__.'/bootstrap/app.php';
 */
 
 $kernel = $app->make(Illuminate\Contracts\Console\Kernel::class);
-
+$pathbase = $app->make('path.base');
+$app->instance('path', $pathbase);
 $status = $kernel->handle(
     $input = new Symfony\Component\Console\Input\ArgvInput,
     new Symfony\Component\Console\Output\ConsoleOutput

--- a/app/composer.json
+++ b/app/composer.json
@@ -32,7 +32,7 @@
     },
     "autoload": {
         "psr-4": {
-            "App\\": "../app/"
+            "App\\": "app/"
         }
     },
     "config": {

--- a/app/vendor/composer/autoload_psr4.php
+++ b/app/vendor/composer/autoload_psr4.php
@@ -48,6 +48,7 @@ return array(
     'Doctrine\\Common\\Lexer\\' => array($vendorDir . '/doctrine/lexer/lib/Doctrine/Common/Lexer'),
     'Doctrine\\Common\\Inflector\\' => array($vendorDir . '/doctrine/inflector/lib/Doctrine/Common/Inflector'),
     'Cron\\' => array($vendorDir . '/dragonmantank/cron-expression/src/Cron'),
+    'ConsoleApp\\' => array($baseDir . '/app'),
     'Carbon\\' => array($vendorDir . '/nesbot/carbon/src/Carbon'),
     'App\\' => array($baseDir . '/'),
 );

--- a/app/vendor/composer/autoload_static.php
+++ b/app/vendor/composer/autoload_static.php
@@ -103,6 +103,7 @@ class ComposerStaticInit38976b38ee8f02b829ea04de92ca3793
         'C' => 
         array (
             'Cron\\' => 5,
+            'ConsoleApp\\' => 11,
             'Carbon\\' => 7,
         ),
         'A' => 
@@ -279,6 +280,10 @@ class ComposerStaticInit38976b38ee8f02b829ea04de92ca3793
         'Cron\\' => 
         array (
             0 => __DIR__ . '/..' . '/dragonmantank/cron-expression/src/Cron',
+        ),
+        'ConsoleApp\\' => 
+        array (
+            0 => __DIR__ . '/../..' . '/app',
         ),
         'Carbon\\' => 
         array (

--- a/includes/application_bottom.php
+++ b/includes/application_bottom.php
@@ -12,7 +12,31 @@
 if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
 }
+
+//  @todo icwtodo Development debug code
+// do not remove for now
+if (defined('DEV_SHOW_APPLICATION_BOTTOM_DEBUG') && DEV_SHOW_APPLICATION_BOTTOM_DEBUG == true) {
+    $langLoaded = $languageLoader->getLanguageFilesLoaded();
+    dump($langLoaded);
+    $files = get_included_files();
+    $langFiles = [];
+    $pattern = '~^' . DIR_FS_CATALOG . DIR_WS_LANGUAGES . '~';
+    foreach ($files as $file) {
+        $shortFile = str_replace(DIR_FS_CATALOG, '', $file);
+        if (in_array($shortFile, $langLoaded['legacy']) || in_array($file, $langLoaded['legacy'])) {
+            continue;
+        }
+        if (in_array($shortFile, $langLoaded['arrays']) || in_array($file, $langLoaded['arrays'])) {
+            continue;
+        }
+        if (preg_match($pattern, $file)) {
+            error_log('legacy language file loaded ' . $file, 3, DIR_FS_LOGS . 'language_loading.log');
+            $langFiles[] = $file;
+        }
+    }
+    dump($langFiles);
 //dump($_SESSION);
+}
 // close session (store variables)
 session_write_close();
 

--- a/includes/classes/PluginManager.php
+++ b/includes/classes/PluginManager.php
@@ -192,8 +192,8 @@ class PluginManager
 
     protected function updatePluginControl($pluginsFromFilesystem)
     {
-        $this->pluginControl->update(['infs' => 0]);
-        $this->pluginControlVersion->update(['infs' => 0]);
+        $this->pluginControl->query()->update(['infs' => 0]);
+        $this->pluginControlVersion->query()->update(['infs' => 0]);
         $insertValues = [];
         $versionInsertValues = [];
         foreach ($pluginsFromFilesystem as $uniqueKey => $plugin) {

--- a/includes/classes/ResourceLoaders/ArraysLanguageLoader.php
+++ b/includes/classes/ResourceLoaders/ArraysLanguageLoader.php
@@ -39,16 +39,16 @@ class ArraysLanguageLoader extends BaseLanguageLoader
     protected function loadArraysFromDirectory($rootPath, $language, $extraPath)
     {
         $path = $rootPath . $language . $extraPath;
-        $fileList = $this->fileSystem->listFilesFromDirectory($path, '~^(lang\.).*\.php$~i');
+        $fileList = $this->fileSystem->listFilesFromDirectory($path, '~^lang\.(.*)\.php$~i');
         $defineList = $this->processArrayFileList($path, $fileList);
         return $defineList;
     }
 
-    protected function pluginLoadArraysFromDirectory($language, $extraPath)
+    protected function pluginLoadArraysFromDirectory($language, $extraPath, $context = 'admin')
     {
         $defineList = [];
         foreach ($this->pluginList as $plugin) {
-            $pluginDir = DIR_FS_CATALOG . 'zc_plugins/' . $plugin['unique_key'] . '/' . $plugin['version'] . '/admin/includes/languages/';
+            $pluginDir = DIR_FS_CATALOG . 'zc_plugins/' . $plugin['unique_key'] . '/' . $plugin['version'] . '/' . $context . '/includes/languages/';
             $defines = $this->loadArraysFromDirectory($pluginDir, $language, $extraPath);
             $defineList = array_merge($defineList, $defines);
         }
@@ -65,6 +65,15 @@ class ArraysLanguageLoader extends BaseLanguageLoader
         return $defineList;
     }
 
+    public function loadExtraLanguageFiles($rootPath, $language, $fileName, $extraPath = '')
+    {
+        $defineListMain = $this->loadDefinesFromArrayFile($rootPath, $language, $fileName, $extraPath);
+        $extraPath .= '/' . $this->templateDir;
+        $defineListTemplate = $this->loadDefinesFromArrayFile($rootPath, $language, $fileName, $extraPath);
+        $defineList = array_merge($defineListMain, $defineListTemplate);
+        $this->makeConstants($defineList);
+    }
+
     public function loadDefinesFromArrayFile($rootPath, $language, $fileName, $extraPath = '')
     {
         $arrayFileName = 'lang.' . $fileName;
@@ -79,7 +88,8 @@ class ArraysLanguageLoader extends BaseLanguageLoader
         $defineList = [];
         foreach ($this->pluginList as $plugin) {
             $pluginDir = DIR_FS_CATALOG . 'zc_plugins/' . $plugin['unique_key'] . '/' . $plugin['version'];
-            $pluginDefineList = $this->loadDefinesFromArrayFile($pluginDir . '/' . $context . '/includes/languages/', $language, $fileName, $extraPath);
+            $pluginDir .= $pluginDir . '/' . $context . '/includes/languages/';
+            $pluginDefineList = $this->loadDefinesFromArrayFile($pluginDir, $language, $fileName, $extraPath);
             $defineList = array_merge($defineList, $pluginDefineList);
         }
         return $defineList;

--- a/includes/classes/ResourceLoaders/CatalogArraysLanguageLoader.php
+++ b/includes/classes/ResourceLoaders/CatalogArraysLanguageLoader.php
@@ -15,47 +15,47 @@ class CatalogArraysLanguageLoader extends ArraysLanguageLoader
     public function loadInitialLanguageDefines($mainLoader)
     {
         $this->mainLoader = $mainLoader;
+        $this->loadMainLanguageFiles();
+        $this->loadLanguageExtraDefinitions();
     }
 
-    protected function loadLanguageForView()
+    public function loadLanguageForView()
     {
-        $defineList = $this->loadDefinesFromArrayFile(DIR_WS_LANGUAGES, $_SESSION['language'], $this->currentPage);
-        $this->addLanguageDefines($defineList);
+        $this->loadExtraLanguageFiles(DIR_WS_LANGUAGES, $_SESSION['language'], $this->currentPage . '.php');
+        $this->loadExtraLanguageFiles(DIR_WS_LANGUAGES, $_SESSION['language'], $this->currentPage . '.php', '/' . $this->templateDir);
+        foreach ($this->pluginList as $plugin) {
+            $pluginDir = DIR_FS_CATALOG . 'zc_plugins/' . $plugin['unique_key'] . '/' . $plugin['version'] . '/catalog/includes/languages/';
+            $this->loadExtraLanguageFiles($pluginDir, $_SESSION['language'], $this->currentPage . '.php');
+            $this->loadExtraLanguageFiles($pluginDir, $_SESSION['language'], $this->currentPage . '.php', '/default');
+        }
     }
 
     protected function loadLanguageExtraDefinitions()
     {
-        $this->loadArraysFromDirectory(DIR_WS_LANGUAGES, $_SESSION['language'], '/extra_definitions');
+        $defineList = $this->loadArraysFromDirectory(DIR_WS_LANGUAGES, $_SESSION['language'], '/extra_definitions');
+        $this->addLanguageDefines($defineList);
+        $defineList = $this->loadArraysFromDirectory(DIR_WS_LANGUAGES, $_SESSION['language'], '/extra_definitions/' . $this->templateDir);
+        $this->addLanguageDefines($defineList);
+        $defineList = $this->pluginLoadArraysFromDirectory($_SESSION['language'], '/extra_definitions', 'catalog');
+        $this->addLanguageDefines($defineList);
+        $defineList = $this->pluginLoadArraysFromDirectory($_SESSION['language'], '/extra_definitions/default');
+        $this->addLanguageDefines($defineList);
     }
 
-    protected function loadBaseLanguageFile()
+    protected function loadMainLanguageFiles()
     {
+        $extraFiles = [FILENAME_EMAIL_EXTRAS, FILENAME_HEADER, FILENAME_BUTTON_NAMES, FILENAME_ICON_NAMES, FILENAME_OTHER_IMAGES_NAMES, FILENAME_CREDIT_CARDS, FILENAME_WHOS_ONLINE, FILENAME_META_TAGS];
         $mainFile = DIR_WS_LANGUAGES . 'lang.' . $_SESSION['language'] . '.php';
         $fallbackFile = DIR_WS_LANGUAGES . 'lang.' . $this->fallback . '.php';
         $defineList = $this->loadDefinesWithFallback($mainFile, $fallbackFile);
         $this->addLanguageDefines($defineList);
-        $defineList = $this->loadDefinesFromArrayFile(DIR_WS_LANGUAGES, $_SESSION['language'], 'gv_name.php');
+        $mainFile = DIR_WS_LANGUAGES . $this->templateDir . '/lang.' . $_SESSION['language'] . '.php';
+        $fallbackFile = DIR_WS_LANGUAGES . $this->templateDir . '/lang.' . $this->fallback . '.php';
+        $defineList = $this->loadDefinesWithFallback($mainFile, $fallbackFile);
         $this->addLanguageDefines($defineList);
-        $defineList = $this->loadDefinesFromArrayFile(DIR_WS_LANGUAGES, $_SESSION['language'], FILENAME_EMAIL_EXTRAS);
-        $this->addLanguageDefines($defineList);
-        $defineList = $this->loadDefinesFromTemplateLanguage(
-            DIR_WS_LANGUAGES, $this->templateDir, $_SESSION['language'], FILENAME_OTHER_IMAGES_NAMES);
-        $this->addLanguageDefines($defineList);
-    }
-
-    public function loadDefinesFromTemplateLanguage($rootPath, $templateDir, $lang, $fileName)
-    {
-        // load order is
-        // always load from catalog language directory
-        // then load from template language file if it exists
-        // then load from plugins @todo
-        $defineList = $this->loadDefinesFromArrayFile(DIR_FS_CATALOG . $rootPath, $lang, $fileName);
-        $this->addLanguageDefines($defineList);
-        if (file_exists(DIR_FS_CATALOG . $rootPath . $_SESSION[$lang] . '/' . $templateDir . '/' . $fileName)) {
-            $defineList = $this->loadDefinesFromArrayFile(
-                DIR_FS_CATALOG . $rootPath, $lang, $fileName, $templateDir . '/');
-            $this->addLanguageDefines($defineList);
+        foreach ($extraFiles as $file) {
+            $file = basename($file, '.php') . ".php";
+            $this->loadExtraLanguageFiles(DIR_WS_LANGUAGES, $_SESSION['language'], $file);
         }
     }
-
 }

--- a/includes/classes/ResourceLoaders/FilesLanguageLoader.php
+++ b/includes/classes/ResourceLoaders/FilesLanguageLoader.php
@@ -12,8 +12,21 @@ use Zencart\FileSystem\FileSystem;
 
 class FilesLanguageLoader extends BaseLanguageLoader
 {
+    public function loadExtraLanguageFiles($rootPath, $language, $fileName, $extraPath = '')
+    {
+        if ($this->mainLoader->hasLanguageFile($rootPath, $language, $fileName, $extraPath .  '/' . $this->templateDir)) {
+            $this->loadFileDefineFile($rootPath . $language . $extraPath . '/' . $this->templateDir . '/' . $fileName);
+        } else {
+            $this->loadFileDefineFile($rootPath . $language . $extraPath . '/' . $fileName);
+        }
+    }
+
     public function loadFileDefineFile($defineFile)
     {
+        $pathInfo = pathinfo(($defineFile));
+        if (preg_match('~^lang\.~i', $pathInfo['basename'])) {
+            return false;
+        }
         if (!is_file($defineFile)) {
             return false;
         }

--- a/includes/classes/ResourceLoaders/LanguageLoader.php
+++ b/includes/classes/ResourceLoaders/LanguageLoader.php
@@ -10,7 +10,6 @@ namespace Zencart\LanguageLoader;
 
 class LanguageLoader
 {
-
     public function __construct($arraysLoader, $filesLoader)
     {
         $this->languageFilesLoaded = ['arrays' => [], 'legacy' => []];
@@ -54,24 +53,26 @@ class LanguageLoader
 
     public function loadExtraLanguageFiles($rootPath, $language, $fileName, $extraPath = '')
     {
-        $defineList = $this->arrayLoader->loadDefinesFromArrayFile($rootPath, $language, $fileName, $extraPath);
-        $this->arrayLoader->makeConstants($defineList);
-        $this->fileLoader->loadFileDefineFile($rootPath . $language . $extraPath . '/' . $fileName);
-        // @todo plugins & late extra definitions
+        $this->arrayLoader->loadExtraLanguageFiles($rootPath, $language, $fileName, $extraPath);
+        $this->fileLoader->loadExtraLanguageFiles($rootPath, $language, $fileName, $extraPath);
     }
 
     public function hasLanguageFile($rootPath, $language, $fileName, $extraPath = '')
     {
-        if (file_exists($rootPath . $language . $extraPath . '/' . $fileName)) {
+        if (is_file($rootPath . $language . $extraPath . '/' . $fileName)) {
             return true;
         }
-        if (file_exists($rootPath . $language . $extraPath . '/lang.' . $fileName)) {
+        if (is_file($rootPath . $language . $extraPath . '/lang.' . $fileName)) {
             return true;
         }
+        return false;
     }
 
     public function isFileAlreadyLoaded($defineFile)
     {
+//        if (in_array(DIR_FS_CATALOG . $defineFile, get_included_files())) {
+//            return true;
+//        }
         $fileInfo = pathinfo($defineFile);
         $searchFile = 'lang.' . $fileInfo['basename'];
         $searchFile = $fileInfo['dirname'] . '/' . $searchFile;

--- a/includes/classes/ResourceLoaders/PageLoader.php
+++ b/includes/classes/ResourceLoaders/PageLoader.php
@@ -8,23 +8,27 @@
 
 namespace Zencart\PageLoader;
 
+use Zencart\Traits\Singleton;
+
 class PageLoader
 {
-    public function __construct(array $installedPlugins, $mainPage, $fileSystem)
+    use Singleton;
+
+    public function init(array $installedPlugins, $mainPage, $fileSystem)
     {
         $this->installedPlugins = $installedPlugins;
         $this->mainPage = $mainPage;
         $this->fileSystem = $fileSystem;
     }
 
-    public function findModulePageDirectory()
+    public function findModulePageDirectory($context = 'catalog')
     {
         if (is_dir(DIR_WS_MODULES . 'pages/' . $this->mainPage)) {
             return DIR_WS_MODULES . 'pages/' . $this->mainPage;
         }
         foreach ($this->installedPlugins as $plugin) {
-            $checkDir = 'zc_plugins/' . $plugin['unique_key'] . '/' . $plugin['version'] . '/';
-            $checkDir .= 'catalog/includes/modules/pages/' . $this->mainPage;
+            $rootDir = DIR_FS_CATALOG . 'zc_plugins/' . $plugin['unique_key'] . '/' . $plugin['version'] . '/' . $context ;
+            $checkDir = $rootDir . '/includes/modules/pages/' . $this->mainPage;
             if (is_dir($checkDir)) return $checkDir;
         }
         return false;
@@ -32,7 +36,9 @@ class PageLoader
 
     function getTemplatePart($pageDirectory, $templatePart, $fileExtension = '.php')
     {
-        $directoryArray = array();
+        //dump('page Directory = ' . $pageDirectory);
+        //dump('template part = ' . $templatePart);
+        $directoryArray = [];
         $directoryArray = $this->getTemplatePartFromDirectory($directoryArray, $pageDirectory, $templatePart,
                                                               $fileExtension);
 
@@ -52,7 +58,7 @@ class PageLoader
             while ($file = $dir->read()) {
                 if (!is_dir($pageDirectory . $file)) {
                     if (substr($file, strrpos($file, '.')) == $fileExtension && preg_match($templatePart, $file)) {
-                        $directoryArray[] = $pageDirectory . '/'. $file;
+                        $directoryArray[] = $file;
                     }
                 }
             }
@@ -83,7 +89,7 @@ class PageLoader
     public function getTemplatePluginDir($templateCode)
     {
         foreach ($this->installedPlugins as $plugin) {
-            $checkDir = 'zc_plugins/' . $plugin['unique_key'] . '/' . $plugin['version'] . '/catalog/includes/template/templates/';
+            $checkDir = 'zc_plugins/' . $plugin['unique_key'] . '/' . $plugin['version'] . '/catalog/includes/templates/default/';
             if (file_exists($checkDir . $templateCode )) {
                 return $checkDir;
             }
@@ -91,14 +97,13 @@ class PageLoader
         return false;
     }
 
-    public function getBodyCode($currentPage)
+    public function getBodyCode()
     {
-        if (file_exists(DIR_WS_MODULES . 'pages/' . $currentPage . '/main_template_vars.php')) {
-            $bodyCode = DIR_WS_MODULES . 'pages/' . $currentPage . '/main_template_vars.php';
+        if (file_exists(DIR_WS_MODULES . 'pages/' . $this->mainPage . '/main_template_vars.php')) {
+            $bodyCode = DIR_WS_MODULES . 'pages/' . $this->mainPage . '/main_template_vars.php';
             return $bodyCode;
         }
-        $bodyCode = $this->getTemplateDir(
-                'tpl_' . preg_replace('/.php/', '', $_GET['main_page']) . '_default.php', DIR_WS_TEMPLATE, $currentPage, 'templates') . '/tpl_' . $_GET['main_page'] . '_default.php';
+        $bodyCode = $this->getTemplateDir('tpl_' . preg_replace('/.php/', '', $this->mainPage) . '_default.php', DIR_WS_TEMPLATE, $this->mainPage, 'templates') . '/tpl_' . $this->mainPage . '_default.php';
         return $bodyCode;
     }
 }

--- a/includes/classes/order_total.php
+++ b/includes/classes/order_total.php
@@ -23,7 +23,7 @@ class order_total extends base {
 
   // class constructor
   function __construct() {
-    global $messageStack;
+    global $messageStack, $languageLoader;
     if (defined('MODULE_ORDER_TOTAL_INSTALLED') && zen_not_null(MODULE_ORDER_TOTAL_INSTALLED)) {
       $module_list = explode(';', MODULE_ORDER_TOTAL_INSTALLED);
 
@@ -36,8 +36,8 @@ class order_total extends base {
         } else {
           $lang_file = zen_get_file_directory(DIR_WS_LANGUAGES . $_SESSION['language'] . '/modules/order_total/', $value, 'false');
         }
-        if (@file_exists($lang_file)) {
-          include_once($lang_file);
+          if ($languageLoader->hasLanguageFile(DIR_FS_CATALOG . DIR_WS_LANGUAGES,  $_SESSION['language'], $value, '/modules/order_total')) {
+              $languageLoader->loadExtraLanguageFiles(DIR_FS_CATALOG . DIR_WS_LANGUAGES,  $_SESSION['language'], $value, '/modules/order_total');
         } else {
           if (IS_ADMIN_FLAG === false && is_object($messageStack)) {
             $messageStack->add('header', WARNING_COULD_NOT_LOCATE_LANG_FILE . $lang_file, 'caution');

--- a/includes/classes/payment.php
+++ b/includes/classes/payment.php
@@ -19,7 +19,7 @@ class payment extends base {
   var $modules, $selected_module, $doesCollectsCardDataOnsite;
 
   function __construct($module = '') {
-      global $PHP_SELF, $language, $credit_covers, $messageStack;
+      global $PHP_SELF, $language, $credit_covers, $messageStack, $languageLoader;
       $this->doesCollectsCardDataOnsite = false;
 
       if (defined('MODULE_PAYMENT_INSTALLED') && !empty(MODULE_PAYMENT_INSTALLED)) {
@@ -61,8 +61,8 @@ class payment extends base {
 
       for ($i=0, $n=sizeof($include_modules); $i<$n; $i++) {
         $lang_file = zen_get_file_directory(DIR_WS_LANGUAGES . $_SESSION['language'] . '/modules/payment/', $include_modules[$i]['file'], 'false');
-        if (@file_exists($lang_file)) {
-          include_once($lang_file);
+        if ($languageLoader->hasLanguageFile(DIR_FS_CATALOG . DIR_WS_LANGUAGES,  $_SESSION['language'], $include_modules[$i]['file'], '/modules/payment')) {
+          $languageLoader->loadExtraLanguageFiles(DIR_FS_CATALOG . DIR_WS_LANGUAGES,  $_SESSION['language'], $include_modules[$i]['file'], '/modules/payment');
         } else {
           if (is_object($messageStack)) {
             if (IS_ADMIN_FLAG === false) {

--- a/includes/classes/shipping.php
+++ b/includes/classes/shipping.php
@@ -19,7 +19,7 @@ class shipping extends base {
   var $modules;
 
   function __construct($module = null) {
-      global $PHP_SELF, $messageStack;
+      global $PHP_SELF, $messageStack, $languageLoader;
 
       if (defined('MODULE_SHIPPING_INSTALLED') && !empty(MODULE_SHIPPING_INSTALLED)) {
         $this->modules = explode(';', MODULE_SHIPPING_INSTALLED);
@@ -48,8 +48,8 @@ class shipping extends base {
         } else {
           $lang_file = zen_get_file_directory(DIR_WS_LANGUAGES . $_SESSION['language'] . '/modules/shipping/', $include_modules[$i]['file'], 'false');
         }
-        if (@file_exists($lang_file)) {
-          include_once($lang_file);
+          if ($languageLoader->hasLanguageFile(DIR_FS_CATALOG . DIR_WS_LANGUAGES,  $_SESSION['language'], $include_modules[$i]['file'], '/modules/shipping')) {
+              $languageLoader->loadExtraLanguageFiles(DIR_FS_CATALOG . DIR_WS_LANGUAGES,  $_SESSION['language'], $include_modules[$i]['file'], '/modules/shipping');
         } else {
           if (is_object($messageStack)) {
             if (IS_ADMIN_FLAG === false) {

--- a/includes/classes/template_func.php
+++ b/includes/classes/template_func.php
@@ -23,6 +23,11 @@ class template_func extends base {
   }
 
   function get_template_part($page_directory, $template_part, $file_extension = '.php') {
+      $pageLoader = Zencart\PageLoader\PageLoader::getInstance();
+      $directory_array = $pageLoader->getTemplatePart($page_directory, $template_part, $file_extension);
+      return $directory_array;
+
+
     $directory_array = array();
     if ($dir = @dir($page_directory)) {
       while ($file = $dir->read()) {

--- a/includes/init_includes/init_sanitize.php
+++ b/includes/init_includes/init_sanitize.php
@@ -9,6 +9,9 @@
  * @version $Id: DrByte 2020 May 17 Modified in v1.5.7 $
  */
 
+use Zencart\PageLoader\PageLoader;
+use Zencart\FileSystem\FileSystem;
+
   if (!defined('IS_ADMIN_FLAG')) {
     die('Illegal Access');
   }
@@ -110,7 +113,11 @@
  */
   if (empty($_GET['main_page'])) $_GET['main_page'] = 'index';
 
-  if (!is_dir(DIR_WS_MODULES .  'pages/' . $_GET['main_page'])) {
+  $pageLoader = PageLoader::getInstance();
+  $pageLoader->init($installedPlugins, $_GET['main_page'], FileSystem::getInstance());
+
+    $pageDir = $pageLoader->findModulePageDirectory();
+  if ( $pageDir === false) {
     if (MISSING_PAGE_CHECK == 'On' || MISSING_PAGE_CHECK == 'true') {
       $_GET['main_page'] = 'index';
     } elseif (MISSING_PAGE_CHECK == 'Page Not Found') {
@@ -118,9 +125,10 @@
       $_GET['main_page'] = FILENAME_PAGE_NOT_FOUND;
     }
   }
+
   $current_page = $_GET['main_page'];
   $current_page_base = $current_page;
-  $code_page_directory = DIR_WS_MODULES . 'pages/' . $current_page_base;
+  $code_page_directory = $pageDir;
   $page_directory = $code_page_directory;
 
 $sanitizedRequest = Request::capture();

--- a/includes/init_includes/init_templates.php
+++ b/includes/init_includes/init_templates.php
@@ -12,6 +12,9 @@
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: DrByte 2020 May 19 Modified in v1.5.7 $
  */
+
+use Zencart\LanguageLoader\LanguageLoaderFactory;
+
 if (!defined('IS_ADMIN_FLAG')) {
     die('Illegal Access');
 }
@@ -68,25 +71,29 @@ if (zen_is_whitelisted_admin_ip()) {
  * Load the appropriate Language files, based on the currently-selected template
  */
 
-  include_once(zen_get_file_directory(DIR_FS_CATALOG . DIR_WS_LANGUAGES, $_SESSION['language'].'.php', 'false'));
+//  include_once(zen_get_file_directory(DIR_FS_CATALOG . DIR_WS_LANGUAGES, $_SESSION['language'].'.php', 'false'));
 
 /**
  * include the template language master (to catch all items not defined in the override file).
- * The intent here is to: load the override version to catch preferencial changes; 
+ * The intent here is to: load the override version to catch preferencial changes;
  * then load the original/master version to catch any defines that didn't get set into the override version during upgrades, etc.
  */
 // THE FOLLOWING MIGHT NEED TO BE DISABLED DUE TO THE EXISTENCE OF function() DECLARATIONS IN MASTER ENGLISH.PHP FILE
 // THE FOLLOWING MAY ALSO SEND NUMEROUS ERRORS IF YOU HAVE ERROR_REPORTING ENABLED, DUE TO REPETITION OF SEVERAL DEFINE STATEMENTS
-  include_once(DIR_WS_LANGUAGES .  $_SESSION['language'] . '.php');
+//  include_once(DIR_WS_LANGUAGES .  $_SESSION['language'] . '.php');
 
 
 /**
  * send the content charset "now" so that all content is impacted by it
  */
-  header("Content-Type: text/html; charset=" . CHARSET);
 
 /**
  * include the extra language definitions
  */
-  include(DIR_WS_MODULES . zen_get_module_directory('extra_definitions.php'));
-?>
+//  include(DIR_WS_MODULES . zen_get_module_directory('extra_definitions.php'));
+
+$languageLoaderFactory = new LanguageLoaderFactory();
+$languageLoader = $languageLoaderFactory->make('catalog', $installedPlugins, $current_page, $template_dir);
+$languageLoader->loadInitialLanguageDefines();
+$languageLoader->finalizeLanguageDefines();
+header("Content-Type: text/html; charset=" . CHARSET);

--- a/includes/languages/english.php
+++ b/includes/languages/english.php
@@ -580,7 +580,7 @@ define('ARIA_PAGINATION_','');
   define('TEXT_PRODUCTS_LISTING_ALPHA_SORTER', '');
   define('TEXT_PRODUCTS_LISTING_ALPHA_SORTER_NAMES', 'Items starting with ...');
   define('TEXT_PRODUCTS_LISTING_ALPHA_SORTER_NAMES_RESET', '-- Reset --');
-  
+
 // The following message, with the associated severity, is displayed in the storefront header when an admin has logged into
 // a customer's account.
 
@@ -601,10 +601,10 @@ define('TEXT_OPTION_DIVIDER', '&nbsp;-&nbsp;');
 
 ///////////////////////////////////////////////////////////
 
-  $file_list = [FILENAME_EMAIL_EXTRAS, FILENAME_HEADER, FILENAME_BUTTON_NAMES, FILENAME_ICON_NAMES, FILENAME_OTHER_IMAGES_NAMES, FILENAME_CREDIT_CARDS, FILENAME_WHOS_ONLINE, FILENAME_META_TAGS];
-  foreach ($file_list as $file) { 
-    $file = str_replace(".php","",$file); 
-    require_once(zen_get_file_directory(DIR_FS_CATALOG . DIR_WS_LANGUAGES . $_SESSION['language'] . "/", $file . '.php', 'false'));
-  }
+//  $file_list = [FILENAME_EMAIL_EXTRAS, FILENAME_HEADER, FILENAME_BUTTON_NAMES, FILENAME_ICON_NAMES, FILENAME_OTHER_IMAGES_NAMES, FILENAME_CREDIT_CARDS, FILENAME_WHOS_ONLINE, FILENAME_META_TAGS];
+//  foreach ($file_list as $file) {
+//    $file = str_replace(".php","",$file);
+//    require_once(zen_get_file_directory(DIR_FS_CATALOG . DIR_WS_LANGUAGES . $_SESSION['language'] . "/", $file . '.php', 'false'));
+//  }
 
 // END OF EXTERNAL LANGUAGE LINKS

--- a/includes/modules/require_languages.php
+++ b/includes/modules/require_languages.php
@@ -9,6 +9,10 @@
 if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
 }
+
+$languageLoader->loadLanguageForView();
+return;
+
 // determine language or template language file
 if (file_exists($language_page_directory . $template_dir . '/' . $current_page_base . '.php')) {
   $template_dir_select = $template_dir . '/';

--- a/includes/templates/responsive_classic/common/main_template_vars.php
+++ b/includes/templates/responsive_classic/common/main_template_vars.php
@@ -44,10 +44,6 @@ if (!defined('IS_ADMIN_FLAG')) {
 /**
  * load page-specific main_template_vars if present, or jump directly to template file
  */
-  if (file_exists(DIR_WS_MODULES . 'pages/' . $current_page_base . '/main_template_vars.php')) {
-    $body_code = DIR_WS_MODULES . 'pages/' . $current_page_base . '/main_template_vars.php';
-  } else {
-    $body_code = $template->get_template_dir('tpl_' . preg_replace('/.php/', '',$_GET['main_page']) . '_default.php',DIR_WS_TEMPLATE, $current_page_base,'templates'). '/tpl_' . $_GET['main_page'] . '_default.php';
-  }
+  $body_code = $pageLoader->getBodyCode();
 
   $zco_notifier->notify('NOTIFY_MAIN_TEMPLATE_VARS_END', $template_dir, $body_code);

--- a/includes/templates/template_default/common/main_template_vars.php
+++ b/includes/templates/template_default/common/main_template_vars.php
@@ -30,10 +30,6 @@ if (!defined('IS_ADMIN_FLAG')) {
 /**
  * load page-specific main_template_vars if present, or jump directly to template file
  */
-  if (file_exists(DIR_WS_MODULES . 'pages/' . $current_page_base . '/main_template_vars.php')) {
-    $body_code = DIR_WS_MODULES . 'pages/' . $current_page_base . '/main_template_vars.php';
-  } else {
-    $body_code = $template->get_template_dir('tpl_' . preg_replace('/.php/', '',$_GET['main_page']) . '_default.php',DIR_WS_TEMPLATE, $current_page_base,'templates'). '/tpl_' . $_GET['main_page'] . '_default.php';
-  }
+  $body_code = $pageLoader->getBodyCode();
 
   $zco_notifier->notify('NOTIFY_MAIN_TEMPLATE_VARS_END', $template_dir, $body_code);

--- a/index.php
+++ b/index.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * index.php represents the hub of the Zen Cart MVC system
- * 
+ *
  * Overview of flow
  * <ul>
  * <li>Load application_top.php - see {@tutorial initsystem}</li>
@@ -20,24 +20,24 @@
  * @version $Id: DrByte 2020 Jun 16 Modified in v1.5.7 $
  */
 /**
- * Load common library stuff 
+ * Load common library stuff
  */
   require('includes/application_top.php');
 
   $language_page_directory = DIR_WS_LANGUAGES . $_SESSION['language'] . '/';
   $directory_array = $template->get_template_part($code_page_directory, '/^header_php/');
-  foreach ($directory_array as $value) { 
+  foreach ($directory_array as $value) {
 /**
- * We now load header code for a given page. 
- * Page code is stored in includes/modules/pages/PAGE_NAME/directory 
+ * We now load header code for a given page.
+ * Page code is stored in includes/modules/pages/PAGE_NAME/directory
  * 'header_php.php' files in that directory are loaded now.
  */
     require($code_page_directory . '/' . $value);
   }
 /**
- * We now load the html_header.php file. This file contains code that would appear within the HTML <head></head> code 
- * it is overridable on a template and page basis. 
- * In that a custom template can define its own common/html_header.php file 
+ * We now load the html_header.php file. This file contains code that would appear within the HTML <head></head> code
+ * it is overridable on a template and page basis.
+ * In that a custom template can define its own common/html_header.php file
  */
   require($template->get_template_dir('html_header.php',DIR_WS_TEMPLATE, $current_page_base,'common'). '/html_header.php');
 /**
@@ -52,7 +52,7 @@
  * Looking in "/includes/modules/pages" for files named "on_load_*.js"
  */
   $directory_array = $template->get_template_part(DIR_WS_MODULES . 'pages/' . $current_page_base, '/^on_load_/', '.js');
-  foreach ($directory_array as $value) { 
+  foreach ($directory_array as $value) {
     $onload_file = DIR_WS_MODULES . 'pages/' . $current_page_base . '/' . $value;
     $read_contents='';
     if ($lines = @file($onload_file)) {
@@ -66,7 +66,7 @@
   $directory_array=array();
   $tpl_dir=$template->get_template_dir('.js', DIR_WS_TEMPLATE, 'jscript/on_load', 'jscript/on_load_');
   $directory_array = $template->get_template_part($tpl_dir ,'/^on_load_/', '.js');
-  foreach ($directory_array as $value) { 
+  foreach ($directory_array as $value) {
     $onload_file = $tpl_dir . '/' . $value;
     $read_contents='';
     if ($lines = @file($onload_file)) {


### PR DESCRIPTION
**move catalog language loading to new resource loader classes**

This includes allowing overrides from plugins

**updates to allow array language files in catalog code**

This includes allowing overrides from plugins

**some initial changes to support plugins in catalog**

Allows plugins to do catalog pages e.g. index.php?main_page=myPluginPage

**language debugging tools in application_bottom.php**

Leaving these in for now. won't show unless a define is present

**move code for creating array files from zcgo to artisan**


** /default ** implies "use these lang defines in the active template"