### PR TITLE
Add NOTIFY_GET_PRODUCT_ALLOW_ADD_TO_CART notifier hook

### DIFF
--- a/includes/functions/functions_lookups.php
+++ b/includes/functions/functions_lookups.php
@@ -701,7 +701,12 @@ function zen_get_configuration_key_value($lookup)
            $allow_add_to_cart->fields['allow_add_to_cart'] = 'N';
       }
     }
-    return $allow_add_to_cart->fields['allow_add_to_cart'];
+
+    $response = $allow_add_to_cart->fields['allow_add_to_cart'];
+
+    $zco_notifier->notify('NOTIFY_GET_PRODUCT_ALLOW_ADD_TO_CART', $lookup, $response);
+
+    return $response;
   }
 
 /*


### PR DESCRIPTION
This allows customizing control over whether a certain product should display an add-to-cart button.
eg: checking "date-available" or stock-on-hand, or other things that might have been customized such as inclusion in a certain marketing campaign, etc.