### PR TITLE
Add NOTIFY_GET_PRODUCT_ALLOW_ADD_TO_CART notifier hook (part 2)

### DIFF
--- a/includes/functions/functions_lookups.php
+++ b/includes/functions/functions_lookups.php
@@ -684,11 +684,13 @@ function zen_get_configuration_key_value($lookup)
     }
   }
 
-/*
+/**
  * Look up whether the given product ID is allowed to be added to cart, according to product-type switches set in Admin
+ * @param int $product_id
+ * @return string Y|N
  */
-  function zen_get_products_allow_add_to_cart($lookup) {
-    global $db;
+  function zen_get_products_allow_add_to_cart($product_id) {
+    global $db, $zco_notifier;
 
     $sql = "select products_type, products_model from " . TABLE_PRODUCTS . " where products_id='" . (int)$lookup . "'";
     $type_lookup = $db->Execute($sql);


### PR DESCRIPTION
This allows customizing control over whether a certain product should display an add-to-cart button.
eg: checking "date-available" or stock-on-hand, or other things that might have been customized such as inclusion in a certain marketing campaign, etc.

Appends to https://github.com/zencart/zencart/pull/3698