### PR TITLE
Do basic logging even if Report All Errors is false

### DIFF
--- a/admin/includes/init_includes/init_report_all_errors_admin.php
+++ b/admin/includes/init_includes/init_report_all_errors_admin.php
@@ -26,6 +26,9 @@ if (!defined('REPORT_ALL_ERRORS_ADMIN')) {
 } elseif (REPORT_ALL_ERRORS_ADMIN != 'No') {
     @ini_set('error_reporting', E_ALL);
     set_error_handler('zen_debug_error_handler', E_ALL);
+} else {
+    @ini_set('error_reporting', E_ALL & ~E_DEPRECATED & ~E_NOTICE & ~E_STRICT); 
+    set_error_handler('zen_debug_error_handler', E_ALL);
 }
 
 if (!defined('REPORT_ALL_ERRORS_NOTICE_BACKTRACE')) {

--- a/includes/init_includes/init_report_all_errors.php
+++ b/includes/init_includes/init_report_all_errors.php
@@ -10,4 +10,7 @@
 if (defined('REPORT_ALL_ERRORS_STORE') && REPORT_ALL_ERRORS_STORE != 'No') {
     @ini_set('error_reporting', E_ALL );
     set_error_handler('zen_debug_error_handler', E_ALL);
+} else {
+    @ini_set('error_reporting', E_ALL & ~E_DEPRECATED & ~E_NOTICE & ~E_STRICT); 
+    set_error_handler('zen_debug_error_handler', E_ALL);
 }


### PR DESCRIPTION
<strike>Recommended for backport to 1.5.7. </strike>

1.5.7 handles this situation correctly.   No backport needed.