### PR TITLE
Changed search order for email templates to use $module (not current_page_base)

### DIFF
--- a/includes/functions/functions_email.php
+++ b/includes/functions/functions_email.php
@@ -536,14 +536,15 @@ use PHPMailer\PHPMailer\SMTP;
     $template_filename_base_en = DIR_FS_EMAIL_TEMPLATES . "email_template_";
     $template_filename = DIR_FS_EMAIL_TEMPLATES . $langfolder . "email_template_" . $current_page_base . ".html";
 
-    $filesToTest = array(DIR_FS_EMAIL_TEMPLATES . $langfolder . "email_template_" . $current_page_base . ".html",
-                         DIR_FS_EMAIL_TEMPLATES . "email_template_" . $current_page_base . ".html",
-                         (isset($block['EMAIL_TEMPLATE_FILENAME']) && $block['EMAIL_TEMPLATE_FILENAME'] != '' ? $block['EMAIL_TEMPLATE_FILENAME'] . '.html' : NULL),
-                         $template_filename_base . str_replace(array('_extra','_admin'),'',$module) . '.html',
-                         $template_filename_base_en . str_replace(array('_extra','_admin'),'',$module) . '.html',
-                         $template_filename_base . 'default' . '.html',
-                         $template_filename_base_en . 'default' . '.html',
-                        );
+    $filesToTest = array(
+       $template_filename_base . str_replace(array('_extra','_admin'),'',$module) . '.html',
+       $template_filename_base_en . str_replace(array('_extra','_admin'),'',$module) . '.html',
+       DIR_FS_EMAIL_TEMPLATES . $langfolder . "email_template_" . $current_page_base . ".html",
+       DIR_FS_EMAIL_TEMPLATES . "email_template_" . $current_page_base . ".html",
+       (isset($block['EMAIL_TEMPLATE_FILENAME']) && $block['EMAIL_TEMPLATE_FILENAME'] != '' ? $block['EMAIL_TEMPLATE_FILENAME'] . '.html' : NULL),
+       $template_filename_base . 'default' . '.html',
+       $template_filename_base_en . 'default' . '.html',
+       );
     $found = FALSE;
     foreach($filesToTest as $val) {
       if (file_exists($val)) {


### PR DESCRIPTION
In the file includes/modules/pages/contact_us/header_php.php

if you call

zen_mail($send_to_name, $send_to_email, EMAIL_SUBJECT, $text_message, $name, $email_address, $html_msg, 'contact_us_special');

the template used should be email/email_template_contact_us_special.html (assuming that exists), not
email/email_template_contact_us.html just because zen_mail was called from the contact_us page.

The $module parameter in the call, not the $current_page_base, should be the top priority. 