### PR TITLE
Update objectinfo annotations to avoid code-inspect false-positives

### DIFF
--- a/admin/includes/classes/object_info.php
+++ b/admin/includes/classes/object_info.php
@@ -55,6 +55,10 @@ class objectInfo
         $this->$field = $value;
     }
 
+    /**
+     * @param $field
+     * @return array|string
+     */
     public function __get($field)
     {
         if (isset($this->$field)) return $this->$field;


### PR DESCRIPTION
It would be faster and still probably completely safe to just return a string without checking but just in case I added a check.

Doing this means that we can use the Type compatibility check in phpStorm (and other debuggers). 