### PR TITLE
Remove old PHP checks

### DIFF
--- a/includes/classes/observers/auto.non_captcha_observer.php
+++ b/includes/classes/observers/auto.non_captcha_observer.php
@@ -54,11 +54,10 @@ class zcObserverNonCaptchaObserver extends base
 
     protected function generate_random_string($input, $strength = 16)
     {
-        $function = PHP_VERSION_ID >= 70000 ? 'random_int' : 'mt_rand';
         $input_length = strlen($input);
         $random_string = '';
         for ($i = 0; $i < $strength; $i++) {
-            $random_character = $input[$function(0, $input_length - 1)];
+            $random_character = $input[random_int(0, $input_length - 1)];
             $random_string .= $random_character;
         }
 

--- a/includes/functions/password_funcs.php
+++ b/includes/functions/password_funcs.php
@@ -102,9 +102,8 @@ function zen_get_entropy($hash = 'sha1', $size = 32)
 
   // Use mcrypt with /dev/urandom if available
   if ($data === null && function_exists('mcrypt_create_iv') && (
-    // There is a bug in Windows + IIS in older versions of PHP
-    (
-strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN' || version_compare(PHP_VERSION, '5.3.7', '>='))))
+    // There is a bug in Windows + IIS 
+    (strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN')))
   {
     // echo('Attempting to create entropy using mcrypt');
     $entropy = mcrypt_create_iv($size, MCRYPT_DEV_URANDOM);


### PR DESCRIPTION
All pre PHP 7 checks can be removed now that we are fully PHP7. 

Fixes #2586. 