### PR TITLE
Fix error logging/reporting

### DIFF
--- a/admin/includes/application_bootstrap.php
+++ b/admin/includes/application_bootstrap.php
@@ -68,7 +68,7 @@ if (file_exists('includes/configure.php')) {
  */
 if (defined('STRICT_ERROR_REPORTING') && STRICT_ERROR_REPORTING == true) {
     @ini_set('display_errors', TRUE);
-    error_reporting(defined('STRICT_REPORTING_LEVEL') ? STRICT_REPORTING_LEVEL : E_ALL);
+    error_reporting(defined('STRICT_ERROR_REPORTING_LEVEL') ? STRICT_ERROR_REPORTING_LEVEL : E_ALL);
 } else {
     error_reporting(0);
 }

--- a/admin/includes/application_bootstrap.php
+++ b/admin/includes/application_bootstrap.php
@@ -66,7 +66,7 @@ if (file_exists('includes/configure.php')) {
  * in php.ini. Otherwise we respect the php.ini setting
  *
  */
-if (defined('STRICT_ERROR_REPORTING') && STRICT_ERROR_REPORTING == true) {
+if (DEBUG_AUTOLOAD || defined('STRICT_ERROR_REPORTING') && STRICT_ERROR_REPORTING == true) {
     @ini_set('display_errors', TRUE);
     error_reporting(defined('STRICT_ERROR_REPORTING_LEVEL') ? STRICT_ERROR_REPORTING_LEVEL : E_ALL);
 } else {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -34,12 +34,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        /**
-         * set the level of error reporting
-         *
-         * Note STRICT_ERROR_REPORTING should never be set to true on a production site. <br />
-         * It is mainly there to show php warnings during testing/bug fixing phases.<br />
-         */
         if (DEBUG_AUTOLOAD || (defined('STRICT_ERROR_REPORTING') && STRICT_ERROR_REPORTING == true)) {
             @ini_set('display_errors', TRUE);
             error_reporting(defined('ILLUMINATE_ERROR_REPORTING_LEVEL') ? ILLUMINATE_ERROR_REPORTING_LEVEL : 0);
@@ -47,7 +41,6 @@ class AppServiceProvider extends ServiceProvider
             error_reporting(0);
         }
         if ($this->app->runningInConsole()) return;
-
         $pluginManager = new PluginManager(new PluginControl, new PluginControlVersion);
         $installedPlugins = $pluginManager->getInstalledPlugins();
         $this->app->instance('installedPlugins', $installedPlugins);

--- a/includes/application_top.php
+++ b/includes/application_top.php
@@ -96,7 +96,7 @@ define('DEBUG_AUTOLOAD', false);
  */
 if (DEBUG_AUTOLOAD || (defined('STRICT_ERROR_REPORTING') && STRICT_ERROR_REPORTING == true)) {
   @ini_set('display_errors', TRUE);
-  error_reporting(defined('STRICT_REPORTING_LEVEL') ? STRICT_REPORTING_LEVEL : E_ALL);
+  error_reporting(defined('STRICT_ERROR_REPORTING_LEVEL') ? STRICT_ERROR_REPORTING_LEVEL : E_ALL);
 } else {
     error_reporting(0);
 }

--- a/includes/illuminate_bootstrap.php
+++ b/includes/illuminate_bootstrap.php
@@ -14,11 +14,25 @@ $laravelRoute = Route::current();
 // if the route is null or a fallback then laravel didn't
 // match anything so return and let Zen Cart handle it.
 if (!isset($laravelRoute) || $laravelRoute->isFallback) {
+    set_error_handler(null);
+    if (DEBUG_AUTOLOAD || (defined('STRICT_ERROR_REPORTING') && STRICT_ERROR_REPORTING == true)) {
+        @ini_set('display_errors', TRUE);
+        error_reporting(defined('STRICT_ERROR_REPORTING_LEVEL') ? STRICT_ERROR_REPORTING_LEVEL : E_ALL);
+    } else {
+        error_reporting(0);
+    }
     return;
 }
 // use a 204 response to indicate that we want to use the response
 // in Zen Cart
 if ($laravelResponse->getStatusCode() == 204) {
+    set_error_handler(null);
+    if (DEBUG_AUTOLOAD || (defined('STRICT_ERROR_REPORTING') && STRICT_ERROR_REPORTING == true)) {
+        @ini_set('display_errors', TRUE);
+        error_reporting(defined('STRICT_ERROR_REPORTING_LEVEL') ? STRICT_ERROR_REPORTING_LEVEL : E_ALL);
+    } else {
+        error_reporting(0);
+    }
     return;
 }
 $laravelResponse->send();


### PR DESCRIPTION
Allow Laravel to take over reporting/logging but only if allowed to
and only during the lifetime of a Laravel request cycle
on return and if we are continuing with Zen Cart, reset the error handler
and reporting levels