### PR TITLE
admin: option name manager, set selected in drop down

### DIFF
--- a/admin/options_values_manager.php
+++ b/admin/options_values_manager.php
@@ -835,7 +835,7 @@ if (zen_not_null($action)) {
                     ?>
                     <div class="col-md-4">
                       <div class="form-group">
-                        <?php echo zen_draw_pull_down_menu('option_id', $optionsValueArray, '', 'class="form-control"'); ?>
+                        <?php echo zen_draw_pull_down_menu('option_id', $optionsValueArray, $filter, 'class="form-control"'); ?>
                       </div>
                     </div>
                     <div class="col-md-6">


### PR DESCRIPTION
The drop down has no default so $GLOBALS[$name] was used in function zen_draw_pull_down_menu.
But this only works/is set when the option name has at least one values associated. 
So after selecting an option name with no values as a filter, the add value dropdown would always show the first option, not the one selected.
This is the simplest fix, as I don't know how $GLOBALS[$name] gets set when there **are** values associated with a name....