### PR TITLE
updates to allow plugin upgrades

### DIFF
--- a/admin/includes/languages/english/lang.plugin_manager.php
+++ b/admin/includes/languages/english/lang.plugin_manager.php
@@ -29,6 +29,7 @@ $define = [
     'TEXT_NOT_INSTALLED' => 'Not Installed',
     'TEXT_INSTALL_SUCCESS' => 'Plugin installed successfully',
     'TEXT_UNINSTALL_SUCCESS' => 'Plugin un-installed successfully',
+    'TEXT_UPGRADE_SUCCESS' => 'Plugin upgraded successfully',
     'TEXT_DISABLE_SUCCESS' => 'Plugin disabled successfully',
     'TEXT_ENABLE_SUCCESS' => 'Plugin enabled successfully',
     'TEXT_UPGRADE_AVAILABLE' => 'Upgrade Available',
@@ -39,7 +40,7 @@ $define = [
     'TEXT_CONFIRM_ENABLE' => 'Are you sure you want to enable this plugin?',
     'TEXT_INFO_UPGRADE' => 'Please select the version you want to upgrade to.',
     'TEXT_INFO_UPGRADE_CONFIRM' => 'Upgrade version %s',
-    'TEXT_INFO_UPGRADE_WARNING' => 'Warning: blah blah',
+    'TEXT_INFO_UPGRADE_WARNING' => '',
     'TEXT_INFO_CONFIRM_CLEAN' => 'Confirm version directories to clean/remove',
 ];
 

--- a/includes/classes/PluginManager.php
+++ b/includes/classes/PluginManager.php
@@ -134,7 +134,7 @@ class PluginManager
 
     protected function getPluginVersions($uniqueKey)
     {
-        $result = $this->pluginControlVersion->where(['unique_key' => $uniqueKey]);
+        $result = $this->pluginControlVersion->where(['unique_key' => $uniqueKey])->get();
         return $result;
     }
 

--- a/includes/classes/PluginSupport/BasePluginInstaller.php
+++ b/includes/classes/PluginSupport/BasePluginInstaller.php
@@ -52,6 +52,19 @@ class BasePluginInstaller
         $this->setPluginVersionStatus($pluginKey, $version, 1);
     }
 
+    public function processUpgrade($pluginKey, $version, $oldVersion)
+    {
+        $this->pluginDir = DIR_FS_CATALOG . 'zc_plugins/' . $pluginKey . '/' . $version;
+        $this->loadInstallerLanguageFile('main.php', $this->pluginDir);
+        $this->pluginInstaller->executeUpgraders($this->pluginDir, $oldVersion);
+        if ($this->errorContainer->hasErrors()) {
+            return false;
+        }
+        $this->setPluginVersionStatus($pluginKey, $oldVersion, 0);
+        $this->setPluginVersionStatus($pluginKey, $version, 1);
+        return true;
+    }
+
     protected function setPluginVersionStatus($pluginKey, $version, $status)
     {
         $sql = "UPDATE " . TABLE_PLUGIN_CONTROL . " SET status = :status:, version = :version: WHERE unique_key = :uniqueKey:";

--- a/includes/classes/PluginSupport/Installer.php
+++ b/includes/classes/PluginSupport/Installer.php
@@ -36,6 +36,11 @@ class Installer
         $this->executeScriptedUninstaller($pluginDir);
     }
 
+    public function executeUpgraders($pluginDir, $oldVersion)
+    {
+        $this->executeScriptedUpgrader($pluginDir, $oldVersion);
+    }
+
     protected function executePatchInstaller($pluginDir)
     {
         $patchFile = 'install.sql';
@@ -79,4 +84,14 @@ class Installer
         $scriptedInstaller = $this->scriptedInstallerFactory->make($pluginDir);
         $scriptedInstaller->doUninstall();
     }
+
+    protected function executeScriptedUpgrader($pluginDir, $oldVersion)
+    {
+        if (!file_exists($pluginDir . '/Installer/ScriptedInstaller.php')) {
+            return;
+        }
+        $scriptedInstaller = $this->scriptedInstallerFactory->make($pluginDir);
+        $scriptedInstaller->doUpgrade($oldVersion);
+    }
+
 }

--- a/includes/classes/PluginSupport/ScriptedInstaller.php
+++ b/includes/classes/PluginSupport/ScriptedInstaller.php
@@ -27,12 +27,22 @@ class ScriptedInstaller
         return $uninstalled;
     }
 
+    public function doUpgrade()
+    {
+        $upgraded = $this->executeUpgrade();
+        return $upgraded;
+    }
     protected function executeInstall()
     {
         return true;
     }
 
     protected function executeUninstall()
+    {
+        return true;
+    }
+
+    protected function executeUpgrade()
     {
         return true;
     }


### PR DESCRIPTION
For upgrades we currently only allow a class based scripted Installer class and not a plain sql file to process any changes to the 
database.

This is done for simplicity. 

If we allowed plain sql files then there would need to have a sql file for each upgrade version step, and process these sequentially 
with the possibility of failure at each step. 

Using a ScriptedInstaller class throws the responsibility on to the plugin maintainer to write code that check the version being installed and the currently installed version and intelligently upgrading any tables/alter tables and data seeding.