### PR TITLE
Fixes #3740

### DIFF
--- a/includes/classes/message_stack.php
+++ b/includes/classes/message_stack.php
@@ -99,6 +99,14 @@ class messageStack extends base
     {
         global $template, $current_page_base;
 
+        // -----
+        // Reset the session-based messages, now that message-output has been requested for
+        // at least one $class.  This implies that the 'templating' phase of a page's
+        // rendering is in progress and that all applicable messages will be output at this
+        // time.
+        //
+        $_SESSION['messageToStack'] = array();
+
         if ($this->size($class) === 0) {
             return;
         }
@@ -123,9 +131,7 @@ class messageStack extends base
                 $this->add($next_message['class'], $next_message['text'], $next_message['type']);
             }
         }
-
-        $_SESSION['messageToStack'] = array();
-
+        
         $count = 0;
 
         foreach ($this->messages as $next_message) {


### PR DESCRIPTION
... deferring the 'reset' of the session-based message-stack until the message-output phase.

The issue reported was a result of 'missed functionality', i.e. that the class' `size` method might be called without a subsequent `output` one.  This change simply moves the session-based messages' reset to the `output` method.  

The assumption is that since the messages are to be output that we've entered the rendering phase of a page-load so any session-based messages will either be output at this time or are no longer pertinent.