### PR TITLE
Support for database caching in core MySQL interface

### DIFF
--- a/admin/includes/dist-configure.php
+++ b/admin/includes/dist-configure.php
@@ -73,9 +73,9 @@ define('DB_DATABASE', '');
 
 /**
  * This is an advanced setting to determine whether you want to cache SQL queries.
- * Options are 'none' (which is the default) and 'file' and 'database'.
+ * Options are 'none', 'file' and 'database' (the default).
  */
-define('SQL_CACHE_METHOD', 'none');
+define('SQL_CACHE_METHOD', 'database');
 
 /**
  * Reserved for future use

--- a/admin/stats_products_viewed.php
+++ b/admin/stats_products_viewed.php
@@ -45,7 +45,7 @@ $sql = "SELECT p.products_id, pd.products_name, sum(v.views) as total_views, l.n
 $sql = $db->bindVars($sql, ':startdate', date('Y-m-d', $startdate), 'string');
 $sql = $db->bindVars($sql, ':enddate', date('Y-m-d', $enddate), 'string');
 $products_split = new splitPageResults($_GET['page'], MAX_DISPLAY_SEARCH_RESULTS_REPORTS, $sql, $products_query_numrows);
-$products = $db->Execute($sql);
+$products = $db->ExecuteNoCache($sql);
 
 ?>
     <!doctype html>

--- a/includes/classes/cache.php
+++ b/includes/classes/cache.php
@@ -34,7 +34,7 @@ class cache extends base {
       break;
       case 'database':
       $sql = "select * from " . TABLE_DB_CACHE . " where cache_entry_name = '" . $zp_cache_name . "'";
-      $zp_cache_exists = $db->Execute($sql);
+      $zp_cache_exists = $db->Execute($sql, false, false);
       if ($zp_cache_exists->RecordCount() > 0 && !$this->sql_cache_is_expired($zf_query, $zf_cachetime)) {
         return true;
       } else {
@@ -64,7 +64,7 @@ class cache extends base {
       break;
       case 'database':
       $sql = "select * from " . TABLE_DB_CACHE . " where cache_entry_name = '" . $zp_cache_name ."'";
-      $cache_result = $db->Execute($sql);
+      $cache_result = $db->Execute($sql, false, false);
       if ($cache_result->RecordCount() > 0) {
         $start_time = $cache_result->fields['cache_entry_created'];
         if (time() - $start_time > $zf_cachetime) return true;
@@ -93,7 +93,7 @@ class cache extends base {
       break;
       case 'database':
       $sql = "delete from " . TABLE_DB_CACHE . " where cache_entry_name = '" . $zp_cache_name . "'";
-      $db->Execute($sql);
+      $db->Execute($sql); 
       return true;
       break;
       case 'memory':
@@ -120,7 +120,7 @@ class cache extends base {
       break;
       case 'database':
       $sql = "select * from " . TABLE_DB_CACHE . " where cache_entry_name = '" . $zp_cache_name . "'";
-      $zp_cache_exists = $db->Execute($sql);
+      $zp_cache_exists = $db->Execute($sql, false, false);
       if ($zp_cache_exists->RecordCount() > 0) {
         return true;
       }
@@ -128,7 +128,7 @@ class cache extends base {
       $sql = "insert ignore into " . TABLE_DB_CACHE . " (cache_entry_name, cache_data, cache_entry_created) VALUES (:cachename, :cachedata, unix_timestamp() )";
       $sql = $db->bindVars($sql, ':cachename', $zp_cache_name, 'string');
       $sql = $db->bindVars($sql, ':cachedata', $result_serialize, 'string');
-      $db->Execute($sql);
+      $db->Execute($sql, false, false);
       return true;
       break;
       case 'memory':
@@ -152,7 +152,7 @@ class cache extends base {
       break;
       case 'database':
       $sql = "select * from " . TABLE_DB_CACHE . " where cache_entry_name = '" . $zp_cache_name . "'";
-      $zp_cache_result = $db->Execute($sql);
+      $zp_cache_result = $db->Execute($sql, false, false);
       $zp_result_array = unserialize(base64_decode($zp_cache_result->fields['cache_data']));
       return $zp_result_array;
       break;
@@ -179,19 +179,17 @@ class cache extends base {
         $za_dir->close();
       }
       return true;
-      break;
-      case 'database':
-      $sql = "delete from " . TABLE_DB_CACHE;
-      $db->Execute($sql);
-      return true;
-      break;
+
       case 'memory':
       return true;
-      break;
+
+      case 'database':
       case 'none':
       default:
+      // Do it just in case cache on in catalog but off in admin 
+      $sql = "delete from " . TABLE_DB_CACHE;
+      $db->ExecuteNoCache($sql); 
       return true;
-      break;
     }
   }
 

--- a/includes/classes/db/mysql/query_factory.php
+++ b/includes/classes/db/mysql/query_factory.php
@@ -172,7 +172,13 @@ class queryFactory extends base {
     echo '</div>';
   }
 
-  function Execute($zf_sql, $zf_limit = false, $zf_cache = false, $zf_cachetime=0, $remove_from_queryCache = false) {
+  function Execute($zf_sql, $zf_limit = false, $zf_cache = true, $zf_cachetime=3600, $remove_from_queryCache = false) {
+     if (strtoupper(substr($zf_sql,0,6)) != 'SELECT') {
+         $zf_cache = false; 
+     }
+     if (defined('IS_ADMIN_FLAG') && IS_ADMIN_FLAG == 'true') {
+         $zf_cache = false; 
+     }
     // bof: collect database queries
     if (defined('STORE_DB_TRANSACTIONS') && STORE_DB_TRANSACTIONS != 'false') {
       global $PHP_SELF, $box_id, $current_page_base;

--- a/includes/dist-configure.php
+++ b/includes/dist-configure.php
@@ -54,9 +54,9 @@ define('DB_DATABASE', '');
 
 /**
  * This is an advanced setting to determine whether you want to cache SQL queries.
- * Options are 'none' (which is the default) and 'file' and 'database'.
+ * Options are 'none', 'file' and 'database' (the default).
  */
-define('SQL_CACHE_METHOD', 'none');
+define('SQL_CACHE_METHOD', 'database');
 
 /**
  * Reserved for future use

--- a/includes/functions/functions_lookups.php
+++ b/includes/functions/functions_lookups.php
@@ -176,7 +176,7 @@
                     from " . TABLE_PRODUCTS . "
                     where products_id = " . (int)$products_id . " LIMIT 1";
 
-    $stock_values = $db->Execute($stock_query);
+    $stock_values = $db->ExecuteNoCache($stock_query);
 
     return $stock_values->fields['products_quantity'];
   }

--- a/includes/functions/sessions.php
+++ b/includes/functions/sessions.php
@@ -50,7 +50,7 @@ function _sess_read($key)
             where sesskey = '" . zen_db_input($key) . "'
             and expiry > '" . time() . "'";
 
-    $value = $db->Execute($qid);
+    $value = $db->ExecuteNoCache($qid);
 
     if (!empty($value->fields['value'])) {
         $value->fields['value'] = base64_decode($value->fields['value']);

--- a/includes/modules/pages/account_password/header_php.php
+++ b/includes/modules/pages/account_password/header_php.php
@@ -41,7 +41,7 @@ if (isset($_POST['action']) && ($_POST['action'] == 'process')) {
                              WHERE  customers_id = :customersID";
 
     $check_customer_query = $db->bindVars($check_customer_query, ':customersID',$_SESSION['customer_id'], 'integer');
-    $check_customer = $db->Execute($check_customer_query);
+    $check_customer = $db->ExecuteNoCache($check_customer_query);
 
     if (zen_validate_password($password_current, $check_customer->fields['customers_password'])) {
       zcPassword::getInstance(PHP_VERSION)->updateLoggedInCustomerPassword($password_new, $_SESSION['customer_id']);

--- a/includes/modules/pages/checkout_confirmation/header_php.php
+++ b/includes/modules/pages/checkout_confirmation/header_php.php
@@ -121,14 +121,14 @@ if (!empty($_SESSION['cc_id'])) {
                             WHERE coupon_id = :couponID";
 
   $discount_coupon_query = $db->bindVars($discount_coupon_query, ':couponID', $_SESSION['cc_id'], 'integer');
-  $discount_coupon = $db->Execute($discount_coupon_query);
+  $discount_coupon = $db->ExecuteNoCache($discount_coupon_query);
 
   $customers_referral_query = "SELECT customers_referral
                                FROM " . TABLE_CUSTOMERS . "
                                WHERE customers_id = :customersID";
 
   $customers_referral_query = $db->bindVars($customers_referral_query, ':customersID', $_SESSION['customer_id'], 'integer');
-  $customers_referral = $db->Execute($customers_referral_query);
+  $customers_referral = $db->ExecuteNoCache($customers_referral_query);
 
   // only use discount coupon if set by coupon
   if ($customers_referral->fields['customers_referral'] == '' and CUSTOMERS_REFERRAL_STATUS == 1) {

--- a/includes/modules/pages/checkout_payment/header_php.php
+++ b/includes/modules/pages/checkout_payment/header_php.php
@@ -68,7 +68,7 @@ if (!empty($_SESSION['cc_id'])) {
                             WHERE coupon_id = :couponID";
 
   $discount_coupon_query = $db->bindVars($discount_coupon_query, ':couponID', $_SESSION['cc_id'], 'integer');
-  $discount_coupon = $db->Execute($discount_coupon_query);
+  $discount_coupon = $db->ExecuteNoCache($discount_coupon_query);
 }
 
 // if no billing destination address was selected, use the customers own address as default
@@ -82,7 +82,7 @@ if (empty($_SESSION['billto'])) {
 
   $check_address_query = $db->bindVars($check_address_query, ':customersID', $_SESSION['customer_id'], 'integer');
   $check_address_query = $db->bindVars($check_address_query, ':addressBookID', $_SESSION['billto'], 'integer');
-  $check_address = $db->Execute($check_address_query);
+  $check_address = $db->ExecuteNoCache($check_address_query);
 
   if ($check_address->fields['total'] != '1') {
     $_SESSION['billto'] = $_SESSION['customer_default_address_id'];
@@ -122,4 +122,3 @@ $breadcrumb->add(NAVBAR_TITLE_2);
 
 // This should be last line of the script:
 $zco_notifier->notify('NOTIFY_HEADER_END_CHECKOUT_PAYMENT');
-?>

--- a/includes/modules/pages/checkout_shipping/header_php.php
+++ b/includes/modules/pages/checkout_shipping/header_php.php
@@ -61,7 +61,7 @@
 
     $check_address_query = $db->bindVars($check_address_query, ':customersID', $_SESSION['customer_id'], 'integer');
     $check_address_query = $db->bindVars($check_address_query, ':addressBookID', $_SESSION['sendto'], 'integer');
-    $check_address = $db->Execute($check_address_query);
+    $check_address = $db->ExecuteNoCache($check_address_query);
 
     if ($check_address->fields['total'] != '1') {
       $_SESSION['sendto'] = $_SESSION['customer_default_address_id'];

--- a/includes/modules/pages/login/header_php.php
+++ b/includes/modules/pages/login/header_php.php
@@ -65,7 +65,7 @@ if (isset($_GET['action']) && $_GET['action'] == 'process') {
                            WHERE customers_email_address = :emailAddress";
 
     $check_customer_query  =$db->bindVars($check_customer_query, ':emailAddress', $email_address, 'string');
-    $check_customer = $db->Execute($check_customer_query);
+    $check_customer = $db->ExecuteNoCache($check_customer_query);
 
     if (!$check_customer->RecordCount()) {
       $error = true;
@@ -105,7 +105,7 @@ if (isset($_GET['action']) && $_GET['action'] == 'process') {
 
         $check_country_query = $db->bindVars($check_country_query, ':customersID', $check_customer->fields['customers_id'], 'integer');
         $check_country_query = $db->bindVars($check_country_query, ':addressBookID', $check_customer->fields['customers_default_address_id'], 'integer');
-        $check_country = $db->Execute($check_country_query);
+        $check_country = $db->ExecuteNoCache($check_country_query);
 
         $_SESSION['customer_id'] = $check_customer->fields['customers_id'];
         $_SESSION['customers_email_address'] = $check_customer->fields['customers_email_address'];
@@ -119,9 +119,9 @@ if (isset($_GET['action']) && $_GET['action'] == 'process') {
         // enforce db integrity: make sure related record exists
         $sql = "SELECT customers_info_date_of_last_logon FROM " . TABLE_CUSTOMERS_INFO . " WHERE customers_info_id = :customersID";
         $sql = $db->bindVars($sql, ':customersID',  $_SESSION['customer_id'], 'integer');
-        $result = $db->Execute($sql);
+        $result = $db->ExecuteNoCache($sql);
         if ($result->RecordCount() == 0) {
-          $sql = "insert into " . TABLE_CUSTOMERS_INFO . " (customers_info_id) values (:customersID)";
+          $sql = "INSERT INTO " . TABLE_CUSTOMERS_INFO . " (customers_info_id) VALUES (:customersID)";
           $sql = $db->bindVars($sql, ':customersID',  $_SESSION['customer_id'], 'integer');
           $db->Execute($sql);
         }

--- a/includes/templates/responsive_classic/common/tpl_main_page.php
+++ b/includes/templates/responsive_classic/common/tpl_main_page.php
@@ -223,8 +223,10 @@ if (!isset($flag_disable_right) || !$flag_disable_right) {
   }
   require($template->get_template_dir('tpl_footer.php',DIR_WS_TEMPLATE, $current_page_base,'common'). '/tpl_footer.php');
 ?>
-
+<!-- FIXME remove after branch merge - here for testing -->
+<div class="smallText center">Parse Time: <?php echo $parse_time; ?> - Number of Queries: <?php echo $db->queryCount(); ?> - Query Time: <?php echo $db->queryTime(); ?></div>
 </div>
+
 <!--bof- banner #6 display -->
 <?php
   if (SHOW_BANNERS_GROUP_SET6 != '' && $banner = zen_banner_exists('dynamic', SHOW_BANNERS_GROUP_SET6)) {


### PR DESCRIPTION
This changes caching to default true for storefront $db->Execute statements which are SELECTs. 

To test, after merging this in, you will need to update your configure files to set the caching to database:

define('SQL_CACHE_METHOD', 'database');

A couple of things we'd want to address: 

a) the lack of caching in
includes/init_includes/init_db_config_read.php 
since this has changed to use Eloquent in 1.5.8, we'll need to write code to do this (as is noted in that file). 

b) Any admin page load clears the cache at the current time.  So if a storeowner was processing orders, they would be continually clearing the cache.  We can optimize this to only clear cache when config updates are done, for example, or perhaps from a link on the dashboard. 

