### PR TITLE
$function incorrectly provided for $order_id

### DIFF
--- a/includes/classes/payment.php
+++ b/includes/classes/payment.php
@@ -267,7 +267,7 @@ class payment extends base {
     if (!$GLOBALS[$this->selected_module]->enabled) return;
     $function = __FUNCTION__;
     if (!method_exists($GLOBALS[$this->selected_module], $function)) return;
-    return $GLOBALS[$this->selected_module]->after_order_create($function);
+    return $GLOBALS[$this->selected_module]->after_order_create($zf_order_id);
   }
 
   function admin_notification($zf_order_id) {
@@ -276,7 +276,7 @@ class payment extends base {
     if (!$GLOBALS[$this->selected_module]->enabled) return;
     $function = __FUNCTION__;
     if (!method_exists($GLOBALS[$this->selected_module], $function)) return;
-    return $GLOBALS[$this->selected_module]->admin_notification($function);
+    return $GLOBALS[$this->selected_module]->admin_notification($zf_order_id);
   }
 
   function get_error() {

--- a/includes/classes/payment.php
+++ b/includes/classes/payment.php
@@ -267,7 +267,7 @@ class payment extends base {
     if (!$GLOBALS[$this->selected_module]->enabled) return;
     $function = __FUNCTION__;
     if (!method_exists($GLOBALS[$this->selected_module], $function)) return;
-    return $GLOBALS[$this->selected_module]->after_order_create($zf_order_id);
+    return $GLOBALS[$this->selected_module]->$function($zf_order_id);
   }
 
   function admin_notification($zf_order_id) {
@@ -276,7 +276,7 @@ class payment extends base {
     if (!$GLOBALS[$this->selected_module]->enabled) return;
     $function = __FUNCTION__;
     if (!method_exists($GLOBALS[$this->selected_module], $function)) return;
-    return $GLOBALS[$this->selected_module]->admin_notification($zf_order_id);
+    return $GLOBALS[$this->selected_module]->$function($zf_order_id);
   }
 
   function get_error() {


### PR DESCRIPTION
In the refactoring of the payment module, the determined `$function` was incorrectly passed to the associated function instead of the data that was passed into the parent function (`$zf_order_id`) causing issues as identified in: https://www.zen-cart.com/showthread.php?226988-parameter-zf_order_id-is-not-being-transferred-into-the-after_order_create-method.