### PR TITLE
Safety code when zc_plugins directory has been removed or never existed

### DIFF
--- a/admin/plugin_manager.php
+++ b/admin/plugin_manager.php
@@ -16,8 +16,6 @@ use Zencart\Filters\FilterFactory;
 
 require('includes/application_top.php');
 
-$pluginManager->inspectAndUpdate();
-
 $errorContainer = new PluginErrorContainer();
 $pluginInstaller = new Installer(new SqlPatchInstaller($db, $errorContainer), new ScriptedInstallerFactory($db, $errorContainer), $errorContainer);
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -42,6 +42,7 @@ class AppServiceProvider extends ServiceProvider
         }
         if ($this->app->runningInConsole()) return;
         $pluginManager = new PluginManager(new PluginControl, new PluginControlVersion);
+        $pluginManager->inspectAndUpdate();
         $installedPlugins = $pluginManager->getInstalledPlugins();
         $this->app->instance('installedPlugins', $installedPlugins);
     }

--- a/includes/classes/PluginManager.php
+++ b/includes/classes/PluginManager.php
@@ -142,6 +142,7 @@ class PluginManager
     {
         $pluginDir = DIR_FS_CATALOG . 'zc_plugins';
         $pluginList = [];
+        if (!is_dir($pluginDir)) return $pluginList;
         $dir = new \DirectoryIterator($pluginDir);
         foreach ($dir as $fileinfo) {
             if ($fileinfo->isDot() || !$fileinfo->isDir()) {
@@ -183,10 +184,6 @@ class PluginManager
 
     protected function updateDbPlugins($pluginsFromFilesystem)
     {
-        if (count($pluginsFromFilesystem) === 0) {
-            return;
-        }
-// @todo validate plugin entries here
         $this->updatePluginControl($pluginsFromFilesystem);
     }
 


### PR DESCRIPTION
Currently code would die with a fatal error
Move inspectAndUpdate to service provider.
if zc_plugins doesn't exist the plugin manager page will throw a warning
leaving for now as I have a refactor branch that will address