### PR TITLE
Extend dtk all-files lookup to include zc_plugins

### DIFF
--- a/admin/developers_tool_kit.php
+++ b/admin/developers_tool_kit.php
@@ -665,6 +665,20 @@ switch ($action) {
           $check_directory[] = $check_dir[$i] . '/';
         }
         break;
+
+      case (4): // all plugins
+        $zv_check_root = false;
+        $filename_listing = '';
+
+        $check_directory = array();
+
+        $sub_dir_files = array();
+        getDirList(DIR_FS_CATALOG . '/zc_plugins', $zv_filestype_group);
+        $check_dir = $sub_dir_files;
+        for ($i = 0, $n = sizeof($check_dir); $i < $n; $i++) {
+          $check_directory[] = $check_dir[$i] . '/';
+        }
+        break;
     }
 
     $result = zen_display_files($zv_check_root, $zv_filestype_group);
@@ -1029,7 +1043,8 @@ if ($found == false) {
             $za_lookup = array(
               array('id' => '1', 'text' => TEXT_ALL_FILES_LOOKUP_CURRENT),
               array('id' => '2', 'text' => TEXT_ALL_FILES_LOOKUP_CURRENT_CATALOG),
-              array('id' => '3', 'text' => TEXT_ALL_FILES_LOOKUP_CURRENT_ADMIN)
+              array('id' => '3', 'text' => TEXT_ALL_FILES_LOOKUP_CURRENT_ADMIN),
+              array('id' => '4', 'text' => TEXT_ALL_FILES_LOOKUP_CURRENT_PLUGINS),
             );
             ?>
             <?php echo zen_draw_label(TEXT_ALL_FILES_LOOKUPS, 'zv_files', 'class="control-label col-sm-3"'); ?>

--- a/admin/includes/languages/english/developers_tool_kit.php
+++ b/admin/includes/languages/english/developers_tool_kit.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * @package admin
- * @copyright Copyright 2003-2016 Zen Cart Development Team
+ * @copyright Copyright 2003-2020 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: DrByte  Mon Oct 19 01:39:59 2015 -0400 Modified in v1.5.5 $
+ * @version $Id: Author: DrByte  Modified in v1.5.7a $
  */
   define('HEADING_TITLE', 'Developers Tool Kit');
   define('TABLE_CONFIGURATION_TABLE', 'Lookup CONSTANT Definitions');
@@ -59,11 +59,12 @@
   define('TEXT_TEMPLATE_LOOKUP_CURRENT_SIDEBOXES', 'All Template files - /sideboxes');
   define('TEXT_TEMPLATE_LOOKUP_CURRENT_PAGES', 'All Template files - /pages');
 
-  define('TEXT_ALL_FILES_CONSTANT', '<strong>Look-up in all files</strong>');
+  define('TEXT_ALL_FILES_CONSTANT', '<strong>Look-up in all files (including zc_plugins)</strong>');
   define('TEXT_ALL_FILES_LOOKUPS', 'All Files Look-ups:');
   define('TEXT_ALL_FILES_LOOKUP_CURRENT', 'All Files - Catalog/Admin');
   define('TEXT_ALL_FILES_LOOKUP_CURRENT_CATALOG', 'All Files - Catalog');
   define('TEXT_ALL_FILES_LOOKUP_CURRENT_ADMIN', 'All Files - Admin');
+  define('TEXT_ALL_FILES_LOOKUP_CURRENT_PLUGINS', 'All Files - Plugins');
 
   define('TEXT_INFO_NO_EDIT_AVAILABLE','No edit available');
   define('TEXT_INFO_CONFIGURATION_HIDDEN', ' or, HIDDEN');


### PR DESCRIPTION
Adds a selection to the All Files search to allow for searching the zc_plugins directory structure.

Fixes #3718