### PR TITLE
While admin product search ignores master cat, product listing needs it

### DIFF
--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -676,6 +676,9 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
                               OR p.products_model LIKE '%:search%'
                             ) ";
                 $where = $db->bindVars($where, ':search', $_GET['search'], 'noquotestring');
+            } else {
+                $products_query_raw.= " LEFT JOIN " . TABLE_PRODUCTS_TO_CATEGORIES . " p2c USING (products_id) ";
+                $where .= " AND p2c.categories_id=" . (int)$current_category_id;
             }
 
             $products_query_raw .= $where . $order_by;


### PR DESCRIPTION
p2c is still needed in order to show cross-linked categories

Updates #3786
Updates fix to #3729