### PR TITLE
Align admin's zen_add_tax with the storefront calculations

### DIFF
--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -1184,9 +1184,9 @@ while (!$chk_sale_categories_all->EOF) {
     global $currencies;
 
     if (DISPLAY_PRICE_WITH_TAX_ADMIN == 'true' || $force) {
-      return zen_round($price, $currencies->currencies[DEFAULT_CURRENCY]['decimal_places']) + zen_calculate_tax($price, $tax);
+      return $price + zen_calculate_tax($price, $tax);
     } else {
-      return zen_round($price, $currencies->currencies[DEFAULT_CURRENCY]['decimal_places']);
+      return $price;
     }
   }
 


### PR DESCRIPTION
... essentially removing the pre-rounding done in the admin that causes various calculations to "go off".

Suggest backport to zc157.