### PR TITLE
Ensure $spider_flag is set

### DIFF
--- a/includes/application_top.php
+++ b/includes/application_top.php
@@ -220,7 +220,7 @@ require(DIR_FS_CATALOG . 'includes/autoload_func.php');
 /**
  * load the counter code
 **/
-if ($spider_flag == false) {
+if (empty($spider_flag)) {
 // counter and counter history
   require(DIR_WS_INCLUDES . 'counter.php');
 }


### PR DESCRIPTION
Identified in https://www.zen-cart.com/showthread.php?227001-PHP-Notice-Undefined-index, there is the possibility that `$spider_flag` is never set, which is then used/called/expected in https://github.com/zencart/zencart/blob/d0c6806c0ced2ac8f3d5c28369e76e70ac99a6d8/includes/application_top.php#L223.  This can happen first if `Force Cookie Use` is set to `true`, and then even if it is set to a value `!= 'True'` then if `block spiders` is `!= 'True'` the variable `$spider_flag` is not set and can/will cause an issue at the above line.

`$spider_flag` is initially set to `true` so that later in the above code, the visit is excluded unless the session is identified as being started by a non-"spider" visitor.

Alternatively, it seems that https://github.com/zencart/zencart/blob/d0c6806c0ced2ac8f3d5c28369e76e70ac99a6d8/includes/application_top.php#L223 could check if `$session_started` is true instead of checking against `$spider_flag` being false?