### PR TITLE
improve admin product search

### DIFF
--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -670,12 +670,16 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
             $where = " WHERE pd.language_id = " . (int)$_SESSION['languages_id'];
 
             if ($search_result && $action != 'edit_category') {
-                $where .= "  AND (pd.products_name LIKE '%:search%'
-                              OR pd.products_description LIKE '%:search%'
-                              OR p.products_id = ':search'
-                              OR p.products_model LIKE '%:search%'
+                $parts = explode(" ", trim($keywords));
+                foreach ($parts as $k => $v) {
+                    $sql_add = " AND (pd.products_name LIKE '%:part%'
+                              OR pd.products_description LIKE '%:part%'
+                              OR p.products_id = ':part'
+                              OR p.products_model LIKE '%:part%'
                             ) ";
-                $where = $db->bindVars($where, ':search', $_GET['search'], 'noquotestring');
+                    $sql_add = $db->bindVars($sql_add, ':part', $v, 'noquotestring');
+                    $where .= $sql_add;
+                }
             } else {
                 $products_query_raw.= " LEFT JOIN " . TABLE_PRODUCTS_TO_CATEGORIES . " p2c USING (products_id) ";
                 $where .= " AND p2c.categories_id=" . (int)$current_category_id;


### PR DESCRIPTION
the store side has a better product search than the admin side.  similar to the work done on the admin customer search, this makes much more sense to me, and makes it easier for admins to find products.

it would be nice to more mimic the store side but the store side function ```zen_parse_search_string``` is not available.

```$keywords``` is assigned well above this line, and i do not see it in use in this script.

finally, it might behoove us, considering the plethora of functions inherent in ZC, to consider refactoring this logic into a function; the function takes 2 arrays as inputs: column names and keywords; and returns a find string for use in all of these areas.

i see this var ```$keywords``` used in the following scripts, and somehow having a function that creates the where clause seems like a good idea.

```
orders.php
specials.php
category_product_listing.php
reviews.php
products_price_manager.php
downloads_manager.php
attributes_controller.php
customers.php
featured.php
```