### PR TITLE
Remove PRODUCT_THROWS_200_WHEN_DISABLED

### DIFF
--- a/includes/functions/functions_products.php
+++ b/includes/functions/functions_products.php
@@ -62,10 +62,6 @@ function zen_product_set_header_response($product_id, $product_info = null)
         $response_code = 410;
     }
 
-    if (defined('PRODUCT_THROWS_200_WHEN_DISABLED') && PRODUCT_THROWS_200_WHEN_DISABLED === true) {
-        $response_code = 200;
-    }
-
     if ($product_status === -1) {
         $response_code = 410;
     }
@@ -85,7 +81,7 @@ function zen_product_set_header_response($product_id, $product_info = null)
     if ($should_throw_404) {
         // if specified product_id doesn't exist, ensure that metatags and breadcrumbs don't share bad data or inappropriate information
         unset($_GET['products_id']);
-        unset($breadcrumb->_trail[sizeof($breadcrumb->_trail)-1]['title']);
+        unset($breadcrumb->_trail[count($breadcrumb->_trail)-1]['title']);
         $robotsNoIndex = true;
         header('HTTP/1.1 404 Not Found');
         return;

--- a/includes/modules/pages/document_general_info/main_template_vars.php
+++ b/includes/modules/pages/document_general_info/main_template_vars.php
@@ -20,12 +20,6 @@
 
   $product_not_found = $product_info->EOF;
 
-  if (!defined('PRODUCT_THROWS_200_WHEN_DISABLED') || PRODUCT_THROWS_200_WHEN_DISABLED !== true) {
-      if (!$product_not_found && $product_info->fields['products_status'] != 1) {
-      $product_not_found = true;
-    }
-  }
-
   if ($product_not_found) {
     $tpl_page_body = '/tpl_product_info_noproduct.php';
   } else {

--- a/includes/modules/pages/document_product_info/main_template_vars.php
+++ b/includes/modules/pages/document_product_info/main_template_vars.php
@@ -20,12 +20,6 @@
 
   $product_not_found = $product_info->EOF;
 
-  if (!defined('PRODUCT_THROWS_200_WHEN_DISABLED') || PRODUCT_THROWS_200_WHEN_DISABLED !== true) {
-      if (!$product_not_found && $product_info->fields['products_status'] != 1) {
-      $product_not_found = true;
-    }
-  }
-
   if ($product_not_found) {
     $tpl_page_body = '/tpl_product_info_noproduct.php';
   } else {

--- a/includes/modules/pages/product_free_shipping_info/main_template_vars.php
+++ b/includes/modules/pages/product_free_shipping_info/main_template_vars.php
@@ -20,12 +20,6 @@
 
   $product_not_found = $product_info->EOF;
 
-  if (!defined('PRODUCT_THROWS_200_WHEN_DISABLED') || PRODUCT_THROWS_200_WHEN_DISABLED !== true) {
-      if (!$product_not_found && $product_info->fields['products_status'] != 1) {
-      $product_not_found = true;
-    }
-  }
-
   if ($product_not_found) {
     $tpl_page_body = '/tpl_product_info_noproduct.php';
   } else {

--- a/includes/modules/pages/product_info/main_template_vars.php
+++ b/includes/modules/pages/product_info/main_template_vars.php
@@ -20,12 +20,6 @@
 
   $product_not_found = $product_info->EOF;
 
-  if (!defined('PRODUCT_THROWS_200_WHEN_DISABLED') || PRODUCT_THROWS_200_WHEN_DISABLED !== true) {
-      if (!$product_not_found && $product_info->fields['products_status'] != 1) {
-          $product_not_found = true;
-      }
-  }
-
   if ($product_not_found) {
     $tpl_page_body = '/tpl_product_info_noproduct.php';
   } else {

--- a/includes/modules/pages/product_music_info/main_template_vars.php
+++ b/includes/modules/pages/product_music_info/main_template_vars.php
@@ -20,12 +20,6 @@
 
   $product_not_found = $product_info->EOF;
 
-  if (!defined('PRODUCT_THROWS_200_WHEN_DISABLED') || PRODUCT_THROWS_200_WHEN_DISABLED !== true) {
-      if (!$product_not_found && $product_info->fields['products_status'] != 1) {
-      $product_not_found = true;
-    }
-  }
-
   if ($product_not_found) {
     $tpl_page_body = '/tpl_product_info_noproduct.php';
   } else {


### PR DESCRIPTION
(It was introduced in 1.5.7 but didn't fully work. In retrospect was probably a bad idea because it forces supporting something into future that should be left behind. Thus removing in 1.5.7a.)

Also removes duplicate logic since the http response is already set in `header_php.php`

Closes #3790 
Ref #3789