### PR TITLE
Shorten args for ExecuteRandomMulti and deprecate ExecuteRandomMultiNoCache

### DIFF
--- a/includes/classes/db/mysql/query_factory.php
+++ b/includes/classes/db/mysql/query_factory.php
@@ -287,7 +287,15 @@ class queryFactory extends base
         return $this->Execute($sqlQuery, false, false, 0, true);
     }
 
-    function ExecuteRandomMulti($sqlQuery, $limit = 0, $unusedCacheFlag = null, $unusedCacheTtl = null, $remove_from_queryCache = false)
+    /**
+     * Execute a SELECT query and return the results in a random order
+     * The results should be iterated with MoveNextRandom()
+     *
+     * @param string $sqlQuery
+     * @param int $limit
+     * @return queryFactoryResult
+     */
+    public function ExecuteRandomMulti(string $sqlQuery, $limit = 0): \queryFactoryResult
     {
         $time_start = explode(' ', microtime());
         $this->zf_sql = $sqlQuery;
@@ -295,7 +303,7 @@ class queryFactory extends base
         $obj->sql_query = $sqlQuery;
         $obj->limit = $limit;
 
-        $zp_db_resource = $this->ensureDbConnected($sqlQuery, $remove_from_queryCache);
+        $zp_db_resource = $this->ensureDbConnected($sqlQuery, true);
 
         if (false === $zp_db_resource) {
             $this->set_error(mysqli_errno($this->link), mysqli_error($this->link), $this->dieOnErrors);
@@ -345,11 +353,11 @@ class queryFactory extends base
     }
 
     /**
-     * Use this ExecuteRandomMulti method to ensure that any SELECT result is pulled from the database, bypassing the cache.
+     * @deprecated since 1.5.8 use ExecuteRandomMulti
      */
     function ExecuteRandomMultiNoCache($sqlQuery)
     {
-        return $this->ExecuteRandomMulti($sqlQuery, 0, false, 0, true);
+        return $this->ExecuteRandomMulti($sqlQuery, 0);
     }
 
     /**

--- a/includes/classes/db/mysql/query_factory.php
+++ b/includes/classes/db/mysql/query_factory.php
@@ -362,6 +362,8 @@ class queryFactory extends base
      */
     function ExecuteRandomMultiNoCache($sqlQuery)
     {
+        trigger_error('Call to deprecated function ExecuteRandomMultiNoCache. Use ExecuteRandomMulti() instead', E_USER_DEPRECATED);
+
         return $this->ExecuteRandomMulti($sqlQuery, 0);
     }
 


### PR DESCRIPTION
This method never caches anything anyway, so we don't need all the caching args.
ALERT: Some plugins may need to be changed if they passed these (ignored) arguments, but removing the arguments in plugin code remains backward compatible since these were optional args anyway.

Also one could argue that we've never needed the `ExecuteRandomMultiNoCache()` method at all. I'd like to remove it, but not sure whether it's actually used by any plugins. Deprecating it here for now.