### PR TITLE
Deprecate zen_db_output()

### DIFF
--- a/admin/invoice.php
+++ b/admin/invoice.php
@@ -251,7 +251,7 @@ if ($order->billing['street_address'] != $order->delivery['street_address']) {
                 <tr>
                   <td class="text-center"><?php echo zen_datetime_short($order_history['date_added']); ?></td>
                   <td><?php echo $orders_status_array[$order_history['orders_status_id']]; ?></td>
-                  <td><?php echo ($order_history['comments'] == '' ? TEXT_NONE : nl2br(zen_db_output($order_history['comments']))); ?>&nbsp;</td>
+                  <td><?php echo ($order_history['comments'] == '' ? TEXT_NONE : nl2br(zen_output_string_protected($order_history['comments']))); ?>&nbsp;</td>
                 </tr>
                 <?php
                 if (ORDER_COMMENTS_INVOICE == 1 && $count_comments >= 1) {

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -942,7 +942,7 @@ if (zen_not_null($action) && $order_exists == true) {
                     <td>
 <?php
                         if ($first) {
-                           echo nl2br(zen_db_output($item['comments']));
+                           echo nl2br(zen_output_string_protected($item['comments']));
                            $first = false;
                         } else {
                            echo nl2br($item['comments']);

--- a/admin/packingslip.php
+++ b/admin/packingslip.php
@@ -184,7 +184,7 @@ if ($order->billing['street_address'] != $order->delivery['street_address']) {
                 <tr>
                   <td class="text-center"><?php echo zen_datetime_short($order_history['date_added']); ?></td>
                   <td><?php echo $orders_status_array[$order_history['orders_status_id']]; ?></td>
-                  <td><?php echo ($order_history['comments'] == '' ? TEXT_NONE : nl2br(zen_db_output($order_history['comments']))); ?>&nbsp;</td>
+                  <td><?php echo ($order_history['comments'] == '' ? TEXT_NONE : nl2br(zen_output_string_protected($order_history['comments']))); ?>&nbsp;</td>
                 </tr>
                 <?php
                 if (ORDER_COMMENTS_PACKING_SLIP == 1 && $count_comments >= 1) {

--- a/admin/reviews.php
+++ b/admin/reviews.php
@@ -193,7 +193,7 @@ if (zen_not_null($action)) {
                 <strong><?php echo ENTRY_FROM; ?></strong> <?php echo $rInfo->customers_name; ?><br>
                 <strong><?php echo ENTRY_DATE; ?></strong> <?php echo zen_date_short($rInfo->date_added); ?>
             </div>
-             <div class="main"><b><?php echo ENTRY_REVIEW; ?></b><br><br><?php echo nl2br(zen_db_output(zen_break_string($rInfo->reviews_text, 15))); ?></div>
+             <div class="main"><b><?php echo ENTRY_REVIEW; ?></b><br><br><?php echo nl2br(zen_output_string_protected(zen_break_string($rInfo->reviews_text, 15))); ?></div>
 
             <?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?>
 

--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -1094,8 +1094,8 @@ class order extends base {
     //comments area
     $html_msg['ORDER_COMMENTS'] = '';
     if ($this->info['comments']) {
-      $email_order .= zen_db_output($this->info['comments']) . "\n\n";
-      $html_msg['ORDER_COMMENTS'] = nl2br(zen_db_output($this->info['comments']));
+      $email_order .= zen_output_string_protected($this->info['comments']) . "\n\n";
+      $html_msg['ORDER_COMMENTS'] = nl2br(zen_output_string_protected($this->info['comments']));
     }
 
     $this->notify('NOTIFY_ORDER_EMAIL_BEFORE_PRODUCTS', array(), $email_order, $html_msg);

--- a/includes/functions/database.php
+++ b/includes/functions/database.php
@@ -28,13 +28,15 @@ function zen_db_input($string)
     return $db->prepare_input($string);
 }
 
-  function zen_db_output($string) {
-    if (IS_ADMIN_FLAG) {
-       return htmlspecialchars($string, ENT_COMPAT, CHARSET, TRUE);
-    } else {
-       return htmlspecialchars($string);
-    }
-  }
+/**
+ * @deprecated use zen_output_string_protected() instead
+ * @param string $string
+ * @return string
+ */
+function zen_db_output(string $string)
+{
+    return zen_output_string_protected($string);
+}
 
 /**
  * Rudimentary input sanitizer

--- a/includes/functions/database.php
+++ b/includes/functions/database.php
@@ -35,6 +35,8 @@ function zen_db_input($string)
  */
 function zen_db_output(string $string)
 {
+    trigger_error('Call to deprecated function zen_db_output. Use zen_output_string_protected() instead', E_USER_DEPRECATED);
+
     return zen_output_string_protected($string);
 }
 

--- a/includes/functions/functions_general_shared.php
+++ b/includes/functions/functions_general_shared.php
@@ -33,21 +33,23 @@ function zen_is_whitelisted_admin_ip($ip = null)
 
 /**
  * Returns a string with conversions for security.
- * @param string The string to be parsed
- * @param string contains a string to be translated, otherwise just quote is translated
- * @param boolean Do we run htmlspecialchars over the string
-*/
-  function zen_output_string($string, $translate = false, $protected = false) {
-    if ($protected == true) {
+ * @param string $string The string to be parsed
+ * @param string|bool $translate contains a string to be translated, otherwise just quote is translated
+ * @param bool $protected Do we run htmlspecialchars over the string
+ * @return string
+ */
+  function zen_output_string($string, $translate = false, $protected = false): string
+  {
+    if ($protected === true) {
       $double_encode = (IS_ADMIN_FLAG ? FALSE : TRUE);
       return htmlspecialchars($string, ENT_COMPAT, CHARSET, $double_encode);
-    } else {
-      if ($translate === false) {
-        return zen_parse_input_field_data($string, array('"' => '&quot;'));
-      } else {
-        return zen_parse_input_field_data($string, $translate);
-      }
     }
+
+    if ($translate === false) {
+      return zen_parse_input_field_data($string, array('"' => '&quot;'));
+    }
+
+    return zen_parse_input_field_data($string, $translate);
   }
 
 /**


### PR DESCRIPTION
It's only being used for screen output, not db-related.
Therefore should use zen_output_string_protected() instead.