### PR TITLE
Fix undefined index tax_groups error in ot-gv

### DIFF
--- a/includes/modules/order_total/ot_gv.php
+++ b/includes/modules/order_total/ot_gv.php
@@ -68,7 +68,7 @@ class ot_gv {
       if ($od_amount['total'] > 0) {
         $tax = 0;
         foreach($order->info['tax_groups'] as $key => $value) {
-          if ($od_amount['tax_groups'][$key]) {
+          if (isset($od_amount['tax_groups'][$key])) {
             $order->info['tax_groups'][$key] -= $od_amount['tax_groups'][$key];
             $tax += $od_amount['tax_groups'][$key];
           }


### PR DESCRIPTION
The `tax_groups` element is a key-value array of `group_name=>rate`.
Built in 
https://github.com/zencart/zencart/blob/0ef00490a5cde1805d1cea5ae0175d057612a8fc/includes/functions/functions_taxes.php#L149

.. which is called by
https://github.com/zencart/zencart/blob/0ef00490a5cde1805d1cea5ae0175d057612a8fc/includes/classes/order.php#L544-L545

... which in turn sets it into `$order->info['tax_groups']` as used in ot-gv:
https://github.com/zencart/zencart/blob/0ef00490a5cde1805d1cea5ae0175d057612a8fc/includes/modules/order_total/ot_gv.php#L332-L334