### PR TITLE
Browsing to unknown page causes fatal error

### DIFF
--- a/includes/init_includes/init_sanitize.php
+++ b/includes/init_includes/init_sanitize.php
@@ -115,13 +115,13 @@ use Zencart\FileSystem\FileSystem;
   $pageLoader = PageLoader::getInstance();
   $pageLoader->init($installedPlugins, $_GET['main_page'], new FileSystem);
 
-    $pageDir = $pageLoader->findModulePageDirectory();
+  $pageDir = $pageLoader->findModulePageDirectory();
   if ( $pageDir === false) {
     if (MISSING_PAGE_CHECK == 'On' || MISSING_PAGE_CHECK == 'true') {
-      $_GET['main_page'] = 'index';
+      zen_redirect(zen_href_link(FILENAME_DEFAULT));
     } elseif (MISSING_PAGE_CHECK == 'Page Not Found') {
       header('HTTP/1.1 404 Not Found');
-      $_GET['main_page'] = FILENAME_PAGE_NOT_FOUND;
+      zen_redirect(zen_href_link(FILENAME_PAGE_NOT_FOUND));
     }
   }
 

--- a/includes/languages/english.php
+++ b/includes/languages/english.php
@@ -570,7 +570,7 @@ define('ARIA_PAGINATION_','');
 
   define('DB_ERROR_NOT_CONNECTED', 'Error - Could not connect to Database');
   define('ERROR_DATABASE_MAINTENANCE_NEEDED', '<a href="https://docs.zen-cart.com/user/troubleshooting/error_71_maintenance_required/" rel="noopener" target="_blank">ERROR 0071 There appears to be a problem with the database. Maintenance is required.</a>');
-
+ 
   // EZ-PAGES Alerts
   define('TEXT_EZPAGES_STATUS_HEADER_ADMIN', 'WARNING: EZ-PAGES HEADER - On for Admin IP Only');
   define('TEXT_EZPAGES_STATUS_FOOTER_ADMIN', 'WARNING: EZ-PAGES FOOTER - On for Admin IP Only');

--- a/includes/languages/english.php
+++ b/includes/languages/english.php
@@ -570,7 +570,7 @@ define('ARIA_PAGINATION_','');
 
   define('DB_ERROR_NOT_CONNECTED', 'Error - Could not connect to Database');
   define('ERROR_DATABASE_MAINTENANCE_NEEDED', '<a href="https://docs.zen-cart.com/user/troubleshooting/error_71_maintenance_required/" rel="noopener" target="_blank">ERROR 0071 There appears to be a problem with the database. Maintenance is required.</a>');
- 
+
   // EZ-PAGES Alerts
   define('TEXT_EZPAGES_STATUS_HEADER_ADMIN', 'WARNING: EZ-PAGES HEADER - On for Admin IP Only');
   define('TEXT_EZPAGES_STATUS_FOOTER_ADMIN', 'WARNING: EZ-PAGES FOOTER - On for Admin IP Only');


### PR DESCRIPTION

Example: browse to index.php?main_page=unknown 

[10-Aug-2020 11:28:24 UTC] Request URI: /gh_demo_158/index.php?main_page=unknown, IP address: ::1
#1  require() called at [/Users/scott/Sites/gh_demo_158/includes/templates/responsive_classic/common/tpl_main_page.php:177]
#2  require(/Users/scott/Sites/gh_demo_158/includes/templates/responsive_classic/common/tpl_main_page.php) called at [/Users/scott/Sites/gh_demo_158/index.php:94]
--> PHP Warning: require(includes/templates/template_default/templates/tpl_unknown_default.php): failed to open stream: No such file or directory in /Users/scott/Sites/gh_demo_158/includes/templates/responsive_classic/common/tpl_main_page.php on line 177.

[10-Aug-2020 11:28:24 UTC] PHP Fatal error:  require(): Failed opening required 'includes/templates/template_default/templates/tpl_unknown_default.php' (include_path='.:/Applications/MAMP/bin/php/php7.3.9/lib/php') in /Users/scott/Sites/gh_demo_158/includes/templates/responsive_classic/common/tpl_main_page.php on line 177
[10-Aug-2020 11:28:24 UTC] PHP Stack trace:
[10-Aug-2020 11:28:24 UTC] PHP   1. {main}() /Users/scott/Sites/gh_demo_158/index.php:0
[10-Aug-2020 11:28:24 UTC] PHP   2. require() /Users/scott/Sites/gh_demo_158/index.php:94
