### PR TITLE
Brands: Correcting PHP notices and empty sections

### DIFF
--- a/includes/languages/english/brands.php
+++ b/includes/languages/english/brands.php
@@ -11,3 +11,5 @@ define('BREADCRUMB_BRANDS', 'Shop By Brand');
 
 define('FEATURED_BRANDS', 'Featured Brands');
 define('OTHER_BRANDS', 'Related Brands');
+
+define('NO_BRANDS_AVAILABLE', 'No brands are currently active for this store.');

--- a/includes/templates/template_default/templates/tpl_brands_default.php
+++ b/includes/templates/template_default/templates/tpl_brands_default.php
@@ -8,26 +8,49 @@
  */
 ?>
 <div id="indexBrandsList" class="centerColumn">
-
-    <h1 id="indexBrandsList-pageHeading" class="pageHeading"><?php echo FEATURED_BRANDS; ?></h1>
-
+    <h1 id="indexBrandsList-pageHeading" class="pageHeading"><?php echo HEADING_TITLE; ?></h1>
+<?php
+    // -----
+    // Display a message if no brands (aka manufacturers) are defined for the current store.
+    //
+    if (empty($brands['featured']) && empty($brands['other'])) {
+?>
+    <p><?php echo NO_BRANDS_AVAILABLE; ?></p>
+<?php
+    }
+    
+    // -----
+    // Display the list of featured brands, so long as at least one exists.
+    //
+    if (!empty($brands['featured'])) {
+?>
     <div class="featuredBrands">
+        <h2><?php echo FEATURED_BRANDS; ?></h2>
 <?php
     $list_box_contents = $brands['featured'];
     $title = '';
-    require($template->get_template_dir('tpl_columnar_display.php', DIR_WS_TEMPLATE, $current_page_base, 'common') . '/tpl_columnar_display.php');
+    require $template->get_template_dir('tpl_columnar_display.php', DIR_WS_TEMPLATE, $current_page_base, 'common') . '/tpl_columnar_display.php';
 ?>
     </div>
     <br class="clearBoth">
-
+<?php
+    }
+    
+    // -----
+    // Display the list of 'other' brands, so long as at least one exists.
+    //
+    if (!empty($brands['other'])) {
+?>
     <div class="otherBrands">
         <h2><?php echo OTHER_BRANDS; ?></h2>
 <?php
     $list_box_contents = $brands['other'];
     $title = '';
-    require($template->get_template_dir('tpl_columnar_display.php', DIR_WS_TEMPLATE, $current_page_base, 'common') . '/tpl_columnar_display.php');
+    require $template->get_template_dir('tpl_columnar_display.php', DIR_WS_TEMPLATE, $current_page_base, 'common') . '/tpl_columnar_display.php';
 ?>
 
     </div>
-
+<?php
+    }
+?>
 </div>


### PR DESCRIPTION
The initial implementation didn't account for stores that have
- No brands defined
- No brands featured
- No brands other than those featured