### PR TITLE
Use KB for smaller files

### DIFF
--- a/includes/modules/downloads.php
+++ b/includes/modules/downloads.php
@@ -91,7 +91,7 @@ if ($downloadsOnThisOrder) {
     $zv_filesize = TEXT_FILESIZE_UNKNOWN;
     if ($data['filesize'] > 0) {
       $zv_filesize = $data['filesize'];
-      if ($zv_filesize >= 11000) {
+      if ($zv_filesize >= 1024*1024/10) {
         $zv_filesize = number_format($zv_filesize/1024/1024,1);
         $zv_filesize_units = TEXT_FILESIZE_MEGS;
       } else if ($zv_filesize >= 1024) {


### PR DESCRIPTION
The current threshold of 11000 is too small to show MB - you wind up with 0.0MB files. 

The comparison could be against `1024*1024` instead of `1024*1024/10` - but it certainly shouldn't be the current `11000`.