### PR TITLE
Add missing space before AND, in zen_draw_products_pull_down_attributes

### DIFF
--- a/includes/functions/functions_categories.php
+++ b/includes/functions/functions_categories.php
@@ -419,7 +419,7 @@ function zen_draw_products_pull_down_attributes($field_name, $parameters = '', $
             // no selection made yet
             break;
         case ((int)$filter_by_option_name > 0) : // an Option Name was selected: show only products using attributes with this Option Name
-            $sql .= "AND pa.options_id = " . (int)$filter_by_option_name;
+            $sql .= " AND pa.options_id = " . (int)$filter_by_option_name;
             $sql .= " ORDER BY " . $order_by;
             break;
         default: //legacy: show all products with attributes


### PR DESCRIPTION
fixes:https://github.com/zencart/zencart/issues/3896

`$sql .= "AND pa.options_id = " . (int)$filter_by_option_name;`

1064 You have an error in your SQL syntax; .....