### PR TITLE
Add an asterisk to fields

### DIFF
--- a/admin/includes/css/stylesheet.css
+++ b/admin/includes/css/stylesheet.css
@@ -812,11 +812,6 @@ input.faint {
     color: #333;
 }
 
-/* Forms - put this last */
-.form-control {
-    width: 90%;
-    display: inline-block;
-}
 .control-label {/*for multiple inputs*/
     font-weight: 700;
 }

--- a/admin/includes/functions/html_output.php
+++ b/admin/includes/functions/html_output.php
@@ -247,30 +247,45 @@ function zen_image_submit($image, $alt = '', $parameters = '')
     return $form;
   }
 
-////
-// Output a form input field
-  function zen_draw_input_field($name, $value = '~*~*#', $parameters = '', $required = false, $type = 'text', $reinsert_value = true) {
-    $type = zen_output_string($type);
-    if ($type === 'price') $type = 'number" step="0.01';
+  /**
+ * 
+ * Output a form input field
+ * @param string $name field name
+ * @param string $value field value
+ * @param string $parameters extra parameters like classes or id
+ * @param boolean $required field is required
+ * @param string $type filed type
+ * @param boolean $reinsert_value
+ * @return string
+ */
+function zen_draw_input_field($name, $value = '~*~*#', $parameters = '', $required = false, $type = 'text', $reinsert_value = true)
+{
+  $type = zen_output_string($type);
+  if ($type === 'price')
+    $type = 'number" step="0.01';
+  $field = ($required ? '<div class="input-group alert-danger">' . PHP_EOL : '');
+  $field .= '<input type="' . $type . '" name="' . zen_output_string($name) . '"';
 
-    $field = '<input type="' . $type . '" name="' . zen_output_string($name) . '"';
-
-    if ( $value == '~*~*#' && (isset($GLOBALS[$name]) && is_string($GLOBALS[$name])) && ($reinsert_value == true) ) {
-      $field .= ' value="' . zen_output_string(stripslashes($GLOBALS[$name])) . '"';
-    } elseif ($value != '~*~*#' && zen_not_null($value)) {
-      $field .= ' value="' . zen_output_string($value) . '"';
-    }
-
-    if (zen_not_null($parameters)) $field .= ' ' . $parameters;
-
-    if ($required && strpos($parameters, 'required') === false) {
-        $field .= ' required';
-    }
-
-    $field .= ' />';
-
-    return $field;
+  if ($value == '~*~*#' && (isset($GLOBALS[$name]) && is_string($GLOBALS[$name])) && ($reinsert_value == true)) {
+    $field .= ' value="' . zen_output_string(stripslashes($GLOBALS[$name])) . '"';
+  } elseif ($value != '~*~*#' && zen_not_null($value)) {
+    $field .= ' value="' . zen_output_string($value) . '"';
   }
+
+  if (zen_not_null($parameters))
+    $field .= ' ' . $parameters;
+
+  if ($required && strpos($parameters, 'required') === false) {
+    $field .= ' required';
+  }
+
+  $field .= ' />' . PHP_EOL;
+  if ($required) {
+    $field .= '<span class="input-group-addon alert-danger">' . '*' . '</span>' . PHP_EOL;
+    $field .= '</div>' . PHP_EOL;
+  }
+  return $field;
+}
 
 ////
 // Output a form password field
@@ -371,35 +386,41 @@ function zen_image_submit($image, $alt = '', $parameters = '')
  * @param boolean $required required
  * @return string
  */
-  function zen_draw_pull_down_menu($name, $values, $default = '', $parameters = '', $required = false) {
-    $field = '<select rel="dropdown" name="' . zen_output_string($name) . '"';
+function zen_draw_pull_down_menu($name, $values, $default = '', $parameters = '', $required = false)
+{
+  $field = ($required ? '<div class="input-group">' . PHP_EOL : '');
+  $field .= '<select rel="dropdown" name="' . zen_output_string($name) . '"';
 
-    if (zen_not_null($parameters)) {
-      $field .= ' ' . $parameters;
-    }
-
-    if ($required && strpos($parameters, 'required') === false) {
-          $field .= ' required';
-    }
-
-    $field .= '>' . "\n";
-
-    if (empty($default) && isset($GLOBALS[$name]) && is_string($GLOBALS[$name])) {
-      $default = stripslashes($GLOBALS[$name]);
-    }
-
-    foreach ($values as $value) {
-      $field .= '<option value="' . zen_output_string($value['id']) . '"';
-      if ($default == $value['id']) {
-        $field .= ' selected="selected"';
-      }
-
-      $field .= '>' . zen_output_string($value['text'], array('"' => '&quot;', '\'' => '&#039;', '<' => '&lt;', '>' => '&gt;')) . '</option>' . "\n";
-    }
-    $field .= '</select>' . "\n";
-
-    return $field;
+  if (zen_not_null($parameters)) {
+    $field .= ' ' . $parameters;
   }
+
+  if ($required && strpos($parameters, 'required') === false) {
+    $field .= ' required';
+  }
+
+  $field .= '>' . "\n";
+
+  if (empty($default) && isset($GLOBALS[$name]) && is_string($GLOBALS[$name])) {
+    $default = stripslashes($GLOBALS[$name]);
+  }
+
+  foreach ($values as $value) {
+    $field .= '<option value="' . zen_output_string($value['id']) . '"';
+    if ($default == $value['id']) {
+      $field .= ' selected="selected"';
+    }
+
+    $field .= '>' . zen_output_string($value['text'], array('"' => '&quot;', '\'' => '&#039;', '<' => '&lt;', '>' => '&gt;')) . '</option>' . "\n";
+  }
+  $field .= '</select>' . "\n";
+  if ($required) {
+    $field .= '<span class="input-group-addon alert-danger">' . '*' . '</span>' . PHP_EOL;
+    $field .= '</div>' . PHP_EOL;
+  }
+
+  return $field;
+}
 
 ////
 // Hide form elements

--- a/admin/includes/functions/html_output.php
+++ b/admin/includes/functions/html_output.php
@@ -261,8 +261,9 @@ function zen_image_submit($image, $alt = '', $parameters = '')
 function zen_draw_input_field($name, $value = '~*~*#', $parameters = '', $required = false, $type = 'text', $reinsert_value = true)
 {
   $type = zen_output_string($type);
-  if ($type === 'price')
+  if ($type === 'price') {
     $type = 'number" step="0.01';
+  }
   $field = ($required ? '<div class="input-group alert-danger">' . PHP_EOL : '');
   $field .= '<input type="' . $type . '" name="' . zen_output_string($name) . '"';
 
@@ -272,8 +273,9 @@ function zen_draw_input_field($name, $value = '~*~*#', $parameters = '', $requir
     $field .= ' value="' . zen_output_string($value) . '"';
   }
 
-  if (zen_not_null($parameters))
+  if (zen_not_null($parameters)) {
     $field .= ' ' . $parameters;
+  }
 
   if ($required && strpos($parameters, 'required') === false) {
     $field .= ' required';


### PR DESCRIPTION
I noticed that in zc 1.5.8 on the admin side there is no longer an asterisk shown on required fields.
These changes add back the asterisk on fields that are set as required through the input or select function.

The asterisk is placed in an input addon span. This ensures the alignment on the right is always the same as fields that are not required
