### PR TITLE
Don't create a manufacturer select list in advanced search if store doesn't use them

### DIFF
--- a/includes/modules/pages/advanced_search/header_php.php
+++ b/includes/modules/pages/advanced_search/header_php.php
@@ -24,3 +24,8 @@
   $sData['pfrom'] =    (isset($_GET['pfrom']) ? zen_output_string($_GET['pfrom']) : '');
   $sData['pto'] =      (isset($_GET['pto'])   ? zen_output_string($_GET['pto']) : '');
 
+  // check manufacturers 
+  $mfr_query = $db->Execute("SELECT manufacturers_id FROM " . TABLE_MANUFACTURERS . " LIMIT 1"); 
+  if ($mfr_query->EOF) { 
+     $skip_manufacturers = true;
+  }

--- a/includes/templates/template_default/templates/tpl_advanced_search_default.php
+++ b/includes/templates/template_default/templates/tpl_advanced_search_default.php
@@ -37,11 +37,13 @@
 <br class="clearBoth" />
 </fieldset>
 
+<?php if (empty($skip_manufacturers)) { ?>
 <fieldset class="floatingBox forward">
     <legend><?php echo ENTRY_MANUFACTURERS; ?></legend>
     <?php echo zen_draw_pull_down_menu('manufacturers_id', zen_get_manufacturers(array(array('id' => '', 'text' => TEXT_ALL_MANUFACTURERS)), PRODUCTS_MANUFACTURERS_STATUS), $sData['manufacturers_id'], 'id="searchMfgId" aria-label="' . PLEASE_SELECT . '"'); ?>
 <br class="clearBoth" />
 </fieldset>
+<?php } ?>
 <br class="clearBoth" />
 
 <fieldset class="floatingBox back">


### PR DESCRIPTION
Some stores don't use manufacturers.  Don't create a dropdown list in advanced search for manufacturers if this is true.  