### PR TITLE
refactor product search

### DIFF
--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -676,7 +676,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
                     'pd.products_description',
                     'p.products_id',
                 ];
-                $where .= zen_build_where($fields, trim($keywords));
+                $where .= zen_build_keyword_where_clause($fields, trim($keywords));
             } else {
                 $products_query_raw.= " LEFT JOIN " . TABLE_PRODUCTS_TO_CATEGORIES . " p2c USING (products_id) ";
                 $where .= " AND p2c.categories_id=" . (int)$current_category_id;

--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -670,16 +670,13 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
             $where = " WHERE pd.language_id = " . (int)$_SESSION['languages_id'];
 
             if ($search_result && $action != 'edit_category') {
-                $parts = explode(" ", trim($keywords));
-                foreach ($parts as $k => $v) {
-                    $sql_add = " AND (pd.products_name LIKE '%:part%'
-                              OR pd.products_description LIKE '%:part%'
-                              OR p.products_id = ':part'
-                              OR p.products_model LIKE '%:part%'
-                            ) ";
-                    $sql_add = $db->bindVars($sql_add, ':part', $v, 'noquotestring');
-                    $where .= $sql_add;
-                }
+                $fields = [
+                    'pd.products_name',
+                    'p.products_model',
+                    'pd.products_description',
+                    'p.products_id',
+                ];
+                $where .= zen_build_where($fields, trim($keywords));
             } else {
                 $products_query_raw.= " LEFT JOIN " . TABLE_PRODUCTS_TO_CATEGORIES . " p2c USING (products_id) ";
                 $where .= " AND p2c.categories_id=" . (int)$current_category_id;

--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -670,13 +670,13 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
             $where = " WHERE pd.language_id = " . (int)$_SESSION['languages_id'];
 
             if ($search_result && $action != 'edit_category') {
-                $fields = [
+                $keyword_search_fields = [
                     'pd.products_name',
                     'p.products_model',
                     'pd.products_description',
                     'p.products_id',
                 ];
-                $where .= zen_build_keyword_where_clause($fields, trim($keywords));
+                $where .= zen_build_keyword_where_clause($keyword_search_fields, trim($keywords));
             } else {
                 $products_query_raw.= " LEFT JOIN " . TABLE_PRODUCTS_TO_CATEGORIES . " p2c USING (products_id) ";
                 $where .= " AND p2c.categories_id=" . (int)$current_category_id;

--- a/admin/customers.php
+++ b/admin/customers.php
@@ -1059,25 +1059,19 @@ if (zen_not_null($action)) {
                   <?php
                   $search = '';
                   if (isset($_GET['search']) && zen_not_null($_GET['search'])) {
-                    $keywords = zen_db_input(zen_db_prepare_input($_GET['search']));
-                    $parts = explode(" ", trim($keywords));
-                    $search = 'WHERE ';
-                    foreach ($parts as $k => $v) {
-                      $sql_add = " (c.customers_lastname LIKE '%:part%'
-                         OR c.customers_firstname LIKE '%:part%'
-                         OR c.customers_email_address LIKE '%:part%'
-                         OR c.customers_telephone RLIKE ':keywords:'
-                         OR a.entry_company RLIKE ':keywords:'
-                         OR a.entry_street_address RLIKE ':keywords:'
-                         OR a.entry_city RLIKE ':keywords:'
-                         OR a.entry_postcode RLIKE ':keywords:')";
-                      if ($k != 0) {
-                        $sql_add = ' AND ' . $sql_add;
-                      }
-                      $sql_add = $db->bindVars($sql_add, ':part', $v, 'noquotestring');
-                      $sql_add = $db->bindVars($sql_add, ':keywords:', $v, 'regexp');
-                      $search .= $sql_add;
-                    }
+                      $keywords = zen_db_input(zen_db_prepare_input($_GET['search']));
+                      $keyword_search_fields = [
+                          'c.customers_lastname',
+                          'c.customers_firstname',
+                          'c.customers_email_address',
+                          'c.customers_telephone',
+                          'a.entry_company',
+                          'a.entry_street_address',
+                          'a.entry_city',
+                          'a.entry_postcode',
+                      ];
+                      $search = zen_build_keyword_where_clause($keyword_search_fields, trim($keywords));
+                      $search = (trim($search) != '') ? preg_replace('/ *AND /i', ' WHERE ', $search, 1) : '';
                   }
                   $new_fields = '';
 

--- a/admin/downloads_manager.php
+++ b/admin/downloads_manager.php
@@ -94,10 +94,13 @@ if (zen_not_null($action)) {
                 $search = '';
                 if (isset($_GET['search']) && zen_not_null($_GET['search'])) {
                   $keywords = zen_db_input(zen_db_prepare_input($_GET['search']));
-                  $search = " and pd.products_name like '%" . $keywords . "%'
-                              or pad.products_attributes_filename like '%" . $keywords . "%'
-                              or pd.products_description like '%" . $keywords . "%'
-                              or p.products_model like '%" . $keywords . "%'";
+                    $keyword_search_fields = [
+                        'pd.products_name',
+                        'p.products_model',
+                        'pd.products_description',
+                        'pad.products_attributes_filename',
+                    ];
+                    $search = zen_build_keyword_where_clause($keyword_search_fields, trim($keywords));
                 }
 
 // order of display
@@ -191,9 +194,9 @@ if (zen_not_null($action)) {
                   '<a href="' . zen_href_link(FILENAME_DOWNLOADS_MANAGER, zen_get_all_get_params(array('padID', 'action')) . 'padID=' . $padInfo->products_attributes_id . '&page=' . $_GET['page'] . '&action=edit') . '" class="btn btn-primary" role="button">' . IMAGE_EDIT . '</a>' .
                   '&nbsp;<a href="' . zen_href_link(FILENAME_ATTRIBUTES_CONTROLLER, 'products_filter=' . $padInfo->products_id . '&current_categories_id=' . $padInfo->master_categories_id) . '" class="btn btn-primary" role="button">' . IMAGE_EDIT_ATTRIBUTES . '</a>'
                 );
-                $contents[] = array('align' => 'center', 'text' => '<a href="'  . zen_href_link(FILENAME_PRODUCT, 'product_type=' . $padInfo->products_type . '&pID=' . $padInfo->products_id . '&action=new_product&page=' . $_GET['page']) . '" class="btn btn-primary" role="button">' . IMAGE_EDIT_PRODUCT . '</a>'); 
+                $contents[] = array('align' => 'center', 'text' => '<a href="'  . zen_href_link(FILENAME_PRODUCT, 'product_type=' . $padInfo->products_type . '&pID=' . $padInfo->products_id . '&action=new_product&page=' . $_GET['page']) . '" class="btn btn-primary" role="button">' . IMAGE_EDIT_PRODUCT . '</a>');
                 if ($padInfo->product_is_always_free_shipping == 1 || $padInfo->products_virtual == 1) {
-                   $contents[] = array('params'=>'errorText', 'text' => '<br />' . TEXT_WARNING_PRODUCT_MISCONFIGURED); 
+                   $contents[] = array('params'=>'errorText', 'text' => '<br />' . TEXT_WARNING_PRODUCT_MISCONFIGURED);
                 }
                 $contents[] = array('text' => '<br />' . TEXT_PRODUCTS_NAME . $padInfo->products_name);
                 $contents[] = array('text' => TEXT_PRODUCTS_MODEL . $padInfo->products_model);

--- a/admin/featured.php
+++ b/admin/featured.php
@@ -155,9 +155,9 @@ if (zen_not_null($action)) {
         } elseif (($action === 'new') && isset($_GET['preID'])) { //update existing Featured
             $form_action = 'insert';
 
-            $product = $db->Execute("SELECT p.products_id, p.products_model, pd.products_name, p.products_price, p.products_priced_by_attribute 
+            $product = $db->Execute("SELECT p.products_id, p.products_model, pd.products_name, p.products_price, p.products_priced_by_attribute
                                    FROM " . TABLE_PRODUCTS . " p,
-                                        " . TABLE_PRODUCTS_DESCRIPTION . " pd 
+                                        " . TABLE_PRODUCTS_DESCRIPTION . " pd
                                    WHERE p.products_id = pd.products_id
                                    AND pd.language_id = " . (int)$_SESSION['languages_id'] . "
                                    AND p.products_id = " . (int)$_GET['preID']);
@@ -315,9 +315,13 @@ if (zen_not_null($action)) {
                     $search = '';
                     if (isset($_GET['search']) && zen_not_null($_GET['search'])) {
                         $keywords = zen_db_input(zen_db_prepare_input($_GET['search']));
-                        $search = " and (pd.products_name like '%" . $keywords . "%'
-                                  or pd.products_description like '%" . $keywords . "%'
-                                  or p.products_model like '%" . $keywords . "%')";
+                        $keyword_search_fields = [
+                            'pd.products_name',
+                            'p.products_model',
+                            'pd.products_description',
+                            'p.products_id',
+                        ];
+                        $search = zen_build_keyword_where_clause($keyword_search_fields, trim($keywords));
                     }
 
                     // order of display
@@ -466,7 +470,7 @@ if (zen_not_null($action)) {
                                 'align' => 'text-center',
                                 'text' => '
                         <a href="' . zen_href_link(FILENAME_FEATURED, 'page=' . $_GET['page'] . '&fID=' . $fInfo->featured_id . '&action=edit' .
-                                        (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . '" class="btn btn-primary" role="button">' . IMAGE_EDIT . '</a> 
+                                        (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . '" class="btn btn-primary" role="button">' . IMAGE_EDIT . '</a>
                         <a href="' . zen_href_link(FILENAME_FEATURED, 'page=' . $_GET['page'] . '&fID=' . $fInfo->featured_id . '&action=delete' .
                                         (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . '" class="btn btn-warning" role="button">' . TEXT_INFO_HEADING_DELETE_FEATURED . '</a>'
                             ];

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -1175,7 +1175,11 @@ if (zen_not_null($action) && $order_exists == true) {
                     $search_distinct = ' distinct ';
                     $new_table = " left join " . TABLE_ORDERS_PRODUCTS . " op on (op.orders_id = o.orders_id) ";
                     $keywords = zen_db_input(zen_db_prepare_input($_GET['search_orders_products']));
-                    $search = " and (op.products_model like '%" . $keywords . "%' or op.products_name like '%" . $keywords . "%')";
+                      $keyword_search_fields = [
+                          'op.products_name',
+                          'op.products_model',
+                      ];
+                      $search = zen_build_keyword_where_clause($keyword_search_fields, trim($keywords));
                     if (substr(strtoupper($_GET['search_orders_products']), 0, 3) == 'ID:') {
                       $keywords = TRIM(substr($_GET['search_orders_products'], 3));
                       $search = " and op.products_id ='" . (int)$keywords . "'";
@@ -1183,7 +1187,28 @@ if (zen_not_null($action) && $order_exists == true) {
                   } elseif (!empty($_GET['search'])) {
 // create search filter
                       $keywords = zen_db_input(zen_db_prepare_input($_GET['search']));
-                      $search = " and (o.customers_city like '%" . $keywords . "%' or o.customers_postcode like '%" . $keywords . "%' or o.date_purchased like '%" . $keywords . "%' or o.billing_name like '%" . $keywords . "%' or o.billing_company like '%" . $keywords . "%' or o.billing_street_address like '%" . $keywords . "%' or o.delivery_city like '%" . $keywords . "%' or o.delivery_postcode like '%" . $keywords . "%' or o.delivery_name like '%" . $keywords . "%' or o.delivery_company like '%" . $keywords . "%' or o.delivery_street_address like '%" . $keywords . "%' or o.billing_city like '%" . $keywords . "%' or o.billing_postcode like '%" . $keywords . "%' or o.customers_email_address like '%" . $keywords . "%' or o.customers_name like '%" . $keywords . "%' or o.customers_company like '%" . $keywords . "%' or o.customers_street_address  like '%" . $keywords . "%' or o.customers_telephone like '%" . $keywords . "%' or o.ip_address  like '%" . $keywords . "%')";
+                      $keyword_search_fields = [
+                          'o.customers_name',
+                          'o.customers_company',
+                          'o.customers_street_address',
+                          'o.customers_city',
+                          'o.customers_postcode',
+                          'o.customers_email_address',
+                          'o.customers_telephone',
+                          'o.date_purchased',
+                          'o.billing_name',
+                          'o.billing_company',
+                          'o.billing_street_address',
+                          'o.billing_city',
+                          'o.billing_postcode',
+                          'o.delivery_name',
+                          'o.delivery_company',
+                          'o.delivery_street_address',
+                          'o.delivery_city',
+                          'o.delivery_postcode',
+                          'o.ip_address',
+                      ];
+                      $search = zen_build_keyword_where_clause($keyword_search_fields, trim($keywords));
                   }
                   $new_fields .= ", o.customers_company, o.customers_email_address, o.customers_street_address, o.delivery_company, o.delivery_name, o.delivery_street_address, o.billing_company, o.billing_name, o.billing_street_address, o.payment_module_code, o.shipping_module_code, o.orders_status, o.ip_address, o.language_code ";
 
@@ -1204,7 +1229,7 @@ if (zen_not_null($action) && $order_exists == true) {
                     $status = (int)zen_db_prepare_input($_GET['status']);
                     $orders_query_raw .= " WHERE s.orders_status_id = " . (int)$status . $search;
                   } else {
-                    $orders_query_raw .= (trim($search) != '') ? preg_replace('/ *AND /i', ' WHERE ', $search) : '';
+                    $orders_query_raw .= (trim($search) != '') ? preg_replace('/ *AND /i', ' WHERE ', $search, 1) : '';
                   }
 
                   $orders_query_raw .= $order_by;
@@ -1395,9 +1420,9 @@ if (zen_not_null($action) && $order_exists == true) {
                         zen_draw_form('statusUpdate', FILENAME_ORDERS, zen_get_all_get_params(['action','language']) . 'action=update_order' . (!isset($_GET['oID']) ? '&oID=' . $oInfo->orders_id : '') . '&language=' . $oInfo->language_code, 'post', '', true) . // form action uses the order language to change the session language on the update. On initial page load (from another page), $_GET['oID'] is not set, hence clause in form action
                         '<fieldset style="border:solid thin slategray;padding:5px"><legend style="width:inherit;">&nbsp;' . IMAGE_UPDATE . '&nbsp;</legend>' .
                         ($oInfo->language_code !== $_SESSION['languages_code'] ? zen_draw_hidden_field('admin_language', $_SESSION['languages_code']) : '') . // if the order language is different to the current admin language, record the admin language, to restore it in the redirect after the status update email has been sent
-                        zen_draw_label(IMAGE_SEND_EMAIL, 'notify', 'class="control-label"') . 
+                        zen_draw_label(IMAGE_SEND_EMAIL, 'notify', 'class="control-label"') .
                         zen_draw_checkbox_field('notify', '1', $notify_email, '', 'class="checkbox-inline" id="notify"') . "<br>\n" .
-                        zen_draw_label(ENTRY_STATUS, 'status', 'class="control-label"') . 
+                        zen_draw_label(ENTRY_STATUS, 'status', 'class="control-label"') .
                         zen_draw_order_status_dropdown('status', $oInfo->orders_status, '', 'onChange="this.form.submit();" id="status" class="form-control"') . "\n" .
                         '</fieldset></form>' . "\n"];
 

--- a/admin/reviews.php
+++ b/admin/reviews.php
@@ -240,12 +240,15 @@ if (zen_not_null($action)) {
 // create search filter
                   $search = '';
                   if (isset($_GET['search']) && zen_not_null($_GET['search'])) {
-                    $keywords = zen_db_input(zen_db_prepare_input($_GET['search']));
-                    $search = " AND (r.customers_name LIKE '%" . $keywords . "%'
-                                OR rd.reviews_text LIKE '%" . $keywords . "%'
-                                OR pd.products_name LIKE '%" . $keywords . "%'
-                                OR pd.products_description LIKE '%" . $keywords . "%'
-                                OR p.products_model LIKE '%" . $keywords . "%') ";
+                      $keywords = zen_db_input(zen_db_prepare_input($_GET['search']));
+                      $keyword_search_fields = [
+                          'r.customers_name',
+                          'rd.reviews_text',
+                          'pd.products_name',
+                          'pd.products_description',
+                          'p.products_model',
+                      ];
+                      $search = zen_build_keyword_where_clause($keyword_search_fields, trim($keywords));
                   }
 
                   if ($status_filter != '' && $status_filter > 0) {

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -211,9 +211,9 @@ if (zen_not_null($action)) {
         } elseif (($action === 'new') && isset($_GET['preID'])) { //update existing Special
             $form_action = 'insert';
 
-            $product = $db->Execute("SELECT p.products_id, p.products_model, pd.products_name, p.products_price, p.products_priced_by_attribute 
+            $product = $db->Execute("SELECT p.products_id, p.products_model, pd.products_name, p.products_price, p.products_priced_by_attribute
                                    FROM " . TABLE_PRODUCTS . " p,
-                                        " . TABLE_PRODUCTS_DESCRIPTION . " pd 
+                                        " . TABLE_PRODUCTS_DESCRIPTION . " pd
                                    WHERE p.products_id = pd.products_id
                                    AND pd.language_id = " . (int)$_SESSION['languages_id'] . "
                                    AND p.products_id = " . (int)$_GET['preID']);
@@ -389,9 +389,13 @@ if (zen_not_null($action)) {
                     $search = '';
                     if (isset($_GET['search']) && zen_not_null($_GET['search'])) {
                         $keywords = zen_db_input(zen_db_prepare_input($_GET['search']));
-                        $search = " and (pd.products_name like '%" . $keywords . "%'
-                                  or pd.products_description like '%" . $keywords . "%'
-                                  or p.products_model like '%" . $keywords . "%')";
+                        $keyword_search_fields = [
+                            'pd.products_name',
+                            'p.products_model',
+                            'pd.products_description',
+                            'p.products_id',
+                        ];
+                        $search = zen_build_keyword_where_clause($keyword_search_fields, trim($keywords));
                     }
 
                     // order of display
@@ -540,7 +544,7 @@ if (zen_not_null($action)) {
                                 'align' => 'text-center',
                                 'text' => '
                                 <a href="' . zen_href_link(FILENAME_SPECIALS, 'page=' . $_GET['page'] . '&sID=' . $sInfo->specials_id . '&action=edit' .
-                                        (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . '" class="btn btn-primary" role="button">' . IMAGE_EDIT . '</a> 
+                                        (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . '" class="btn btn-primary" role="button">' . IMAGE_EDIT . '</a>
                                 <a href="' . zen_href_link(FILENAME_SPECIALS, 'page=' . $_GET['page'] . '&sID=' . $sInfo->specials_id . '&action=delete' .
                                         (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . '" class="btn btn-warning" role="button">' . TEXT_INFO_HEADING_DELETE_SPECIALS . '</a>'
                             ];

--- a/includes/functions/functions_search.php
+++ b/includes/functions/functions_search.php
@@ -157,7 +157,7 @@ function zen_parse_search_string($search_str = '', &$objects = array()) {
     return false;
 }
 
-    function zen_build_where($fields, $string)
+    function zen_build_keyword_where_clause($fields, $string)
     {
         global $db;
         if (zen_parse_search_string(stripslashes($string), $search_keywords)) {
@@ -172,25 +172,26 @@ function zen_parse_search_string($search_str = '', &$objects = array()) {
                         break;
                     default:
                         $sql_add = " (";
-                        $first = true;
-                        foreach ($fields as $k => $v) {
-                            if (!$first) {
+                        $first_field = true;
+                        foreach ($fields as $field_name) {
+                            if (!$first_field) {
                                 $sql_add .= ' OR ';
                             }
-                            $first = false;
-                            if (strpos($v, '_id')) {
-                                $sql_add .= " :field = :keyword_num";
-                                $sql_add = $db->bindVars($sql_add, ':keyword_num', $search_keywords[$i], 'integer');
+                            $first_field = false;
+                            if (strpos($field_name, '_id')) {
+                                $sql_add .= " :field_name = :numeric_keyword";
+
                             } else {
-                                $sql_add .= " :field LIKE '%:keyword%'";
+                                $sql_add .= " :field_name LIKE '%:keyword%'";
                             }
-                            $sql_add = $db->bindVars($sql_add, ':field', $v, 'noquotestring');
+                            $sql_add = $db->bindVars($sql_add, ':field_name', $field_name, 'noquotestring');
                         }
                         $sql_add .= ") ";
 
                         $where_str .= $sql_add;
 
                         $where_str = $db->bindVars($where_str, ':keyword', $search_keywords[$i], 'noquotestring');
+                        $where_str = $db->bindVars($where_str, ':numeric_keyword', $search_keywords[$i], 'integer');
                         break;
                 }
             }

--- a/includes/functions/functions_search.php
+++ b/includes/functions/functions_search.php
@@ -168,7 +168,7 @@ function zen_parse_search_string($search_str = '', &$objects = array()) {
                     case ')':
                     case 'and':
                     case 'or':
-                        $where_str .= " " . $search_keywords[$i] . " ";
+                        $where_str .= " " . strtoupper($search_keywords[$i]) . " ";
                         break;
                     default:
                         $sql_add = " (";


### PR DESCRIPTION
pursuant to a conversation on the above referenced PR, i thought about refactoring the building of where clauses for sql statements on keyword searches.  my thoughts are to have a function, where you pass an array of field names, and a string of keywords.  the function would then build the where part of the sql statement.

in the conversation on PR #3804, there are a bunch of scripts where this might be beneficial.

this PR shows proof of concept and i'm certainly open to input.  

it is built off code from:
https://github.com/zencart/zencart/blob/4717032046d64e92ff5a71552b019636ef3fc8f5/includes/modules/pages/advanced_search_result/header_php.php#L317-L359
and that could certainly be part of the refactoring as well.