### PR TITLE
Still provide error message if final query doesn't have a semi-colon.

### DIFF
--- a/admin/sqlpatch.php
+++ b/admin/sqlpatch.php
@@ -281,9 +281,6 @@ function executeSql($lines, $database, $table_prefix = '') {
           $complete_line = false;
         }
       } //endif found ';'
-        else {
-            $messageStack->add(ERROR_LINE_INCOMPLETE, 'error');
-        }
 
       if ($complete_line) {
         if ($debug == true) {
@@ -325,6 +322,10 @@ function executeSql($lines, $database, $table_prefix = '') {
       } //endif $complete_line
     } //endif ! # or -
   } // end foreach $lines
+
+  if (zen_not_null($newline)) {
+    $messageStack->add(ERROR_LINE_INCOMPLETE, 'error'); // Why not attempt to process this line instead of alert about it?
+  }
   zen_record_admin_activity('Admin SQL Patch tool executed a query.', 'notice');
   return array('queries' => $results, 'string' => $string, 'output' => $return_output, 'ignored' => ($ignored_count), 'errors' => $errors);
 }


### PR DESCRIPTION
Relates to: https://www.zen-cart.com/showthread.php?227174-Spurious-error-message-Query-incomplete-missing-closing-semicolon&p=1372630#post1372630
The addition of the message was proposed for entry in PR #3288.