### PR TITLE
disallow add to shopping cart for actionBuyNow and fix redirect

### DIFF
--- a/includes/classes/shopping_cart.php
+++ b/includes/classes/shopping_cart.php
@@ -2036,7 +2036,9 @@ class shoppingCart extends base
         if (isset($_GET['products_id'])) {
             if (zen_requires_attribute_selection($_GET['products_id'])) {
                 zen_redirect(zen_href_link(zen_get_info_page($_GET['products_id']), 'products_id=' . $_GET['products_id']));
-            } else {
+            }
+            $allow_into_cart = zen_get_products_allow_add_to_cart((int)$_GET['products_id']);
+            if ($allow_into_cart == 'Y') {
                 $add_max = zen_get_products_quantity_order_max($_GET['products_id']);
                 $cart_qty = $this->in_cart_mixed($_GET['products_id']);
                 $new_qty = zen_get_buy_now_qty($_GET['products_id']);
@@ -2064,15 +2066,17 @@ class shoppingCart extends base
             }
         }
         // display message if all is good and not on shopping_cart page
-        if ((DISPLAY_CART == 'false' && $_GET['main_page'] != FILENAME_SHOPPING_CART) && $messageStack->size('shopping_cart') == 0) {
+        if ((DISPLAY_CART == 'false' && $_GET['main_page'] != FILENAME_SHOPPING_CART) && $messageStack->size('shopping_cart') == 0 && ($allow_into_cart == 'Y')) {
             $messageStack->add_session('header', ($this->display_debug_messages ? 'FUNCTION ' . __FUNCTION__ . ': ' : '') . SUCCESS_ADDED_TO_CART_PRODUCTS, 'success');
         } else {
-            if (DISPLAY_CART == 'false') {
-                zen_redirect(zen_href_link(FILENAME_SHOPPING_CART));
+            if (DISPLAY_CART == 'false'  && ($allow_into_cart !== 'Y')) {
+                //zen_redirect(zen_href_link(FILENAME_SHOPPING_CART));
+                $messageStack->add_session('header', ($this->display_debug_messages ? 'FUNCTION ' . __FUNCTION__ . ': ' : '') . FAILURE_ADDED_TO_CART_PRODUCTS, 'error');
             }
         }
+        $exclude[] = 'action';
         if (is_array($parameters) && !in_array('products_id', $parameters) && !(strpos($goto, 'reviews') > 5)) $parameters[] = 'products_id';
-        zen_redirect(zen_href_link($goto, zen_get_all_get_params($parameters)));
+        zen_redirect(zen_href_link($goto, zen_get_all_get_params($exclude)));
     }
 
     /**

--- a/includes/classes/shopping_cart.php
+++ b/includes/classes/shopping_cart.php
@@ -2071,11 +2071,10 @@ class shoppingCart extends base
         } else {
             if (DISPLAY_CART == 'false'  && ($allow_into_cart !== 'Y')) {
                 //zen_redirect(zen_href_link(FILENAME_SHOPPING_CART));
-                $messageStack->add_session('header', ($this->display_debug_messages ? 'FUNCTION ' . __FUNCTION__ . ': ' : '') . FAILURE_ADDED_TO_CART_PRODUCTS, 'error');
+                $messageStack->add_session('header', ($this->display_debug_messages ? 'FUNCTION ' . __FUNCTION__ . ': ' : '') . FAILED_TO_ADD_UNAVAILABLE_PRODUCTS, 'error');
             }
         }
         $exclude[] = 'action';
-        if (is_array($parameters) && !in_array('products_id', $parameters) && !(strpos($goto, 'reviews') > 5)) $parameters[] = 'products_id';
         zen_redirect(zen_href_link($goto, zen_get_all_get_params($exclude)));
     }
 

--- a/includes/languages/english.php
+++ b/includes/languages/english.php
@@ -336,6 +336,7 @@ define('ARIA_PAGINATION_','');
   define('SUCCESS_ADDED_TO_CART_PRODUCT', 'Successfully added Product to the cart ...');
 // only for where multiple add to cart is used:
   define('SUCCESS_ADDED_TO_CART_PRODUCTS', 'Successfully added selected Product(s) to the cart ...');
+  define('FAILURE_ADDED_TO_CART_PRODUCTS', 'The selected Product(s) are not currently available for purchase...');
 
   define('TEXT_PRODUCT_WEIGHT_UNIT','lbs');
 

--- a/includes/languages/english.php
+++ b/includes/languages/english.php
@@ -336,7 +336,7 @@ define('ARIA_PAGINATION_','');
   define('SUCCESS_ADDED_TO_CART_PRODUCT', 'Successfully added Product to the cart ...');
 // only for where multiple add to cart is used:
   define('SUCCESS_ADDED_TO_CART_PRODUCTS', 'Successfully added selected Product(s) to the cart ...');
-  define('FAILURE_ADDED_TO_CART_PRODUCTS', 'The selected Product(s) are not currently available for purchase...');
+  define('FAILED_TO_ADD_UNAVAILABLE_PRODUCTS', 'The selected Product(s) are not currently available for purchase...');
 
   define('TEXT_PRODUCT_WEIGHT_UNIT','lbs');
 


### PR DESCRIPTION
pursuant to conversation on #3937; i have added a message for attempting to add an invalid product to the cart, and also addressed uncalled for redirects.  i think we should respect the created links and remove the action.  

in the referenced issue, creating a link to add 1 to the cart and go directly to the product page for that item fails; as the `products_id` gets added to the parameter exclude list.  apparently there is an attempt to make this not happen for reviews, however, i believe the `$parameters` array will already contain the `products_id`, so in my testing the if statement does nothing.

the addition of a notifier in the `zen_get_products_allow_add_to_cart` function is great, and was the exact idea that i had.  i think the function should check for an inactive product as it is already hitting the products table.  it seems that the function might be able to do more, prior to handing over to the observer.