### PR TITLE
Stop MODULE_PAYMENT_PAYFLOW_TRANSACTION_MODE notice

### DIFF
--- a/includes/modules/payment/paypal/paypalwpp_admin_notification.php
+++ b/includes/modules/payment/paypal/paypalwpp_admin_notification.php
@@ -430,10 +430,10 @@ $authcapt_on = (isset($_GET['authcapt']) && $_GET['authcapt'] == 'on');
 
 if (isset($response['RESPMSG']) /*|| defined('MODULE_PAYMENT_PAYFLOW_STATUS')*/) { // payflow
     $output .= $outputPFmain;
-    if (method_exists($this, '_doVoid') && (MODULE_PAYMENT_PAYPALDP_TRANSACTION_MODE == 'Auth Only' || MODULE_PAYMENT_PAYFLOW_TRANSACTION_MODE == 'Auth Only' || $authcapt_on)) {
+    if (method_exists($this, '_doVoid') && (MODULE_PAYMENT_PAYPALDP_TRANSACTION_MODE == 'Auth Only' || (defined('MODULE_PAYMENT_PAYFLOW_TRANSACTION_MODE') && MODULE_PAYMENT_PAYFLOW_TRANSACTION_MODE == 'Auth Only') || $authcapt_on)) {
         $output .= $outputVoid;
     }
-    if (method_exists($this, '_doCapt') && (MODULE_PAYMENT_PAYPALDP_TRANSACTION_MODE == 'Auth Only' || MODULE_PAYMENT_PAYFLOW_TRANSACTION_MODE == 'Auth Only' || $authcapt_on)) {
+    if (method_exists($this, '_doCapt') && (MODULE_PAYMENT_PAYPALDP_TRANSACTION_MODE == 'Auth Only' || (defined('MODULE_PAYMENT_PAYFLOW_TRANSACTION_MODE') && MODULE_PAYMENT_PAYFLOW_TRANSACTION_MODE == 'Auth Only') || $authcapt_on)) {
         $output .= $outputCapt;
     }
     if (method_exists($this, '_doRefund')) {


### PR DESCRIPTION
[11-Sep-2020 17:10:02 Europe/London] Request URI: /admin/orders.php?oID=613520&action=edit, IP address: removed
#1  require(/home/store/public_html/includes/modules/payment/paypal/paypalwpp_admin_notification.php) called at [/home/store/public_html/includes/modules/payment/paypaldp.php:987]
#2  paypaldp->admin_notification() called at [/home/store/public_html/admin/orders.php:863]
--> PHP Warning: Use of undefined constant MODULE_PAYMENT_PAYFLOW_TRANSACTION_MODE - assumed 'MODULE_PAYMENT_PAYFLOW_TRANSACTION_MODE' (this will throw an Error in a future version of PHP) in /home/store/public_html/includes/modules/payment/paypal/paypalwpp_admin_notification.php on line 419.


As reported in https://www.zen-cart.com/showthread.php?227199-Use-of-undefined-constant-MODULE_PAYMENT_PAYFLOW_TRANSACTION_MODE