### PR TITLE
Missed HTML defines for emails

### DIFF
--- a/includes/functions/functions_email.php
+++ b/includes/functions/functions_email.php
@@ -105,6 +105,8 @@ use PHPMailer\PHPMailer\SMTP;
         if (!isset($block['EMAIL_SUBJECT']) || $block['EMAIL_SUBJECT'] == '')       $block['EMAIL_SUBJECT'] = $email_subject;
         if (!isset($block['EMAIL_FROM_NAME']) || $block['EMAIL_FROM_NAME'] == '')   $block['EMAIL_FROM_NAME'] = $from_email_name;
         if (!isset($block['EMAIL_FROM_ADDRESS']) || $block['EMAIL_FROM_ADDRESS'] == '') $block['EMAIL_FROM_ADDRESS'] = $from_email_address;
+        if (!isset($block['EMAIL_SALUTATION'])) $block['EMAIL_SALUTATION'] = EMAIL_SALUTATION; 
+        if (!isset($block['EMAIL_ORDER_UPDATE_MESSAGE'])) $block['EMAIL_ORDER_UPDATE_MESSAGE'] = ''; 
       }
       $email_html = (!is_array($block) && substr($block, 0, 6) == '<html>') ? $block : zen_build_html_email_from_template($module, $block);
       if (!is_array($block) && ($block == '' || $block == 'none')) $email_html = '';

--- a/includes/languages/english.php
+++ b/includes/languages/english.php
@@ -568,6 +568,7 @@ define('ARIA_PAGINATION_','');
   define('ENTRY_EMAIL_HTML_DISPLAY','HTML');
   define('ENTRY_EMAIL_TEXT_DISPLAY','TEXT-Only');
   define('EMAIL_SEND_FAILED','ERROR: Failed sending email to: "%s" <%s> with subject: "%s"');
+  define('EMAIL_SALUTATION', 'Dear');
 
   define('DB_ERROR_NOT_CONNECTED', 'Error - Could not connect to Database');
   define('ERROR_DATABASE_MAINTENANCE_NEEDED', '<a href="https://docs.zen-cart.com/user/troubleshooting/error_71_maintenance_required/" rel="noopener" target="_blank">ERROR 0071 There appears to be a problem with the database. Maintenance is required.</a>');


### PR DESCRIPTION
To reproduce the issue, update an order from the Admin Order Details page and observe the HTML email.  The two values         `$EMAIL_SALUTATION` and `$EMAIL_ORDER_UPDATE_MESSAGE` are not filled in. 


![image](https://user-images.githubusercontent.com/4391638/93788577-ed511380-fbfe-11ea-99ab-318a3b5356cb.png)
