### PR TITLE
Add samesite cookie parameter support for v157

### DIFF
--- a/admin/includes/init_includes/init_sessions.php
+++ b/admin/includes/init_includes/init_sessions.php
@@ -4,7 +4,7 @@
  * @copyright Copyright 2003-2016 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: DrByte  Sun Jan 10 02:53:32 2016 -0500 Modified in v1.5.5 $
+ * @version $Id: DrByte 2020 Sept Modified in v1.5.7a $
  */
 if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
@@ -23,7 +23,22 @@ $domainPrefix = (!defined('SESSION_ADD_PERIOD_PREFIX') || SESSION_ADD_PERIOD_PRE
 if (filter_var($cookieDomain, FILTER_VALIDATE_IP)) $domainPrefix = '';
 $secureFlag = (substr(HTTP_SERVER, 0, 6) == 'https:') ? TRUE : FALSE;
 
-session_set_cookie_params(0, $path, (zen_not_null($cookieDomain) ? $domainPrefix . $cookieDomain : ''), $secureFlag, TRUE);
+$samesite = (defined('COOKIE_SAMESITE')) ? COOKIE_SAMESITE : 'lax';
+if (!in_array($samesite, ['lax', 'strict', 'none'])) $samesite = 'lax';
+
+if (PHP_VERSION_ID >= 70300) {
+  session_set_cookie_params([
+    'lifetime' => 0,
+    'path' => $path,
+    'domain' => (zen_not_null($cookieDomain) ? $domainPrefix . $cookieDomain : ''),
+    'secure' => $secureFlag,
+    'httponly' => true,
+    'samesite' => $samesite,
+  ]);
+} else {
+  session_set_cookie_params(0, $path, (zen_not_null($cookieDomain) ? $domainPrefix . $cookieDomain : ''), $secureFlag, true);
+  ini_set('session.cookie_samesite', $samesite);
+}
 
 /**
  * Sanitize the IP address, and resolve any proxies.

--- a/includes/init_includes/init_sessions.php
+++ b/includes/init_includes/init_sessions.php
@@ -1,12 +1,11 @@
 <?php
 /**
  * session handling
- * see {@link  http://www.zen-cart.com/wiki/index.php/Developers_API_Tutorials#InitSystem wikitutorials} for more details.
- *
+ * see  {@link  https://docs.zen-cart.com/dev/code/init_system/} for more details.
  * @copyright Copyright 2003-2020 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: DrByte 2020 Mar 11 Modified in v1.5.7 $
+ * @version $Id: DrByte 2020 Sept Modified in v1.5.7a $
  */
 if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
@@ -40,7 +39,23 @@ $domainPrefix = (!defined('SESSION_ADD_PERIOD_PREFIX') || SESSION_ADD_PERIOD_PRE
 if (filter_var($cookieDomain, FILTER_VALIDATE_IP)) $domainPrefix = '';
 $secureFlag = ((ENABLE_SSL == 'true' && substr(HTTP_SERVER, 0, 6) == 'https:' && substr(HTTPS_SERVER, 0, 6) == 'https:') || (ENABLE_SSL == 'false' && substr(HTTP_SERVER, 0, 6) == 'https:')) ? TRUE : FALSE;
 
-session_set_cookie_params(0, $path, (zen_not_null($cookieDomain) ? $domainPrefix . $cookieDomain : ''), $secureFlag, TRUE);
+$samesite = (defined('COOKIE_SAMESITE')) ? COOKIE_SAMESITE : 'lax';
+if (!in_array($samesite, ['lax', 'strict', 'none'])) $samesite = 'lax';
+
+
+if (PHP_VERSION_ID >= 70300) {
+  session_set_cookie_params([
+    'lifetime' => 0,
+    'path' => $path,
+    'domain' => (zen_not_null($cookieDomain) ? $domainPrefix . $cookieDomain : ''),
+    'secure' => $secureFlag,
+    'httponly' => true,
+    'samesite' => $samesite,
+  ]);
+} else {
+  session_set_cookie_params(0, $path, (zen_not_null($cookieDomain) ? $domainPrefix . $cookieDomain : ''), $secureFlag, true);
+  ini_set('session.cookie_samesite', $samesite);
+}
 
 /**
  * set the session ID if it exists


### PR DESCRIPTION
Sets the default `samesite` handling to `lax`. 
NOTE: This only works on sites using SSL. If you're not using SSL then this is pointless (and you won't be able to do secure payments).

If you need to override the default of `lax` mode (as some payment redirections will require), create a file named `/includes/extra_configures/samesite_cookie.php` containing the following:

```php
<?php
// -----
// Samesite cookie needs to be none when doing offsite payment gateway redirects
//
define('COOKIE_SAMESITE', 'none');
```

This same change should work on Zen Cart v1.5.5 and 1.5.6.