### PR TITLE
Eliminate notice on each catalog page load.

### DIFF
--- a/includes/classes/InitSystem.php
+++ b/includes/classes/InitSystem.php
@@ -214,6 +214,7 @@ class InitSystem
 
     protected function getLoadersFromFilelist($fileList)
     {
+        $autoLoadConfig = [];
         foreach ($fileList as $file) {
             require($file);
         }


### PR DESCRIPTION
````
[Datetime TimeZone Obscured] Request URI: /index.php?main_page=product_info&products_id=1, IP address: obscured
#1  Zencart\InitSystem\InitSystem->getLoadersFromFilelist() called at [/includes/classes/InitSystem.php:171]
#2  Zencart\InitSystem\InitSystem->loadAutoLoadersFromSystem() called at [/includes/classes/InitSystem.php:182]
#3  Zencart\InitSystem\InitSystem->loadPluginAutoLoaders() called at [/includes/classes/InitSystem.php:34]
#4  Zencart\InitSystem\InitSystem->loadAutoLoaders() called at [/includes/application_top.php:215]
#5  require(/includes/application_top.php) called at [/index.php:25]
--> PHP Notice: Undefined variable: autoLoadConfig in /includes/classes/InitSystem.php on line 221.
````
