### PR TITLE
Ensure that posted products_id is an array on update

### DIFF
--- a/includes/classes/shopping_cart.php
+++ b/includes/classes/shopping_cart.php
@@ -1702,6 +1702,9 @@ class shoppingCart extends base {
     $change_state = array();
     $this->flag_duplicate_quantity_msgs_set = array();
     $cart_delete = (isset($_POST['cart_delete']) && is_array($_POST['cart_delete'])) ? $_POST['cart_delete'] : array();
+    if (empty($_POST['products_id']) || !is_array($_POST['products_id'])) {
+      $_POST['products_id'] = [];
+    }
     for ($i=0, $n=sizeof($_POST['products_id']); $i<$n; $i++) {
       $adjust_max= 'false';
       if ($_POST['cart_quantity'][$i] == '') {


### PR DESCRIPTION
Inspired from: https://www.zen-cart.com/showthread.php?227158-Parameter-must-be-an-array-or-an-object-that-implements-Countable-in-shopping-cart
