### PR TITLE
Remove <br> tag from email error message

### DIFF
--- a/includes/functions/functions_email.php
+++ b/includes/functions/functions_email.php
@@ -370,7 +370,7 @@ use PHPMailer\PHPMailer\SMTP;
         } else {
           error_log($msg);
         }
-        $ErrorInfo .= ($mail->ErrorInfo != '') ? $mail->ErrorInfo . '<br />' : '';
+        $ErrorInfo .= ($mail->ErrorInfo != '') ? $mail->ErrorInfo . "\n" : '';
       }
       $zco_notifier->notify('NOTIFY_EMAIL_AFTER_SEND');
       foreach($oldVars as $key => $val) {
@@ -390,7 +390,7 @@ use PHPMailer\PHPMailer\SMTP;
       trigger_error('Email Error: ' . $ErrorInfo);
     }
 
-    return isset($ErrorInfo) ? $ErrorInfo : '';
+    return isset($ErrorInfo) ? nl2br($ErrorInfo) : '';
   }  // end function
 
 /**


### PR DESCRIPTION
The line break means the message looks like this: 

```
--> PHP Notice: Email Error: SMTP connect() failed. https://github.com/PHPMailer/PHPMailer/wiki/Troubleshooting<br /> in /home/username/zencart/includes/functions/functions_email.php on line 377.
```

No need for the line break in the middle. 