### PR TITLE
Strip currency code before inserting PayPal record

### DIFF
--- a/includes/modules/payment/paypalwpp.php
+++ b/includes/modules/payment/paypalwpp.php
@@ -533,7 +533,7 @@ if (false) { // disabled until clarification is received about coupons in PayPal
                           'mc_gross' => (float)$this->amt,
                           'mc_fee' => (float)urldecode($this->feeamt),
                           'mc_currency' => $this->responsedata['PAYMENTINFO_0_CURRENCYCODE'],
-                          'settle_amount' => (float)(isset($this->responsedata['PAYMENTINFO_0_SETTLEAMT']) ? urldecode($this->responsedata['PAYMENTINFO_0_SETTLEAMT']) : $this->amt),
+                          'settle_amount' => (float)(isset($this->responsedata['PAYMENTINFO_0_SETTLEAMT']) ? urldecode($this->responsedata['PAYMENTINFO_0_SETTLEAMT']) : (float)$this->amt),
                           'settle_currency' => $this->responsedata['PAYMENTINFO_0_CURRENCYCODE'],
                           'exchange_rate' => (isset($this->responsedata['PAYMENTINFO_0_EXCHANGERATE']) && urldecode($this->responsedata['PAYMENTINFO_0_EXCHANGERATE']) > 0) ? urldecode($this->responsedata['PAYMENTINFO_0_EXCHANGERATE']) : 1.0,
                           'notify_version' => '0',


### PR DESCRIPTION
Credit to @lat9 for this fix, as reported in 
https://www.zen-cart.com/showthread.php?227112-PayPal-Express-Checkout-issue

Recommended for backport. 

Symptom: 

The admin will see "duplicate orders" of which only the last one was actually charged. 

A PHP notice is created which will look like this: 

--> PHP Fatal error: 1265:Data truncated for column 'settle_amount' at row 1 :: INSERT INTO paypal (order_id, txn_type, module_name, module_mode, reason_code, payment_type, payment_status, pending_reason, invoice, first_name, last_name, payer_business_name, address_name, address_street, address_city, address_state, address_zip, address_country, address_status, payer_email, payer_id, payer_status, payment_date, business, receiver_email, receiver_id, txn_id, parent_txn_id, num_cart_items, mc_gross, mc_fee, mc_currency, settle_amount, settle_currency, exchange_rate, notify_version, verify_sign, date_added, memo) VALUES ('33629', 'expresscheckout', 'paypalwpp', 'PayPal', 'None', 'PayPal Express Checkout (instant)', 'Completed', 'None', 'EC-1D193611XXXX', 'john', 'doe', '', 'john doe', '1234 Main St', 'Leawood', 'KS', '66206', 'United States', 'Confirmed', 'johndoe@gmail.com', 'N8LM5GDABCDE', 'unverified', '2020-10-04 22:34:32', '', 'customer.yahoo.com', '', '10N3565XXXXX', '', '10', '275.49', '8.29', 'USD', '275.49 USD', 'USD', '1', '0', '', now(), '{Record generated by payment module}') ==> (as called by) /home/user/public_html/site/includes/functions/database.php on line 44 <== in /home/user/public_html/site/includes/classes/db/mysql/query_factory.php on line 170.

You can see the settle_amount field, which should be decimal, is provided as '275.49 USD'.

This is a new bug in 1.5.7. 
