### PR TITLE
Need padding between qty box and update icon on shopping cart page

### DIFF
--- a/includes/templates/responsive_classic/css/responsive_mobile.css
+++ b/includes/templates/responsive_classic/css/responsive_mobile.css
@@ -266,7 +266,7 @@ td.cartProductDisplay{display:block;width:100%;}
 #shoppingCartDefault .rowEven{background:#eee;}
 td.cartQuantity br, td.cartQuantityUpdate br{display:none;}
 td.cartQuantity{padding:20px 10px 0 10px;}
-td.cartQuantityUpdate{padding:25px 0 0 0;}
+td.cartQuantityUpdate{padding:25px 0 0 10px;}
 .cartAttribsList{text-align:left;margin-left:15%;}
 span.cartProdTitle{text-align:left;float:left;margin-top:15px;width:70%;}
 .cartImage{float:left;width:18%;}


### PR DESCRIPTION
Responsive Classic template on a mobile device (iPhone 7).  

Before image: 

<img width="374" alt="before" src="https://user-images.githubusercontent.com/4391638/95249986-7fecd780-07e7-11eb-9cdb-33eab9ec4686.png">

After image: 

<img width="386" alt="after" src="https://user-images.githubusercontent.com/4391638/95250001-85e2b880-07e7-11eb-9a94-362e5b0d8ff6.png">

Looks ok on tablet; issue is only on phone. 