### PR TITLE
Prevents php notice using PluginManager and a plugin has an upgrade a…

### DIFF
--- a/includes/classes/TableViewControllers/BaseController.php
+++ b/includes/classes/TableViewControllers/BaseController.php
@@ -229,12 +229,12 @@ class BaseController implements TableViewController
 
     public function getTableConfigBoxHeader()
     {
-        return $this->tableDefinition['header'];
+        return $this->tableDefinition['header'] ?? [];
     }
 
     public function getTableConfigBoxContent()
     {
-        return $this->tableDefinition['content'];
+        return $this->tableDefinition['content'] ?? [];
     }
 
     public function getSplitPage()


### PR DESCRIPTION
…vailable.

I haven't been able to fully figure out why this is happening or rather
why the __construct has `tableDefinition['configBox']` which doesn't seem
to be used and that these methods don't reference that particular key, but
when I tried to substitute the `configBox` value(s) in these modifications
then the pluginmanager would not move forward in providing information
or allowing the next action. Therefore, an empty array seemed to be the only
fix to support moving to the next step, although I haven't seen the update
operation successfully performed without first uninstalling and then reinstalling.