### PR TITLE
Prevent button truncation on checkout confirmation

### DIFF
--- a/includes/templates/responsive_classic/css/responsive_mobile.css
+++ b/includes/templates/responsive_classic/css/responsive_mobile.css
@@ -290,7 +290,7 @@ h2{text-align:center;}
 #checkoutConfirmDefault .back{width:100%;}
 #checkoutConfirmDefault .forward{float:right !important;width:100%;}
 #checkoutConfirmDefault td{padding:15px;}
-#checkoutConfirmDefault span.cssButton.normal_button.button.small_edit, .small_edit:hover{width:20%;margin-left:7px;}
+#checkoutConfirmDefault span.cssButton.normal_button.button.small_edit, .small_edit:hover{}
 #checkoutSuccessLogoff .forward{margin:25px;}
 
 /*bof account pages*/
@@ -308,7 +308,7 @@ div#accountLinksWrapper.back {float:none;width:100%;}
 .forward, .back{float:none;}
 .button{display:block;text-align:center;padding:12px 20px;}
 input.cssButton.submit_button.button.button_send, .button_send:hover, input.cssButton.submit_button.button.button_login, .button_login:hover, input.cssButton.submit_button.button.button_update, .button_update:hover, input.cssButton.submit_button.button.button_submit, .button_submit:hover{width:100%;padding: 12px 30px 30px 30px;}
-span.cssButton.normal_button.button.small_edit, .small_edit:hover{float:left;width:33%;}
+span.cssButton.normal_button.button.small_edit, .small_edit:hover{float:left;}
 span.cssButton.normal_button.button.button_delete_small, .button_delete_small:hover{float:right;width:33%;} 
 #accountDefault .forward, #accountHistInfo .forward{float:none;text-align:center;}
 .amount{float:right !important;}


### PR DESCRIPTION
Before: 

<img width="383" alt="old_checkout_confirmation" src="https://user-images.githubusercontent.com/4391638/95317148-c2072f00-0862-11eb-84b9-aabb61643a42.png">


After: 

<img width="363" alt="new_checkout_confirmation" src="https://user-images.githubusercontent.com/4391638/95317159-c92e3d00-0862-11eb-9fe1-34b0f027b730.png">
