### PR TITLE
Corrections in "audiences" processing

### DIFF
--- a/admin/mail.php
+++ b/admin/mail.php
@@ -261,7 +261,7 @@ if ($action == 'preview') {
         <div class="row">
             <?php echo zen_draw_form('mail', FILENAME_MAIL, 'action=preview' . (isset($_GET['cID']) ? '&cID=' . (int)$_GET['cID'] : '') . (isset($_GET['customer']) ? '&customer=' . zen_output_string_protected($_GET['customer']) : '') . (isset($_GET['origin']) ? '&origin=' . zen_output_string_protected($_GET['origin']) : ''), 'post', 'onsubmit="return check_form(mail);" enctype="multipart/form-data" class="form-horizontal"'); ?>
             <?php
-            $customers = get_audiences_list('email', 'customers_email_address', (isset($_GET['customer']) ? zen_output_string_protected($_GET['customer']) : ''));
+            $customers = get_audiences_list('email', 'false', (isset($_GET['customer']) ? zen_output_string_protected($_GET['customer']) : ''));
             ?>
           <div class="form-group">
               <?php echo zen_draw_label(TEXT_CUSTOMER, 'customers_email_address', 'class="col-sm-3 control-label"'); ?>

--- a/includes/functions/audience.php
+++ b/includes/functions/audience.php
@@ -32,19 +32,23 @@
   if ($queries_list->RecordCount() > 1) {  // if more than one query record found
     $audience_list[] = array('id' => '', 'text' => TEXT_SELECT_AN_OPTION); //provide a "not-selected" value
   }
+  $show_count = false;
+  if ($display_count === 'true' || $display_count === true) {  // if it's literal 'true' or logical true
+     $show_count = true;
+  }
 
   foreach ($queries_list as $query_list) {
     // if requested, show recordcounts at end of descriptions of each entry
     // This could slow things down considerably, so use sparingly !!!!
-    if ($display_count=='true' || $display_count ==true ) {  // if it's literal 'true' or logical true
-    $count_array = $db->Execute(parsed_query_string($query_list['query_string']) );
-    $count = $count_array->RecordCount();
+    if ($show_count) { 
+      $count_array = $db->Execute(parsed_query_string($query_list['query_string']) );
+      $count = $count_array->RecordCount();
     }
 
     // generate an array consisting of 2 columns which are identical. Key and Text are same.
     // Thus, when the array is used in a Select Box, the key is the same as the displayed description
     // The key can then be used to get the actual select SQL statement using the get...addresses_query function, below.
-    $audience_list[] = array('id' => $query_list['query_name'], 'text' => $query_list['query_name'] . ' (' . $count . ')');
+    $audience_list[] = array('id' => $query_list['query_name'], 'text' => $query_list['query_name'] . ($show_count ? ' (' . $count . ')' : ''));
   }
 
   //if this is called by an emailing module which offers individual customers as an option, add all customers email addresses as well.


### PR DESCRIPTION
a) get_audiences_list second parameter should be 'true' or 'false', not 'customers_email_address'.  In this case, 'false' makes sense because you're emailing one customer and you don't want to wait for the counts to be created. 

b) in get_audiences_list, second parameter needs exact compare to 'true' or true.  Using == means you always enter the loop, because 'customers_email_address' (or 'false') will == true. 

c) The check for display_counts should be done in one place and reused in determining whether to add the count to the string; current code appends "(0)" when this display_counts is false, which is misleading. 