### PR TITLE
[157] Use alternate method to set samesite cookie attribute on PHP < 7.0

### DIFF
--- a/admin/includes/init_includes/init_sessions.php
+++ b/admin/includes/init_includes/init_sessions.php
@@ -36,8 +36,7 @@ if (PHP_VERSION_ID >= 70300) {
     'samesite' => $samesite,
   ]);
 } else {
-  session_set_cookie_params(0, $path, (zen_not_null($cookieDomain) ? $domainPrefix . $cookieDomain : ''), $secureFlag, true);
-  ini_set('session.cookie_samesite', $samesite);
+  session_set_cookie_params(0, $path .'; samesite='.$samesite, (zen_not_null($cookieDomain) ? $domainPrefix . $cookieDomain : ''), $secureFlag, true);
 }
 
 /**

--- a/includes/init_includes/init_sessions.php
+++ b/includes/init_includes/init_sessions.php
@@ -53,8 +53,7 @@ if (PHP_VERSION_ID >= 70300) {
     'samesite' => $samesite,
   ]);
 } else {
-  session_set_cookie_params(0, $path, (zen_not_null($cookieDomain) ? $domainPrefix . $cookieDomain : ''), $secureFlag, true);
-  ini_set('session.cookie_samesite', $samesite);
+  session_set_cookie_params(0, $path .'; samesite='.$samesite, (zen_not_null($cookieDomain) ? $domainPrefix . $cookieDomain : ''), $secureFlag, true);
 }
 
 /**


### PR DESCRIPTION
... since the associated `php.ini` setting wasn't introduced until PHP 7.0, so the `ini_set` operation yields an empty value for the samesite attribute.