### PR TITLE
Remove unnecessary casting and variable use.

### DIFF
--- a/includes/modules/pages/ask_a_question/header_php.php
+++ b/includes/modules/pages/ask_a_question/header_php.php
@@ -20,7 +20,7 @@ if ($pid === false) {
     $sql = "SELECT pd.products_name, p.products_image, p.products_model
             FROM " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_DESCRIPTION . " pd
             WHERE p.products_id = pd.products_id
-            AND p.products_id = " . (int)$_GET['pid'] . "
+            AND p.products_id = " . $pid . "
             AND pd.language_id = " . (int)$_SESSION['languages_id'] . "
             AND p.products_status = 1
             LIMIT 1";
@@ -109,7 +109,7 @@ if (isset($_GET['action']) && ($_GET['action'] == 'send')) {
             OFFICE_EMAIL . "\t" . $email_address . "\n";
             if (!empty($telephone)) $text_message .= OFFICE_LOGIN_PHONE . "\t" . $telephone . "\n";
             $text_message .= TEXT_PRODUCT_NAME . "\t" . $product_details['products_name'] . "\n" .
-            zen_href_link(FILENAME_PRODUCT_INFO, 'products_id=' . (int)$_GET['pid']) .
+            zen_href_link(FILENAME_PRODUCT_INFO, 'products_id=' . $pid) .
             "\n";
             $text_message .= "\n" .
             '------------------------------------------------------' . "\n\n" .
@@ -117,13 +117,13 @@ if (isset($_GET['action']) && ($_GET['action'] == 'send')) {
             '------------------------------------------------------' . "\n\n" .
             $extra_info['TEXT'];
             // Prepare HTML-portion of message
-            $html_msg['EMAIL_MESSAGE_HTML'] = '<b>'.TEXT_PRODUCT_NAME.': </b><a href="' . zen_href_link(FILENAME_PRODUCT_INFO, 'products_id=' . (int)$_GET['pid']) . '">' . $product_details['products_name'] . '</a><br />' . strip_tags($_POST['enquiry']);
+            $html_msg['EMAIL_MESSAGE_HTML'] = '<b>'.TEXT_PRODUCT_NAME.': </b><a href="' . zen_href_link(FILENAME_PRODUCT_INFO, 'products_id=' . $pid) . '">' . $product_details['products_name'] . '</a><br />' . strip_tags($_POST['enquiry']);
             $html_msg['CONTACT_US_OFFICE_FROM'] = OFFICE_FROM . ' ' . $name . '<br />' . OFFICE_EMAIL . '(' . $email_address . ')';
             $html_msg['EXTRA_INFO'] = $extra_info['HTML'];
             // Send message
             zen_mail($send_to_name, $send_to_email, EMAIL_SUBJECT, $text_message, $name, $email_address, $html_msg,'ask_a_question');
         }
-        zen_redirect(zen_href_link(FILENAME_ASK_A_QUESTION, 'action=success&pid=' . (int)$_GET['pid'], 'SSL'));
+        zen_redirect(zen_href_link(FILENAME_ASK_A_QUESTION, 'action=success&pid=' . $pid, 'SSL'));
     } else {
         $error = true;
         if (empty($name)) {

--- a/includes/modules/pages/ask_a_question/header_php.php
+++ b/includes/modules/pages/ask_a_question/header_php.php
@@ -20,7 +20,7 @@ if ($pid === false) {
     $sql = "SELECT pd.products_name, p.products_image, p.products_model
             FROM " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_DESCRIPTION . " pd
             WHERE p.products_id = pd.products_id
-            AND p.products_id = " . $pid . "
+            AND p.products_id = " . (int)$pid . "
             AND pd.language_id = " . (int)$_SESSION['languages_id'] . "
             AND p.products_status = 1
             LIMIT 1";


### PR DESCRIPTION
$pid is already cast to the integer of $_GET['pid'], simplifies the code
to use that cast value throughout the header file.