### PR TITLE
Support admin use of .svg image extension

### DIFF
--- a/admin/.htaccess
+++ b/admin/.htaccess
@@ -41,7 +41,7 @@ DirectoryIndex index.php
 </FilesMatch>
 
 # but now allow just *certain* necessary files:
-<FilesMatch "(?i).*\.(php|js|css|html?|ico|otf|jpe?g|gif|webp|png|swf|flv|xml|xsl|csv|txt)$">
+<FilesMatch "(?i).*\.(php|js|css|html?|ico|otf|jpe?g|gif|webp|png|svg|swf|flv|xml|xsl|csv|txt)$">
   <IfModule mod_authz_core.c>
     Require all granted
   </IfModule>
@@ -108,6 +108,7 @@ IndexIgnore */*
   ExpiresByType image/x-icon A86400
   ExpiresByType image/jpeg A2592000
   ExpiresByType image/png A2592000
+  ExpiresByType image/svg A2592000
   ExpiresByType text/cache-manifest "access plus 0 seconds"
 
 </ifmodule>


### PR DESCRIPTION
I did not identify if a suggestion such as this had previously been denied. This adds the allowance of files with the extension `svg` to be loaded/displayed in the admin area. the `svg` extension was already recognized in the optional caching improvements section.  This also adds expiration control for the same `svg` file extension

This has been suggested in response to Zen Cart forum thread: https://www.zen-cart.com/showthread.php?227351-Use-logo-svg-in-place-of-logo-gif-or-logo-png