### PR TITLE
Products to Categories, global tool copy links to another product, not working

### DIFF
--- a/admin/products_to_categories.php
+++ b/admin/products_to_categories.php
@@ -120,12 +120,12 @@ if (zen_not_null($action)) {
 
                 $product_categories = [];
                 foreach (zen_get_linked_categories_for_product($products_filter, [$source_product_master_categories_id, $target_product_master_categories_id]) as $row) {
-                    $product_categories[] = (int)$row['categories_id'];
+                    $product_categories[] = (int)$row;
                 }
 
                 $target_categories = [];
                 foreach (zen_get_linked_categories_for_product($target_product_id, [$source_product_master_categories_id, $target_product_master_categories_id]) as $row) {
-                    $target_categories[] = (int)$row['categories_id'];
+                    $target_categories[] = (int)$row;
                 }
 
                 $target_categories_update = [];

--- a/includes/functions/functions_categories.php
+++ b/includes/functions/functions_categories.php
@@ -1050,7 +1050,7 @@ function zen_get_target_categories_products($parent_id = 0, $spacing = '', $cate
             $products = $db->Execute($sql);
 
             foreach ($products as $product) {
-                if ($product['products_id'] !== $products_filter) {
+                if ((int)$product['products_id'] !== $products_filter) {
                     $category_product_tree_array[] = [
                         'id' => $product['products_id'],
                         'text' => $spacing .


### PR DESCRIPTION
1) Comparison: global $products_filter is integer, slq result was string: the source product appeared in the target list.
2) Copy links always returned "Nothing to do".  (int)$row['categories_id'] was always 1 as the array returned from the new function is a simple array of ids.
