### PR TITLE
Do not round concatenated value used in sorting

### DIFF
--- a/includes/functions/functions_prices.php
+++ b/includes/functions/functions_prices.php
@@ -425,7 +425,7 @@ function zen_get_products_base_price($product_id)
     // do not select display only attributes and attributes_price_base_included is true
     $sql = "SELECT options_id, price_prefix, options_values_price,
                    attributes_display_only, attributes_price_base_included,
-            ROUND(CONCAT(price_prefix, options_values_price), 5) AS value
+            CONCAT(price_prefix, options_values_price) AS value
             FROM " . TABLE_PRODUCTS_ATTRIBUTES . "
             WHERE products_id = " . (int)$product_id . "
             AND attributes_display_only != 1


### PR DESCRIPTION
The round operation can fail and return 0 in some cases, making the value field zero.  Removing it prevents this from occurring.

**WITH round:** 

mysql> select options_values_price, round(concat(price_prefix, options_values_price), 5) as value from zen_products_attributes where products_id = '661' and attributes_display_only != '1' and attributes_price_base_included='1' order by options_id, value;
+----------------------+---------+
| options_values_price | value   |
+----------------------+---------+
|             110.0000 | 0.00000 |
|              90.0000 | 0.00000 |
|              50.0000 | 0.00000 |
|              70.0000 | 0.00000 |
+----------------------+---------+
4 rows in set (0.00 sec)

**WITHOUT round:** 

mysql> select options_values_price, concat(price_prefix, options_values_price) as value from zen_products_attributes where products_id = '661' and attributes_display_only != '1' and attributes_price_base_included='1' order by options_id, value;
+----------------------+-----------+
| options_values_price | value     |
+----------------------+-----------+
|             110.0000 |  110.0000 |
|              50.0000 |  50.0000  |
|              70.0000 |  70.0000  |
|              90.0000 |  90.0000  |
+----------------------+-----------+
4 rows in set (0.00 sec)