### PR TITLE
Correct for when DIR_WS_CATALOG is a subfolder

### DIFF
--- a/admin/includes/ckeditor.php
+++ b/admin/includes/ckeditor.php
@@ -33,7 +33,7 @@ foreach ($var as $key)
 
                 CKEDITOR.replace(jQuery(this).attr('name'),
                     {
-                        customConfig: '<?php echo (function_exists('zen_catalog_base_link') ? zen_catalog_base_link() : '/') . DIR_WS_EDITORS . 'ckeditor/config.js'; ?>',
+                        customConfig: '<?php echo (function_exists('zen_catalog_base_link') ? zen_catalog_base_link() : DIR_WS_HTTPS_CATALOG) . DIR_WS_EDITORS . 'ckeditor/config.js'; ?>',
                         language: lang[index]
                     });
             }


### PR DESCRIPTION
Recommended for backport to 1.5.7b.  
This will allow people to copy  `admin/includes/ckeditor.php`  to older Zen Cart installs that don't have the `zen_catalog_base_link` function. 