### PR TITLE
fix PHP notice when no salemakers exist

### DIFF
--- a/admin/salemaker.php
+++ b/admin/salemaker.php
@@ -522,7 +522,7 @@ if (zen_not_null($action)) {
                 $contents[] = array('align' => 'center', 'text' => '<br>' . zen_image_submit('button_delete.gif', IMAGE_DELETE) . '&nbsp;<a href="' . zen_href_link(FILENAME_SALEMAKER, 'page=' . $_GET['page'] . '&sID=' . $sInfo->sale_id) . '">' . zen_image_button('button_cancel.gif', IMAGE_CANCEL) . '</a>');
                 break;
               default:
-                if (is_object($sInfo)) {
+                if (!empty($sInfo) && is_object($sInfo)) {
                   $heading[] = array('text' => '<h4>' . $sInfo->sale_name . '</h4>');
 
                   $contents[] = array('align' => 'center', 'text' => '<a href="' . zen_href_link(FILENAME_SALEMAKER, 'page=' . $_GET['page'] . '&sID=' . $sInfo->sale_id . '&action=edit') . '" class="btn btn-primary" role="button">' . IMAGE_EDIT . '</a> <a href="' . zen_href_link(FILENAME_SALEMAKER, 'page=' . $_GET['page'] . '&sID=' . $sInfo->sale_id . '&action=copy') . '" class="btn btn-primary" role="button">' . IMAGE_COPY_TO . '</a> <a href="' . zen_href_link(FILENAME_SALEMAKER, 'page=' . $_GET['page'] . '&sID=' . $sInfo->sale_id . '&action=delete') . '" class="btn btn-warning" role="button">' . IMAGE_DELETE . '</a>');


### PR DESCRIPTION
i am not sure what is preferred; `!empty()` or `isset()` as both are used on this variable prior to the `is_object` check.  i choose to use the former.