### PR TITLE
Allow notifier to add info to email inquiry

### DIFF
--- a/includes/modules/pages/contact_us/header_php.php
+++ b/includes/modules/pages/contact_us/header_php.php
@@ -85,11 +85,11 @@ if (isset($_GET['action']) && ($_GET['action'] == 'send')) {
             if (!empty($telephone)) $text_message .= OFFICE_LOGIN_PHONE . "\t" . $telephone . "\n"; 
             $text_message .= "\n" .
             '------------------------------------------------------' . "\n\n" .
-            strip_tags($_POST['enquiry']) .  "\n\n" .
+            $enquiry .  "\n\n" .
             '------------------------------------------------------' . "\n\n" .
             $extra_info['TEXT'];
             // Prepare HTML-portion of message
-            $html_msg['EMAIL_MESSAGE_HTML'] = strip_tags($_POST['enquiry']);
+            $html_msg['EMAIL_MESSAGE_HTML'] = $enquiry;
             $html_msg['CONTACT_US_OFFICE_FROM'] = OFFICE_FROM . ' ' . $name . '<br />' . OFFICE_EMAIL . '(' . $email_address . ')';
             $html_msg['EXTRA_INFO'] = $extra_info['HTML'];
             // Send message


### PR DESCRIPTION
we have already `strip_tags` on the posted `enquiry` var; and now passed it to a notifier.  

if one had modified the template to allow additional information to be posted (ie an order number) and wants to include that in the email; modifying the `$enquiry` var seems to be the place to do it.

in fact, i see value in adding an order number field (as i do for my clients) to the contact us page.  in this way, the email can have the order number field AND we can in turn populate the order comments table for a record of that communication.

if not, this change makes sense to me.

