### PR TITLE
Catch exception when send() fails

### DIFF
--- a/includes/functions/functions_email.php
+++ b/includes/functions/functions_email.php
@@ -359,7 +359,12 @@ use PHPMailer\PHPMailer\SMTP;
       /**
        * Send the email. If an error occurs, trap it and display it in the messageStack
        */
-      if (!$mail->send()) {
+      $success = false;
+      try { 
+         $success = $mail->send(); 
+      } catch (Exception $e) {
+      }
+      if (!$success) { 
         $msg = sprintf(EMAIL_SEND_FAILED . '&nbsp;'. $mail->ErrorInfo, $to_name, $to_email_address, $email_subject);
         if ($messageStack !== NULL) {
           if (IS_ADMIN_FLAG === true) {


### PR DESCRIPTION
includes/classes/vendors/PHPMailer/src/PHPMailer.php line 1364 notes that send() can throw an exception, but we don't catch it in Zen Cart.  This means a fatal error, which could cause the checkout confirmation page to appear to hang (and cause multiple re-submits).  