### PR TITLE
fix empty quote of enabled shipping module

### DIFF
--- a/includes/classes/shipping.php
+++ b/includes/classes/shipping.php
@@ -164,7 +164,7 @@ class shipping extends base {
         if (FALSE == $GLOBALS[$include_quotes[$i]]->enabled) continue;
         $save_shipping_weight = $shipping_weight;
         $quotes = $GLOBALS[$include_quotes[$i]]->quote($method);
-        if (!isset($quotes['tax'])) $quotes['tax'] = 0;
+        if (!isset($quotes['tax']) && !empty($quotes)) $quotes['tax'] = 0;
         $shipping_weight = $save_shipping_weight;
         if (is_array($quotes)) $quotes_array[] = $quotes;
       }


### PR DESCRIPTION
just because a shipping module is ENABLED does not mean the module will return a quote. 

adding a tax element to an empty quote creates more problems down the line.