### PR TITLE
fix selected quote not getting set

### DIFF
--- a/includes/modules/shipping_estimator.php
+++ b/includes/modules/shipping_estimator.php
@@ -215,7 +215,7 @@ if ($_SESSION['cart']->count_contents() > 0) {
                 }
             }
 
-            if (isset($selected_quote[0]['error']) && $selected_quote[0]['error'] || !zen_not_null($selected_quote[0]['methods'][0]['cost'])) {
+            if (!isset($selected_quote) || (isset($selected_quote[0]['error']) && $selected_quote[0]['error']) || !zen_not_null($selected_quote[0]['methods'][0]['cost'])) {
                 $order->info['shipping_method'] = isset($selected_shipping['title']) ? $selected_shipping['title'] : '';
                 $order->info['shipping_cost'] = isset($selected_shipping['cost']) ? $selected_shipping['cost'] : 0;
                 $order->info['total']+= isset($selected_shipping['cost']) ? $selected_shipping['cost'] : 0;


### PR DESCRIPTION
looking at this code, i see the arrow anti-pattern; and it gets a bit confusing.  with more time, i would consider a refactor.

however, just looking at the code, one can see how `$selected_quote` might not get set, which has happened to me with my existing datasets.

setting the shipping to the same values as if there was an error in the selected quote seems like the best option for now, and corrects the warnings that i am seeing.