### PR TITLE
break out of product loop if item removed from cart

### DIFF
--- a/includes/classes/shopping_cart.php
+++ b/includes/classes/shopping_cart.php
@@ -1257,6 +1257,7 @@ class shoppingCart extends base
                         $_SESSION['valid_to_checkout'] = false;
                         $_SESSION['cart_errors'] .= ERROR_PRODUCT . $products->fields['products_name'] . ERROR_PRODUCT_STATUS_SHOPPING_CART . '<br>';
                         $this->remove($products_id);
+                        break;
                     } else {
                         if (isset($this->contents[$products_id]['attributes'])) {
                             $chkcount = 0;


### PR DESCRIPTION
when a customer is logged into their account and they have items in their cart, if that item goes inactive prior to them checking out, PHP notices for undefined index and Trying to access array offset on value of type null get generated.

breaking out of the products loop (similar to lines 1282-1283) addresses these notices.