### PR TITLE
Polyfill PHP functions for mismatched PHP versions

### DIFF
--- a/admin/includes/application_bootstrap.php
+++ b/admin/includes/application_bootstrap.php
@@ -97,6 +97,7 @@ if (file_exists('includes/defined_paths.php')) {
     die('ERROR: /includes/defined_paths.php file not found. Cannot continue.');
     exit;
 }
+require DIR_FS_CATALOG . DIR_WS_FUNCTIONS . 'php_polyfills.php';
 /**
  * ignore version-check if INI file setting has been set
  */

--- a/admin/includes/functions/extra_functions/load_php_polyfills.php
+++ b/admin/includes/functions/extra_functions/load_php_polyfills.php
@@ -1,8 +1,0 @@
-<?php
-/**
- * @copyright Copyright 2003-2020 Zen Cart Development Team
- * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: New in v1.5.7c $
- */
-
-include DIR_FS_CATALOG . '/includes/functions/extra_functions/php_polyfills.php';

--- a/includes/application_top.php
+++ b/includes/application_top.php
@@ -138,6 +138,7 @@ if (file_exists('includes/defined_paths.php')) {
     die('ERROR: /includes/defined_paths.php file not found. Cannot continue.');
     exit;
 }
+require DIR_FS_CATALOG . DIR_WS_FUNCTIONS . 'php_polyfills.php';
 /**
  * include the list of extra configure files
  */

--- a/includes/functions/php_polyfills.php
+++ b/includes/functions/php_polyfills.php
@@ -126,25 +126,26 @@ if (!defined('PHP_FLOAT_MAX')) {
     define('PHP_FLOAT_MAX', 1.7976931348623157E+308);
 }
 if (!defined('PHP_OS_FAMILY')) {
-    define('PHP_OS_FAMILY', static function ()
-        {
-            if ('\\' === \DIRECTORY_SEPARATOR) {
-                return 'Windows';
-            }
-
-            $map = array(
-                'Darwin' => 'Darwin',
-                'DragonFly' => 'BSD',
-                'FreeBSD' => 'BSD',
-                'NetBSD' => 'BSD',
-                'OpenBSD' => 'BSD',
-                'Linux' => 'Linux',
-                'SunOS' => 'Solaris',
-            );
-
-            return isset($map[PHP_OS]) ? $map[PHP_OS] : 'Unknown';
+    function php_os_family()
+    {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            return 'Windows';
         }
-    );
+
+        $map = array(
+            'Darwin' => 'Darwin',
+            'DragonFly' => 'BSD',
+            'FreeBSD' => 'BSD',
+            'NetBSD' => 'BSD',
+            'OpenBSD' => 'BSD',
+            'Linux' => 'Linux',
+            'SunOS' => 'Solaris',
+        );
+
+        return isset($map[PHP_OS]) ? $map[PHP_OS] : 'Unknown';
+    }
+
+    define('PHP_OS_FAMILY', php_os_family());
 }
 if (!function_exists('utf8_encode')) {
     function utf8_encode($s)


### PR DESCRIPTION
This provides (many, but not all) core PHP functions introduced between 5.6 and 8.0 for the purpose of backward-compatibility.

Revised implementation of #4141