### PR TITLE
Remove inspected entry from whos_online URI if session no longer exists

### DIFF
--- a/admin/whos_online.php
+++ b/admin/whos_online.php
@@ -39,14 +39,14 @@ $selectedView = isset($_GET['q']) ? $_GET['q'] : '';
 $wo = new WhosOnline();
 if (!empty($_GET['inspect'])) {
     $sql = "SELECT s.sesskey
-          FROM " . TABLE_SESSIONS . " s
-          WHERE s.sesskey = :session_id:";
-    $sql = $db->bindVars($sql, ':session_id:', $_GET['inspect'], 'stringIgnoreNull');
+            FROM " . TABLE_SESSIONS . " s
+            WHERE s.sesskey = :session_id:";
+    $sql = $db->bindVars($sql, ':session_id:', $_GET['inspect'], 'string');
 
-    $sql_result = $db->Execute($sql);
+    $result = $db->Execute($sql);
 
-    if ($sql_result->EOF) {
-      unset($_GET['inspect']);
+    if ($result->EOF) {
+        unset($_GET['inspect']);
     }
 }
 $whos_online = $wo->retrieve($selectedView, (empty($_GET['inspect']) ? '' : $_GET['inspect']), $_SESSION['wo_exclude_spiders'], $_SESSION['wo_exclude_admins']);

--- a/admin/whos_online.php
+++ b/admin/whos_online.php
@@ -37,6 +37,18 @@ if (!isset($_SESSION['wo_timeout']) || $_SESSION['wo_timeout'] < 3) {
 
 $selectedView = isset($_GET['q']) ? $_GET['q'] : '';
 $wo = new WhosOnline();
+if (!empty($_GET['inspect'])) {
+    $sql = "SELECT s.sesskey
+          FROM " . TABLE_SESSIONS . " s
+          WHERE s.sesskey = :session_id:";
+    $sql = $db->bindVars($sql, ':session_id:', $_GET['inspect'], 'stringIgnoreNull');
+
+    $sql_result = $db->Execute($sql);
+
+    if ($sql_result->EOF) {
+      unset($_GET['inspect']);
+    }
+}
 $whos_online = $wo->retrieve($selectedView, (empty($_GET['inspect']) ? '' : $_GET['inspect']), $_SESSION['wo_exclude_spiders'], $_SESSION['wo_exclude_admins']);
 
 $optURL = FILENAME_WHOS_ONLINE . '.php?' . zen_get_all_get_params(['t', 'na', 'ns']);


### PR DESCRIPTION
If tracking a particular session, when the session disappears or is removed
it remains to be tracked; however, no longer exists. Further, if the session
being tracked is incorrectly entered, it will appear ass if the session
does not have a cart even if there is one.

This becomes a visible problem if there are two or more sessions active,
one of them is being tracked and the page is set to refresh periodically.
When that session expires and eventually only one session exists, at that
point, it is not possible to click on a session to force tracking it.

This clears the tracking data if it doesn't exist.