### PR TITLE
Correct PHP notice generated by zen_get_categories_parent_name

### DIFF
--- a/includes/functions/functions_categories.php
+++ b/includes/functions/functions_categories.php
@@ -456,23 +456,17 @@ function zen_get_categories($categories_array = array(), $parent_id = '0', $inde
   function zen_get_categories_parent_name($categories_id) {
     global $db;
 
-    $categories_parent_name = '';
-    $lookup_query = "SELECT parent_id FROM " . TABLE_CATEGORIES . " WHERE categories_id = " . (int)$categories_id . " LIMIT 1";
+    $lookup_query =
+        "SELECT cd.categories_name
+           FROM " . TABLE_CATEGORIES_DESCRIPTION . " cd
+                INNER JOIN " . TABLE_CATEGORIES . " c
+                    ON c.categories_id = $categories_id
+          WHERE cd.categories_id = c.parent_id
+            AND cd.language_id = " . (int)$_SESSION['languages_id'] . "
+          LIMIT 1";
     $lookup = $db->Execute($lookup_query);
     
-    if (!$lookup->EOF) {
-        $lookup_query = 
-            "SELECT categories_name 
-               FROM " . TABLE_CATEGORIES_DESCRIPTION . " 
-              WHERE categories_id = " . $lookup->fields['parent_id'] . " 
-                AND language_id = " . $_SESSION['languages_id'] . "
-              LIMIT 1";
-        $lookup = $db->Execute($lookup_query);
-        if (!$lookup->EOF) {
-            $categories_parent_name = $lookup->fields['categories_name'];
-        }
-    }
-    return $categories_parent_name;
+    return ($lookup->EOF) ? '' : $lookup->fields['categories_name'];
   }
 
 ////

--- a/includes/functions/functions_categories.php
+++ b/includes/functions/functions_categories.php
@@ -456,13 +456,23 @@ function zen_get_categories($categories_array = array(), $parent_id = '0', $inde
   function zen_get_categories_parent_name($categories_id) {
     global $db;
 
-    $lookup_query = "select parent_id from " . TABLE_CATEGORIES . " where categories_id='" . (int)$categories_id . "'";
+    $categories_parent_name = '';
+    $lookup_query = "SELECT parent_id FROM " . TABLE_CATEGORIES . " WHERE categories_id = " . (int)$categories_id . " LIMIT 1";
     $lookup = $db->Execute($lookup_query);
-
-    $lookup_query = "select categories_name from " . TABLE_CATEGORIES_DESCRIPTION . " where categories_id='" . (int)$lookup->fields['parent_id'] . "' and language_id= " . $_SESSION['languages_id'];
-    $lookup = $db->Execute($lookup_query);
-
-    return $lookup->fields['categories_name'];
+    
+    if (!$lookup->EOF) {
+        $lookup_query = 
+            "SELECT categories_name 
+               FROM " . TABLE_CATEGORIES_DESCRIPTION . " 
+              WHERE categories_id = " . $lookup->fields['parent_id'] . " 
+                AND language_id = " . $_SESSION['languages_id'] . "
+              LIMIT 1";
+        $lookup = $db->Execute($lookup_query);
+        if (!$lookup->EOF) {
+            $categories_parent_name = $lookup->fields['categories_name'];
+        }
+    }
+    return $categories_parent_name;
   }
 
 ////


### PR DESCRIPTION
Seeing a log similar to

```
[05-Jan-2021 19:29:41 UTC] Request URI: /zc157a_bs4/index.php?main_page=index&cPath=22, IP address: 127.0.0.1
#1  zen_get_categories_parent_name() called at [C:\xampp\htdocs\zc157a_bs4\includes\modules\bootstrap\product_listing.php:134]
#2  include(C:\xampp\htdocs\zc157a_bs4\includes\modules\bootstrap\product_listing.php) called at [C:\xampp\htdocs\zc157a_bs4\includes\templates\bootstrap\templates\tpl_modules_product_listing.php:12]
#3  require(C:\xampp\htdocs\zc157a_bs4\includes\templates\bootstrap\templates\tpl_modules_product_listing.php) called at [C:\xampp\htdocs\zc157a_bs4\includes\templates\bootstrap\templates\tpl_index_product_list.php:105]
#4  require(C:\xampp\htdocs\zc157a_bs4\includes\templates\bootstrap\templates\tpl_index_product_list.php) called at [C:\xampp\htdocs\zc157a_bs4\includes\modules\pages\index\main_template_vars.php:232]
#5  require(C:\xampp\htdocs\zc157a_bs4\includes\modules\pages\index\main_template_vars.php) called at [C:\xampp\htdocs\zc157a_bs4\includes\templates\bootstrap\common\tpl_main_page.php:195]
#6  require(C:\xampp\htdocs\zc157a_bs4\includes\templates\bootstrap\common\tpl_main_page.php) called at [C:\xampp\htdocs\zc157a_bs4\index.php:94]
--> PHP Notice: Undefined index: categories_name in C:\xampp\htdocs\zc157a_bs4\includes\functions\functions_categories.php on line 465.
```

... when browsing a 1st-tier sub-category.  Using the current zc157c-alpha fileset.