### PR TITLE
Refactor ot_coupon to expose validation methods

### DIFF
--- a/includes/modules/order_total/ot_coupon.php
+++ b/includes/modules/order_total/ot_coupon.php
@@ -8,6 +8,10 @@
  * @version $Id: Modified in v1.5.8 $
  */
 
+/*
+ * NOTE: Notifier NOTIFY_OT_COUPON_CALCS_FINISHED formerly had its first parameter return an array with a 'coupon' entry which was a queryFactoryResult. It is now just an array of the ->fields values
+ */
+
 /**
  * Order Total class to handle discount coupons
  */
@@ -17,12 +21,28 @@ class ot_coupon
      * module title
      * @var string
      */
-    var $title;
+    public $title;
     /**
      * display elements used on checkout pages
      * @var array
      */
-    var $output;
+    public $output = [];
+
+    /**
+     * while being applied to an order, this is the coupon_code under consideration
+     * @var string
+     */
+    var $coupon_code;
+    /**
+     * amount of deduction calculated/afforded while being applied to an order
+     * @var float|null
+     */
+    var $deduction;
+
+    /**
+     * error messages from coupon validation
+     */
+    protected $validation_errors = [];
 
     function __construct()
     {
@@ -30,6 +50,7 @@ class ot_coupon
         $this->header = MODULE_ORDER_TOTAL_COUPON_HEADER;
         $this->title = MODULE_ORDER_TOTAL_COUPON_TITLE;
         $this->description = MODULE_ORDER_TOTAL_COUPON_DESCRIPTION;
+        $this->credit_class = true;
         $this->user_prompt = '';
         $this->sort_order = defined('MODULE_ORDER_TOTAL_COUPON_SORT_ORDER') ? MODULE_ORDER_TOTAL_COUPON_SORT_ORDER : null;
         if (null === $this->sort_order) return false;
@@ -38,8 +59,6 @@ class ot_coupon
         $this->include_tax = MODULE_ORDER_TOTAL_COUPON_INC_TAX;
         $this->calculate_tax = MODULE_ORDER_TOTAL_COUPON_CALC_TAX;
         $this->tax_class = MODULE_ORDER_TOTAL_COUPON_TAX_CLASS;
-        $this->credit_class = true;
-        $this->output = [];
         if (IS_ADMIN_FLAG === true) {
             if ($this->include_tax == 'true' && $this->calculate_tax != "None") {
                 $this->title .= '<span class="alert">' . MODULE_ORDER_TOTAL_COUPON_INCLUDE_ERROR . '</span>';
@@ -48,18 +67,22 @@ class ot_coupon
     }
 
     /**
-     * Produces final deduction values.
-     * This information is used to produce the output shown on the checkout pages
+     * Produces final deduction values,
+     * updates $order amounts,
+     * and generates the $this->output for showing discount information on checkout pages
      */
     function process()
     {
         global $order, $currencies;
-        $order_total = $this->get_order_total(isset($_SESSION['cc_id']) ? $_SESSION['cc_id'] : '');
         $od_amount = ['tax' => 0, 'total' => 0];
-        if ($order_total > 0) {
+
+        $order_total = $this->get_order_total(isset($_SESSION['cc_id']) ? $_SESSION['cc_id'] : '');
+
+        if ($order_total['orderTotal'] > 0) {
             $od_amount = $this->calculate_deductions();
         }
         $this->deduction = $od_amount['total'];
+
         if ($od_amount['total'] > 0) {
             $tax = 0;
             foreach ($order->info['tax_groups'] as $key => $value) {
@@ -70,14 +93,19 @@ class ot_coupon
                 }
             }
             // free shipping for free shipping 'S' or percentage off and free shipping 'E' or amount off and free shipping 'O'
-            if ($od_amount['type'] == 'S' || $od_amount['type'] == 'E' || $od_amount['type'] == 'O') $order->info['shipping_cost'] = 0;
-            $order->info['total'] = $order->info['total'] - $od_amount['total'];
+            if (in_array($od_amount['type'], ['S', 'E', 'O'])) {
+                $order->info['shipping_cost'] = 0;
+            }
+
+            $order->info['total'] -= $od_amount['total'];
+
             if (DISPLAY_PRICE_WITH_TAX != 'true') {
                 $order->info['total'] -= $tax;
             }
-            $order->info['tax'] = $order->info['tax'] - $tax;
-            //      if ($this->calculate_tax == "Standard") $order->info['total'] -= $tax;
+            $order->info['tax'] -= $tax;
+
             if ($order->info['total'] < 0) $order->info['total'] = 0;
+
             $this->output[] = [
                 'title' => $this->title . ': ' . $this->coupon_code . ' :',
                 'text' => '-' . $currencies->format($od_amount['total']),
@@ -87,13 +115,8 @@ class ot_coupon
     }
 
     /**
-     * @return bool
+     * Reset any variables related to this module
      */
-    function selection_test()
-    {
-        return false;
-    }
-
     function clear_posts()
     {
         unset($_POST['dc_redeem_code']);
@@ -101,50 +124,39 @@ class ot_coupon
     }
 
     /**
-     * Enter description here...
-     *
-     * @param float $order_total
-     * @return float
+     * Per order_total class, this function is not used. See process() instead.
      */
-    function pre_confirmation_check($order_total)
+    function pre_confirmation_check()
     {
-        global $order;
-        $od_amount = ['tax' => 0, 'total' => 0];
-        if ($order_total > 0) {
-            $od_amount = $this->calculate_deductions();
-        }
-        $order->info['total'] = $order->info['total'] - $od_amount['total'];
-
-        if (DISPLAY_PRICE_WITH_TAX != 'true') {
-// @TODO -- where did $tax come from here?
-//      $order->info['total'] -= $tax;
-        }
-        return $od_amount['total'] + (DISPLAY_PRICE_WITH_TAX == 'true' ? 0 : $od_amount['tax']);
+        //
     }
 
     /**
+     * This function is not used by this module
+     *
      * @return bool
      */
-    function use_credit_amount()
+    function selection_test()
     {
         return false;
     }
 
     /**
+     * Prepare input field data for coupon code redemption on checkout_payment page
+     *
      * @return array
      */
     function credit_selection()
     {
-        global $discount_coupon, $request_type;
+        global $discount_coupon;
 
         $couponLink = '';
-        if (isset($discount_coupon->fields['coupon_code']) && isset($_SESSION['cc_id'])) {
+        if (!empty($discount_coupon->fields['coupon_code']) && !empty($_SESSION['cc_id'])) {
             $coupon_code = $discount_coupon->fields['coupon_code'];
-            $couponLink = '<a href="javascript:couponpopupWindow(\'' .
-                zen_href_link(FILENAME_POPUP_COUPON_HELP, 'cID=' . $_SESSION['cc_id'], $request_type) .
-                '\')">' . $coupon_code . '</a>';
+            $couponLink = $this->generateCouponPopupLink($_SESSION['cc_id'], $coupon_code);
         }
-        // note the placement of the redeem code can be moved within the array on the instructions or the title
+
+        // note that the placement of the redeem code can be moved within the array on the instructions or the title
         $selection = [
             'id' => $this->code,
             'module' => $this->title,
@@ -164,271 +176,201 @@ class ot_coupon
     }
 
     /**
+     * Make a link to the coupon-help popup page.
+     * This link is used in status messages and error messages.
+     * The referred page displays information about the coupon's valid uses.
      *
+     * @param int $coupon_id
+     * @param string $coupon_code
+     * @return string
+     */
+    protected function generateCouponPopupLink($coupon_id, $coupon_code)
+    {
+        global $request_type;
+
+        $couponLink = '<a href="javascript:couponpopupWindow(\'' .
+            zen_href_link(FILENAME_POPUP_COUPON_HELP, 'cID=' . $coupon_id, $request_type) .
+            '\')"' .
+            ' title="' . TEXT_COUPON_LINK_TITLE . '"' .
+            '>' . $coupon_code . '</a>';
+
+        return $couponLink;
+    }
+
+    /**
+     * When on checkout_confirmation, process POSTed dc_redeem_code for validity or requested removal
+     * Also displays messageStack error alerts, and performs redirects back to Payment page if invalid
      */
     function collect_posts()
     {
-        global $db, $currencies, $messageStack, $order, $zco_notifier;
+        global $messageStack;
+
+        $coupon_code = isset($_POST['dc_redeem_code']) ? trim($_POST['dc_redeem_code']) : '';
+
+        // Check whether the customer has requested to un-apply the coupon. This will redirect, which halts further execution.
+        $this->remove_coupon_if_requested($coupon_code);
+
+        // @TODO get rid of the use of $discount_coupon here; might be as simple as using $_SESSION['cc_id'] since that's what's used to set this
         global $discount_coupon;
-        $_POST['dc_redeem_code'] = isset($_POST['dc_redeem_code']) ? trim($_POST['dc_redeem_code']) : '';
 
-        if (!defined('TEXT_COMMAND_TO_DELETE_CURRENT_COUPON_FROM_ORDER')) define('TEXT_COMMAND_TO_DELETE_CURRENT_COUPON_FROM_ORDER', 'REMOVE');
-        // remove discount coupon by request
-        if (isset($_POST['dc_redeem_code']) && strtoupper($_POST['dc_redeem_code']) == TEXT_COMMAND_TO_DELETE_CURRENT_COUPON_FROM_ORDER) {
-            unset($_POST['dc_redeem_code']);
-            unset($_SESSION['cc_id']);
-
-            $zco_notifier->notify('NOTIFY_OT_COUPON_COUPON_REMOVED');
-
-            $messageStack->add_session('checkout_payment', TEXT_REMOVE_REDEEM_COUPON, 'caution');
+        if (empty($coupon_code) && empty($discount_coupon->fields['coupon_code'])) {
+            return;
         }
 
-        if ((isset($_POST['dc_redeem_code']) && $_POST['dc_redeem_code'] != '') || (isset($discount_coupon->fields['coupon_code']) && $discount_coupon->fields['coupon_code'] != '')) {
-            // set current Discount Coupon based on current or existing
-            if ($discount_coupon != null) {
-                if (isset($_POST['dc_redeem_code']) && $discount_coupon->fields['coupon_code'] == '') {
-                    $dc_check = $_POST['dc_redeem_code'];
-                } else {
-                    $dc_check = $discount_coupon->fields['coupon_code'];
-                }
-            } else {
-                if (isset($_POST['dc_redeem_code'])) {
-                    $dc_check = $_POST['dc_redeem_code'];
-                } else if ($discount_coupon != null) {
-                    $dc_check = $discount_coupon->fields['coupon_code'];
-                } else {
-                    $dc_check = "UNKNOWN_COUPON";
-                }
-            }
+        // $discount_coupon might be set externally, and if it is then we use that if POST is empty
+        if (empty($coupon_code) && !empty($discount_coupon->fields['coupon_code'])) {
+            $coupon_code = $discount_coupon->fields['coupon_code'];
+        }
+
+        if (empty($coupon_code)) {
+            $coupon_code = "UNKNOWN_COUPON";
+        }
+
+        $coupon_id = $this->performValidations($coupon_code);
+        $this->setMessageStackValidationAlerts();
 
 
-            $sql = "SELECT *
-                    FROM " . TABLE_COUPONS . "
-                    WHERE coupon_code= :couponCodeEntered
-                    AND coupon_active = 'Y'
-                    AND coupon_type != 'G'";
+        // display all error messages
+        if (!empty($this->validation_errors)) {
+            $this->clear_posts();
+            zen_redirect(zen_href_link(FILENAME_CHECKOUT_PAYMENT, '', 'SSL', true, false));
+        }
 
-            $sql = $db->bindVars($sql, ':couponCodeEntered', $dc_check, 'string');
-
-            $coupon_result = $db->Execute($sql);
-
-            if (!$coupon_result->EOF) {
-
-                if ($coupon_result->RecordCount() < 1) {
-                    $messageStack->add_session('redemptions', sprintf(TEXT_INVALID_REDEEM_COUPON, $dc_check), 'caution');
-                    $this->clear_posts();
-                    zen_redirect(zen_href_link(FILENAME_CHECKOUT_PAYMENT, '', 'SSL', true, false));
-                }
-
-                $zco_notifier->notify('NOTIFY_OT_COUPON_COUPON_INFO', ['coupon_result' => $coupon_result->fields, 'code' => $dc_check]);
-
-                //$order_total = $this->get_order_total($coupon_result->fields['coupon_id']);
-
-                // display all error messages at once
-                $error_issues = 0;
-                $dc_link_count = 0;
-                $dc_link = '<a href="javascript:couponpopupWindow(\'' . zen_href_link(FILENAME_POPUP_COUPON_HELP, 'cID=' . $coupon_result->fields['coupon_id']) . '\')" title="' . TEXT_COUPON_LINK_TITLE . '">' . $dc_check . '</a>';
-                $orderTotalDetails = $this->get_order_total($coupon_result->fields['coupon_id']);
-                if ($coupon_result->fields['coupon_calc_base'] == 0) {
-                    $coupon_total_minimum = $orderTotalDetails['orderTotal']; // restricted products
-                    $coupon_total = $orderTotalDetails['orderTotal']; // restricted products
-                }
-                if ($coupon_result->fields['coupon_calc_base'] == 1) {
-                    $coupon_total_minimum = $orderTotalDetails['orderTotal']; // restricted products
-                    $coupon_total = $orderTotalDetails['totalFull']; // all products
-                }
-//echo 'Product: ' . $orderTotalDetails['orderTotal'] . ' Order: ' . $orderTotalDetails['totalFull'] . ' $coupon_total: ' . $coupon_total . '<br>';
-// left for total order amount vs qualified order amount just switch the commented lines
-//        if ($order_total['totalFull'] < $coupon_result->fields['coupon_minimum_order'])
-//        if ((string)$order_total['orderTotal'] > 0 && (string)$order_total['orderTotal'] < $coupon_result->fields['coupon_minimum_order'])
-//        if ($coupon_result->fields['coupon_minimum_order'] > 0 && strval($order_total['orderTotal']) < $coupon_result->fields['coupon_minimum_order'])
-//        if ((string)$coupon_total > 0 && (string)$coupon_total < $coupon_result->fields['coupon_minimum_order'])
-                if ((string)$coupon_total > 0 && (string)$coupon_total_minimum < $coupon_result->fields['coupon_minimum_order']) {
-                    // $order_total['orderTotal'] . ' vs ' . $order_total['totalFull']
-                    $messageStack->add_session('redemptions', sprintf(TEXT_INVALID_REDEEM_COUPON_MINIMUM, ($dc_link_count === 0 ? $dc_link : $dc_check), $currencies->format($coupon_result->fields['coupon_minimum_order'])), 'caution');
-                    $error_issues++;
-                    $dc_link_count++;
-
-//          $this->clear_posts();
-//          zen_redirect(zen_href_link(FILENAME_CHECKOUT_PAYMENT, '', 'SSL',true, false));
-                }
-
-                // JTD - handle coupon product restrictions
-                // look through the items in the cart to see if this coupon is valid for any item in the cart
-                $products = $_SESSION['cart']->get_products();
-                $foundvalid = true;
-
-                if ($foundvalid == true) {
-                    $foundvalid = false;
-                    for ($i = 0, $n = count($products); $i < $n; $i++) {
-                        if (is_product_valid($products[$i]['id'], $coupon_result->fields['coupon_id'])) {
-                            $foundvalid = true;
-                            continue;
-                        }
-                    }
-                }
-                if ($foundvalid == true) {
-                    // check if products on special or sale are valid
-                    $foundvalid = false;
-                    for ($i = 0, $n = count($products); $i < $n; $i++) {
-                        if (is_coupon_valid_for_sales($products[$i]['id'], $coupon_result->fields['coupon_id'])) {
-                            $foundvalid = true;
-                            continue;
-                        }
-                    }
-                }
-                if (!$foundvalid) {
-                    $this->clear_posts();
-                }
-//        if (!$foundvalid) zen_redirect(zen_href_link(FILENAME_CHECKOUT_PAYMENT, 'credit_class_error_code=' . $this->code . '&credit_class_error=' . urlencode(TEXT_INVALID_COUPON_PRODUCT . ' ' . $dc_check), 'SSL',true, false));
-                if (!$foundvalid) {
-                    $messageStack->add_session('redemptions', sprintf(TEXT_INVALID_COUPON_PRODUCT, ($dc_link_count === 0 ? $dc_link : $dc_check)), 'caution');
-                    $error_issues++;
-                    $dc_link_count++;
-                }
-
-// validate number of Orders
-                if ($coupon_result->fields['coupon_order_limit'] > 0) {
-                    $sql = "SELECT orders_id FROM " . TABLE_ORDERS . " WHERE customers_id = '" . $_SESSION['customer_id'] . "'";
-                    $chk_customer_orders = $db->Execute($sql);
-                    if ($chk_customer_orders->RecordCount() > $coupon_result->fields['coupon_order_limit']) {
-                        $messageStack->add_session('redemptions', sprintf(TEXT_INVALID_COUPON_ORDER_LIMIT, ($dc_link_count === 0 ? $dc_link : $dc_check), $coupon_result->fields['coupon_order_limit']), 'caution');
-                        $error_issues++;
-                        $dc_link_count++;
-                    }
-                }
-
-                // JTD - end of handling coupon product restrictions
-
-                $date_query = $db->Execute("SELECT coupon_start_date FROM " . TABLE_COUPONS . "
-                                  WHERE coupon_code='" . zen_db_prepare_input($dc_check) . "' LIMIT 1");
-
-                if (date("Y-m-d H:i:s") < $date_query->fields['coupon_start_date']) {
-                    $messageStack->add_session('redemptions', sprintf(TEXT_INVALID_STARTDATE_COUPON, ($dc_link_count === 0 ? $dc_link : $dc_check), zen_date_short($date_query->fields['coupon_start_date'])), 'caution');
-                    $error_issues++;
-                    $dc_link_count++;
-//          $this->clear_posts();
-//          zen_redirect(zen_href_link(FILENAME_CHECKOUT_PAYMENT, '', 'SSL', true, false));
-                }
-
-                $date_query = $db->Execute("SELECT coupon_expire_date FROM " . TABLE_COUPONS . "
-                                  WHERE coupon_code='" . zen_db_prepare_input($dc_check) . "' LIMIT 1");
-
-                if (date("Y-m-d H:i:s") >= $date_query->fields['coupon_expire_date']) {
-                    $messageStack->add_session('redemptions', sprintf(TEXT_INVALID_FINISHDATE_COUPON, ($dc_link_count === 0 ? $dc_link : $dc_check), zen_date_short($date_query->fields['coupon_expire_date'])), 'caution');
-                    $error_issues++;
-                    $dc_link_count++;
-//          $this->clear_posts();
-//          zen_redirect(zen_href_link(FILENAME_CHECKOUT_PAYMENT, '', 'SSL', true, false));
-                }
-
-                $coupon_count = $db->Execute("SELECT coupon_id
-                                            FROM " . TABLE_COUPON_REDEEM_TRACK . "
-                                            WHERE coupon_id = '" . (int)$coupon_result->fields['coupon_id'] . "'");
-
-                $coupon_count_customer = $db->Execute("SELECT coupon_id
-                                              FROM " . TABLE_COUPON_REDEEM_TRACK . "
-                                              WHERE coupon_id = '" . $coupon_result->fields['coupon_id'] . "'
-                                              AND customer_id = '" . (int)$_SESSION['customer_id'] . "'");
-
-                $coupon_uses_per_user_exceeded = ($coupon_count_customer->RecordCount() >= $coupon_result->fields['uses_per_user'] && $coupon_result->fields['uses_per_user'] > 0);
-                $zco_notifier->notify('NOTIFY_OT_COUPON_USES_PER_USER_CHECK', $coupon_result->fields, $coupon_uses_per_user_exceeded);
-                if ($coupon_uses_per_user_exceeded) {
-                    $messageStack->add_session('redemptions', sprintf(TEXT_INVALID_USES_COUPON, ($dc_link_count === 0 ? $dc_link : $dc_check), $coupon_result->fields['uses_per_coupon']), 'caution');
-                    $error_issues++;
-                    $dc_link_count++;
-//          $this->clear_posts();
-//          zen_redirect(zen_href_link(FILENAME_CHECKOUT_PAYMENT, '', 'SSL', true, false));
-                }
-
-                if ($coupon_count_customer->RecordCount() >= $coupon_result->fields['uses_per_user'] && $coupon_result->fields['uses_per_user'] > 0) {
-                    $messageStack->add_session('redemptions', sprintf(TEXT_INVALID_USES_USER_COUPON, ($dc_link_count === 0 ? $dc_link : $dc_check), $coupon_result->fields['uses_per_user']), 'caution');
-                    $error_issues++;
-                    $dc_link_count++;
-//          $this->clear_posts();
-//          zen_redirect(zen_href_link(FILENAME_CHECKOUT_PAYMENT, '', 'SSL', true, false));
-                }
-
-                $_SESSION['cc_id'] = $coupon_result->fields['coupon_id'];
-                if ($_SESSION['cc_id'] > 0) {
-                    $sql = "SELECT coupon_id, coupon_amount, coupon_type, coupon_minimum_order, uses_per_coupon, uses_per_user,
-                                   restrict_to_products, restrict_to_categories, coupon_zone_restriction, coupon_code
-                            FROM " . TABLE_COUPONS . "
-                            WHERE coupon_id= :couponIDEntered
-                            AND coupon_active='Y'";
-                    $sql = $db->bindVars($sql, ':couponIDEntered', $_SESSION['cc_id'], 'string');
-
-                    $coupon_result = $db->Execute($sql);
-
-                    $foundvalid = true;
-
-                    $check_flag = false;
-
-                    // base restrictions zone restrictions for Delivery or Billing address
-                    switch ($coupon_result->fields['coupon_type']) {
-                        case 'S': // shipping
-                        case 'O': // amount off and free shipping
-                        case 'E': // percentage and Free Shipping
-                            // use delivery address
-                            $check_zone_country_id = $order->delivery['country']['id'];
-                            $check_zone_id = $order->delivery['zone_id'];
-                            break;
-                        case 'F': // amount
-                        case 'P': // percentage
-                        case 'G': // GV coupon
-                        default:
-                            // use billing address
-                            $check_zone_country_id = $order->billing['country']['id'];
-                            $check_zone_id = $order->billing['zone_id'];
-                            break;
-                    }
-
-                    $sql = "SELECT zone_id, zone_country_id
-                            FROM " . TABLE_ZONES_TO_GEO_ZONES . "
-                            WHERE geo_zone_id = " . (int)$coupon_result->fields['coupon_zone_restriction'] . "
-                            AND zone_country_id = " . (int)$check_zone_country_id . "
-                            ORDER BY zone_id";
-                    $check = $db->Execute($sql);
-
-                    if ($coupon_result->fields['coupon_zone_restriction'] > 0) {
-                        while (!$check->EOF) {
-                            if ($check->fields['zone_id'] < 1) {
-                                $check_flag = true;
-                                break;
-                            } elseif ($check->fields['zone_id'] == $check_zone_id) {
-                                $check_flag = true;
-                                break;
-                            }
-                            $check->MoveNext();
-                        }
-                        $foundvalid = $check_flag;
-                    }
-                    // remove if fails address validation
-                    if (!$foundvalid) {
-                        $messageStack->add_session('redemptions', sprintf(TEXT_REMOVE_REDEEM_COUPON_ZONE, ($dc_link_count === 0 ? $dc_link : $dc_check)), 'caution');
-                        $dc_link_count++;
-                    }
-                    // display all error messages
-                    if ($error_issues > 0 || !$foundvalid) {
-                        $this->clear_posts();
-                        zen_redirect(zen_href_link(FILENAME_CHECKOUT_PAYMENT, '', 'SSL', true, false));
-                    }
-
-                    if ($foundvalid) {
-                        //      if ($_POST['submit_redeem_coupon_x'] && !$_POST['gv_redeem_code']) zen_redirect(zen_href_link(FILENAME_CHECKOUT_PAYMENT, 'credit_class_error_code=' . $this->code . '&credit_class_error=' . urlencode(TEST_NO_REDEEM_CODE), 'SSL', true, false));
-                        $messageStack->add('checkout', TEXT_VALID_COUPON, 'success');
-                    }
-                }
-            } else {
-                $messageStack->add_session('redemptions', sprintf(TEXT_INVALID_REDEEM_COUPON, $dc_check), 'caution');
-                $this->clear_posts();
-                zen_redirect(zen_href_link(FILENAME_CHECKOUT_PAYMENT, '', 'SSL', true, false));
-            }
-
+        // if not redirected yet, it must be valid, so now we assign it to the session
+        if (!empty($coupon_id)) {
+            $_SESSION['cc_id'] = $coupon_id;
+            $messageStack->add('checkout', TEXT_VALID_COUPON, 'success');
         }
     }
 
     /**
+     * Return validation errors array.
+     * Used by external calls to validation when wanting to do something other than stuffing the errors onto the messageStack
+     *
+     * @return array
+     */
+    function getValidationErrors()
+    {
+        return $this->validation_errors;
+    }
+
+    /**
+     * Set validation errors into messageStack
+     *
+     * @param int $limit max number of errors to push onto the messageStack. (Sometimes only want one instead of everything.)
+     * @param string $stack messageStack location/array to populate with error messages
+     * @param string $alertLevel what kind of alert should be generated. Default is 'caution'
+     */
+    function setMessageStackValidationAlerts($limit = 0, $stack = 'redemptions', $alertLevel = 'caution')
+    {
+        global $messageStack;
+        $i = 0;
+
+        foreach ($this->validation_errors as $errorMessage) {
+            $messageStack->add_session($stack, $errorMessage, $alertLevel);
+            $i++;
+            if (!empty($limit) && $i > $limit) {
+                break;
+            }
+        }
+    }
+
+    /**
+     * Validate supplied $coupon_code for validity in database and against
+     * any configured restrictions on products, customers, number of uses, dates, address zones, etc.
+     *
+     * @param string $coupon_code
+     * @return int|null|void
+     */
+    function performValidations($coupon_code)
+    {
+        global $currencies, $zco_notifier;
+        $this->validation_errors = [];
+
+        $coupon_details = $this->getCouponDetailsFromDb($coupon_code);
+
+        if (empty($coupon_details) || $coupon_details['coupon_active'] !== 'Y') {
+            $this->validation_errors[] = sprintf(TEXT_INVALID_REDEEM_COUPON, $coupon_code);
+            return;
+        }
+
+        $zco_notifier->notify('NOTIFY_OT_COUPON_COUPON_INFO', ['coupon_result' => $coupon_details, 'code' => $coupon_code]);
+
+        // get popup link to insert into validation error messages
+        $dc_link = $this->generateCouponPopupLink($coupon_details['coupon_id'], $coupon_code);
+
+
+        if (!empty($_SESSION['cart']->contents)) {
+            $validMinimumPurchaseAmount = $this->validateCouponMinimumPurchaseAmount($coupon_details);
+            if (!$validMinimumPurchaseAmount) {
+                $this->validation_errors[] = sprintf(TEXT_INVALID_REDEEM_COUPON_MINIMUM, (empty($this->validation_errors) ? $dc_link : $coupon_code), $currencies->format($coupon_details['coupon_minimum_order']));
+                // return;
+            }
+
+            $validForProductsInCart = $this->validateCouponProductRestrictions($coupon_details['coupon_id']);
+            if (!$validForProductsInCart) {
+                $this->clear_posts();
+                $this->validation_errors[] = sprintf(TEXT_INVALID_COUPON_PRODUCT, (empty($this->validation_errors) ? $dc_link : $coupon_code));
+                // return;
+            }
+
+            $validMaxOrdersLimit = $this->validateCouponMaxOrdersLimit($coupon_details);
+            if (!$validMaxOrdersLimit) {
+                $this->validation_errors[] = sprintf(TEXT_INVALID_COUPON_ORDER_LIMIT, (empty($this->validation_errors) ? $dc_link : $coupon_code), $coupon_details['coupon_order_limit']);
+            }
+        }
+
+        $validStartDate = $this->validateCouponStartDate($coupon_details);
+        if (!$validStartDate) {
+            $this->validation_errors[] = sprintf(TEXT_INVALID_STARTDATE_COUPON, (empty($this->validation_errors) ? $dc_link : $coupon_code), zen_date_short($coupon_details['coupon_start_date']));
+            // return;
+        }
+
+        $validEndDate = $this->validateCouponEndDate($coupon_details);
+        if (!$validEndDate) {
+            $this->validation_errors[] = sprintf(TEXT_INVALID_FINISHDATE_COUPON, (empty($this->validation_errors) ? $dc_link : $coupon_code), zen_date_short($coupon_details['coupon_expire_date']));
+            // return;
+        }
+
+
+        $validNotExceededNumberOfUses = $this->validateCouponMaximumUses($coupon_details);
+        if (!$validNotExceededNumberOfUses) {
+            $this->validation_errors[] = sprintf(TEXT_INVALID_USES_COUPON, (empty($this->validation_errors) ? $dc_link : $coupon_code), $coupon_details['uses_per_coupon']);
+            // return;
+        }
+
+        $validNotExceededNumberOfUsesByCustomer = $this->validateCouponUsesPerCustomer($coupon_details);
+//        $coupon_uses_per_customer_exceeded_guest_checkout = $this->validateCouponUsesPerGuestCheckoutCustomer($coupon_details);
+        if (!$validNotExceededNumberOfUsesByCustomer) {
+            $this->validation_errors[] = sprintf(TEXT_INVALID_USES_USER_COUPON, (empty($this->validation_errors) ? $dc_link : $coupon_code), $coupon_details['uses_per_user']);
+            // return;
+        }
+
+        global $order;
+        if ($order !== null) {
+            $validForAddress = $this->validateCouponForAddress($coupon_details);
+            if (!$validForAddress) {
+                $this->validation_errors[] = sprintf(TEXT_REMOVE_REDEEM_COUPON_ZONE, (empty($this->validation_errors) ? $dc_link : $coupon_code));
+            }
+        }
+
+        return $coupon_details['coupon_id'];
+    }
+
+    /**
+     * This function is not used by this module
+     *
+     * @return bool
+     */
+    function use_credit_amount()
+    {
+        return false;
+    }
+
+    /**
+     * This function is not used by this module
+     *
+     * @param $i
      * @return bool
      */
     function update_credit_account($i)
@@ -437,14 +379,13 @@ class ot_coupon
     }
 
     /**
-     * Enter description here...
-     *
+     * Track coupon redemption
      */
     function apply_credit()
     {
         global $db, $insert_id;
-        $cc_id = empty($_SESSION['cc_id']) ? 0 : $_SESSION['cc_id'];
-        if ($this->deduction != 0) {
+        $cc_id = empty($_SESSION['cc_id']) ? 0 : (int)$_SESSION['cc_id'];
+        if (!empty($this->deduction)) {
             $db->Execute("INSERT INTO " . TABLE_COUPON_REDEEM_TRACK . "
                     (coupon_id, redeem_date, redeem_ip, customer_id, order_id)
                     VALUES ('" . (int)$cc_id . "', now(), '" . $_SERVER['REMOTE_ADDR'] . "', '" . (int)$_SESSION['customer_id'] . "', '" . (int)$insert_id . "')");
@@ -453,133 +394,160 @@ class ot_coupon
     }
 
     /**
+     * Calculate actual deductions according to configured coupon rules
+     *
+     * Also sets $this->coupon_code
+     *
      * @return array $od_amount
      */
     function calculate_deductions()
     {
-        global $db, $order, $messageStack, $currencies, $zco_notifier;
-        $currencyDecimalPlaces = $currencies->get_decimal_places($_SESSION['currency']);
+        global $db, $currencies, $zco_notifier;
+
         $od_amount = ['tax' => 0, 'total' => 0];
-        if (!empty($_SESSION['cc_id'])) {
-            $coupon = $db->Execute("SELECT * FROM " . TABLE_COUPONS . " WHERE coupon_id = " . (int)$_SESSION['cc_id']);
-            $this->coupon_code = $coupon->fields['coupon_code'];
-            $orderTotalDetails = $this->get_order_total($_SESSION['cc_id']);
-// left for total order amount ($orderTotalDetails['totalFull']) vs qualified order amount ($order_total['orderTotal']) just switch the commented lines 2 of 3
-            if ($coupon->fields['coupon_calc_base'] == 0) {
-                $coupon_total_minimum = $orderTotalDetails['orderTotal']; // restricted products
-                $coupon_total = $orderTotalDetails['orderTotal']; // restricted products
-            }
-            if ($coupon->fields['coupon_calc_base'] == 1) {
-                $coupon_total_minimum = $orderTotalDetails['orderTotal']; // restricted products
-                $coupon_total = $orderTotalDetails['totalFull']; // all products
-            }
-//echo 'ot_coupon coupon_total: ' . $coupon->fields['coupon_calc_base'] . '<br>$orderTotalDetails[orderTotal]: ' . $orderTotalDetails['orderTotal'] . '<br>$orderTotalDetails[totalFull]: ' . $orderTotalDetails['totalFull'] . '<br>$coupon_total: ' . $coupon_total . '<br><br>$coupon->fields[coupon_minimum_order]: ' . $coupon->fields['coupon_minimum_order'] . '<br>$coupon_total_minimum: ' . $coupon_total_minimum . '<br>';
-// @@TODO - adjust all Totals to use $coupon_total but strong review for what total applies where for Percentage, Amount, etc.
-            if ($coupon->RecordCount() > 0 && $orderTotalDetails['orderTotal'] != 0) {
+        if (empty($_SESSION['cc_id'])) {
+            return $od_amount;
+        }
 
-                if ((string)$coupon_total_minimum >= $coupon->fields['coupon_minimum_order']) {
-                    $coupon_product_count = 1;
-                    if ($coupon->fields['coupon_product_count'] && in_array($coupon->fields['coupon_type'], ['F', 'O'])) {
-                        $products = $_SESSION['cart']->get_products();
-                        $coupon_product_count = 0;
-                        for ($i = 0, $n = count($products); $i < $n; $i++) {
-                            if (is_product_valid($products[$i]['id'], $coupon->fields['coupon_id'])) {
-                                $coupon_product_count += $_SESSION['cart']->get_quantity($products[$i]['id']);
-                            }
+        $currencyDecimalPlaces = $currencies !== null ? $currencies->get_decimal_places($_SESSION['currency']) : 2;
+
+        $result = $db->Execute("SELECT * FROM " . TABLE_COUPONS . " WHERE coupon_id = " . (int)$_SESSION['cc_id']);
+
+        if ($result->RecordCount() < 1 || empty($result->fields['coupon_code'])) {
+            return $od_amount;
+        }
+        $coupon_details = $result->fields;
+
+        $this->coupon_code = $coupon_details['coupon_code'];
+
+        $orderTotalDetails = $this->get_order_total($coupon_details['coupon_id']);
+
+        $orderAmountToCompareAgainstCouponMinimum = (string)$orderTotalDetails['orderTotal'];
+
+        $orderAmountTotal = (string)$orderTotalDetails['orderTotal'];  // coupon is applied against value of only qualifying/restricted products in cart
+        if ($coupon_details['coupon_calc_base'] == 1) {
+            $orderAmountTotal = (string)$orderTotalDetails['totalFull']; // coupon is applied against value of all products in cart
+        }
+
+//echo 'ot_coupon coupon_total: ' . $coupon_details['coupon_calc_base'] . '<br>$orderTotalDetails[orderTotal]: ' . $orderTotalDetails['orderTotal'] . '<br>$orderTotalDetails[totalFull]: ' . $orderTotalDetails['totalFull'] . '<br>$orderAmountTotal: ' . $orderAmountTotal . '<br><br>$coupon_details[coupon_minimum_order]: ' . $coupon_details['coupon_minimum_order'] . '<br>$orderAmountToCompareAgainstCouponMinimum: ' . $orderAmountToCompareAgainstCouponMinimum . '<br>';
+
+        // @TODO - adjust all Totals to use $orderAmountTotal but strong review for what total applies where for Percentage, Amount, etc.
+
+        if ($orderTotalDetails['orderTotal'] > 0) {
+
+            if ((string)$orderAmountToCompareAgainstCouponMinimum >= $coupon_details['coupon_minimum_order']) {
+
+                // Default to 1 here if fixed-rate discounts are applied "per order" (not per each product)
+                $coupon_product_count = 1;
+                // If coupon is set to calculate amounts based on per-each-product, count the number of products (multiplied by qty) in the cart
+                if ($coupon_details['coupon_product_count'] > 0 && in_array($coupon_details['coupon_type'], ['F', 'O'])) {
+                    $products = $_SESSION['cart']->get_products();
+                    $coupon_product_count = 0;
+                    foreach ($products as $product) {
+                        if (is_product_valid($product['id'], $coupon_details['coupon_id'])) {
+                            $coupon_product_count += $_SESSION['cart']->get_quantity($product['id']);
                         }
-                        //  $messageStack->add_session('checkout_payment', 'Coupon cont: ' . $coupon_product_count, 'caution');
                     }
-                    $coupon_is_free_shipping = false;
-                    switch ($coupon->fields['coupon_type']) {
-                        case 'S': // Free Shipping
-                            $od_amount['total'] = $orderTotalDetails['shipping'];
-                            $od_amount['type'] = 'S';
-                            $od_amount['tax'] = ($this->calculate_tax == 'Standard') ? $orderTotalDetails['shippingTax'] : 0;
-                            if (isset($_SESSION['shipping_tax_description']) && $_SESSION['shipping_tax_description'] != '') {
-                                $od_amount['tax_groups'][$_SESSION['shipping_tax_description']] = $od_amount['tax'];
-                            }
-                            return $od_amount;
-                            break;
-                        case 'P': // percentage
-//              $od_amount['total'] = zen_round($orderTotalDetails['orderTotal']*($coupon->fields['coupon_amount']/100), $currencyDecimalPlaces);
-                            $od_amount['total'] = zen_round($coupon_total * ($coupon->fields['coupon_amount'] / 100), $currencyDecimalPlaces);
-                            $od_amount['type'] = $coupon->fields['coupon_type'];
-//              $ratio = $od_amount['total']/$orderTotalDetails['orderTotal'];
-                            $ratio = $od_amount['total'] / $coupon_total;
-                            break;
-                        case 'E': // percentage & Free Shipping
-//              $od_amount['total'] = zen_round($orderTotalDetails['orderTotal']*($coupon->fields['coupon_amount']/100), $currencyDecimalPlaces);
-                            $od_amount['total'] = zen_round($coupon_total * ($coupon->fields['coupon_amount'] / 100), $currencyDecimalPlaces);
-                            $od_amount['type'] = $coupon->fields['coupon_type'];
-                            // add in Free Shipping
-                            $coupon_is_free_shipping = true;
-                            $od_amount['tax'] = ($this->calculate_tax == 'Standard') ? $orderTotalDetails['shippingTax'] : 0;
-                            $ratio = $od_amount['total'] / $coupon_total;
-                            if (isset($_SESSION['shipping_tax_description']) && $_SESSION['shipping_tax_description'] != '') {
-                                $od_amount['tax_groups'][$_SESSION['shipping_tax_description']] = $od_amount['tax'];
-                            }
-                            break;
-                        case 'F': // amount Off
-//              $od_amount['total'] = zen_round($coupon->fields['coupon_amount'] * ($orderTotalDetails['orderTotal']>0), $currencyDecimalPlaces);
-                            $od_amount['total'] = zen_round(($coupon->fields['coupon_amount'] > $orderTotalDetails['orderTotal'] ? $orderTotalDetails['orderTotal'] : $coupon->fields['coupon_amount']) * ($orderTotalDetails['orderTotal'] > 0) * $coupon_product_count, $currencyDecimalPlaces);
-                            $od_amount['type'] = $coupon->fields['coupon_type']; // amount off 'F' or amount off and free shipping 'O'
-//              $ratio = $od_amount['total']/$orderTotalDetails['orderTotal'];
-                            $ratio = $od_amount['total'] / $coupon_total;
-                            break;
-                        case 'O': // amount off & Free Shipping
-//              $od_amount['total'] = zen_round($coupon->fields['coupon_amount'] * ($orderTotalDetails['orderTotal']>0), $currencyDecimalPlaces);
-                            $od_amount['total'] = zen_round(($coupon->fields['coupon_amount'] > $orderTotalDetails['orderTotal'] ? $orderTotalDetails['orderTotal'] : $coupon->fields['coupon_amount']) * ($orderTotalDetails['orderTotal'] > 0) * $coupon_product_count, $currencyDecimalPlaces);
-                            //$od_amount['total'] = zen_round($coupon->fields['coupon_amount'] * ($coupon_total>0), $currencyDecimalPlaces);
-                            $od_amount['type'] = $coupon->fields['coupon_type']; // amount off 'F' or amount off and free shipping 'O'
-                            // add in Free Shipping
-                            $coupon_is_free_shipping = true;
-                            $od_amount['tax'] = ($this->calculate_tax == 'Standard') ? $orderTotalDetails['shippingTax'] : 0;
-                            $ratio = $od_amount['total'] / $coupon_total;
-                            if (isset($_SESSION['shipping_tax_description']) && $_SESSION['shipping_tax_description'] != '') {
-                                $od_amount['tax_groups'][$_SESSION['shipping_tax_description']] = $od_amount['tax'];
-                            }
+                    //  $messageStack->add_session('checkout_payment', 'Coupon products-count: ' . $coupon_product_count, 'caution');
+                }
 
-                            break;
-                        case 'G': // GV coupon
-                        default:
-                    }
-//@@TODO - Standard and Credit_Note
-                    switch ($this->calculate_tax) {
-                        case 'None':
-                            break;
-                        case 'Standard':
-                            if ($od_amount['total'] >= $orderTotalDetails['orderTotal']) $ratio = 1;
-                            foreach ($orderTotalDetails['orderTaxGroups'] as $key => $value) {
-                                $this_tax = $orderTotalDetails['orderTaxGroups'][$key];
-                                if ($this->include_shipping != 'true') {
-                                    if (isset($_SESSION['shipping_tax_description']) && $_SESSION['shipping_tax_description'] == $key) {
-                                        $this_tax -= $orderTotalDetails['shippingTax'];
-                                    }
+                // Determine return values for discount amounts based on coupon type
+                $coupon_includes_free_shipping = false;
+                $od_amount['type'] = $coupon_details['coupon_type'];
+
+                switch ($coupon_details['coupon_type']) {
+                    case 'S': // Free Shipping
+                        $od_amount['total'] = $orderTotalDetails['shipping'];
+                        $od_amount['tax'] = ($this->calculate_tax == 'Standard') ? $orderTotalDetails['shippingTax'] : 0;
+                        if (isset($_SESSION['shipping_tax_description']) && $_SESSION['shipping_tax_description'] != '') {
+                            $od_amount['tax_groups'][$_SESSION['shipping_tax_description']] = $od_amount['tax'];
+                        }
+                        // early-return skips further processing for type 'S'
+                        return $od_amount;
+                        break;
+                    case 'P': // percentage
+//                        $od_amount['total'] = zen_round($orderTotalDetails['orderTotal']*($coupon_details['coupon_amount']/100), $currencyDecimalPlaces);
+                        $od_amount['total'] = zen_round($orderAmountTotal * ($coupon_details['coupon_amount'] / 100), $currencyDecimalPlaces);
+//                        $ratio = $od_amount['total']/$orderTotalDetails['orderTotal'];
+                        $ratio = $od_amount['total'] / $orderAmountTotal;
+                        break;
+                    case 'E': // percentage & Free Shipping
+//                        $od_amount['total'] = zen_round($orderTotalDetails['orderTotal']*($coupon_details['coupon_amount']/100), $currencyDecimalPlaces);
+                        $od_amount['total'] = zen_round($orderAmountTotal * ($coupon_details['coupon_amount'] / 100), $currencyDecimalPlaces);
+                        // add in Free Shipping
+                        $coupon_includes_free_shipping = true;
+                        $od_amount['tax'] = ($this->calculate_tax == 'Standard') ? $orderTotalDetails['shippingTax'] : 0;
+                        $ratio = $od_amount['total'] / $orderAmountTotal;
+                        if (isset($_SESSION['shipping_tax_description']) && $_SESSION['shipping_tax_description'] != '') {
+                            $od_amount['tax_groups'][$_SESSION['shipping_tax_description']] = $od_amount['tax'];
+                        }
+                        break;
+                    case 'F': // Fixed amount Off
+//                        $od_amount['total'] = zen_round($coupon_details['coupon_amount'] * ($orderTotalDetails['orderTotal']>0), $currencyDecimalPlaces);
+                        $od_amount['total'] = zen_round(($coupon_details['coupon_amount'] > $orderTotalDetails['orderTotal'] ? $orderTotalDetails['orderTotal'] : $coupon_details['coupon_amount']) * ($orderTotalDetails['orderTotal'] > 0) * $coupon_product_count, $currencyDecimalPlaces);
+//                        $ratio = $od_amount['total']/$orderTotalDetails['orderTotal'];
+                        $ratio = $od_amount['total'] / $orderAmountTotal;
+                        break;
+                    case 'O': // Both Fixed amount off & Free Shipping
+//                        $od_amount['total'] = zen_round($coupon_details['coupon_amount'] * ($orderTotalDetails['orderTotal']>0), $currencyDecimalPlaces);
+                        $od_amount['total'] = zen_round(($coupon_details['coupon_amount'] > $orderTotalDetails['orderTotal'] ? $orderTotalDetails['orderTotal'] : $coupon_details['coupon_amount']) * ($orderTotalDetails['orderTotal'] > 0) * $coupon_product_count, $currencyDecimalPlaces);
+                        //$od_amount['total'] = zen_round($coupon_details['coupon_amount'] * ($orderAmountTotal>0), $currencyDecimalPlaces);
+                        // add in Free Shipping
+                        $coupon_includes_free_shipping = true;
+                        $od_amount['tax'] = ($this->calculate_tax == 'Standard') ? $orderTotalDetails['shippingTax'] : 0;
+                        $ratio = $od_amount['total'] / $orderAmountTotal;
+                        if (isset($_SESSION['shipping_tax_description']) && $_SESSION['shipping_tax_description'] != '') {
+                            $od_amount['tax_groups'][$_SESSION['shipping_tax_description']] = $od_amount['tax'];
+                        }
+                        break;
+                    case 'G': // GV / Gift Certificate
+                    default:
+                        // n/a
+                }
+
+                // adjust for tax
+                switch ($this->calculate_tax) {
+                    case 'Standard':
+                        if ($od_amount['total'] >= $orderTotalDetails['orderTotal']) $ratio = 1;
+                        foreach ($orderTotalDetails['orderTaxGroups'] as $key => $value) {
+                            $this_tax = $orderTotalDetails['orderTaxGroups'][$key];
+                            if ($this->include_shipping != 'true') {
+                                if (isset($_SESSION['shipping_tax_description']) && $_SESSION['shipping_tax_description'] == $key) {
+                                    $this_tax -= $orderTotalDetails['shippingTax'];
                                 }
-                                $od_amount['tax_groups'][$key] = zen_round($this_tax * $ratio, $currencyDecimalPlaces);
-                                $od_amount['tax'] += $od_amount['tax_groups'][$key];
                             }
-                            if (DISPLAY_PRICE_WITH_TAX == 'true' && $coupon->fields['coupon_type'] == 'F') $od_amount['total'] = $od_amount['total'] + $od_amount['tax'];
-                            break;
-                        case 'Credit Note':
-                            $tax_rate = zen_get_tax_rate($this->tax_class);
-                            $od_amount['tax'] = zen_calculate_tax($od_amount['total'], $tax_rate);
-                            $tax_description = zen_get_tax_description($this->tax_class);
-                            $od_amount['tax_groups'][$tax_description] = $od_amount['tax'];
-                    }
-                    if ($coupon_is_free_shipping) {
-                        $od_amount['total'] += $orderTotalDetails['shipping'];
-                    }
+                            $od_amount['tax_groups'][$key] = zen_round($this_tax * $ratio, $currencyDecimalPlaces);
+                            $od_amount['tax'] += $od_amount['tax_groups'][$key];
+                        }
+                        if (DISPLAY_PRICE_WITH_TAX == 'true' && $coupon_details['coupon_type'] == 'F') {
+                            $od_amount['total'] += $od_amount['tax'];
+                        }
+                        break;
+                    case 'Credit Note':
+                        $tax_rate = zen_get_tax_rate($this->tax_class);
+                        $od_amount['tax'] = zen_calculate_tax($od_amount['total'], $tax_rate);
+                        $tax_description = zen_get_tax_description($this->tax_class);
+                        $od_amount['tax_groups'][$tax_description] = $od_amount['tax'];
+                        break;
+                    case 'None':
+                    default:
+                        break;
+                }
+
+                // adjust for free-shipping
+                if ($coupon_includes_free_shipping) {
+                    $od_amount['total'] += $orderTotalDetails['shipping'];
                 }
             }
-
-            // -----
-            // Let an observer know that the coupon-related calculations have finished, providing read-only
-            // copies of (a) the base coupon information, (b) the results from 'get_order_total' and this
-            // method's return values.
-            //
-            $zco_notifier->notify('NOTIFY_OT_COUPON_CALCS_FINISHED', ['coupon' => $coupon, 'order_totals' => $orderTotalDetails, 'od_amount' => $od_amount,]);
         }
+
+        // -----
+        // Let an observer know that the coupon-related calculations have finished, providing read-only
+        // copies of (a) the base coupon information, (b) the results from 'get_order_total' and this
+        // method's return values.
+        //
+        $zco_notifier->notify('NOTIFY_OT_COUPON_CALCS_FINISHED', ['coupon' => $coupon_details, 'order_totals' => $orderTotalDetails, 'od_amount' => $od_amount], $coupon_details);
+
 //    print_r($order->info);
 //    print_r($orderTotalDetails);echo "<br><br>";
 //    echo 'RATIo = '. $ratio;
@@ -587,32 +555,47 @@ class ot_coupon
         return $od_amount;
     }
 
-    function get_order_total($couponCode)
+    /**
+     * Calculate eligible total amounts against which discounts will be applied
+     *
+     * @param int $coupon_id
+     * @return array
+     */
+    function get_order_total($coupon_id)
     {
         global $order, $zco_notifier;
         $orderTaxGroups = $order->info['tax_groups'];
         $orderTotalTax = $order->info['tax'];
         $orderTotal = $order->info['total'];
+
+        // for products which are not applicable for this coupon, calculate their value in the cart and reduce it from the final order-total that the coupon's discounts will apply to
         $products = $_SESSION['cart']->get_products();
-        for ($i = 0, $n = count($products); $i < $n; $i++) {
-            $is_product_valid = (is_product_valid($products[$i]['id'], $couponCode) && is_coupon_valid_for_sales($products[$i]['id'], $couponCode));
+        $i = 0;
+        foreach ($products as $product) {
+            $i++;
+            $is_product_valid = (is_product_valid($product['id'], $coupon_id) && is_coupon_valid_for_sales($product['id'], $coupon_id));
 
             $zco_notifier->notify('NOTIFY_OT_COUPON_PRODUCT_VALIDITY', ['is_product_valid' => $is_product_valid, 'i' => $i]);
 
+            // @TODO - defer this to the shopping_cart class so product price calculations are handled in one central place
             if (!$is_product_valid) {
-                $products_tax = zen_get_tax_rate($products[$i]['tax_class_id']);
-                $productsTaxAmount = (zen_calculate_tax($products[$i]['final_price'], $products_tax)) * $products[$i]['quantity'];
-                $orderTotal -= $products[$i]['final_price'] * $products[$i]['quantity'];
+                $products_tax = zen_get_tax_rate($product['tax_class_id']);
+                $productsTaxAmount = (zen_calculate_tax($product['final_price'], $products_tax)) * $product['quantity'];
+
+                $orderTotal -= $product['final_price'] * $product['quantity'];
+
                 if ($this->include_tax == 'true') {
                     $orderTotal -= $productsTaxAmount;
                 }
                 if (DISPLAY_PRICE_WITH_TAX == 'true') {
                     $orderTotal -= $productsTaxAmount;
                 }
-                $orderTaxGroups[zen_get_tax_description($products[$i]['tax_class_id'])] -= $productsTaxAmount;
-                $orderTotalTax -= (zen_calculate_tax($products[$i]['final_price'], zen_get_tax_rate($products[$i]['tax_class_id']))) * $products[$i]['quantity'];
+                $orderTotalTax -= $productsTaxAmount;
+                $orderTaxGroups[zen_get_tax_description($product['tax_class_id'])] -= $productsTaxAmount;
             }
         }
+
+        // shipping/tax
         if ($this->include_shipping != 'true') {
             $orderTotal -= $order->info['shipping_cost'];
             if (isset($_SESSION['shipping_tax_description']) && $_SESSION['shipping_tax_description'] != '') {
@@ -680,5 +663,352 @@ class ot_coupon
         $keys = implode("','", $this->keys);
 
         $db->Execute("DELETE FROM " . TABLE_CONFIGURATION . " where configuration_key IN ('" . $keys . "')");
+    }
+
+    /**
+     * Remove discount coupon by request
+     *
+     * Redirects back to checkout_payment on success
+     *
+     * @param string $coupon_code
+     */
+    public function remove_coupon_if_requested($coupon_code = '')
+    {
+        global $messageStack;
+
+        if (empty($coupon_code)) {
+            $coupon_code = isset($_POST['dc_redeem_code']) ? trim($_POST['dc_redeem_code']) : '';
+        }
+
+        if (empty($coupon_code)) {
+            return;
+        }
+
+        if (!defined('TEXT_COMMAND_TO_DELETE_CURRENT_COUPON_FROM_ORDER')) define('TEXT_COMMAND_TO_DELETE_CURRENT_COUPON_FROM_ORDER', 'REMOVE');
+
+        if (strtoupper($coupon_code) == TEXT_COMMAND_TO_DELETE_CURRENT_COUPON_FROM_ORDER) {
+
+            $this->remove_coupon_from_current_session();
+
+            $messageStack->add_session('checkout_payment', TEXT_REMOVE_REDEEM_COUPON, 'caution');
+        }
+    }
+
+    /**
+     * Remove coupon from session/order and trigger notifier
+     */
+    public function remove_coupon_from_current_session()
+    {
+        global $zco_notifier;
+
+        $this->clear_posts();
+
+        $zco_notifier->notify('NOTIFY_OT_COUPON_COUPON_REMOVED');
+    }
+
+    /**
+     * @param string $coupon_code
+     * @return array
+     */
+    protected function getCouponDetailsFromDb($coupon_code = '')
+    {
+        global $db;
+
+        $sql = "SELECT *
+                FROM " . TABLE_COUPONS . "
+                WHERE coupon_code= :couponCodeEntered
+                AND coupon_type != 'G'";
+
+        $sql = $db->bindVars($sql, ':couponCodeEntered', $coupon_code, 'string');
+
+        $result = $db->Execute($sql, 1);
+
+        return $result->RecordCount() ? $result->fields : null;
+    }
+
+    /**
+     * look through the items in the cart to see if this coupon is valid for any item in the cart
+     *
+     * @param int $coupon_id coupon_id from coupons table
+     * @return bool
+     */
+    protected function validateCouponProductRestrictions($coupon_id)
+    {
+        $products = $_SESSION['cart']->get_products();
+
+        global $zco_notifier;
+        $found_valid = null;
+        $zco_notifier->notify('NOTIFY_COUPON_VALIDATION_PRODUCT_RESTRICTIONS', $coupon_id, $products, $found_valid);
+        if ($found_valid !== null) {
+            return $found_valid;
+        }
+
+        $found_valid = true;
+
+        if ($found_valid) {
+            $found_valid = false;
+            foreach ($products as $product) {
+                if (is_product_valid($product['id'], $coupon_id)) {
+                    $found_valid = true;
+                    continue;
+                }
+            }
+        }
+        if ($found_valid) {
+            // check if products on special or sale are valid
+            $found_valid = false;
+            foreach ($products as $product) {
+                if (is_coupon_valid_for_sales($product['id'], $coupon_id)) {
+                    $found_valid = true;
+                    continue;
+                }
+            }
+        }
+
+        return $found_valid;
+    }
+
+    /**
+     * Check whether the customer has placed more orders than the coupon's allowed limit.
+     * This is mainly to encourage shopping by "new" customers.
+     *
+     * @param array $coupon_details
+     * @return bool
+     */
+    protected function validateCouponMaxOrdersLimit($coupon_details)
+    {
+        global $db;
+
+        // zero means no limit set on the coupon
+        if (empty($coupon_details['coupon_order_limit'])) {
+            return true;
+        }
+
+        // Find out how many orders the customer has placed
+        $sql = "SELECT orders_id FROM " . TABLE_ORDERS . " WHERE customers_id = " . (int)$_SESSION['customer_id'];
+        $result = $db->Execute($sql);
+
+        // must have less orders than the coupon's allowed limit
+        return !($result->RecordCount() > $coupon_details['coupon_order_limit']);
+    }
+
+    /**
+     * Check whether the coupon's start date is valid
+     *
+     * @TODO - what about zero-dates or null dates?
+     *
+     * @param array $coupon_details
+     * @return bool
+     */
+    protected function validateCouponStartDate($coupon_details)
+    {
+        if (date("Y-m-d H:i:s") < $coupon_details['coupon_start_date']) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Check whether the coupon's expiry date is valid
+     *
+     * @TODO - what about zero-dates or null dates?
+     *
+     * @param array $coupon_details
+     * @return bool
+     */
+    protected function validateCouponEndDate($coupon_details)
+    {
+        if (date("Y-m-d H:i:s") >= $coupon_details['coupon_expire_date']) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Check whether the coupon's minimum_order amount has been reached
+     *
+     * @param array $coupon_details
+     * @return bool
+     */
+    protected function validateCouponMinimumPurchaseAmount($coupon_details)
+    {
+        // 0 means unlimited
+        if (empty($coupon_details['coupon_minimum_order'])) {
+            return true;
+        }
+
+        $orderTotalDetails = $this->get_order_total($coupon_details['coupon_id']);
+
+        $orderAmountToCompareAgainstCouponMinimum = (string)$orderTotalDetails['orderTotal'];
+
+        $orderAmountTotal = (string)$orderTotalDetails['orderTotal'];  // coupon is applied against value of only qualifying/restricted products in cart
+        if ($coupon_details['coupon_calc_base'] == 1) {
+            $orderAmountTotal = (string)$orderTotalDetails['totalFull']; // coupon is applied against value of all products in cart
+        }
+
+//echo 'Product: ' . $orderTotalDetails['orderTotal'] . ' Order: ' . $orderTotalDetails['totalFull'] . ' $orderAmountTotal: ' . $orderAmountTotal . '<br>';
+
+// ALTERNATE POTENTIAL RULES
+// for total order amount vs qualified order amount just switch the commented lines
+//        if ((string)$orderTotalDetails['totalFull'] < $coupon_details['coupon_minimum_order'])
+//        if ((string)$orderTotalDetails['orderTotal'] < $coupon_details['coupon_minimum_order'])
+//        if ($orderAmountTotal > 0 && $orderAmountTotal < $coupon_details['coupon_minimum_order'])
+
+        if ($orderAmountTotal > 0 && $orderAmountToCompareAgainstCouponMinimum < $coupon_details['coupon_minimum_order']) {
+            // $order_total['orderTotal'] . ' vs ' . $order_total['totalFull']
+            return false;
+        }
+
+        return true;
+    }
+
+
+    /**
+     * Check whether this coupon has been used (by anybody) more than the maximum number of times allowed
+     *
+     * @param array $coupon_details
+     * @return bool
+     */
+    protected function validateCouponMaximumUses($coupon_details)
+    {
+        global $db;
+
+        // 0 means unlimited
+        if (empty($coupon_details['uses_per_coupon'])) {
+            return true;
+        }
+
+        $sql = "SELECT count(coupon_id) as total_uses_of_coupon
+                FROM " . TABLE_COUPON_REDEEM_TRACK . "
+                WHERE coupon_id = " . (int)$coupon_details['coupon_id'];
+
+        $result = $db->Execute($sql);
+
+        return ($result->RecordCount() < $coupon_details['uses_per_coupon']);
+    }
+
+    /**
+     * Check whether coupon has been used by this customer more times than the allowed per-customer limit
+     *
+     * @param array $coupon_details
+     * @param int|null $customer_id
+     * @return bool
+     */
+    protected function validateCouponUsesPerCustomer($coupon_details, $customer_id = null)
+    {
+        global $db, $zco_notifier;
+
+        // 0 means unlimited
+        if (empty($coupon_details['uses_per_user'])) {
+            return true;
+        }
+
+        if (empty($customer_id) && zen_is_logged_in()) {
+            $customer_id = (int)$_SESSION['customer_id'];
+        }
+
+        // NOTE: prior to v158 eligibility during guest checkout was checked via the NOTIFY_OT_COUPON_USES_PER_USER_CHECK Notifier
+        if (empty($customer_id) && zen_in_guest_checkout()) {
+            $customer_id = 0;
+
+            $guest_result = $this->validateCouponUsesPerGuestCheckoutCustomer($coupon_details);
+
+            if ($guest_result !== null) {
+                return $guest_result;
+            }
+        }
+
+        $sql = "SELECT coupon_id
+                FROM " . TABLE_COUPON_REDEEM_TRACK . "
+                WHERE coupon_id = " . (int)$coupon_details['coupon_id'] . "
+                AND customer_id = " . (int)$customer_id;
+
+        $result = $db->Execute($sql);
+
+        $valid = ($result->RecordCount() < $coupon_details['uses_per_user']);
+
+        // NOTE: Prior to v158 this Notifier hook was used to alter $valid status if in Guest Checkout in plugins such as OPC
+        $zco_notifier->notify('NOTIFY_OT_COUPON_USES_PER_USER_CHECK', $coupon_details, $valid);
+
+        return $valid;
+    }
+
+    /**
+     * @TODO
+     * Check whether coupon has been used by this Guest Checkout customer more times than the allowed per-customer limit
+     *
+     * @param array $coupon_details
+     * @return bool|null
+     */
+    protected function validateCouponUsesPerGuestCheckoutCustomer($coupon_details)
+    {
+        global $zco_notifier;
+
+        if (!zen_in_guest_checkout()) {
+            return null;
+        }
+
+        // NOTE: prior to v158 eligibility during guest checkout was checked via the NOTIFY_OT_COUPON_USES_PER_USER_CHECK Notifier in validateCouponUsesPerCustomer()
+
+        $valid = null;
+        $zco_notifier->notify('NOTIFY_OT_COUPON_USES_PER_CUSTOMER_GUEST_CHECKOUT_CHECK', $coupon_details, $valid);
+
+        return $valid;
+    }
+
+    /**
+     * Check whether the coupon is valid for the customer's address, based on coupon zone-restrictions
+     *
+     * @param array $coupon_details
+     * @return bool
+     */
+    protected function validateCouponForAddress($coupon_details)
+    {
+        global $db, $order;
+
+        // 0 means no restrictions set
+        if (empty($coupon_details['coupon_zone_restriction'])) {
+            return true;
+        }
+
+        // determine zone restrictions based on Delivery or Billing address
+        switch ($coupon_details['coupon_type']) {
+            case 'S': // shipping
+            case 'O': // amount off and free shipping
+            case 'E': // percentage and Free Shipping
+                // use delivery address
+                $check_zone_country_id = $order->delivery['country']['id'];
+                $check_zone_id = $order->delivery['zone_id'];
+                break;
+            case 'F': // amount
+            case 'P': // percentage
+            case 'G': // GV coupon
+            default:
+                // use billing address
+                $check_zone_country_id = $order->billing['country']['id'];
+                $check_zone_id = $order->billing['zone_id'];
+                break;
+        }
+
+        $sql = "SELECT zone_id, zone_country_id
+                FROM " . TABLE_ZONES_TO_GEO_ZONES . "
+                WHERE geo_zone_id = " . (int)$coupon_details['coupon_zone_restriction'] . "
+                AND zone_country_id = " . (int)$check_zone_country_id . "
+                ORDER BY zone_id";
+        $results = $db->Execute($sql);
+
+        foreach ($results as $result) {
+            if ($result['zone_id'] < 1) {
+                return true;
+            }
+
+            if ($result['zone_id'] == $check_zone_id) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/not_for_release/testFramework/unittests/testsDiscountCoupon/DiscountCouponsTest.php
+++ b/not_for_release/testFramework/unittests/testsDiscountCoupon/DiscountCouponsTest.php
@@ -82,6 +82,7 @@ class DiscountCouponsTest extends zcDiscountCouponTest
         );
         define('DISPLAY_PRICE_WITH_TAX', 'false');
         $this->instantiateQfr(array(
+            'coupon_id' => '1',
             'coupon_code' => 'test',
             'coupon_total' => 0,
             'coupon_minimum_order' => 0,
@@ -113,6 +114,7 @@ class DiscountCouponsTest extends zcDiscountCouponTest
         );
         define('DISPLAY_PRICE_WITH_TAX', 'false');
         $this->instantiateQfr(array(
+            'coupon_id' => '1',
             'coupon_code' => 'test',
             'coupon_total' => 0,
             'coupon_minimum_order' => 0,
@@ -144,6 +146,7 @@ class DiscountCouponsTest extends zcDiscountCouponTest
         );
         define('DISPLAY_PRICE_WITH_TAX', 'false');
         $this->instantiateQfr(array(
+            'coupon_id' => '1',
             'coupon_code' => 'test',
             'coupon_total' => 0,
             'coupon_minimum_order' => 0,
@@ -175,6 +178,7 @@ class DiscountCouponsTest extends zcDiscountCouponTest
         );
         define('DISPLAY_PRICE_WITH_TAX', 'false');
         $this->instantiateQfr(array(
+            'coupon_id' => '1',
             'coupon_code' => 'test',
             'coupon_total' => 0,
             'coupon_minimum_order' => 0,
@@ -206,6 +210,7 @@ class DiscountCouponsTest extends zcDiscountCouponTest
         );
         define('DISPLAY_PRICE_WITH_TAX', 'false');
         $this->instantiateQfr(array(
+            'coupon_id' => '1',
             'coupon_code' => 'test',
             'coupon_total' => 0,
             'coupon_minimum_order' => 0,
@@ -237,6 +242,7 @@ class DiscountCouponsTest extends zcDiscountCouponTest
         );
         define('DISPLAY_PRICE_WITH_TAX', 'false');
         $this->instantiateQfr(array(
+            'coupon_id' => '1',
             'coupon_code' => 'test',
             'coupon_total' => 0,
             'coupon_minimum_order' => 0,
@@ -268,6 +274,7 @@ class DiscountCouponsTest extends zcDiscountCouponTest
         );
         define('DISPLAY_PRICE_WITH_TAX', 'false');
         $this->instantiateQfr(array(
+            'coupon_id' => '1',
             'coupon_code' => 'test',
             'coupon_total' => 0,
             'coupon_minimum_order' => 0,
@@ -299,6 +306,7 @@ class DiscountCouponsTest extends zcDiscountCouponTest
         );
         define('DISPLAY_PRICE_WITH_TAX', 'false');
         $this->instantiateQfr(array(
+            'coupon_id' => '1',
             'coupon_code' => 'test',
             'coupon_total' => 0,
             'coupon_minimum_order' => 0,
@@ -330,6 +338,7 @@ class DiscountCouponsTest extends zcDiscountCouponTest
         );
         define('DISPLAY_PRICE_WITH_TAX', 'false');
         $this->instantiateQfr(array(
+            'coupon_id' => '1',
             'coupon_code' => 'test',
             'coupon_total' => 0,
             'coupon_minimum_order' => 0,
@@ -361,6 +370,7 @@ class DiscountCouponsTest extends zcDiscountCouponTest
         );
         define('DISPLAY_PRICE_WITH_TAX', 'false');
         $this->instantiateQfr(array(
+            'coupon_id' => '1',
             'coupon_code' => 'test',
             'coupon_total' => 0,
             'coupon_minimum_order' => 0,


### PR DESCRIPTION
This refactoring segments several big long blocks of code into smaller functions.

The end result is that it now allows for some external processes to use the module's coupon validation rules.

For example, it would be fairly easy to capture a `?coupon=FOO` from the URL and ask ot_coupon whether it is valid, and if it's valid then apply it to the Session (eg, cart) automatically.
Handy for emailings or in-site clickable links.

**Backward compatible with v1.5.7** save for a small change in the data passed to the `NOTIFY_OT_COUPON_CALCS_FINISHED` notifier that was added in 1.5.7.