### PR TITLE
Correct non-numeric value.

### DIFF
--- a/includes/functions/functions_prices.php
+++ b/includes/functions/functions_prices.php
@@ -607,12 +607,12 @@
 
     $discount_type_id = zen_get_products_sale_discount_type($product_id);
 
+    $special_price_discount = 0;
     if ($new_products_price != 0) {
       $special_price_discount = ($new_special_price != 0 ? ($new_special_price/$new_products_price) : 1);
-    } else {
-      $special_price_discount = '';
-    }
-    $sale_price_discount = '';
+    } 
+    
+    $sale_price_discount = 0;
     if ($new_products_price != 0) {
       $sale_price_discount = ($new_sale_price != 0 ? ($new_sale_price/$new_products_price) : 1);
     }


### PR DESCRIPTION
When using PHP 7.4+ and attempting to perform mathematical operations against an empty string (`''`), a warning message is generated about a non-numeric value being encountered as a result of the returned value from the price function `zen_get_discount_calc`.  Although the thread where this was recently reported identifies problems with the output from that function, there are mathematical operations performed within the function that could also cause similar messages because the empty quote may be multiplied by a number which is expected to also generate a warning.

This appears to resolve the issue identified at this specific post: https://www.zen-cart.com/showthread.php?227580-A-non-numeric-value-encountered-in-shopping_cart-php&p=1376008#post1376008