### PR TITLE
Refactor prod cat pulldowns into class file.

### DIFF
--- a/admin/includes/auto_loaders/config.product_category_pulldowns.php
+++ b/admin/includes/auto_loaders/config.product_category_pulldowns.php
@@ -1,0 +1,13 @@
+<?php
+
+$autoLoadConfig[210][] = array('autoType'=>'class',
+                               'loadFile'=> 'pulldown.php',
+                               'classPath'=>DIR_FS_CATALOG . DIR_WS_CLASSES);
+
+$autoLoadConfig[210][] = array('autoType'=>'class',
+                               'loadFile'=> 'productPulldown.php',
+                               'classPath'=>DIR_FS_CATALOG . DIR_WS_CLASSES);
+
+$autoLoadConfig[210][] = array('autoType'=>'class',
+                               'loadFile'=> 'categoryPulldown.php',
+                               'classPath'=>DIR_FS_CATALOG . DIR_WS_CLASSES);

--- a/includes/classes/categoryPulldown.php
+++ b/includes/classes/categoryPulldown.php
@@ -1,0 +1,81 @@
+<?php
+
+    class categoryPulldown extends pulldown
+    {
+
+        function __construct()
+        {
+            parent::__construct();
+
+            $this->show_parent = false;
+            $this->show_full_path = false;
+
+            $this->sort = " ORDER BY categories_name";
+
+            $this->keyword_search_fields = [
+                'cd.categories_name',
+                'c.parent_id',
+                'cd.categories_description',
+                'c.categories_id',
+            ];
+
+        }
+
+        public function showParent(bool $status)
+        {
+            $this->show_parent = $status;
+            return $this;
+        }
+
+        public function showFullPath(bool $status)
+        {
+            $this->show_full_path = $status;
+            return $this;
+        }
+
+        protected function setSQL()
+        {
+            $this->attributes_join = str_replace('p.products_id', 'ptoc.products_id', $this->attributes_join);
+            $this->sql = "SELECT DISTINCT c.categories_id, cd.categories_name
+            FROM " . TABLE_CATEGORIES . " c
+            LEFT JOIN " . TABLE_CATEGORIES_DESCRIPTION . " cd ON (c.categories_id = cd.categories_id AND cd.language_id = " . (int)$_SESSION['languages_id'] . ")
+            LEFT JOIN " . TABLE_PRODUCTS_TO_CATEGORIES . " ptoc on (c.categories_id = ptoc.categories_id) 
+            " . $this->attributes_join . "
+            WHERE TRUE ";
+        }
+
+        protected function processSQL()
+        {
+            $this->setSQL();
+            $this->runSQL();
+
+            foreach ($this->results as $result) {
+                if (in_array($result['categories_id'], $this->exclude)) {
+                    continue;
+                }
+                $this->values[] = [
+                    'id' => $result['categories_id'],
+                    'text' => $this->categoryText($result),
+                ];
+            }
+        }
+
+        private function categoryText($category)
+        {
+            if (!empty($this->attributes_join)) {
+                $text = $category['categories_name'];
+                if ($this->show_full_path) {
+                    $text = zen_output_generated_category_path($category['categories_id']);
+                }
+                return $text;
+            }
+            $parent = '';
+            if ($this->show_parent) {
+                $parent = zen_get_categories_parent_name($category['categories_id']);
+                if ($parent != '') {
+                    $parent = ' : in ' . $parent;
+                }
+            }
+            return $category['categories_name'] . $parent . ($this->show_id ? ' - ID# ' . $category['categories_id'] : '');
+        }
+    }

--- a/includes/classes/productPulldown.php
+++ b/includes/classes/productPulldown.php
@@ -1,0 +1,129 @@
+<?php
+
+    class productPulldown extends pulldown
+    {
+        private $keyed_allowed_sort_array = [
+            'products_name' => 'pd',
+            'products_model' => 'p',
+            'products_name' => 'p',
+            'products_id' => 'p',
+            'products_price' => 'p',
+            'products_sort_order' => 'p',
+        ];
+
+        function __construct()
+        {
+            parent::__construct();
+
+            $this->show_model = false;
+            $this->show_price = true;
+            $this->set_selected = 0;
+            $this->categories_join = '';
+
+            $this->sort = ' ORDER BY pd.products_name';
+
+            $this->keyword_search_fields = [
+                'pd.products_name',
+                'p.products_model',
+                'pd.products_description',
+                'p.products_id',
+            ];
+        }
+
+        public function setSort($fieldnameArray)
+        {
+            if (empty($fieldnameArray)) {
+                return $this;
+            }
+
+            $first = true;
+            $this->sort = '';
+            foreach ($fieldnameArray as $fieldname) {
+                if (array_key_exists($fieldname, $this->keyed_allowed_sort_array)) {
+                    $this->sort = ($first ? ' ORDER BY ' : ', ') . $this->keyed_allowed_sort_array[$fieldname] . '.' . $fieldname;
+                    $first = false;
+                }
+            }
+            return $this;
+        }
+
+        public function setCategory(int $category_id)
+        {
+            $this->categories_join = " LEFT JOIN " . TABLE_PRODUCTS_TO_CATEGORIES . " ptc ON (ptc.products_id = p.products_id)";
+            $this->condition .= " AND ptc.categories_id = " . (int)$category_id;
+            return $this;
+        }
+
+        public function showModel(bool $status)
+        {
+            $this->show_model = $status;
+            return $this;
+        }
+
+        public function showPrice(bool $status)
+        {
+            $this->show_price = $status;
+            return $this;
+        }
+
+        public function onlyActive(bool $status)
+        {
+        	$condition = " AND p.products_status = 1";
+        	$this->condition = str_replace($condition, '', $this->condition);
+        	if ($status) {
+		        $this->condition .= " AND p.products_status = 1";
+	        }
+            return $this;
+        }
+
+        protected function setSQL()
+        {
+            $this->sql = "SELECT DISTINCT pd.products_id, p.products_sort_order, p.products_price, p.products_model
+                FROM " . TABLE_PRODUCTS . " p"
+                . $this->categories_join . "
+                INNER JOIN " . TABLE_PRODUCTS_DESCRIPTION . " pd ON (p.products_id = pd.products_id) 
+				" . $this->attributes_join . "
+				WHERE pd.language_id = " . (int)$_SESSION['languages_id'];
+        }
+
+
+        protected function processSQL()
+        {
+            global $currencies;
+
+            $this->setSQL();
+            $this->runSQL();
+
+            $parm_2 = '';
+            $parm_3 = '';
+
+            if ($this->show_model) {
+                $parm_2 = '%2$s';
+            }
+
+            if ($this->show_price) {
+                $parm_3 = ' (%3$s)';
+            }
+
+            $this->output_string = '%1$s ' . $parm_2 . $parm_3; // format string with name first
+
+            if (strpos($this->sort, 'model') && (!empty($this->attributes_join))) { // show model first only when attributes exist
+                $this->output_string = (!empty($parm_2) ? $parm_2 . '-' : '') . ' %1$s' . $parm_3; // format string with model first
+            }
+
+
+            foreach ($this->results as $result) {
+                if (in_array($result['products_id'], $this->exclude)) {
+                    continue;
+                }
+                $display_price = $this->show_price ? zen_get_products_base_price($result['products_id']) : '';
+                $name = zen_get_products_name($result['products_id']);
+                $this->values[] = [
+                    'id' => $result['products_id'],
+                    'text' => sprintf($this->output_string, trim(zen_clean_html($name)),
+                            ($this->show_model ? ' [' . $result['products_model'] . '] ' : ''),
+                            $currencies->format($display_price)) . ($this->show_id ? ' - ID# ' . $result['products_id'] : ''),
+                ];
+            }
+        }
+    }

--- a/includes/classes/pulldown.php
+++ b/includes/classes/pulldown.php
@@ -1,0 +1,101 @@
+<?php
+
+    abstract class pulldown extends base
+    {
+        var $pulldown, $attributes_join, $show_id, $set_selected, $parameters, $condition, $exclude;
+
+
+        function __construct()
+        {
+            $this->exclude = [];
+
+            $this->show_id = false;
+
+            $this->set_selected = 0;
+            $this->values = [];
+
+            $this->keywords = '';
+
+            $this->attributes_join = '';
+
+            $this->condition = ' ';
+
+            // default styling
+            $this->parameters = '';
+            //$this->parameters = 'required size="15" class="form-control" id="products_id"';
+        }
+
+        public function setDefault(int $id)
+        {
+            $this->set_selected = $id;
+            return $this;
+        }
+
+        public function showID(bool $status)
+        {
+            $this->show_id = $status;
+            return $this;
+        }
+
+        public function setOptionFilter(int $filter_id)
+        {
+            $this->includeAttributes(true);
+            $this->condition .= " AND pa.options_id =" . (int)$filter_id;
+            return $this;
+        }
+
+        public function exclude(array $array)
+        {
+            $this->exclude = $array;
+            return $this;
+        }
+
+        public function includeAttributes(bool $status)
+        {
+        	$this->attributes_join = '';
+        	if ($status) {
+		        $this->attributes_join = " RIGHT JOIN " . TABLE_PRODUCTS_ATTRIBUTES . " pa on (p.products_id = pa.products_id)";
+	        }
+            return $this;
+        }
+
+        public function setSearchTerms(string $keywords)
+        {
+            $this->keywords = $keywords;
+            return $this;
+        }
+
+        abstract protected function processSQL();
+
+        abstract protected function setSQL();
+
+        protected function runSQL()
+        {
+            global $db;
+
+            $this->sql .= $this->condition;
+
+            if (empty($this->keywords)) {
+                $this->keywords = ($_REQUEST['keywords'] ?? '');
+            }
+
+            if (!empty($this->keywords)) {
+                $this->sql .= zen_build_keyword_where_clause($this->keyword_search_fields,
+                    zen_db_input(zen_db_prepare_input($this->keywords)));
+            }
+
+            $this->sql .= $this->sort;
+            $this->results = $db->Execute($this->sql);
+        }
+
+        public function generatePullDownHtml(string $name, $parameters = '', bool $required = false)
+        {
+            $this->processSQL();
+
+            if (empty($parameters)) {
+                $parameters = $this->parameters;
+            }
+
+            return zen_draw_pull_down_menu($name, $this->values, $this->set_selected, $parameters, $required);
+        }
+    }


### PR DESCRIPTION
in looking at the 2 category and 2 product functions, i decided to refactor them into a small class file.  i'm not hugely tied to any of it, but it makes much more sense to me.

persuant to our conversation in #4083, we talked a bit about separating the db functions from the decorating.  i'm not sure if by decorating you were referring to the html parameters; or the names in the pulldown.  the names in the pulldown are harder to separate without doing unnecessary db hits.

in any event, this can easily be tested with the following code:

```
<?php
	require 'includes/application_top.php';
	require 'includes/classes/prod_cat_pulldown.php';

	echo zen_draw_products_pull_down_categories('test');
	echo __FILE__ . ':' . __LINE__ . '<br>';

	$pull_down = new prod_cat_pulldown('category');
	echo $pull_down->pull_down('test');
	echo __FILE__ . ':' . __LINE__ . '<br>';

	echo zen_draw_products_pull_down_attributes('test2');
	echo __FILE__ . ':' . __LINE__ . '<br>';

	$pull_down = new prod_cat_pulldown();
	echo $pull_down->pull_down('test2');

	die(__FILE__ . ':' . __LINE__);
```
you can play with any of the vars in the `__construct` or pass most of them when creating the instance of the class.