### PR TITLE
[158] account: Format order-totals using currency in which order was placed

### DIFF
--- a/includes/templates/responsive_classic/templates/tpl_account_default.php
+++ b/includes/templates/responsive_classic/templates/tpl_account_default.php
@@ -43,7 +43,7 @@
     <td class="accountOrderId"><?php if ($display_as_mobile) { echo '<b class="hide">' . TABLE_HEADING_ORDER_NUMBER . '&#58;&nbsp;&nbsp;</b>'; }?><?php echo TEXT_NUMBER_SYMBOL . $orders['orders_id']; ?></td>
     <td class="accountOrderAddress"><?php if ($display_as_mobile) { echo '<b class="hide">' . TABLE_HEADING_SHIPPED_TO . '&#58;&nbsp;&nbsp;</b>'; }?><address><?php echo zen_output_string_protected($orders['order_name']) . '<br>' . $orders['order_country']; ?></address></td>
     <td class="accountOrderStatus"><?php if ($display_as_mobile) { echo '<b class="hide">' . TABLE_HEADING_STATUS . '&#58;&nbsp;&nbsp;</b>'; }?><?php echo $orders['orders_status_name']; ?></td>
-    <td class="accountOrderTotal alignRight"><?php if ($display_as_mobile) { echo '<b class="hide">' . TABLE_HEADING_TOTAL . '&#58;&nbsp;&nbsp;</b>'; }?><?php echo $orders['order_total']; ?></td>
+    <td class="accountOrderTotal alignRight"><?php if ($display_as_mobile) { echo '<b class="hide">' . TABLE_HEADING_TOTAL . '&#58;&nbsp;&nbsp;</b>'; }?><?php echo $currencies->format($orders['order_total'], false, $orders['currency']); ?></td>
     <td class="accountOrderViewButton alignRight"><?php echo '<a href="' . zen_href_link(FILENAME_ACCOUNT_HISTORY_INFO, 'order_id=' . $orders['orders_id'], 'SSL') . '"> ' . zen_image_button(BUTTON_IMAGE_VIEW_SMALL, BUTTON_VIEW_SMALL_ALT) . '</a>'; ?></td>
   </tr>
 

--- a/includes/templates/template_default/templates/tpl_account_default.php
+++ b/includes/templates/template_default/templates/tpl_account_default.php
@@ -41,7 +41,7 @@
     <td class="accountOrderId"><?php echo TEXT_NUMBER_SYMBOL . $orders['orders_id']; ?></td>
     <td class="accountAddress"><address><?php echo zen_output_string_protected($orders['order_name']) . '<br>' . $orders['order_country']; ?></address></td>
     <td class="accountOrderStatus"><?php echo $orders['orders_status_name']; ?></td>
-    <td class="accountOrderTotal alignRight"><?php echo $orders['order_total']; ?></td>
+    <td class="accountOrderTotal alignRight"><?php echo $currencies->format($orders['order_total'], false, $orders['currency']); ?></td>
     <td class="accountOrderViewButton alignRight"><?php echo '<a href="' . zen_href_link(FILENAME_ACCOUNT_HISTORY_INFO, 'order_id=' . $orders['orders_id'], 'SSL') . '"> ' . zen_image_button(BUTTON_IMAGE_VIEW_SMALL, BUTTON_VIEW_SMALL_ALT) . '</a>'; ?></td>
   </tr>
 


### PR DESCRIPTION
The 'Total' column displaying the customer's previous orders is currently being displayed as a 'raw' number instead of using a currency format..