### PR TITLE
Prevents notice during module setting.

### DIFF
--- a/admin/modules.php
+++ b/admin/modules.php
@@ -277,6 +277,7 @@ if (zen_not_null($action)) {
                       <?php
                       if (isset($mInfo) && is_object($mInfo) && ($class == $mInfo->code)) {
                         echo zen_image(DIR_WS_IMAGES . 'icon_arrow_right.gif');
+                        $_GET['module'] = !isset($_GET['module']) ? $mInfo->code : $_GET['module'];
                       } else {
                         echo '<a href="' . zen_href_link(FILENAME_MODULES, 'set=' . $set . '&module=' . $class, 'SSL') . '">' . zen_image(DIR_WS_IMAGES . 'icon_info.gif', IMAGE_ICON_INFO) . '</a>';
                       }


### PR DESCRIPTION
Reproducible by accessing the modules page (e.g. shipping) from some other
page in the admin, editing the default selected module and saving that
module without navigating to anything else.  During this process, the
uri parameter of module will not be set and later cause a notice on line 65.

Had previously submitted a fix for line 65; however, recently was able
to recreate the issue directly and specifically.