### PR TITLE
change of country does not leave zone dropdown option "Please Select..." as selected.

### DIFF
--- a/includes/modules/pages/address_book_process/jscript_addr_pulldowns.php
+++ b/includes/modules/pages/address_book_process/jscript_addr_pulldowns.php
@@ -30,9 +30,16 @@ function update_zone(theForm) {
   // build dynamic list of countries/zones for pulldown
 <?php echo zen_js_zone_list('SelectedCountry', 'theForm', 'zone_id'); ?>
 
-  // if we had a value before reset, set it again
-  if (SelectedZone != "") theForm.elements["zone_id"].value = SelectedZone;
-
+    // set selected option for zone
+    theForm.elements["zone_id"].value = ""; // set as default "Select..."
+    if (SelectedZone !== "") {  // if the previously-selected-zone exists in the array (html collection), set that zone as selected
+        for (let item of theForm.zone_id.options) {
+            if (item.value === SelectedZone) {
+                theForm.elements["zone_id"].value = SelectedZone;
+                break;
+            }
+        }
+    }
 }
 
   function hideStateField(theForm) {


### PR DESCRIPTION
For account edit address.

On change of country, js was only checking if the previous option was not "".

`  if (SelectedZone != "") theForm.elements["zone_id"].value = SelectedZone;`

and then used that value irrespective if it existed in the options list object or not.

So when there is no match, nothing is "selected" and so the drop-down field is blank instead of showing "Please Select..."

![Clipboard01](https://user-images.githubusercontent.com/4391026/108375033-e0623b80-7201-11eb-8f46-527f4a9ffe76.gif)

My solution iterates through the object until it finds a match, maybe there is a better way...

