### PR TITLE
account, edit address. when state not set, $state is false in header, triggers strict error with trim

### DIFF
--- a/includes/modules/pages/address_book_process/header_php.php
+++ b/includes/modules/pages/address_book_process/header_php.php
@@ -67,7 +67,7 @@ if (isset($_POST['action']) && (($_POST['action'] == 'process') || ($_POST['acti
    * error checking when updating or adding an entry
    */
   if (ACCOUNT_STATE == 'true') {
-    $state = (isset($_POST['state'])) ? zen_db_prepare_input($_POST['state']) : FALSE;
+    $state = (isset($_POST['state'])) ? zen_db_prepare_input($_POST['state']) : '';
     if (isset($_POST['zone_id'])) {
       $zone_id = zen_db_prepare_input($_POST['zone_id']);
     } else {
@@ -327,7 +327,7 @@ if (!isset($_GET['delete'])) {
     $entry->fields['entry_country_id'] = $selected_country;
   }
   $flag_show_pulldown_states = ((($process == true || $entry_state_has_zones == true) && $zone_name == '') || ACCOUNT_STATE_DRAW_INITIAL_DROPDOWN == 'true' || $error_state_input) ? true : false;
-  $state = ($flag_show_pulldown_states && $state != FALSE) ? $state : $zone_name;
+  $state = ($flag_show_pulldown_states && $state !== '') ? $state : $zone_name;
   $state_field_label = ($flag_show_pulldown_states) ? '' : ENTRY_STATE;
 }
 


### PR DESCRIPTION
When the state (free text field) is not set (when dropdown in use), on form submission, $state is set in header to FALSE.
Later this is operated on by trim which errors in strict mode as it is a boolean instead of a string.
It seems safe to change the FALSE to ''.

