### PR TITLE
Parameter for zen_redirect of zen_href_link incorrect.

### DIFF
--- a/admin/orders.php
+++ b/admin/orders.php
@@ -155,7 +155,7 @@ if (zen_not_null($action) && $order_exists == true) {
           break;
         default:
           $messageStack->add_session(sprintf(TEXT_EXTENSION_NOT_UNDERSTOOD, $file_extension), 'error');
-          zen_redirect(zen_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('download', 'action')) . 'action=edit'), 'NONSSL');
+          zen_redirect(zen_href_link(FILENAME_ORDERS, zen_get_all_get_params(array('download', 'action')) . 'action=edit', 'NONSSL'));
       }
       $fs_path = DIR_FS_CATALOG_IMAGES . 'uploads/' . $fileName;
       if (!file_exists($fs_path)) {


### PR DESCRIPTION
The admin version of `zen_redirect` has only one parameter which is the
destination address. The generation of that address through `zen_href_link`
accepts an indicator of whether to use `SSL` or `NONSSL`. That value is
expected to be in the third position of calling the `zen_href_link`
function. The modified line originally has `NONSSL` as the second parameter
to the `zen_redirect` function. When modified as provided, this would
correctly become the third parameter.