### PR TITLE
Allow ship/pay/ot modules to offer their own help

### DIFF
--- a/admin/includes/languages/lang.english.php
+++ b/admin/includes/languages/lang.english.php
@@ -210,6 +210,7 @@ $define = [
     'IMAGE_INSERT' => 'Insert',
     'IMAGE_MODULE_INSTALL' => 'Install Module',
     'IMAGE_MODULE_REMOVE' => 'Remove Module',
+    'IMAGE_MODULE_HELP' => 'Help',
     'IMAGE_MOVE' => 'Move',
     'IMAGE_NEW_BANNER' => 'New Banner',
     'IMAGE_NEW_CATEGORY' => 'New Category',
@@ -534,6 +535,7 @@ $define = [
     'TEXT_BOOLEAN_VALIDATE' => 'The value is required to be a boolean value or equivalent.',
     'TEXT_ASC' => 'asc',
     'TEXT_DESC' => 'desc',
+    'TEXT_DOCS_HELP' => 'Help on Zen Cart Documentation Site',
 ];
 
 return $define;

--- a/admin/modules.php
+++ b/admin/modules.php
@@ -335,6 +335,21 @@ if (!empty($action)) {
             default:
               $heading[] = ['text' => '<h4>' . $mInfo->title . '</h4>'];
 
+              $help_button = [];
+              $file_extension = substr($PHP_SELF, strrpos($PHP_SELF, '.'));
+              $class = basename($_GET['module']);
+              if (file_exists($module_directory . $class . $file_extension)) {
+                  if (file_exists(DIR_FS_CATALOG_LANGUAGES . $_SESSION['language'] . '/modules/' . $module_type . '/' . $class . $file_extension)) {
+                    include DIR_FS_CATALOG_LANGUAGES . $_SESSION['language'] . '/modules/' . $module_type . '/' . $class . $file_extension;
+                    include_once $module_directory . $class . $file_extension;
+                    $module = new $class;
+                    if (method_exists($module, 'help')) { 
+                       $help_text = $module->help();
+                       $help_title = $module->title; 
+                       $help_button = array('align' => 'text-center', 'text' => '<button type="button" class="btn btn-primary" data-toggle="modal" data-target="#helpModal">' . IMAGE_MODULE_HELP . '</button>');
+                    }
+                  }
+              }
               if ($mInfo->status == '1') {
                 $keys = '';
                 foreach($mInfo->keys as $value) {
@@ -369,6 +384,9 @@ if (!empty($action)) {
                   $contents[] = ['align' => 'text-center', 'text' => TEXT_WARNING_SSL_EDIT];
                 }
                 $contents[] = ['align' => 'text-center', 'text' => '<a href="' . zen_href_link(FILENAME_MODULES, 'set=' . $set . '&module=' . $mInfo->code . '&action=remove', 'SSL') . '" class="btn btn-warning" role="button" id="removeButton"><i class="fa fa-minus"></i> ' . IMAGE_MODULE_REMOVE . '</a>'];
+                if (!empty($help_button)) { 
+                   $contents[] = $help_button; 
+                }
                 $contents[] = ['text' => '<br>' . $mInfo->description];
                 $contents[] = ['text' => '<br>' . $keys];
               } else {
@@ -376,6 +394,9 @@ if (!empty($action)) {
                   $contents[] = ['align' => 'text-center', 'text' => zen_draw_form('install_module', FILENAME_MODULES, 'set=' . $set . '&action=install') . zen_draw_hidden_field('module', $mInfo->code) . '<button type="submit" id="installButton" class="btn btn-primary"><i class="fa fa-plus"></i> ' . IMAGE_MODULE_INSTALL . '</button></form>'];
                 } else {
                   $contents[] = ['align' => 'text-center', 'text' => TEXT_WARNING_SSL_INSTALL];
+                }
+                if (!empty($help_button)) { 
+                   $contents[] = $help_button; 
                 }
                 $contents[] = ['text' => '<br>' . $mInfo->description];
               }
@@ -397,6 +418,29 @@ if (!empty($action)) {
     <!-- footer //-->
     <?php require(DIR_WS_INCLUDES . 'footer.php'); ?>
     <!-- footer_eof //-->
+
+<?php if (!empty($help_text)) { ?>
+<div id="helpModal" class="modal fade">
+      <div class="modal-dialog">
+           <div class="modal-content">
+                <div class="modal-header">
+                     <button type="button" class="close" data-dismiss="modal">&times;</button>
+                     <h4 class="modal-title"><?php echo $help_title . ' ' . IMAGE_MODULE_HELP; ?></h4>
+                </div>
+                <div class="modal-body">
+<?php echo $help_text; ?> 
+                </div>
+                <div class="modal-footer">
+                     <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                </div>
+           </div>
+      </div>
+</div>
+<?php } ?>
+
+  </body>
+</html>
+<?php require(DIR_WS_INCLUDES . 'application_bottom.php'); ?>
   </body>
 </html>
 <?php require(DIR_WS_INCLUDES . 'application_bottom.php'); ?>

--- a/includes/languages/english/modules/payment/paypal.php
+++ b/includes/languages/english/modules/payment/paypal.php
@@ -62,3 +62,4 @@
   define('MODULES_PAYMENT_PAYPALSTD_LINEITEM_TEXT_SURCHARGES_LONG', 'Handling charges and other applicable fees');
   define('MODULES_PAYMENT_PAYPALSTD_LINEITEM_TEXT_DISCOUNTS_SHORT', 'Discounts');
   define('MODULES_PAYMENT_PAYPALSTD_LINEITEM_TEXT_DISCOUNTS_LONG', 'Credits applied, including discount coupons, gift certificates, etc');
+  define('MODULES_PAYMENT_PAYPALSTD_NOT_RECOMMENDED', 'Please note this module is no longer recommended.  See <a href="https://docs.zen-cart.com/user/payment/paypal_standard/" target="_blank" rel="noreferrer noopener">this page</a> for an explanation.'); 

--- a/includes/modules/order_total/ot_coupon.php
+++ b/includes/modules/order_total/ot_coupon.php
@@ -1011,4 +1011,8 @@ class ot_coupon
 
         return false;
     }
+    function help() {
+       return '
+ <a href="https://docs.zen-cart.com/user/order_total/coupons/" target="_blank" rel="noreferrer noopener">' . TEXT_DOCS_HELP . '</a><br>'; 
+    }
 }

--- a/includes/modules/payment/paypal.php
+++ b/includes/modules/payment/paypal.php
@@ -673,4 +673,9 @@ class paypal extends base {
     }
   }
 
+  function help() {
+       return '
+ <a href="https://docs.zen-cart.com/user/payment/paypal/" target="_blank" rel="noreferrer noopener">' . TEXT_DOCS_HELP . '</a><br>' . 
+       MODULES_PAYMENT_PAYPALSTD_NOT_RECOMMENDED . '<br>';  
+    }
 }


### PR DESCRIPTION
I did a couple of examples (coupons, PayPal Standard) in this PR to show how the result would look.  I can do the others once this PR is merged. 

Here is a screenshot of the dialog produced for the help in PayPal Standard:

<img width="604" alt="module_help" src="https://user-images.githubusercontent.com/4391638/111037047-70099d00-83f0-11eb-97e8-62df4dda6275.png">
