### PR TITLE
products to categories: simplify query...result is lowest products_id

### DIFF
--- a/admin/products_to_categories.php
+++ b/admin/products_to_categories.php
@@ -56,15 +56,7 @@ $languages = zen_get_languages();
 $action = ($_GET['action'] ?? '');
 
 if ($action === 'new_cat') {//this form action is from products_previous_next_display.php when a new category is selected
-// @TODO this is a pretty elaborate query for getting a single products_id in order to do a redirect!
-    $sql = "SELECT ptc.*
-            FROM " . TABLE_PRODUCTS_TO_CATEGORIES . " ptc
-            LEFT JOIN " . TABLE_PRODUCTS_DESCRIPTION . " pd ON (p.products_id = pd.products_id AND pd.language_id = " . (int)$_SESSION['languages_id'] . ")
-            INNER JOIN " . TABLE_PRODUCTS . " p USING (products_id)
-            WHERE ptc.categories_id = " . $current_category_id . "
-            ORDER BY p.products_model"; // Order By determines which product is pre-selected in the list when a new category is viewed
-    $result = $db->Execute($sql);
-    $products_filter = (!$result->EOF) ? $result->fields['products_id'] : ''; // Empty if category has no products/has subcategories
+    $products_filter = zen_get_linked_products_for_category($current_category_id, true);
     zen_redirect(zen_href_link(FILENAME_PRODUCTS_TO_CATEGORIES, 'products_filter=' . $products_filter . '&current_category_id=' . $current_category_id));
 }
 


### PR DESCRIPTION
Fixes https://github.com/zencart/zencart/issues/4249
This is the same as used in attribute controller.
Note that the products_id returned from the function zen_get_linked_products_for_category is the lowest numerical id, and is used as the preselected product in the list.

![Clipboard01](https://user-images.githubusercontent.com/4391026/111070456-20030700-84d2-11eb-8fb9-aae4329273cc.gif)

The overly complicated (and bug-causing) query that this replaces, **was** returning the first products_model (my preference, of course).

A similiar query is also in products_price_manager, but returning the lowest product name.

So, three places, three "defaults". 

I would suggest replacing the products_price_manager with the same function call, so at least there is consistency.
Then conclude the discussion about how to allow the user to have their choice of sorting option, prior to modifying this function and other functions to have consistent sorting, such as the actual product listing sorted as chosen (by product_id/product_name/product_model) and with appropriate formatting per option chosen.

Personally I'll be looking at modifying the function zen_get_linked_products_for_category for the time being.