### PR TITLE
fixes php notice and improves search results on fields ending in _id

### DIFF
--- a/includes/functions/functions_search.php
+++ b/includes/functions/functions_search.php
@@ -173,15 +173,20 @@ function zen_parse_search_string($search_str = '', &$objects = array()) {
                     default:
                         $sql_add = " (";
                         $first_field = true;
+                        $sql_or = ' ';
                         foreach ($fields as $field_name) {
                             if (!$first_field) {
-                                $sql_add .= ' OR ';
+                                $sql_or = ' OR ';
                             }
-                            $first_field = false;
                             if (strpos($field_name, '_id')) {
-                                $sql_add .= " :field_name = :numeric_keyword";
-
+                                if ((int)$search_keywords[$i] != 0) {
+                                    $first_field = false;
+                                    $sql_add .= $sql_or;
+                                    $sql_add .= " :field_name = :numeric_keyword";
+                                }
                             } else {
+                                $first_field = false;
+                                $sql_add .= $sql_or;
                                 $sql_add .= " :field_name LIKE '%:keyword%'";
                             }
                             $sql_add = $db->bindVars($sql_add, ':field_name', $field_name, 'noquotestring');
@@ -197,5 +202,5 @@ function zen_parse_search_string($search_str = '', &$objects = array()) {
             }
             $where_str .= " )";
         }
-        return $where_str;
+        return $where_str ?? ' ';
     }


### PR DESCRIPTION
the previous change on line 163 (eliminating the early return) introduced a PHP notice if no valid keywords are submitted to the function.  the coalesce function on line 205 addresses that issue.

in my previous testing for my category and product pulldowns PR, i also discovered a situation that text being cast as integers would result in `0` which gave results that were not as accurate as i like.  i pushed that change in that PR, but probably should have created its own PR.  given that i wanted to address the (minor) PHP notice i added that fix here.