### PR TITLE
category-product listing: correct unequal columns for search results

### DIFF
--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -564,7 +564,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
           //     ),
           // );
           //
-          // Observer notes:  
+          // Observer notes:
           // - Be sure to check that the $p2/$extra_headings value is specifically (bool)false before initializing, since
           //   multiple observers might be injecting content!
           // - If heading-columns are added, be sure to add the associated data columns, too, via the
@@ -599,7 +599,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
           //     ),
           // );
           //
-          // Observer notes:  
+          // Observer notes:
           // - Be sure to check that the $p2/$extra_headings value is specifically (bool)false before initializing, since
           //   multiple observers might be injecting content!
           // - If heading-columns are added, be sure to add the associated data columns, too, via the
@@ -742,7 +742,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
             //
             $extra_select = $extra_from = $extra_joins = $extra_ands = '';
             $zco_notifier->notify('NOTIFY_ADMIN_PROD_LISTING_PRODUCTS_QUERY', '', $extra_select, $extra_from, $extra_joins, $extra_ands, $order_by);
-            
+
             $products_query_raw = "SELECT p.products_type, p.products_id, pd.products_name, p.products_quantity,
                                           p.products_price, p.products_status, p.products_model, p.products_sort_order,
                                           p.master_categories_id";
@@ -839,7 +839,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
               //     ),
               // );
               //
-              // Observer notes:  
+              // Observer notes:
               // - Be sure to check that the $p2/$extra_data value is specifically (bool)false before initializing, since
               //   multiple observers might be injecting content!
               // - If heading-columns are added, be sure to add the associated header columns, too, via the
@@ -870,7 +870,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
               //     ),
               // );
               //
-              // Observer notes:  
+              // Observer notes:
               // - Be sure to check that the $p2/$extra_data value is specifically (bool)false before initializing, since
               //   multiple observers might be injecting content!
               // - If heading-columns are added, be sure to add the associated header columns, too, via the

--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -521,7 +521,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
           }
 
           $categories_count = 0;
-          $sql = "SELECT c.categories_id, cd.categories_name, c.parent_id, c.sort_order, c.categories_status
+          $sql = "SELECT c.categories_id, c.categories_image, cd.categories_name, c.parent_id, c.sort_order, c.categories_status
                   FROM " . TABLE_CATEGORIES . " c
                   LEFT JOIN " . TABLE_CATEGORIES_DESCRIPTION . " cd ON c.categories_id = cd.categories_id
                     AND cd.language_id = " . (int)$_SESSION['languages_id'];
@@ -544,13 +544,12 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
             <thead>
               <tr>
                 <th class="text-right shrink"><?php echo TABLE_HEADING_ID; ?></th>
-                <th colspan="2"><?php echo TABLE_HEADING_CATEGORIES_PRODUCTS; ?></th>
+                <th><?php echo TABLE_HEADING_CATEGORIES_PRODUCTS; ?></th>
+                <th class="hidden-sm hidden-xs"><?php echo TABLE_HEADING_IMAGE; ?></th>
                 <?php if ($show_prod_labels) { ?>
-
-                  <th class="hidden-sm hidden-xs"></th>
                   <th class="hidden-sm hidden-xs"><?php echo TABLE_HEADING_MODEL; ?></th>
+                <?php } ?>
                 <th class="text-right hidden-sm hidden-xs"><?php echo TABLE_HEADING_PRICE; ?></th>
-                <?php }; ?>
 <?php
           // -----
           // Additional column-headings can be added before the Quantity column.
@@ -646,13 +645,15 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
               ?>
               <tr class="category-listing-row" data-cid="<?php echo $category['categories_id']; ?>">
                 <td class="text-right"><?php echo $category['categories_id']; ?></td>
-                <td colspan="2">
+                  <td>
+                      <a href="<?php echo zen_catalog_href_link('index', zen_get_path($category['categories_id'])); ?>" rel="noopener" target="_blank" title="<?php echo BOX_HEADING_CATALOG; ?>"><?php echo zen_image(DIR_WS_IMAGES . 'icon_popup.gif', BOX_HEADING_CATALOG); ?></a>
                   <a href="<?php echo zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING, zen_get_path($category['categories_id'])); ?>" class="folder"><i class="fa fa-lg fa-folder"></i>&nbsp;<strong><?php echo $category['categories_name']; ?></strong></a>
                 </td>
+                  <td class="hidden-sm hidden-xs"><?php echo zen_image(DIR_WS_CATALOG_IMAGES . $category['categories_image'], $category['categories_name'], IMAGE_SHOPPING_CART_WIDTH, IMAGE_SHOPPING_CART_HEIGHT); ?></td>
                 <?php if ($show_prod_labels) { ?>
-                  <td class="hidden-sm hidden-xs">&nbsp;</td>
-                <td class="text-right hidden-sm hidden-xs"><?php echo zen_get_discount_calc('', $category['categories_id'], true); ?></td>
-                <?php }; ?>
+                  <td class="hidden-sm hidden-xs"><!-- no model for categories --></td>
+                <?php } ?>
+                  <td class="text-right hidden-sm hidden-xs"><?php echo zen_get_discount_calc('', $category['categories_id'], true); ?></td>
                 <?php if ($search_result || SHOW_COUNTS_ADMIN == 'true') { ?>
                   <td class="text-right hidden-sm hidden-xs">
                     <?php
@@ -814,11 +815,9 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
               ?>
               <tr class="product-listing-row" data-pid="<?php echo $product['products_id']; ?>">
                 <td class="text-right"><?php echo $product['products_id']; ?></td>
-                <td class="dataTableButtonCell" style="width:16px;"><a href="<?php echo zen_catalog_href_link($type_handler . '_info', 'cPath=' . $cPath . '&products_id=' . $product['products_id'] . '&language=' . $_SESSION['languages_code'] . '&product_type=' . $product['products_type']); ?>" rel="noopener" target="_blank">
-                        <?php echo zen_image(DIR_WS_ICONS . 'preview.gif', ICON_PREVIEW); ?>
+                <td><a href="<?php echo zen_catalog_href_link($type_handler . '_info', 'cPath=' . $cPath . '&products_id=' . $product['products_id'] . '&language=' . $_SESSION['languages_code'] . '&product_type=' . $product['products_type']); ?>" rel="noopener" target="_blank">
+                        <?php echo zen_image(DIR_WS_IMAGES . 'icon_popup.gif', BOX_HEADING_CATALOG); ?>
                     </a>
-                </td>
-                <td>
                     <a href="<?php echo zen_href_link(FILENAME_PRODUCT, 'cPath=' . $cPath . '&product_type=' . $product['products_type'] . '&pID=' . $product['products_id'] . '&action=new_product' . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')); ?>" title="<?php echo IMAGE_EDIT; ?>" style="text-decoration: none">
                         <?php echo $product['products_name']; ?>
                     </a>

--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -645,7 +645,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
               ?>
               <tr class="category-listing-row" data-cid="<?php echo $category['categories_id']; ?>">
                 <td class="text-right"><?php echo $category['categories_id']; ?></td>
-                  <td>
+                  <td class="dataTableButtonCell">
                       <a href="<?php echo zen_catalog_href_link('index', zen_get_path($category['categories_id'])); ?>" rel="noopener" target="_blank" title="<?php echo BOX_HEADING_CATALOG; ?>"><?php echo zen_image(DIR_WS_IMAGES . 'icon_popup.gif', BOX_HEADING_CATALOG); ?></a>
                   <a href="<?php echo zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING, zen_get_path($category['categories_id'])); ?>" class="folder"><i class="fa fa-lg fa-folder"></i>&nbsp;<strong><?php echo $category['categories_name']; ?></strong></a>
                 </td>
@@ -815,7 +815,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
               ?>
               <tr class="product-listing-row" data-pid="<?php echo $product['products_id']; ?>">
                 <td class="text-right"><?php echo $product['products_id']; ?></td>
-                <td><a href="<?php echo zen_catalog_href_link($type_handler . '_info', 'cPath=' . $cPath . '&products_id=' . $product['products_id'] . '&language=' . $_SESSION['languages_code'] . '&product_type=' . $product['products_type']); ?>" rel="noopener" target="_blank">
+                <td class="dataTableButtonCell"><a href="<?php echo zen_catalog_href_link($type_handler . '_info', 'cPath=' . $cPath . '&products_id=' . $product['products_id'] . '&language=' . $_SESSION['languages_code'] . '&product_type=' . $product['products_type']); ?>" rel="noopener" target="_blank">
                         <?php echo zen_image(DIR_WS_IMAGES . 'icon_popup.gif', BOX_HEADING_CATALOG); ?>
                     </a>
                     <a href="<?php echo zen_href_link(FILENAME_PRODUCT, 'cPath=' . $cPath . '&product_type=' . $product['products_type'] . '&pID=' . $product['products_id'] . '&action=new_product' . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')); ?>" title="<?php echo IMAGE_EDIT; ?>" style="text-decoration: none">

--- a/admin/includes/languages/english/lang.category_product_listing.php
+++ b/admin/includes/languages/english/lang.category_product_listing.php
@@ -10,6 +10,7 @@ $define = [
     'HEADING_TITLE' => 'Categories / Products',
     'HEADING_TITLE_GOTO' => 'Go To:',
     'TABLE_HEADING_ID' => 'ID',
+    'TABLE_HEADING_IMAGE' => 'Image',
     'TABLE_HEADING_CATEGORIES_PRODUCTS' => 'Categories / Products',
     'TABLE_HEADING_PRICE' => 'Price/Special/Sale',
     'TABLE_HEADING_QUANTITY' => 'Quantity',


### PR DESCRIPTION
Initiated by the unequal row count between category and product results, I've attempted to simplify this mixmatch between the category and product information.

a) Added images and a title to the category listing to bring it closer to the product listing. Show/hide the images I intend to add to another PR. 
b) Added a preview icon to the cats and changed the icon to the popup icon for all: as it is not a **pre-**view but a real view of the catalog, and I didn't think the current icon reflected the function.
Put that icon/link with the name instead of in its own table cell/column, removing colspan.

This makes it much easier to understand the layout.
simplify table row layout (add category image, merge preview icon with name), correct unequal rowcount for search results, change review icon to popup for category and product.

Before:
![1 cats](https://user-images.githubusercontent.com/4391026/114861192-38c24d80-9ded-11eb-9685-533d0d151d6c.gif)

![2 prods](https://user-images.githubusercontent.com/4391026/114861207-3f50c500-9ded-11eb-979a-7d63b1775652.gif)

![3 search](https://user-images.githubusercontent.com/4391026/114861231-4677d300-9ded-11eb-93b2-ecab59e06fb8.gif)

After:
![4 cats](https://user-images.githubusercontent.com/4391026/114861260-4d064a80-9ded-11eb-8bf1-ff336857b9bd.gif)

![5 prods](https://user-images.githubusercontent.com/4391026/114861276-51cafe80-9ded-11eb-98db-4de4d472f559.gif)

![6 search](https://user-images.githubusercontent.com/4391026/114861291-58597600-9ded-11eb-8163-7cd1d95c6d07.gif)

Ok, let the shouting begin....


