### PR TITLE
Non-numeric value on max_length of datetime field type

### DIFF
--- a/includes/classes/db/mysql/query_factory.php
+++ b/includes/classes/db/mysql/query_factory.php
@@ -715,5 +715,8 @@ class queryFactoryMeta {
     $rgx = preg_match('/^[a-z]*/', $type, $matches);
     $this->type = $matches[0];
     $this->max_length = preg_replace('/[a-z\(\)]/', '', $type);
+    if ($type == 'datetime') {
+      $this->max_length = '26';
+    }
   }
 }


### PR DESCRIPTION
Assigns the proposed maximum PHP length for a datetime field as proposed
in the MySql documentation at:
https://dev.mysql.com/doc/refman/8.0/en/datetime.html

Solution here is as posted at:
https://www.zen-cart.com/showthread.php?227778-A-non-numeric-value-encountered-in-functions_general-php&p=1378411#post1378411

Incorporation resolved warning logging seen on a live site.