### PR TITLE
Fix typo

### DIFF
--- a/admin/includes/header.php
+++ b/admin/includes/header.php
@@ -14,7 +14,7 @@ if (defined('STRICT_ERROR_REPORTING') && STRICT_ERROR_REPORTING == true) {
 }
 /*
  * pull in any necessary JS for the page
- * Left here for lagacy pages that do not use the new admin_html_head.php file
+ * Left here for legacy pages that do not use the new admin_html_head.php file
  */
 require_once DIR_WS_INCLUDES . 'javascript_loader.php';
 


### PR DESCRIPTION
Remaining legacy files which do not include `admin/includes/admin_html_head.php`: 

```
ajax.php
alert_page.php
currency_cron.php
home.php
index.php
keepalive.php
logoff.php
popup_image.php
salemaker_info.php
salemaker_popup.php
sqlpatch.php
```
