### PR TITLE
Don't call php_uname if exec disabled

### DIFF
--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -330,7 +330,6 @@ function zen_get_system_information($privacy = false)
 
     $errnum = 0;
     $system = $host = $kernel = $output = '';
-    list($system, $host, $kernel) = array('', $_SERVER['SERVER_NAME'], php_uname());
     $uptime = (DISPLAY_SERVER_UPTIME == 'true') ? 'Unsupported' : 'Disabled/Unavailable';
 
     // check to see if "exec()" is disabled in PHP -- if not, get additional info via command line
@@ -342,6 +341,7 @@ function zen_get_system_information($privacy = false)
         }
     }
     if (!$exec_disabled) {
+        list($system, $host, $kernel) = array('', $_SERVER['SERVER_NAME'], php_uname());
         @exec('uname -a 2>&1', $output, $errnum);
         if ($errnum == 0 && count($output)) list($system, $host, $kernel) = preg_split('/[\s,]+/', $output[0], 5);
         $output = '';


### PR DESCRIPTION
Doing so will cause a PHP log on systems where php_uname() "has been disabled for security reasons."  