### PR TITLE
add boolean to send-extra-order-email notifier

### DIFF
--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -1275,12 +1275,18 @@ class order extends base
 
             // Add extra heading stuff via observer class
             $this->extra_header_text = '';
-            $this->notify('NOTIFY_ORDER_INVOICE_CONTENT_FOR_ADDITIONAL_EMAILS', $zf_insert_id, $email_order, $html_msg);
+            $sendExtraOrderEmail = true;
+            $this->notify('NOTIFY_ORDER_INVOICE_CONTENT_FOR_ADDITIONAL_EMAILS', $zf_insert_id, $email_order, $html_msg, $sendExtraOrderEmail);
             $email_order = $this->extra_header_text . $email_order;
             $html_msg['EMAIL_TEXT_HEADER'] = nl2br($this->extra_header_text) . $html_msg['EMAIL_TEXT_HEADER'];
 
-            zen_mail('', SEND_EXTRA_ORDER_EMAILS_TO, SEND_EXTRA_NEW_ORDERS_EMAILS_TO_SUBJECT . ' ' . EMAIL_TEXT_SUBJECT . EMAIL_ORDER_NUMBER_SUBJECT . $zf_insert_id,
-                $email_order . $extra_info['TEXT'], STORE_NAME, EMAIL_FROM, $html_msg, 'checkout_extra', $this->attachArray, $this->customer['firstname'] . ' ' . $this->customer['lastname'], $this->customer['email_address']);
+            if ($sendExtraOrderEmail) {
+                zen_mail('', SEND_EXTRA_ORDER_EMAILS_TO,
+                    SEND_EXTRA_NEW_ORDERS_EMAILS_TO_SUBJECT . ' ' . EMAIL_TEXT_SUBJECT . EMAIL_ORDER_NUMBER_SUBJECT . $zf_insert_id,
+                    $email_order . $extra_info['TEXT'], STORE_NAME, EMAIL_FROM, $html_msg, 'checkout_extra',
+                    $this->attachArray, $this->customer['firstname'] . ' ' . $this->customer['lastname'],
+                    $this->customer['email_address']);
+            }
         }
         $this->notify('NOTIFY_ORDER_AFTER_SEND_ORDER_EMAIL', $zf_insert_id, $email_order, $extra_info, $html_msg);
     }


### PR DESCRIPTION
as 1 example: with the addition of `emp_admin_login` into the base ZC, i see instances where stores that are entering orders via this tool would not want the extra emails in their inbox.  adding a boolean to the existing notifier could accomplish this task.