### PR TITLE
correct misleading message, and correct minimum order amount requirements

### DIFF
--- a/includes/modules/order_total/ot_coupon.php
+++ b/includes/modules/order_total/ot_coupon.php
@@ -289,8 +289,10 @@ class ot_coupon
 
         $coupon_details = $this->getCouponDetailsFromDb($coupon_code);
 
-        if (empty($coupon_details) || $coupon_details['coupon_active'] !== 'Y') {
-            $this->validation_errors[] = sprintf(TEXT_INVALID_REDEEM_COUPON, $coupon_code);
+        if (empty($coupon_details) || $coupon_details['coupon_active'] !== 'Y')  {
+            if (!$this->isCodeEqualToRemoveCode($coupon_code)) {
+                $this->validation_errors[] = sprintf(TEXT_INVALID_REDEEM_COUPON, $coupon_code);
+            }
             return;
         }
 
@@ -426,8 +428,9 @@ class ot_coupon
 
         $orderAmountTotal = (string)$orderTotalDetails['orderTotal'];  // coupon is applied against value of only qualifying/restricted products in cart
         if ($coupon_details['coupon_calc_base'] == 1) {
-            $orderAmountTotal = (string)$orderTotalDetails['totalFull']; // coupon is applied against value of all products in cart
+            $orderAmountToCompareAgainstCouponMinimum = (string)$orderTotalDetails['totalFull']; // coupon minimum comparison includes sale items that may not be included in deduction
         }
+
 
 //echo 'ot_coupon coupon_total: ' . $coupon_details['coupon_calc_base'] . '<br>$orderTotalDetails[orderTotal]: ' . $orderTotalDetails['orderTotal'] . '<br>$orderTotalDetails[totalFull]: ' . $orderTotalDetails['totalFull'] . '<br>$orderAmountTotal: ' . $orderAmountTotal . '<br><br>$coupon_details[coupon_minimum_order]: ' . $coupon_details['coupon_minimum_order'] . '<br>$orderAmountToCompareAgainstCouponMinimum: ' . $orderAmountToCompareAgainstCouponMinimum . '<br>';
 
@@ -686,12 +689,16 @@ class ot_coupon
 
         if (!defined('TEXT_COMMAND_TO_DELETE_CURRENT_COUPON_FROM_ORDER')) define('TEXT_COMMAND_TO_DELETE_CURRENT_COUPON_FROM_ORDER', 'REMOVE');
 
-        if (strtoupper($coupon_code) == TEXT_COMMAND_TO_DELETE_CURRENT_COUPON_FROM_ORDER) {
+        if ($this->isCodeEqualToRemoveCode($coupon_code)) {
 
             $this->remove_coupon_from_current_session();
 
             $messageStack->add_session('checkout_payment', TEXT_REMOVE_REDEEM_COUPON, 'caution');
         }
+    }
+
+    private function isCodeEqualToRemoveCode($code) {
+        return (strtoupper($code) == TEXT_COMMAND_TO_DELETE_CURRENT_COUPON_FROM_ORDER);
     }
 
     /**
@@ -744,7 +751,6 @@ class ot_coupon
         }
 
         $found_valid = true;
-
         if ($found_valid) {
             $found_valid = false;
             foreach ($products as $product) {
@@ -845,7 +851,7 @@ class ot_coupon
 
         $orderAmountTotal = (string)$orderTotalDetails['orderTotal'];  // coupon is applied against value of only qualifying/restricted products in cart
         if ($coupon_details['coupon_calc_base'] == 1) {
-            $orderAmountTotal = (string)$orderTotalDetails['totalFull']; // coupon is applied against value of all products in cart
+            $orderAmountToCompareAgainstCouponMinimum = (string)$orderTotalDetails['totalFull']; // coupon minimum comparison includes sale items that may not be included in deduction
         }
 
 //echo 'Product: ' . $orderTotalDetails['orderTotal'] . ' Order: ' . $orderTotalDetails['totalFull'] . ' $orderAmountTotal: ' . $orderAmountTotal . '<br>';

--- a/includes/modules/order_total/ot_coupon.php
+++ b/includes/modules/order_total/ot_coupon.php
@@ -289,7 +289,7 @@ class ot_coupon
 
         $coupon_details = $this->getCouponDetailsFromDb($coupon_code);
 
-        if (empty($coupon_details) || $coupon_details['coupon_active'] !== 'Y')  {
+        if (empty($coupon_details) || $coupon_details['coupon_active'] !== 'Y') {
             if (!$this->isCodeEqualToRemoveCode($coupon_code)) {
                 $this->validation_errors[] = sprintf(TEXT_INVALID_REDEEM_COUPON, $coupon_code);
             }


### PR DESCRIPTION
preface: coupons are hard and confusing.

this PR has 2 corrections. 1 is a question of style; the other corrects incorrect logic.

the style correction removes an error message buyers would see when removing a coupon.  it is very easily demonstrable on a vanilla v158 install.  create a coupon; add items to your cart applicable to said coupon; use the coupon; now use the remove code to remove it.  one gets 2 messages, one of which is the `TEXT_INVALID_REDEEM_CODE`, which seems completely wrong to me.

now, if one has no coupons as part of the cart, and types in the remove code, no message comes up.  i thought about this scenario, and thought about coding for it; easily enough done, but is it of any value?  rare situation...  but following the directions on the screen and getting an error message seems way wrong to me and IMO needs to be corrected.

the logic correction appears twice.  the way the code is now is clearly wrong.  the tool tips in the admin of coupon admin clearly state how things are calculated.  the corrections on lines 429/431 and 848/854 are clearly necessary.  the way the code is now, the order minimum logic is wrong as well as the amount deducted for the coupon.