### PR TITLE
Provide variable to disable product tax column display

### DIFF
--- a/admin/invoice.php
+++ b/admin/invoice.php
@@ -15,6 +15,7 @@ $oID = zen_db_prepare_input($_GET['oID']);
 include DIR_FS_CATALOG . DIR_WS_CLASSES . 'order.php';
 $order = new order($oID);
 $show_including_tax = (DISPLAY_PRICE_WITH_TAX == 'true');
+$show_product_tax = true;
 
 // prepare order-status pulldown list
 $orders_statuses = array();
@@ -124,7 +125,9 @@ if ($order->billing['street_address'] != $order->delivery['street_address']) {
             <th class="dataTableHeadingContent">&nbsp;</th>
             <th class="dataTableHeadingContent"><?php echo TABLE_HEADING_PRODUCTS; ?></th>
             <th class="dataTableHeadingContent"><?php echo TABLE_HEADING_PRODUCTS_MODEL; ?></th>
+<?php if ($show_product_tax) { ?>
             <th class="dataTableHeadingContent text-right"><?php echo TABLE_HEADING_TAX; ?></th>
+<?php } ?>
             <th class="dataTableHeadingContent text-right"><?php echo ($show_including_tax) ? TABLE_HEADING_PRICE_EXCLUDING_TAX : TABLE_HEADING_PRICE; ?></th>
 <?php if ($show_including_tax)  { ?>
             <th class="dataTableHeadingContent text-right"><?php echo TABLE_HEADING_PRICE_INCLUDING_TAX; ?></th>
@@ -197,9 +200,11 @@ if ($order->billing['street_address'] != $order->delivery['street_address']) {
               <td class="dataTableContent">
                 <?php echo $order->products[$i]['model']; ?>
               </td>
+<?php if ($show_product_tax) { ?>
               <td class="dataTableContent text-right">
                 <?php echo zen_display_tax_value($order->products[$i]['tax']); ?>%
               </td>
+<?php } ?>
               <td class="dataTableContent text-right">
                 <strong><?php echo $currencies->format($order->products[$i]['final_price'], true, $order->info['currency'], $order->info['currency_value']) . ($order->products[$i]['onetime_charges'] != 0 ? '<br>' . $currencies->format($order->products[$i]['onetime_charges'], true, $order->info['currency'], $order->info['currency_value']) : ''); ?></strong>
               </td>

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -14,6 +14,7 @@ if (isset($module)) {
 
 $quick_view_popover_enabled = false;
 $includeAttributesInProductDetailRows = true;
+$show_product_tax = true;
 
 require(DIR_WS_CLASSES . 'currencies.php');
 $currencies = new currencies();
@@ -743,7 +744,9 @@ if (!empty($action) && $order_exists == true) {
             <tr class="dataTableHeadingRow">
               <th class="dataTableHeadingContent" colspan="2"><?php echo TABLE_HEADING_PRODUCTS; ?></th>
               <th class="dataTableHeadingContent hidden-xs"><?php echo TABLE_HEADING_PRODUCTS_MODEL; ?></th>
+<?php if ($show_product_tax) { ?>
               <th class="dataTableHeadingContent text-right hidden-xs"><?php echo TABLE_HEADING_TAX; ?></th>
+<?php } ?>
               <th class="dataTableHeadingContent text-right"><?php echo ($show_including_tax) ? TABLE_HEADING_PRICE_EXCLUDING_TAX : TABLE_HEADING_PRICE; ?></th>
 <?php if ($show_including_tax)  { ?>
               <th class="dataTableHeadingContent text-right hidden-xs"><?php echo TABLE_HEADING_PRICE_INCLUDING_TAX; ?></th>
@@ -794,9 +797,11 @@ if (!empty($action) && $order_exists == true) {
                 <td class="dataTableContent hidden-xs">
                   <?php echo $order->products[$i]['model']; ?>
                 </td>
+<?php if ($show_product_tax) { ?>
                 <td class="dataTableContent text-right hidden-xs">
                   <?php echo zen_display_tax_value($order->products[$i]['tax']); ?>%
                 </td>
+<?php } ?>
                 <td class="dataTableContent text-right">
                   <strong><?php echo $currencies->format($order->products[$i]['final_price'], true, $order->info['currency'], $order->info['currency_value']) . ($order->products[$i]['onetime_charges'] != 0 ? '<br>' . $currencies->format($order->products[$i]['onetime_charges'], true, $order->info['currency'], $order->info['currency_value']) : ''); ?></strong>
                 </td>


### PR DESCRIPTION
People using external tax calculation software like Taxcloud will find it confusing to see the an inaccurate tax column for products.  We can make this easily switchable in the orders and invoice admin modules. 