### PR TITLE
Remove php notice when searching for non-existent description

### DIFF
--- a/includes/functions/functions_taxes.php
+++ b/includes/functions/functions_taxes.php
@@ -2,7 +2,7 @@
 /**
  * functions_taxes
  *
- * @copyright Copyright 2003-2020 Zen Cart Development Team
+ * @copyright Copyright 2003-2021 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: lat9 2019 Dec 16 Modified in v1.5.7 $
@@ -271,12 +271,9 @@
 
       $tax = $db->Execute($tax_query);
 
-      // If description not found, then no tax to add.
-      if ($tax->EOF) {
-        $tax->fields['tax_rate'] = 0.0;
+      if (!$tax->EOF) {
+          $tax_rate += $tax->fields['tax_rate'];
       }
-
-      $tax_rate += $tax->fields['tax_rate'];
     }
 
     return $tax_rate;

--- a/includes/functions/functions_taxes.php
+++ b/includes/functions/functions_taxes.php
@@ -271,6 +271,11 @@
 
       $tax = $db->Execute($tax_query);
 
+      // If description not found, then no tax to add.
+      if ($tax->EOF) {
+        $tax->fields['tax_rate'] = 0.0;
+      }
+
       $tax_rate += $tax->fields['tax_rate'];
     }
 


### PR DESCRIPTION
If function is used to look up tax rates based on a description, even
TEXT_UNKNOWN_TAX_RATE is not present and therefore leads to the problem
described at this ZC forum thread:
https://www.zen-cart.com/showthread.php?228051-tax_rate-undefined-index

Chose the specific use of setting the tax rate to 0.0 so that one could
"easily" consider other rates to apply if necessary or some other
variation. Another alternative to this could have been to upfront
evaluate `$description` and if it equaled TEXT_UNKNOWN_TAX_RATE to then
continue the loop which would skip the tax assignment.