### PR TITLE
change category search to use new function

### DIFF
--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -526,9 +526,12 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
                   LEFT JOIN " . TABLE_CATEGORIES_DESCRIPTION . " cd ON c.categories_id = cd.categories_id
                     AND cd.language_id = " . (int)$_SESSION['languages_id'];
 
-          if (isset($_GET['search'])) {
-              $sql .= " WHERE cd.categories_name like '%:search%'";
-              $sql = $db->bindVars($sql, ':search', $_GET['search'], 'noquotestring');
+            if (isset($_GET['search'])) {
+              $keyword_search_fields = [
+                'cd.categories_name',
+                'cd.categories_description',
+              ];
+              $sql .= zen_build_keyword_where_clause($keyword_search_fields, trim($keywords), true);
           } else {
               $sql .= " WHERE c.parent_id = :category";
               $sql = $db->bindVars($sql, ':category', $current_category_id, 'integer');


### PR DESCRIPTION
this came out of #4343.

while i do not feel strongly about the inclusion of category description (and i think inclusion is probably a good idea); i do feel strongly about consistency across the project.  in the current search on the category products page on the demo data, a search of `sci fic` returns nothing.  which is inconsistent with the boolean type searchs being done on products.  and for that reason alone, i think this change is warranted.  (said search terms with this PR return category 11.)