### PR TITLE
Support product page return if file upload problem

### DIFF
--- a/includes/classes/shopping_cart.php
+++ b/includes/classes/shopping_cart.php
@@ -1986,6 +1986,9 @@ class shoppingCart extends base
                                         break;
                                     }
                                 } else {
+                                    $real_ids[TEXT_PREFIX . $_POST[UPLOAD_PREFIX . $i]] = isset($_POST[TEXT_PREFIX . UPLOAD_PREFIX . $i]) ? $_POST[TEXT_PREFIX . UPLOAD_PREFIX . $i] : '';
+                                    $the_list .= TEXT_ERROR_OPTION_FOR . '<span class="alertBlack">' . zen_options_name($_POST[UPLOAD_PREFIX . $i]) . '</span>' . TEXT_INVALID_SELECTION . '<span class="alertBlack">' . ($_POST[TEXT_PREFIX . UPLOAD_PREFIX . $i] == (int)PRODUCTS_OPTIONS_VALUES_TEXT_ID ? TEXT_INVALID_USER_INPUT : zen_values_name($value)) . '</span>' . '<br>';
+                                    $new_qty = 0; // Don't increase the quantity of product in the cart.
                                     break;
                                 }
                             } else { // No file uploaded -- use previous value


### PR DESCRIPTION
If there is a problem with the upload of a file as determined by
the upload class' parse method, then regardless the page to which to
return this presents a message and stops the addition of the remainder of
the product conditions.

Without this code, the product could be added to the cart without the
uploaded information (specifically removed because of issue bringing the
code to this section) even if the file upload attribute was marked as
required.

Discussed in Zen Cart forum at: https://www.zen-cart.com/showthread.php?228049-items-added-to-Shopping-Cart-despite-errors