### PR TITLE
Fix expire sql cache only if file/db entry exist

### DIFF
--- a/includes/classes/cache.php
+++ b/includes/classes/cache.php
@@ -19,14 +19,14 @@ if (!defined('IS_ADMIN_FLAG')) {
  */
 class cache extends base {
 
-  function sql_cache_exists($zf_query, $zf_cachetime) {
+  function sql_cache_exists($zf_query, $zf_cachetime=null) {
     global $db;
     $zp_cache_name = $this->cache_generate_cache_name($zf_query);
     switch (SQL_CACHE_METHOD) {
       case 'file':
       // where using a single directory at the moment. Need to look at splitting into subdirectories
       // like adodb
-      if (file_exists(DIR_FS_SQL_CACHE . '/' . $zp_cache_name . '.sql') && !$this->sql_cache_is_expired($zf_query, $zf_cachetime)) {
+      if (file_exists(DIR_FS_SQL_CACHE . '/' . $zp_cache_name . '.sql') && (is_null($zf_cachetime) || !$this->sql_cache_is_expired($zf_query, $zf_cachetime))) {
         return true;
       } else {
         return false;
@@ -35,7 +35,7 @@ class cache extends base {
       case 'database':
       $sql = "select * from " . TABLE_DB_CACHE . " where cache_entry_name = '" . $zp_cache_name . "'";
       $zp_cache_exists = $db->Execute($sql);
-      if ($zp_cache_exists->RecordCount() > 0 && !$this->sql_cache_is_expired($zf_query, $zf_cachetime)) {
+      if ($zp_cache_exists->RecordCount() > 0 && (is_null($zf_cachetime) || !$this->sql_cache_is_expired($zf_query, $zf_cachetime))) {
         return true;
       } else {
         return false;
@@ -86,25 +86,27 @@ class cache extends base {
   function sql_cache_expire_now($zf_query) {
     global $db;
     $zp_cache_name = $this->cache_generate_cache_name($zf_query);
-    switch (SQL_CACHE_METHOD) {
-      case 'file':
-      @unlink(DIR_FS_SQL_CACHE . '/' . $zp_cache_name . '.sql');
-      return true;
-      break;
-      case 'database':
-      $sql = "delete from " . TABLE_DB_CACHE . " where cache_entry_name = '" . $zp_cache_name . "'";
-      $db->Execute($sql);
-      return true;
-      break;
-      case 'memory':
-      unset($this->cache_array[$zp_cache_name]);
-      return true;
-      break;
-      case 'none':
-      default:
-      return true;
-      break;
-    }
+      if ($this->sql_cache_exists($zf_query)) {
+          switch (SQL_CACHE_METHOD) {
+              case 'file':
+                  @unlink(DIR_FS_SQL_CACHE . '/' . $zp_cache_name . '.sql');
+                  return true;
+                  break;
+              case 'database':
+                  $sql = "delete from " . TABLE_DB_CACHE . " where cache_entry_name = '" . $zp_cache_name . "'";
+                  $db->Execute($sql);
+                  return true;
+                  break;
+              case 'memory':
+                  unset($this->cache_array[$zp_cache_name]);
+                  return true;
+                  break;
+              case 'none':
+              default:
+                  return true;
+                  break;
+          }
+      }
   }
 
   function sql_cache_store($zf_query, $zf_result_array) {


### PR DESCRIPTION
This fixes this PHP Warning that happen when the file never existed:
```
PHP Warning: unlink(/var/www/html/cache/zc_7eb4ed1f36d90140477d9474b61e0e26.sql): No such file or directory in /var/www/html/includes/classes/cache.php on line 92
```

In order to be able to use the `existing sql_cache_exists()` method I update it to be null by default, if no cache time is passed to it.