### PR TITLE
ZC158, admin, categories: fix image meta info

### DIFF
--- a/admin/categories.php
+++ b/admin/categories.php
@@ -385,15 +385,17 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
         <hr>
             <h2><?php echo TEXT_CATEGORIES_IMAGE; ?></h2>
             <?php
-            if (!empty($cInfo->categories_image) && file_exists(DIR_FS_CATALOG_IMAGES . $cInfo->categories_image)) { ?>
+            if (!empty($cInfo->categories_image)) { ?>
                 <div class="form-group">
                     <div class="col-sm-offset-3 col-sm-9 col-md-6">
                         <div><?php echo zen_info_image($cInfo->categories_image, $cInfo->categories_name, '', '', 'class="table-bordered img-responsive"'); ?></div>
                         <br>
                         <?php
-                        list($width, $height) = getimagesize(DIR_FS_CATALOG_IMAGES . $cInfo->categories_image);
-                        $kb = filesize(DIR_FS_CATALOG_IMAGES . $cInfo->categories_image)/1024;
-                        echo sprintf(TEXT_FILENAME,   '/images/' . $cInfo->categories_image, $width, $height, $kb);
+                        if (file_exists(DIR_FS_CATALOG_IMAGES . $cInfo->categories_image)) {
+                            [$width, $height] = getimagesize(DIR_FS_CATALOG_IMAGES . $cInfo->categories_image);
+                            $kb = filesize(DIR_FS_CATALOG_IMAGES . $cInfo->categories_image) / 1024;
+                        }
+                        echo sprintf(TEXT_FILENAME, '/' . DIR_WS_IMAGES . $cInfo->categories_image, $width ?? 0, $height ?? 0, $kb ?? 0);
                         ?>
                     </div>
                 </div>


### PR DESCRIPTION
If a category image was defined but missing/not found, this info was being hidden.
Moved clause to prevent php error from getimagesize.
