### PR TITLE
Bugfix: ZC158, admin, specials, remove cast to float

### DIFF
--- a/admin/specials.php
+++ b/admin/specials.php
@@ -98,7 +98,7 @@ if (!empty($action)) {
         $products_price = (float)$_POST['products_price'];
       }
 
-      $tmp_value = (float)$_POST['specials_price'];
+      $tmp_value = zen_db_prepare_input($_POST['specials_price']);
       $specials_price = (!zen_not_null($tmp_value) || $tmp_value === '' || $tmp_value === 0) ? 0 : $tmp_value;
 
       if (substr($specials_price, -1) === '%') {


### PR DESCRIPTION
Problem: `$specials_price` is converted to `float` resulting in a percentage-based special price becoming an absolute price