### PR TITLE
Sort Configuration > My Store alphabetically

### DIFF
--- a/admin/configuration.php
+++ b/admin/configuration.php
@@ -104,10 +104,23 @@ if ($gID == 7) {
             </thead>
             <tbody>
                 <?php
-                $configuration = $db->Execute("SELECT configuration_id, configuration_title, configuration_value, configuration_key, use_function
+                $query = "SELECT configuration_id, configuration_title, configuration_value, configuration_key, use_function
                                                FROM " . TABLE_CONFIGURATION . "
-                                               WHERE configuration_group_id = " . (int)$gID . "
-                                               ORDER BY sort_order");
+                                               WHERE configuration_group_id = " . (int)$gID; 
+
+                $default_sort = true; 
+                if (defined('CONFIGURATION_MENU_ENTRIES_TO_SORT_BY_NAME') && !empty(CONFIGURATION_MENU_ENTRIES_TO_SORT_BY_NAME)) {
+                   $sorted_menus = explode(",", CONFIGURATION_MENU_ENTRIES_TO_SORT_BY_NAME);
+                   if (in_array($gID, $sorted_menus)) {
+                     $default_sort = false; 
+                   }
+                }
+                if ($default_sort) { 
+                   $query .= " ORDER BY sort_order";
+                } else {
+                   $query .= " ORDER BY configuration_title";
+                }
+                $configuration = $db->Execute($query); 
                 foreach ($configuration as $item) {
                   if (!empty($item['use_function'])) {
                     $use_function = $item['use_function'];

--- a/admin/includes/languages/lang.english.php
+++ b/admin/includes/languages/lang.english.php
@@ -526,6 +526,7 @@ $define = [
     'ERROR_CURRENCY_INVALID' => 'Error: The exchange rate for %s (%s) was not updated via %s. Is it a valid currency code?',
     'WARNING_PRIMARY_SERVER_FAILED' => 'Warning: The primary exchange rate server (%s) failed for %s (%s) - trying the secondary exchange rate server.',
     'MENU_CATEGORIES_TO_SORT_BY_NAME' => 'reports,tools',
+    'CONFIGURATION_MENU_ENTRIES_TO_SORT_BY_NAME' => '1', 
     'PLUGIN_INSTALL_SQL_FAILURE' => 'one or more database errors occured',
     'ARIA_PAGINATION_ROLE_LABEL_GENERAL' => 'Pagination',
     'ARIA_PAGINATION_ROLE_LABEL_FOR' => '%s Pagination',


### PR DESCRIPTION
To sort more configuration menus by name, modify `CONFIGURATION_MENU_ENTRIES_TO_SORT_BY_NAME` in 
`admin/includes/languages/lang.english.php` (1.5.8). 

To sort more top level menus by name, modify `MENU_CATEGORIES_TO_SORT_BY_NAME` in `admin/includes/languages/english.php` (1.5.7) or `admin/includes/languages/lang.english.php` (1.5.8). 


