### PR TITLE
Remove duplicate definition of shipping weight units string in zones module 

### DIFF
--- a/includes/languages/english/modules/shipping/zones.php
+++ b/includes/languages/english/modules/shipping/zones.php
@@ -23,7 +23,6 @@
 define('MODULE_SHIPPING_ZONES_TEXT_TITLE', 'Zone Rates');
 define('MODULE_SHIPPING_ZONES_TEXT_DESCRIPTION', 'Zone Based Rates');
 define('MODULE_SHIPPING_ZONES_TEXT_WAY', 'Shipping to');
-define('MODULE_SHIPPING_ZONES_TEXT_UNITS', 'lb(s)');
 define('MODULE_SHIPPING_ZONES_INVALID_ZONE', 'No shipping available to the selected country');
 define('MODULE_SHIPPING_ZONES_UNDEFINED_RATE', 'The shipping rate cannot be determined at this time');
 ?>

--- a/includes/modules/shipping/zones.php
+++ b/includes/modules/shipping/zones.php
@@ -188,14 +188,13 @@
                   $show_box_weight = ' (' . $shipping_num_boxes . ' ' . TEXT_SHIPPING_BOXES . ')';
                   break;
                 case (2):
-                  $show_box_weight = ' (' . number_format($shipping_weight * $shipping_num_boxes,2) . MODULE_SHIPPING_ZONES_TEXT_UNITS . ')';
+                  $show_box_weight = ' (' . number_format($shipping_weight * $shipping_num_boxes,2) . TEXT_SHIPPING_WEIGHT . ')';
                   break;
                 default:
-                  $show_box_weight = ' (' . $shipping_num_boxes . ' x ' . number_format($shipping_weight,2) . MODULE_SHIPPING_ZONES_TEXT_UNITS . ')';
+                  $show_box_weight = ' (' . $shipping_num_boxes . ' x ' . number_format($shipping_weight,2) . TEXT_SHIPPING_WEIGHT . ')';
                   break;
                 }
 
-//                $shipping_method = MODULE_SHIPPING_ZONES_TEXT_WAY . ' ' . $dest_country . (SHIPPING_BOX_WEIGHT_DISPLAY >= 2 ? ' : ' . $shipping_weight . ' ' . MODULE_SHIPPING_ZONES_TEXT_UNITS : '');
                 $shipping_method = MODULE_SHIPPING_ZONES_TEXT_WAY . ' ' . $dest_country . $show_box_weight;
                 $done = true;
         if (strstr($zones_table[$i+1], '%')) {


### PR DESCRIPTION
We don't need a second weight abbreviation.  Use the main one.