### PR TITLE
refactor of order class

### DIFF
--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -841,6 +841,7 @@ class order extends base
 
         for ($i = 0, $n = sizeof($this->products); $i < $n; $i++) {
             $this->products_ordered_attributes = '';
+            $attributes_exist = '0';
             if (isset($this->products[$i]['attributes'])) {
                 $custom_insertable_text = '';
                 $attributes_exist = '1';
@@ -1010,10 +1011,8 @@ class order extends base
             $this->notify('NOTIFY_ORDER_PROCESSING_ATTRIBUTES_BEGIN');
 
             //------ bof: insert customer-chosen options to order--------
-            $attributes_exist = '0';
             $this->products_ordered_attributes = '';
             if (isset($this->products[$i]['attributes'])) {
-                $attributes_exist = '1';
                 for ($j = 0, $n2 = sizeof($this->products[$i]['attributes']); $j < $n2; $j++) {
                     if (DOWNLOAD_ENABLED == 'true') {
                         $attributes_query = "SELECT popt.products_options_name, poval.products_options_values_name,
@@ -1247,7 +1246,9 @@ class order extends base
         $html_msg['ADDRESS_BILLING_DETAIL'] = zen_address_format($this->billing['format_id'], $this->billing, true, '', "<br>");
 
         $payment = '';
-        if (file_exists(DIR_WS_MODULES . 'payment/' . ($this->info['payment_module_code'] ?? 'NO_PAYMENT') . '.php')) {
+        if (isset($_SESSION['payment']) && is_object($GLOBALS[$_SESSION['payment']])) {
+            $payment = $GLOBALS[$_SESSION['payment']];
+        } elseif (file_exists(DIR_WS_MODULES . 'payment/' . ($this->info['payment_module_code'] ?? 'NO_PAYMENT') . '.php')) {
             require_once(DIR_WS_MODULES . 'payment/' . $this->info['payment_module_code'] . '.php');
             require_once(DIR_WS_LANGUAGES . $_SESSION['language'] . '/modules/payment/' . $this->info['payment_module_code'] . '.php');
             $payment = new $this->info['payment_module_code'];


### PR DESCRIPTION
this started from looking at this here:

https://www.zen-cart.com/showthread.php?228112-Resend-customer-s-order-confirmation&p=1381502#post1381502

prior to putting any more energy into this refactor, i am curious about what the direction is of what i consider to be an important class?  i would prefer to not continue work if there is already development/plans for this class.

that said, there seems to be a lot of legacy code that could get cleaned up.  i see no need to use session information for sending of an order email confirmation, as the order is already in the database.  the same goes for the GLOBALS vars.

it would be nice if when we instantiate this class, we had all the information associated with the class. 

considering the popularity of plugins like EO, i can see the need for after editing an order, a store owner would want to resend an email confirmation with the new order information.

thoughts?