### PR TITLE
Modify query for "Starting From" price

### DIFF
--- a/includes/functions/functions_prices.php
+++ b/includes/functions/functions_prices.php
@@ -426,13 +426,13 @@ function zen_get_products_base_price($product_id)
 
     // do not select display only attributes and attributes_price_base_included is true
     $sql = "SELECT options_id, price_prefix, options_values_price,
-                   attributes_display_only, attributes_price_base_included,
-            CONCAT(price_prefix, options_values_price) AS value
-            FROM " . TABLE_PRODUCTS_ATTRIBUTES . "
-            WHERE products_id = " . (int)$product_id . "
-            AND attributes_display_only != 1
-            AND attributes_price_base_included=1
-            ORDER BY options_id, value";
+                    attributes_display_only, attributes_price_base_included,
+             CAST(CONCAT(price_prefix, options_values_price) AS decimal(15,4)) AS value
+             FROM " . TABLE_PRODUCTS_ATTRIBUTES . "
+             WHERE products_id = " . (int)$product_id . "
+             AND attributes_display_only != 1
+             AND attributes_price_base_included=1
+             ORDER BY options_id, value";
     $results = $db->Execute($sql);
 
     $the_options_id = 'x';


### PR DESCRIPTION
I was finding erratic results with the "Starting At" price when changing attribute prices...at some point the displayed price would not be the cheapest.
I found this to be the culprit:
https://github.com/zencart/zencart/blob/190bda0360fe1b3ad64c00fbcbd2da9404012884/includes/functions/functions_prices.php#L428-L436

The code subsequent to the query iterates through the results only once per option_id and so it is expected that the first instance of option_id in the query result will be the cheapest option. The sql concat structure produces the "value" field on which the results per options_id are ordered.

However, "value" is a string with maybe a + or - in it and so a set of attributes is sorted as this 

+11
+6
-1
no prefix 1

so +11 will be taken and displayed as the cheapest option.

I found that this change returned the correct sort order

> ORDER BY options_id, cast(value as signed)

-1
no prefix 1
+6
+11


I have been some days delving into pricing for a observer-based Dual Pricing, but what a world of pain the pricing regime is/very hard to understand!

Are there plans to rework/simplify this?
