### PR TITLE
Widen comments block in invoice

### DIFF
--- a/admin/invoice.php
+++ b/admin/invoice.php
@@ -266,7 +266,7 @@ if ($order->billing['street_address'] != $order->delivery['street_address']) {
         ?>
       </table>
       <?php if (ORDER_COMMENTS_INVOICE > 0) { ?>
-        <table class="table table-condensed" style="width:25%;">
+        <table class="table table-condensed" style="width:100%;">
           <thead>
             <tr>
               <th class="text-center"><strong><?php echo TABLE_HEADING_DATE_ADDED; ?></strong></th>


### PR DESCRIPTION
Fix in case there's another 157 branch release.  
From: https://www.zen-cart.com/showthread.php?227861-printed-order-comments-are-squished-instead-of-spanning-page-width&p=1379049#post1379049