### PR TITLE
Update for PHP 8.0, callback related

### DIFF
--- a/admin/includes/classes/configurationValidation.php
+++ b/admin/includes/classes/configurationValidation.php
@@ -31,55 +31,57 @@ class configurationValidation extends base
                          'flags' => '',
                          );
         
-        if (isset($val)) {
-            $send_to_array = explode(",", $val);
-            // If count($send_to_array) > 1 then there are multiple addresses to be parsed.
-            foreach ($send_to_array as $key => $address) {
-                $send_to_name = '';
-                $send_to_email = trim($address);
-                // Collect the portion within <> symbols
-                preg_match('/\<[^>]+\>/', $address, $send_email_array);
-                // If there are parts to the above, then set/collect them.
-                if (!empty($send_email_array)) {
-                    $send_to_email = preg_replace ("/>/", "", $send_email_array[0]);
-                    $send_to_email = trim(preg_replace("/</", "", $send_to_email));
-                    $send_to_name  = trim(preg_replace('/\<[^*]*/', '', $address));
-                }
-                
-                // Collect the individual name/email as part of an array.
-                $results[$key]['send_to_name'] = filter_var($send_to_name, FILTER_SANITIZE_STRING, $options);
-                $results[$key]['send_to_email'] = filter_var($send_to_email, FILTER_VALIDATE_EMAIL, $options);
-                
-                // Restore the inner email address back to its state for capture.
-                if (!empty($send_email_array) && $results[$key]['send_to_email'] !== false) {
-                    $results[$key]['send_to_email'] = '<' . $results[$key]['send_to_email'] . '>';
-                }
-                
-                // If the email address is not assigned, but there is content in the name, validate that the name is a correct email address.
-                if ($results[$key]['send_to_email'] === false && !empty($results[$key]['send_to_name'])) {
-                    $results[$key]['send_to_name'] = filter_var($results[$key]['send_to_name'], FILTER_VALIDATE_EMAIL, $options);
-                }
-                
-                // Remove array parameters that have failed validation.
-                foreach ($results[$key] as $key2 => $value2) {
-                    if (empty($value2)) {
-                        unset($results[$key][$key2]);
-                    }
-                }
-                unset($key2, $value2);
-                
-                // If this round of review identified no record, then move to the next record.
-                if (empty($results[$key])) {
-                    continue;
-                }
-                
-                // Collect the filtered email information into a single record.
-                $response[$key] = implode(" ", $results[$key]);
+        if (!isset($val)) {
+            return false;
+        }
+        
+        $send_to_array = explode(",", $val);
+        // If count($send_to_array) > 1 then there are multiple addresses to be parsed.
+        foreach ($send_to_array as $key => $address) {
+            $send_to_name = '';
+            $send_to_email = trim($address);
+            // Collect the portion within <> symbols
+            preg_match('/\<[^>]+\>/', $address, $send_email_array);
+            // If there are parts to the above, then set/collect them.
+            if (!empty($send_email_array)) {
+                $send_to_email = preg_replace ("/>/", "", $send_email_array[0]);
+                $send_to_email = trim(preg_replace("/</", "", $send_to_email));
+                $send_to_name  = trim(preg_replace('/\<[^*]*/', '', $address));
             }
             
-            // Collect email addresses entered as a string.
-            $final_result = implode(", ", $response);
+            // Collect the individual name/email as part of an array.
+            $results[$key]['send_to_name'] = filter_var($send_to_name, FILTER_SANITIZE_STRING, $options);
+            $results[$key]['send_to_email'] = filter_var($send_to_email, FILTER_VALIDATE_EMAIL, $options);
+            
+            // Restore the inner email address back to its state for capture.
+            if (!empty($send_email_array) && $results[$key]['send_to_email'] !== false) {
+                $results[$key]['send_to_email'] = '<' . $results[$key]['send_to_email'] . '>';
+            }
+            
+            // If the email address is not assigned, but there is content in the name, validate that the name is a correct email address.
+            if ($results[$key]['send_to_email'] === false && !empty($results[$key]['send_to_name'])) {
+                $results[$key]['send_to_name'] = filter_var($results[$key]['send_to_name'], FILTER_VALIDATE_EMAIL, $options);
+            }
+            
+            // Remove array parameters that have failed validation.
+            foreach ($results[$key] as $key2 => $value2) {
+                if (empty($value2)) {
+                    unset($results[$key][$key2]);
+                }
+            }
+            unset($key2, $value2);
+            
+            // If this round of review identified no record, then move to the next record.
+            if (empty($results[$key])) {
+                continue;
+            }
+            
+            // Collect the filtered email information into a single record.
+            $response[$key] = implode(" ", $results[$key]);
         }
+        
+        // Collect email addresses entered as a string.
+        $final_result = implode(", ", $response);
         
         // If there are no email addresses that are valid, then identify that failed validation.
         if (empty($final_result) && zen_not_null($val)) {

--- a/admin/includes/classes/configurationValidation.php
+++ b/admin/includes/classes/configurationValidation.php
@@ -16,6 +16,11 @@ if (!defined('IS_ADMIN_FLAG')) {
 
 class configurationValidation extends base
 {
+    /**
+     *  Usage setting val_function for the configuration key to something similar
+     *    to the below will call on this code to support storage of the email related information.
+     *    val_function = '{"error":"TEXT_EMAIL_ADDRESS_VALIDATE","id":"FILTER_CALLBACK","options":{"options":["configurationValidation","sanitizeEmail"]}}'
+     **/
     static public function sanitizeEmail($val) {
         $results = array();
         $send_email_array = array();
@@ -99,7 +104,7 @@ class configurationValidation extends base
     
     
     /**
-     *  Usage setting val_function  for the configuration key to something similar
+     *  Usage setting val_function for the configuration key to something similar
      *    to the below will call on this code to support storage of the boolean related value.
      *    val_function = '{"error":"TEXT_BOOLEAN_VALIDATE","id":"FILTER_CALLBACK","options":{"options":["configurationValidation","sanitizeBoolean"]}}'
      **/

--- a/admin/includes/classes/configurationValidation.php
+++ b/admin/includes/classes/configurationValidation.php
@@ -82,7 +82,7 @@ class configurationValidation extends base
         }
         
         // If there are no email addresses that are valid, then identify that failed validation.
-        if (empty($final_result)) {
+        if (empty($final_result) && zen_not_null($val)) {
             return false;
         }
         

--- a/admin/includes/classes/configurationValidation.php
+++ b/admin/includes/classes/configurationValidation.php
@@ -16,7 +16,7 @@ if (!defined('IS_ADMIN_FLAG')) {
 
 class configurationValidation extends base
 {
-    static public function sanitizeEmail(&$val) {
+    static public function sanitizeEmail($val) {
         $results = array();
         $send_email_array = array();
         $send_to_array = array();
@@ -87,7 +87,9 @@ class configurationValidation extends base
         }
         
         // Provide the filtered value back as $val.
-        $val = $final_result;
+        // Unfortunately call back functions as of PHP 8.0 do not support call by reference modifications and therefore, $val can not be modified.
+        //   The function returns the value that has been determined, so if $val needed to be modified, then $val should become the result of this call.
+        // $val = $final_result;
         
         // Set $configuration_value that is to be stored as the filtered email address.
         return $GLOBALS['configuration_value'] = $final_result;
@@ -99,7 +101,7 @@ class configurationValidation extends base
      *    to the below will call on this code to support storage of the boolean related value.
      *    val_function = '{"error":"TEXT_BOOLEAN_VALIDATE","id":"FILTER_CALLBACK","options":{"options":["configurationValidation","sanitizeBoolean"]}}'
      **/
-    static public function sanitizeBoolean(&$val) {
+    static public function sanitizeBoolean($val) {
         $options = array(
                          'options' => array(
                                       'default' => null,


### PR DESCRIPTION
Refactored sanitizeEmail to eliminate a grouped if statement, providing an early escape for processing.

Callback function receives data by value not by reference. In PHP 8.0, this throws a php warning: `Warning:  configurationValidation::sanitizeEmail(): Argument #1 ($val) must be passed by reference, value given in [...][...]`. Result is that any other usage of these functions to sanitize, must consider the returned value or `$GLOBALS['configuration_value']` as modified within these functions instead of "reusing" the variable that was sent.

Note that sanitizeBoolean permits the value to be "representative" of a boolean value.  As a result, the value returned is true (that value is considered of the boolean type or false if it is not of the boolean type (returned from two points, the second of which is a fallback check)), but `$GLOBALS['configuration_value']` may be other than strictly `true` or strictly `false`, where `$GLOBALS['configuration_value']` will represent the actual value that was being checked/sanitized to be boolean.

Also, in testing the revision to this, discovered that there was no clear way to store an empty email address. That issue is/was also addressed in this branch.