### PR TITLE
Modify the deprecation message for admin use of zen_db_output

### DIFF
--- a/includes/functions/database.php
+++ b/includes/functions/database.php
@@ -35,7 +35,11 @@ function zen_db_input($string)
  */
 function zen_db_output(string $string)
 {
-    trigger_error('Call to deprecated function zen_db_output. Use zen_output_string_protected() instead', E_USER_DEPRECATED);
+    trigger_error('Call to deprecated function zen_db_output. Use zen_output_string_protected() ' . (IS_ADMIN_FLAG ? 'for single encoding or consider htmlspecialchars() to support original double encoding ' : '') . 'instead', E_USER_DEPRECATED);
+
+    if (IS_ADMIN_FLAG) {
+      return htmlspecialchars($string, ENT_COMPAT, CHARSET, true);
+    }
 
     return zen_output_string_protected($string);
   }


### PR DESCRIPTION
The message suggests to replace `zen_db_output` with
`zen_output_string_protected`.

Issue is that the admin processing of `zen_output_string_protected` is
different than the catalog side and only the catalog side provides the
equivalent "output" as `zen_db_output` did.

Basically zen_db_output double encoded even on the admin side. Usage of
double encoding may have been incorrect in some uses. That should be
corrected in a different way than the deprecation of the function.

Unfortunately, `zen_output_string_protected` is in a way also mis-represented
as it does *not* double encode on the admin side where double encoding
would be *"more"* protected, although also may directly cause an issue
because characters such as an ampersand would have the ampersand double-encoded.
Double encoded would be like having the ampersand converted
to an ampersand followed by the text amp; and then that first ampersand
would have the same action taken on it (double encoding).