### PR TITLE
Change 'installer' to 'Installer'

### DIFF
--- a/includes/classes/PluginSupport/BasePluginInstaller.php
+++ b/includes/classes/PluginSupport/BasePluginInstaller.php
@@ -78,7 +78,7 @@ class BasePluginInstaller
     protected function loadInstallerLanguageFile($file)
     {
         $lng = $_SESSION['language'];
-        $filename = $this->pluginDir . '/installer/languages/' . $lng . '/' . $file;
+        $filename = $this->pluginDir . '/Installer/languages/' . $lng . '/' . $file;
         if (file_exists($filename)) {
             require_once($filename);
         }


### PR DESCRIPTION
I think that this change is required as well as the typo that has already been changed by Dr Byte
e.g.
/includes/classes/PluginSupport/Installer.php:        if (!file_exists($pluginDir . '/Installer/' . $patchFile)) {