### PR TITLE
product, collect_info: use empty on observer-returned optional values

### DIFF
--- a/admin/includes/modules/product/collect_info.php
+++ b/admin/includes/modules/product/collect_info.php
@@ -210,8 +210,8 @@ if (zen_get_categories_status($current_category_id) == 0 && $pInfo->products_sta
     $zco_notifier->notify('NOTIFY_ADMIN_PRODUCT_COLLECT_INFO_EXTRA_INPUTS', $pInfo, $extra_product_inputs);
     if (!empty($extra_product_inputs)) {
         foreach ($extra_product_inputs as $extra_input) {
-            $addl_class = (isset($extra_input['label']['addl_class'])) ? (' ' . $extra_input['label']['addl_class']) : '';
-            $parms = (isset($extra_input['label']['parms'])) ? (' ' . $extra_input['label']['parms']) : '';
+            $addl_class = (!empty($extra_input['label']['addl_class'])) ? (' ' . $extra_input['label']['addl_class']) : '';
+            $parms = (!empty($extra_input['label']['parms'])) ? (' ' . $extra_input['label']['parms']) : '';
 ?>
             <div class="form-group">
                 <?php echo zen_draw_label($extra_input['label']['text'], $extra_input['label']['field_name'], 'class="col-sm-3 control-label' . $addl_class . '"' . $parms); ?>


### PR DESCRIPTION
When using this observer and constructing the array to be returned, I think for code clarity it would be prudent to include all the fields in the construction for example
`$p2[] = ['label' => ['text' => $label_text, 'addl_class' => $label_addl_class, 'parms' => $label_parms, 'field_name' => $label_field_name], 'input' => $input];`

In this case unused parameters would create an additional space if isset is used instead of empty.