### PR TITLE
Add notifier to init_admin_auth.php, enabling additional non-superuser actions to be denied

### DIFF
--- a/admin/includes/init_includes/init_admin_auth.php
+++ b/admin/includes/init_includes/init_admin_auth.php
@@ -69,7 +69,7 @@ if (basename($PHP_SELF) != FILENAME_ALERT_PAGE . '.php')
         zen_record_admin_activity('Attempted access to unauthorized page [' . $page . ']. Redirected to DENIED page instead.', 'notice');
         zen_redirect(zen_href_link(FILENAME_DENIED, '', 'SSL'));
       }
-        $zco_notifier->notify('NOTIFY_ADMIN_ACTIVITY_ACTION_EVENT');
+        $zco_notifier->notify('NOTIFY_ADMIN_NONSUPERUSER_ACTION');
     }
 
   }

--- a/admin/includes/init_includes/init_admin_auth.php
+++ b/admin/includes/init_includes/init_admin_auth.php
@@ -69,6 +69,7 @@ if (basename($PHP_SELF) != FILENAME_ALERT_PAGE . '.php')
         zen_record_admin_activity('Attempted access to unauthorized page [' . $page . ']. Redirected to DENIED page instead.', 'notice');
         zen_redirect(zen_href_link(FILENAME_DENIED, '', 'SSL'));
       }
+        $zco_notifier->notify('NOTIFY_ADMIN_ACTIVITY_ACTION_EVENT', $_GET);
     }
 
   }

--- a/admin/includes/init_includes/init_admin_auth.php
+++ b/admin/includes/init_includes/init_admin_auth.php
@@ -69,7 +69,7 @@ if (basename($PHP_SELF) != FILENAME_ALERT_PAGE . '.php')
         zen_record_admin_activity('Attempted access to unauthorized page [' . $page . ']. Redirected to DENIED page instead.', 'notice');
         zen_redirect(zen_href_link(FILENAME_DENIED, '', 'SSL'));
       }
-        $zco_notifier->notify('NOTIFY_ADMIN_ACTIVITY_ACTION_EVENT', $_GET);
+        $zco_notifier->notify('NOTIFY_ADMIN_ACTIVITY_ACTION_EVENT');
     }
 
   }


### PR DESCRIPTION
add an observer to catch any action by non-superuser
if non-superuser is NOT allowed to delete a category, a product or an order, this notifier can easily be used to prevent such actions