### PR TITLE
Correct FileSystem->isXXXDir response.

### DIFF
--- a/includes/classes/FileSystem.php
+++ b/includes/classes/FileSystem.php
@@ -66,8 +66,8 @@ class FileSystem extends IlluminateFilesystem
     {
         if (!defined('DIR_FS_ADMIN')) return false;
         $test = str_replace(DIR_FS_ADMIN, '', $filePath);
-        if ($test != $filePath) return false;
-        return true;
+        if ($test != $filePath) return true;
+        return false;
     }
 
     public function isCatalogDir($filePath)
@@ -75,8 +75,8 @@ class FileSystem extends IlluminateFilesystem
         if ($this->isAdminDir($filePath)) return false;
         if (!defined('DIR_FS_CATALOG')) return false;
         $test = str_replace(DIR_FS_CATALOG, '', $filePath);
-        if ($test != $filePath) return false;
-        return true;
+        if ($test != $filePath) return true;
+        return false;
 
     }
 

--- a/includes/classes/InitSystem.php
+++ b/includes/classes/InitSystem.php
@@ -78,16 +78,21 @@ class InitSystem
         if (isset($entry['classPath'])) {
             $filePath = $entry['classPath'];
         }
+        $classResult = 'ZC';
         if ($entry['loaderType'] == 'plugin') {
-            $filePath = $this->findPluginDirectory($filePath, $entry['pluginInfo']['unique_key']);
+            $pluginFilePath = $this->findPluginDirectory($filePath, $entry['pluginInfo']['unique_key']);
+            if (file_exists($pluginFilePath . $entry['loadFile'])) {
+                $filePath = $pluginFilePath;
+                $classResult = 'PLUGIN';
+            }
         }
-        $this->debugList[] = 'processing class - ' . $filePath  . $entry['loadFile'];
+        $this->debugList[] = 'processing ' . $classResult . ' class - ' . $filePath  . $entry['loadFile'];
         $result = 'FAILED';
         if (file_exists($filePath . $entry['loadFile'])) {
             $result = 'SUCCESS';
             $this->actionList[] = ['type' => 'include', 'filePath' => $filePath . $entry['loadFile'], 'forceLoad' => $entry['forceLoad']];
         }
-        $this->debugList[] = 'loading class - ' . $filePath . $entry['loadFile'] . ' - ' . $result;
+        $this->debugList[] = 'loading ' . $classResult . ' class - ' . $filePath . $entry['loadFile'] . ' - ' . $result;
     }
 
     /**
@@ -262,7 +267,13 @@ class InitSystem
         $relDir = $this->fileSystem->getRelativeDir($filePath);
         $pluginDir = $this->pluginManager->getPluginVersionDirectory($pluginName, $this->installedPlugins);
         $actualDir = $pluginDir . $this->context . '/' . $relDir;
-        return $actualDir;
+        if ($this->fileSystem->isAdminDir($filePath)) {
+            return $actualDir;
+        }
+        if ($this->fileSystem->isCatalogDir($filePath)) {
+          return $pluginDir . 'catalog' . '/' . $relDir;
+        }
+        return $actualDir; // OR should $filePath be returned?
     }
 
 }

--- a/includes/init_includes/init_observers.php
+++ b/includes/init_includes/init_observers.php
@@ -30,7 +30,7 @@ $observersMain = (new FileSystem)->listFilesFromDirectory(DIR_WS_CLASSES . 'obse
 $observersMain = collect($observersMain)->map(function ($item, $key) {
     return DIR_WS_CLASSES . 'observers/' . $item;
 })->toArray();
-$context = (new FileSystem)->isAdminDir(__DIR__) ? 'admin' : 'catalog';
+$context = IS_ADMIN_FLAG ? 'admin' : 'catalog';
 $observersPlugins = [];
 foreach ($installedPlugins as $plugin) {
     $path = DIR_FS_CATALOG . 'zc_plugins/' . $plugin['unique_key'] . '/' . $plugin['version'] . '/' . $context . '/' . DIR_WS_CLASSES . 'observers/';

--- a/includes/modules/extra_functions.php
+++ b/includes/modules/extra_functions.php
@@ -18,7 +18,7 @@ $extraFuncsMain = (new FileSystem)->listFilesFromDirectory(DIR_WS_FUNCTIONS . 'e
 $extraFuncsMain = collect($extraFuncsMain)->map(function ($item, $key) {
     return DIR_WS_FUNCTIONS . 'extra_functions/' . $item;
 })->toArray();
-$context = (new FileSystem)->isAdminDir(__DIR__) ? 'admin' : 'catalog';
+$context = IS_ADMIN_FLAG ? 'admin' : 'catalog';
 $extraFuncsPlugins = [];
 foreach ($installedPlugins as $plugin) {
     $path = DIR_FS_CATALOG . 'zc_plugins/' . $plugin['unique_key'] . '/' . $plugin['version'] . '/' . $context . '/' . DIR_WS_FUNCTIONS . 'extra_functions/';


### PR DESCRIPTION
When admin attempts to use the FileSystem class to determine if a
provided file is asking to use the Admin or Catalog directoy where the full
folder path has been provided, then now returns true if the full path pointed
to that directory side.

Then in identifying the directory to access for a plugin, the previous response
was to only address a path off of the then `$this->context` which had previously
only identified the directory `zc_plugins/admin`; however, even admin plugins
may need to access catalog files either directly in the ZC catalog or in the
plugin's catalog directory. The `InitSystem` class now at least supports admin
access to catalog side files that are stored as a part of the plugin in:
`zc_plugins/PLUGIN_NAME/VERSION/catalog` BUT, operation/access of the plugin
from the catalog side remains disabled. A file (class) included in the plugin's
directory can override the ZC version by being loaded instead of the catalog version.

I.e. if a class is placed in both the `includes/classes/observers` folder
and `zc_plugins/PLUGIN_NAME/VERSION/catalog/includes/classes/observers` folder
the zc_plugins version will be loaded instead of the includes version at least
as demonstrated by a single `zc_plugins/PLUGIN_NAME/VERSION/admin/includes/auto_loaders` file
that either fully referenced DIR_FS_CATALOG . DIR_WS_CLASSES . 'observers' as the classPath
or just `'loadFile' => 'observers/OBSERVER_NAME.php',`.

Additionally when capturing the `debugList` information, the class being
accessed is identified as a `'PLUGIN'` or `'ZC'` class, though this terminology
is modifiable.  Because some classes are included from the current "directory" (admin/catalog)
I did not amplify the messaging to indicate admin/catalog for the messaging
context.  I believe it would be easy to do because could detect `IS_ADMIN_FLAG`
and assign the appropriate designation (which unfortunately is not provided
defined variable... I did; however, maintain sonme level of consistency about
the term being within a single pair of quotes so that if it is to be changed that it would
be easier/global to adjust.

Lastly, in processing/determining whether the loading code is in the admin
or in the catalog, both `includes/init_includes/init_observers.php` and
`includes/modules/extra_functions.php` were updated to use:
````diff
- $context = (new FileSystem)->isAdminDir(__DIR__) ? 'admin' : 'catalog';
+ $context = IS_ADMIN_FLAG ? 'admin' : 'catalog';
````
Because __DIR__ returns the location of where the file is stored in this
case and not side of the store attempting to access the file. This appears to
cause and/or prevent loading admin related files. By following the setting
of `IS_ADMIN_FLAG`, the plugin file(s) associated with the accessing folder (admin/catalog)
are able to be loaded/collected.


For a relative directory, the plugin's "prefix" to the path is provided to indicate
ensure that the appropriate sub-directory within the plugin directory is identified.

Then because InitSystem->findPluginDirectory needs to return the root of the
plugin, the relative directory location (space within the applicable
plugin sub-directory) is potentially modified to

This fixes #4432 and relates to #4434.