### PR TITLE
V158 pages login combine cart

### DIFF
--- a/includes/modules/pages/login/header_php.php
+++ b/includes/modules/pages/login/header_php.php
@@ -107,7 +107,7 @@ if (isset($_GET['action']) && $_GET['action'] == 'process') {
 
         // check current cart contents count if required
         $zc_check_basket_after = $_SESSION['cart']->count_contents();
-        if (SHOW_SHOPPING_CART_COMBINED > 0 && !empty($zc_check_basket_before) && ($zc_check_basket_before != $zc_check_basket_after) && $_SESSION['cart']->count_contents() > 0) {
+        if (SHOW_SHOPPING_CART_COMBINED > 0 && $zc_check_basket_after > 0 && $zc_check_basket_before != $zc_check_basket_after) {
           if (SHOW_SHOPPING_CART_COMBINED == 2) {
             // warning only do not send to cart
             $messageStack->add_session('header', WARNING_SHOPPING_CART_COMBINED, 'caution');

--- a/includes/modules/pages/login/header_php.php
+++ b/includes/modules/pages/login/header_php.php
@@ -107,7 +107,7 @@ if (isset($_GET['action']) && $_GET['action'] == 'process') {
 
         // check current cart contents count if required
         $zc_check_basket_after = $_SESSION['cart']->count_contents();
-        if (SHOW_SHOPPING_CART_COMBINED > 0 && ($zc_check_basket_before != $zc_check_basket_after) && $_SESSION['cart']->count_contents() > 0) {
+        if (SHOW_SHOPPING_CART_COMBINED > 0 && !empty($zc_check_basket_before) && ($zc_check_basket_before != $zc_check_basket_after) && $_SESSION['cart']->count_contents() > 0) {
           if (SHOW_SHOPPING_CART_COMBINED == 2) {
             // warning only do not send to cart
             $messageStack->add_session('header', WARNING_SHOPPING_CART_COMBINED, 'caution');

--- a/includes/modules/pages/login/header_php.php
+++ b/includes/modules/pages/login/header_php.php
@@ -106,7 +106,7 @@ if (isset($_GET['action']) && $_GET['action'] == 'process') {
 
         // check current cart contents count if required
         $zc_check_basket_after = $_SESSION['cart']->count_contents();
-        if (($zc_check_basket_before != $zc_check_basket_after) && $_SESSION['cart']->count_contents() > 0 && SHOW_SHOPPING_CART_COMBINED > 0) {
+        if (SHOW_SHOPPING_CART_COMBINED > 0 && ($zc_check_basket_before != $zc_check_basket_after) && $_SESSION['cart']->count_contents() > 0) {
           if (SHOW_SHOPPING_CART_COMBINED == 2) {
             // warning only do not send to cart
             $messageStack->add_session('header', WARNING_SHOPPING_CART_COMBINED, 'caution');

--- a/includes/modules/pages/login/header_php.php
+++ b/includes/modules/pages/login/header_php.php
@@ -90,6 +90,7 @@ if (isset($_GET['action']) && $_GET['action'] == 'process') {
         $messageStack->add('login', TEXT_LOGIN_ERROR);
       } else {
 
+        $zc_check_basket_before = 0;
         // save current cart contents count if required
         if (SHOW_SHOPPING_CART_COMBINED > 0) {
             $zc_check_basket_before = $_SESSION['cart']->count_contents();


### PR DESCRIPTION
3 commits provided, First truly fixes the issue, but understand that alternate solutions may be considered desirable and are provided.

1 -     Prevent debug log when hiding cart combine
    
    Addresses the issue described at:
    https://www.zen-cart.com/showthread.php?228272-Help-with-Error-Log-(PHP-Notice-Undefined-variable-zc_check_basket_before)
    
    This takes the shortest/simplest action to correct the issue by use of logic
    instead of additional code.  Any other change simply adds more code to file
    but may be desired to ensure updaters take at least one action which would
    prevent this issue in a common otherwise unmodified store.
    
    This is applicable to V1.5.7 and previous version as well, but likely
    is not made known unless using strict PHP operation as it does not appear
    to have been revealed until a high enough version of php was used and
    someone reported it.

2 -     Pre-assign value
    
    This at least prevents the message that the variable is not defined which
    was identifeid at: https://www.zen-cart.com/showthread.php?228272-Help-with-Error-Log-(PHP-Notice-Undefined-variable-zc_check_basket_before)
    
    This is additional action that isn't *required* to be present based on the
    change of the previous commit.
    
    It would resolve the issue if incorporated alone.

3 -     Add a value check to resequence of configuration value
    
    This adds a check against `!empty` to ensure that `$zc_check_basket_before`
    has been defined even though its value is expected to represent the quantity
    of product in the cart which is expected to be zero or greater. Therefore
    it does not account for a quantity greater than 0 as well. Such a consideration
    may be necessary for a site where returns are provided at checkout and the
    quantity of returns is for some reason expected to be a negative number.
