### PR TITLE
Allow other multiple addresses to process

### DIFF
--- a/includes/functions/functions_email.php
+++ b/includes/functions/functions_email.php
@@ -176,7 +176,7 @@ use PHPMailer\PHPMailer\SMTP;
        */
       $zco_notifier->notify('NOTIFY_EMAIL_DETERMINING_EMAIL_FORMAT', $to_email_address, $customers_email_format, $module);
 
-      if ($customers_email_format == 'NONE' || $customers_email_format == 'OUT') return false; //if requested no mail, then don't send.
+      if ($customers_email_format == 'NONE' || $customers_email_format == 'OUT') continue; //if requested no mail, then don't send, but continue processing others.
 
       // handling admin/"extra"/copy emails:
       if (ADMIN_EXTRA_EMAIL_FORMAT == 'TEXT' && substr($module,-6)=='_extra') {


### PR DESCRIPTION
If there is more than one recipient for an email, but only one of the recipients requested not to receive an email, existing code would stop processing emails beyond that individual. Worst case would be that the first of many did not want an email and therefore none would receive one.  This change continues to interupt the process of sending the email; however, will allow the code beyond the loop to process error information and to use the notifier that is present (which may have an effect on "output").

This change is backwards compatible.