### PR TITLE
V158 add and incorporate function zen set category image

### DIFF
--- a/admin/categories.php
+++ b/admin/categories.php
@@ -162,17 +162,13 @@ if (!empty($action)) {
       }
       // remove the existing image
       if (!empty($_POST['image_delete'])) {
-          $db->Execute("UPDATE " . TABLE_CATEGORIES . "
-                            SET categories_image = ''
-                            WHERE categories_id = " . (int)$categories_id);
+          zen_set_category_image($categories_id, '');
           $messageStack->add_session(sprintf(MESSAGE_IMAGE_REMOVED_CATEGORY, (int)$categories_id, zen_get_category_name($categories_id, $_SESSION['languages_id'])), 'success');
           // or assign a manually-typed/existing image
       } elseif ($_POST['categories_image_manual'] !== '') {
           $categories_image_name = zen_db_input($_POST['img_dir'] . $_POST['categories_image_manual']);
           if (file_exists(DIR_FS_CATALOG_IMAGES . $categories_image_name)) {
-              $db->Execute("UPDATE " . TABLE_CATEGORIES . "
-                      SET categories_image = '" . $categories_image_name . "'
-                      WHERE categories_id = " . (int)$categories_id);
+              zen_set_category_image($categories_id, $categories_image_name);
               $messageStack->add_session(sprintf(MESSAGE_IMAGE_ADDED_MANUAL, (int)$categories_id, zen_get_category_name($categories_id, $_SESSION['languages_id']), $categories_image_name), 'success');
           } else {
               $messageStack->add_session(sprintf(ERROR_IMAGE_MANUAL_NOT_FOUND, $categories_image_name));
@@ -187,9 +183,7 @@ if (!empty($action)) {
           if ($categories_image->filename !== 'none' && $categories_image->filename != '') {
               // save filename when not set to none and not blank
               $db_filename = zen_limit_image_filename($categories_image_name, TABLE_CATEGORIES, 'categories_image');
-              $db->Execute("UPDATE " . TABLE_CATEGORIES . "
-                          SET categories_image = '" . $db_filename . "'
-                          WHERE categories_id = " . (int)$categories_id);
+              zen_set_category_image($categories_id, $db_filename);
           }
       }
 

--- a/includes/functions/functions_categories.php
+++ b/includes/functions/functions_categories.php
@@ -1145,6 +1145,19 @@ function zen_set_category_status($category_id, $status)
     $db->Execute($sql);
 }
 
+/**
+ * @param int $category_id
+ * @param string $image_name
+ */
+function zen_set_category_image($category_id, $image_name = '')
+{
+    global $db;
+    $sql = "UPDATE " . TABLE_CATEGORIES . "
+            SET categories_image = :image_name
+            WHERE categories_id = " . (int)$category_id;
+    $sql = $db->bindVars($sql, ':image_name', $image_name, 'stringIgnoreNull');
+    $db->Execute($sql);
+}
 
 
 /**


### PR DESCRIPTION
Incorporates the idea of reducing number of lines of code and code duplication by use of a single function instead of the same code rewritten multiple times differing only in the image that is assigned. This is similar to the newly added `zen_set_category_status` function.

The second commit in this PR implements the use of the new function `zen_set_category_image` that is in `catalog/includes/functions/functions_categories.php`.