### PR TITLE
correct misuse of ternary operator

### DIFF
--- a/includes/templates/template_default/templates/tpl_checkout_payment_default.php
+++ b/includes/templates/template_default/templates/tpl_checkout_payment_default.php
@@ -125,7 +125,7 @@
     if (sizeof($selection) > 1) {
         if (empty($selection[$i]['noradio'])) {
  ?>
-<?php echo zen_draw_radio_field('payment', $selection[$i]['id'], ($selection[$i]['id'] == ($_SESSION['payment'] ?: '')), 'id="pmt-'.$selection[$i]['id'].'"'); ?>
+<?php echo zen_draw_radio_field('payment', $selection[$i]['id'], ($selection[$i]['id'] == ($_SESSION['payment'] ?? '')), 'id="pmt-'.$selection[$i]['id'].'"'); ?>
 <?php   } ?>
 <?php
     } else {


### PR DESCRIPTION
use of the ternary operator `?:` does NOT address an isset situation.

use of the null coalescing operator addresses this problem.

from the php page on the operators:

The expression (expr1) ?? (expr2) evaluates to expr2 if expr1 is null, and expr1 otherwise.
In particular, this operator does not emit a notice or warning if the left-hand side value does not exist, just like isset(). 

