### PR TITLE
Add TINYTEXT to the list of types that don't provide a length

### DIFF
--- a/includes/classes/db/mysql/query_factory.php
+++ b/includes/classes/db/mysql/query_factory.php
@@ -967,6 +967,7 @@ class queryFactoryMeta
             if (strtoupper($type) === 'DATE') $this->max_length = 10;
             if (strtoupper($type) === 'DATETIME') $this->max_length = 19; // ignores fractional which would be 26
             if (strtoupper($type) === 'TIMESTAMP') $this->max_length = 19; // ignores fractional which would be 26
+            if (strtoupper($type) === 'TINYTEXT') $this->max_length = 255; 
         }
     }
 }


### PR DESCRIPTION
Without this fix, you get a PHP log in 1.5.7 when editing a product that looks like this: 

[18-Sep-2021 06:57:43 America/New_York] Request URI: /store/admin/index.php?cmd=product&cPath=105_110&product_type=1&pID=3826&action=new_product, IP address: ::1
#1  zen_set_field_length() called at [/Users/scott/Sites/store/admin/includes/modules/product/collect_info.php:452]
#2  require(/Users/scott/Sites/store/admin/includes/modules/product/collect_info.php) called at [/Users/scott/Sites/store/admin/product.php:102]
#3  require(/Users/scott/Sites/store/admin/product.php) called at [/Users/scott/Sites/store/admin/index.php:11]
--> PHP Warning: A non-numeric value encountered in /Users/scott/Sites/store/admin/includes/functions/general.php on line 2230.
