### PR TITLE
Wider order number required for sites with 6+ digit order numbers

### DIFF
--- a/admin/orders.php
+++ b/admin/orders.php
@@ -557,7 +557,7 @@ if (!empty($action) && $order_exists == true) {
           <div class="col-sm-3 col-lg-4 text-left noprint">
             <?php echo $left_side_buttons; ?>
           </div>
-          <div class="col-sm-6 col-lg-4 noprint">
+          <div class="col-sm-6 col-lg-6 noprint">
             <div class="input-group">
               <span class="input-group-btn">
                   <?php echo $prev_button; ?>


### PR DESCRIPTION
Without this fix, order navigation looks like this: 
<img width="500" alt="without" src="https://user-images.githubusercontent.com/4391638/135331796-0823a32c-288a-4f4d-98b6-a64d4cdc585f.png">

With this fix, it looks better: 

<img width="713" alt="with2 png " src="https://user-images.githubusercontent.com/4391638/135332197-75b85fa7-cf7b-4d5c-a6ea-476d8b8d8895.png">

