### PR TITLE
Option Values Manager fixes for php warning Undefined variable $check_dups

### DIFF
--- a/admin/options_values_manager.php
+++ b/admin/options_values_manager.php
@@ -95,6 +95,7 @@ if (!empty($action)) {
                                  AND pov.products_options_values_name = '" . zen_db_input($value_name) . "'
                                  AND pov2po.products_options_id = " . (int)$option_id);
           if ($check->RecordCount() > 1) {
+              $check_dups = '';
             foreach ($check as $item) {
               $check_dups .= ' - ' . $item['products_options_values_id'];
             }
@@ -144,6 +145,7 @@ if (!empty($action)) {
                                  AND pov2po.products_options_id = " . (int)$option_id);
 
           if ($check->RecordCount() > 1) {
+              $check_dups = '';
             foreach ($check as $item) {
               $check_dups .= ' - ' . $item['products_options_values_id'];
             }


### PR DESCRIPTION
Fix for:
if a duplicate name is inserted, triggers php warning Undefined variable $check_dups
