### PR TITLE
ZC158 options values manager fix for comparison fail from php8

### DIFF
--- a/admin/options_values_manager.php
+++ b/admin/options_values_manager.php
@@ -663,14 +663,16 @@ if (!empty($action)) {
           ?>
         </div>
         <?php
+        $filter_condition = '';
+        if ($filter !== 0) $filter_condition = " AND po.products_options_id = " . $filter; 
         $values_query_raw = "SELECT pov.products_options_values_id, pov.products_options_values_name, pov2po.products_options_id, pov.products_options_values_sort_order
                              FROM " . TABLE_PRODUCTS_OPTIONS_VALUES . " pov
                              LEFT JOIN " . TABLE_PRODUCTS_OPTIONS_VALUES_TO_PRODUCTS_OPTIONS . " pov2po ON pov2po.products_options_values_id = pov.products_options_values_id
                              LEFT JOIN " . TABLE_PRODUCTS_OPTIONS . " po ON po.products_options_id = pov2po.products_options_id
-                               AND po.language_id = " . (int)$_SESSION['languages_id'] . "
+                             AND po.language_id = " . (int)$_SESSION['languages_id'] . "
                              WHERE pov.language_id = " . (int)$_SESSION['languages_id'] . "
-                             AND pov2po.products_options_values_id != " . PRODUCTS_OPTIONS_VALUES_TEXT_ID . "
-                             " . (isset($filter) && $filter != '' ? " AND po.products_options_id = " . (int)$filter : "") . "
+                             AND pov2po.products_options_values_id != " . PRODUCTS_OPTIONS_VALUES_TEXT_ID . 
+                             $filter_condition . "
                              ORDER BY po.products_options_name, LPAD(pov.products_options_values_sort_order,11,'0'), pov.products_options_values_name";
         $values_split = new splitPageResults($currentPage, $max_search_results, $values_query_raw, $values_query_numrows);
         ?>


### PR DESCRIPTION
When there is no filter set of an option name:
php version <8 : all the option values are listed
php version >8 : no option values are listed
due to string to number comparison change:
https://www.php.net/manual/en/migration80.incompatible.php

In this file the filter is set to an integer or 0 integer, and all comparisons apart from this one in the query are already strict.