### PR TITLE
Sold out should not be presented as a button

### DIFF
--- a/includes/functions/functions_general.php
+++ b/includes/functions/functions_general.php
@@ -205,11 +205,11 @@ function zen_get_buy_now_button($product_id, string $buy_now_link, $additional_l
             $return_button = '<a href="' . zen_href_link(FILENAME_ASK_A_QUESTION, 'pid=' . (int)$product_id, 'SSL') . '">' . TEXT_CALL_FOR_PRICE . '</a>';
             break;
         case ($button_check->fields['products_quantity'] <= 0 and SHOW_PRODUCTS_SOLD_OUT_IMAGE == '1'):
-            if ($_GET['main_page'] == zen_get_info_page($product_id)) {
-                $return_button = zen_image_button(BUTTON_IMAGE_SOLD_OUT, BUTTON_SOLD_OUT_ALT);
-            } else {
-                $return_button = zen_image_button(BUTTON_IMAGE_SOLD_OUT_SMALL, BUTTON_SOLD_OUT_SMALL_ALT);
-            }
+            global $template;
+            $image = BUTTON_IMAGE_SOLD_OUT; 
+            $alt = BUTTON_SOLD_OUT_ALT; 
+            $return_button = '<span class="text-center">' . zen_image($template->get_template_dir($image, DIR_WS_TEMPLATE, $current_page_base, 'buttons/' . $_SESSION['language'] . '/') . $image, $alt, '', '', '') . '</span>'; 
+            $zco_notifier->notify('NOTIFY_ZEN_SOLD_OUT_IMAGE', array_merge($button_check->fields, ['products_id' => (int)$product_id]), $return_button);
             break;
         default:
             $return_button = $buy_now_link;


### PR DESCRIPTION
It's confusing to have Sold Out use the same styling as a button with an action.  This change reverts to using the old style image. 

Before:
<img width="438" alt="sold_out_old" src="https://user-images.githubusercontent.com/4391638/140116919-fe368dc5-e771-461d-a341-586e84e1af23.png">

After: 
<img width="444" alt="sold_out_new" src="https://user-images.githubusercontent.com/4391638/140117086-53893190-78e4-40c4-adcd-0c8818b31ff6.png">
 
