### PR TITLE
Fix incorrect call to get_audiences_list()

### DIFF
--- a/admin/mail.php
+++ b/admin/mail.php
@@ -261,7 +261,7 @@ if ($action == 'preview') {
         <div class="row">
             <?php echo zen_draw_form('mail', FILENAME_MAIL, 'action=preview' . (isset($_GET['cID']) ? '&cID=' . (int)$_GET['cID'] : '') . (isset($_GET['customer']) ? '&customer=' . zen_output_string_protected($_GET['customer']) : '') . (isset($_GET['origin']) ? '&origin=' . zen_output_string_protected($_GET['origin']) : ''), 'post', 'onsubmit="return check_form(mail);" enctype="multipart/form-data" class="form-horizontal"'); ?>
             <?php
-            $customers = get_audiences_list('email', 'false', (isset($_GET['customer']) ? zen_output_string_protected($_GET['customer']) : ''));
+            $customers = get_audiences_list('email', '', (isset($_GET['customer']) ? zen_output_string_protected($_GET['customer']) : ''));
             ?>
           <div class="form-group">
               <?php echo zen_draw_label(TEXT_CUSTOMER, 'customers_email_address', 'class="col-sm-3 control-label"'); ?>


### PR DESCRIPTION
Fixes #4494 
This bug also exists in Zen Cart 1.5.7. 

Now admin/mail.php will show the counts of each audience if the admin setting Admin > Configuration > Email > Audience-Select Count Display is set to true. 