### PR TITLE
ZC158 Admin, Move Product from a search result: use cPath value from current_category_id of selected product

### DIFF
--- a/admin/includes/modules/move_product.php
+++ b/admin/includes/modules/move_product.php
@@ -29,7 +29,7 @@ if (!isset($product_master_category_string)) $product_master_category_string = z
 
 $heading = [];
 $heading[] = ['text' => '<h4>' . TEXT_INFO_HEADING_MOVE_PRODUCT . '</h4>'];
-$contents = ['form' => zen_draw_form('products', FILENAME_CATEGORY_PRODUCT_LISTING, 'action=move_product_confirm&cPath=' . $cPath . (isset($_GET['page']) ? '&page=' . $_GET['page'] : ''), 'post', 'class="form-horizontal"') . zen_draw_hidden_field('products_id', $pInfo->products_id)];
+$contents = ['form' => zen_draw_form('products', FILENAME_CATEGORY_PRODUCT_LISTING, 'action=move_product_confirm&cPath=' . $current_category_id . (isset($_GET['page']) ? '&page=' . $_GET['page'] : ''), 'post', 'class="form-horizontal"') . zen_draw_hidden_field('products_id', $pInfo->products_id)];
 $contents[] = ['text' => '<h3>' . 'ID#' . $pInfo->products_id . ': ' . $pInfo->products_name . '</h3>'];
 $contents[] = ['text' => TEXT_MOVE_PRODUCTS_INTRO];
 $contents[] = ['text' => zen_draw_label(sprintf(TEXT_MOVE_PRODUCT, $pInfo->products_id, $pInfo->products_name, $current_category_id, $product_current_category_string), 'move_to_category_id', 'style="font-weight:normal;font-size:larger;"') . zen_draw_pull_down_menu('move_to_category_id', zen_get_category_tree(), $current_category_id, 'id="move_to_category_id" class="form-control"')];


### PR DESCRIPTION
Move product was not working from a search result listing.

The Move Product infobox form action has a cPath parameter. On form submission this cPath is used to generate the current_category_id **for that product** which in turn is used in the move sql prior to changing the entry in the products_to_categories table.

So, this cPath must be one in which the product is located (whether master or linked), to generate a valid current_category_id.

1) If you navigate to a product and use the Move function, the cPath on the form action is a valid one for that product and so the Move works.
2) If you search, and use the Move function from one of the products in the list, the cPath used on the form action is the one related to the **last product in the results list**.

Here you see the Matrox is in category 4, but the form action is using cPath 15 which is for the last dvd in the list:

![Clipboard03](https://user-images.githubusercontent.com/4391026/146070460-26e953b4-3b75-4d98-86cb-c8be03945a2f.gif)


This cPath is not related to the product in question, so there is no valid entry for it in p2c and so there is no move.

So I think the case of it working in 1) is only because all the products in that category have the same cPath.

To demonstrate this do a search for dvd and try and move the graphics card from the results. No move.

So, in the infobox form action I’ve changed the cPath value from the cPath to current_category_id.

