### PR TITLE
v158 Begin numbering so that all items on first page area always selectable.

### DIFF
--- a/admin/banner_manager.php
+++ b/admin/banner_manager.php
@@ -480,7 +480,7 @@ if (!empty($action)) {
 // reset page when page is unknown
                 if ((empty($_GET['page']) || $_GET['page'] == '1') && !empty($_GET['bID'])) {
                   $check_page = $db->Execute($banners_query_raw);
-                  $check_count = 1;
+                  $check_count = 0;
                   if ($check_page->RecordCount() > MAX_DISPLAY_SEARCH_RESULTS) {
                     foreach ($check_page as $item) {
                       if ($item['banners_id'] == (int)$_GET['bID']) {

--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -779,11 +779,11 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
 // Split Page
 
 // reset page when page is unknown
-            if ((isset($_GET['page']) && ($_GET['page'] == '1' || $_GET['page'] == '')) && isset($_GET['pID']) && $_GET['pID'] != '') {
+            if ((empty($_GET['page']) || $_GET['page'] == '1') && !empty($_GET['pID'])) {
               $old_page = $_GET['page'];
               $check_page = $db->Execute($products_query_raw);
               if ($check_page->RecordCount() > MAX_DISPLAY_RESULTS_CATEGORIES) {
-                $check_count = 1;
+                $check_count = 0;
                 foreach ($check_page as $item) {
                   if ($item['products_id'] == $_GET['pID']) {
                     break;

--- a/admin/customer_groups.php
+++ b/admin/customer_groups.php
@@ -84,7 +84,7 @@ if (!empty($action)) {
                 // reset page when page is unknown
                 if ((empty($_GET['page']) || $_GET['page'] == '1') && !empty($_GET['gID'])) {
                     $check_page = $db->Execute($sql);
-                    $check_count = 1;
+                    $check_count = 0;
                     if ($check_page->RecordCount() > $max_records_per_page) {
                         foreach ($check_page as $item) {
                             if ((int)$item['group_id'] === (int)$_GET['gID']) {

--- a/admin/customers.php
+++ b/admin/customers.php
@@ -843,9 +843,9 @@ if (!empty($action)) {
 
 // Split Page
 // reset page when page is unknown
-                if (($_GET['page'] == '' || $_GET['page'] == '1') && !empty($_GET['cID'])) {
+                if ((empty($_GET['page']) || $_GET['page'] == '1') && !empty($_GET['cID'])) {
                   $check_page = $db->Execute($customers_query_raw);
-                  $check_count = 1;
+                  $check_count = 0;
                   if ($check_page->RecordCount() > MAX_DISPLAY_SEARCH_RESULTS_CUSTOMER) {
                     foreach ($check_page as $item) {
                       if ($item['customers_id'] == $_GET['cID']) {

--- a/admin/ezpages.php
+++ b/admin/ezpages.php
@@ -557,6 +557,22 @@ if (!empty($action)) {
                                     " . $ez_order_by;
 
 // Split Page
+// reset page when page is unknown
+                if ((empty($_GET['page']) || $_GET['page'] == '1') && !empty($_GET['ezID'])) {
+                  $check_page = $db->Execute($pages_query_raw);
+                  $check_count = 0;
+                  if ($check_page->RecordCount() > MAX_DISPLAY_SEARCH_RESULTS_EZPAGE) {
+                    foreach ($check_page as $item) {
+                      if ($item['pages_id'] == $_GET['ezID']) {
+                        break;
+                      }
+                      $check_count++;
+                    }
+                    $_GET['page'] = round((($check_count / MAX_DISPLAY_SEARCH_RESULTS_EZPAGE) + (fmod_round($check_count, MAX_DISPLAY_SEARCH_RESULTS_EZPAGE) != 0 ? .5 : 0)), 0);
+                  } else {
+                    $_GET['page'] = 1;
+                  }
+                }
 
                 $pages_split = new splitPageResults($_GET['page'], MAX_DISPLAY_SEARCH_RESULTS_EZPAGE, $pages_query_raw, $pages_query_numrows);
                 $pages = $db->Execute($pages_query_raw);

--- a/admin/featured.php
+++ b/admin/featured.php
@@ -367,6 +367,25 @@ if (!empty($action)) {
                                        " . $order_by;
 
                 // Split Page
+                // reset page when page is unknown
+                if ((empty($_GET['page']) || $_GET['page'] == '1') && !empty($_GET['fID'])) {
+                    $old_page = $_GET['page'];
+                    $check_page = $db->Execute($featured_query_raw);
+                    if ($check_page->RecordCount() > MAX_DISPLAY_SEARCH_RESULTS_FEATURED_ADMIN) {
+                        $check_count = 0;
+                        foreach ($check_page as $item) {
+                            if ((int)$item['featured_id'] === (int)$_GET['fID']) {
+                                break;
+                            }
+                            $check_count++;
+                        }
+                        $_GET['page'] = round((($check_count / MAX_DISPLAY_SEARCH_RESULTS_FEATURED_ADMIN) + (fmod_round($check_count, MAX_DISPLAY_SEARCH_RESULTS_FEATURED_ADMIN) !== 0 ? .5 : 0)));
+                        $page = $_GET['page'];
+                    } else {
+                        $_GET['page'] = 1;
+                    }
+                }
+
                 // create split page control
                 $featured_split = new splitPageResults($_GET['page'], MAX_DISPLAY_SEARCH_RESULTS_FEATURED_ADMIN, $featured_query_raw, $featured_query_numrows);
                 $featureds = $db->Execute($featured_query_raw);

--- a/admin/geo_zones.php
+++ b/admin/geo_zones.php
@@ -179,9 +179,9 @@ if (!empty($action)) {
                                       ORDER BY c.countries_name, association_id";
 // Split Page
 // reset page when page is unknown
-                  if ((!isset($_GET['spage']) or $_GET['spage'] == '' or $_GET['spage'] == '1') && !empty($_GET['sID'])) {
+                  if ((empty($_GET['spage']) || $_GET['spage'] == '1') && !empty($_GET['sID'])) {
                     $check_page = $db->Execute($zones_query_raw);
-                    $check_count = 1;
+                    $check_count = 0;
                     if ($check_page->RecordCount() > MAX_DISPLAY_SEARCH_RESULTS) {
                       foreach ($check_page as $item) {
                         if ($item['association_id'] == $_GET['sID']) {
@@ -248,9 +248,9 @@ if (!empty($action)) {
                                         ORDER BY geo_zone_name";
 // Split Page
 // reset page when page is unknown
-                    if ((!isset($_GET['zpage']) or $_GET['zpage'] == '' or $_GET['zpage'] == '1') && !empty($_GET['zID'])) {
+                    if ((empty($_GET['zpage']) ||$_GET['zpage'] == '1') && !empty($_GET['zID'])) {
                       $check_page = $db->Execute($zones_query_raw);
-                      $check_count = 1;
+                      $check_count = 0;
                       if ($check_page->RecordCount() > MAX_DISPLAY_SEARCH_RESULTS) {
                         foreach ($check_page as $item) {
                           if ($item['geo_zone_id'] == $_GET['zID']) {

--- a/admin/group_pricing.php
+++ b/admin/group_pricing.php
@@ -101,7 +101,7 @@ if ($query->fields['count'] > 0 && (!defined('MODULE_ORDER_TOTAL_GROUP_PRICING_S
 // reset page when page is unknown
                 if ((empty($_GET['page']) || $_GET['page'] == '1') && !empty($_GET['gID'])) {
                   $check_page = $db->Execute($groups_query_raw);
-                  $check_count = 1;
+                  $check_count = 0;
                   if ($check_page->RecordCount() > MAX_DISPLAY_SEARCH_RESULTS) {
                     foreach ($check_page as $item) {
                       if ($item['group_id'] == $_GET['gID']) {

--- a/admin/manufacturers.php
+++ b/admin/manufacturers.php
@@ -168,6 +168,23 @@ if (!empty($action)) {
                                           FROM " . TABLE_MANUFACTURERS . "
                                           ORDER BY weighted DESC, manufacturers_name";
 
+              // reset page when page is unknown
+              if ((empty($_GET['page']) || $_GET['page'] == '1') && !empty($_GET['mID'])) {
+                $check_page = $db->Execute($manufacturers_query_raw);
+                $check_count = 0;
+                if ($check_page->RecordCount() > MAX_DISPLAY_SEARCH_RESULTS) {
+                  foreach ($check_page as $item) {
+                    if ($item['manufacturers_id'] == $_GET['mID']) {
+                      break;
+                    }
+                    $check_count++;
+                  }
+                  $_GET['page'] = round((($check_count / MAX_DISPLAY_SEARCH_RESULTS) + (fmod_round($check_count, MAX_DISPLAY_SEARCH_RESULTS) != 0 ? .5 : 0)), 0);
+                } else {
+                  $_GET['page'] = 1;
+                }
+              }
+
               $manufacturers_split = new splitPageResults($_GET['page'], MAX_DISPLAY_SEARCH_RESULTS, $manufacturers_query_raw, $manufacturers_query_numrows);
               $manufacturers = $db->Execute($manufacturers_query_raw);
               foreach ($manufacturers as $manufacturer) {

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -1248,9 +1248,9 @@ if (!empty($action) && $order_exists == true) {
 
 // Split Page
 // reset page when page is unknown
-                  if (($_GET['page'] == '' or $_GET['page'] <= 1) && !empty($_GET['oID'])) {
+                  if ((empty($_GET['page']) || $_GET['page'] <= 1) && !empty($_GET['oID'])) {
                     $check_page = $db->Execute($orders_query_raw);
-                    $check_count = 1;
+                    $check_count = 0;
                     if ($check_page->RecordCount() > MAX_DISPLAY_SEARCH_RESULTS_ORDERS) {
                       while (!$check_page->EOF) {
                         if ($check_page->fields['orders_id'] == $_GET['oID']) {

--- a/admin/reviews.php
+++ b/admin/reviews.php
@@ -308,6 +308,23 @@ if (!empty($action)) {
                                       GROUP BY r.reviews_id, rd.languages_id
                                       " . $order_by;
 
+                // reset page when page is unknown
+                if ((empty($_GET['page']) || $_GET['page'] == '1') && !empty($_GET['rID'])) {
+                  $check_page = $db->Execute($reviews_query_raw);
+                  $check_count = 0;
+                  if ($check_page->RecordCount() > MAX_DISPLAY_SEARCH_RESULTS) {
+                    foreach ($check_page as $item) {
+                      if ($item['reviews_id'] == $_GET['rID']) {
+                        break;
+                      }
+                      $check_count++;
+                    }
+                    $_GET['page'] = round((($check_count / MAX_DISPLAY_SEARCH_RESULTS) + (fmod_round($check_count, MAX_DISPLAY_SEARCH_RESULTS) != 0 ? .5 : 0)), 0);
+                  } else {
+                    $_GET['page'] = 1;
+                  }
+                }
+
                 $reviews_split = new splitPageResults($_GET['page'], MAX_DISPLAY_SEARCH_RESULTS, $reviews_query_raw, $reviews_query_numrows);
                 $reviews = $db->Execute($reviews_query_raw);
                 foreach ($reviews as $review) {

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -455,6 +455,25 @@ if (!empty($action)) {
                                        " . $order_by;
 
                 // Split Page
+                // reset page when page is unknown
+                if ((empty($_GET['page']) || $_GET['page'] == '1') && !empty($_GET['sID'])) {
+                    $old_page = $_GET['page'];
+                    $check_page = $db->Execute($specials_query_raw);
+                    if ($check_page->RecordCount() > MAX_DISPLAY_SEARCH_RESULTS) {
+                        $check_count = 0;
+                        foreach ($check_page as $item) {
+                            if ((int)$item['specials_id'] === (int)$_GET['sID']) {
+                                break;
+                            }
+                            $check_count++;
+                        }
+                        $_GET['page'] = round((($check_count / MAX_DISPLAY_SEARCH_RESULTS) + (fmod_round($check_count, MAX_DISPLAY_SEARCH_RESULTS) !== 0 ? .5 : 0)));
+                        $page = $_GET['page'];
+                    } else {
+                        $_GET['page'] = 1;
+                    }
+                }
+
                 // create split page control
                 $specials_split = new splitPageResults($_GET['page'], MAX_DISPLAY_SEARCH_RESULTS, $specials_query_raw, $specials_query_numrows);
                 $specials = $db->Execute($specials_query_raw);


### PR DESCRIPTION
Through observation this counter needs to begin at a value of 0 so that
when a quantity spans more than one page, that the last item on the first
page can be selected allowing the page to reload with it selected and
editable. There may be other arrangements, but this fixes the issue with
the code continuing to exist here.

In some cases, added back the recently removed code to support this operation.

Fixed #4489