### PR TITLE
V157 admin last item multi page correct

### DIFF
--- a/admin/banner_manager.php
+++ b/admin/banner_manager.php
@@ -420,7 +420,7 @@ if (zen_not_null($action)) {
 // reset page when page is unknown
                   if ((empty($_GET['page']) || $_GET['page'] == '1') && !empty($_GET['bID'])) {
                     $check_page = $db->Execute($banners_query_raw);
-                    $check_count = 1;
+                    $check_count = 0;
                     if ($check_page->RecordCount() > MAX_DISPLAY_SEARCH_RESULTS) {
                       foreach ($check_page as $item) {
                         if ($item['banners_id'] == (int)$_GET['bID']) {

--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -802,11 +802,11 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
 // Split Page
 
 // reset page when page is unknown
-            if ((isset($_GET['page']) && ($_GET['page'] == '1' || $_GET['page'] == '')) && isset($_GET['pID']) && $_GET['pID'] != '') {
+            if ((empty($_GET['page']) || $_GET['page'] == '1') && !empty($_GET['pID'])) {
               $old_page = $_GET['page'];
               $check_page = $db->Execute($products_query_raw);
               if ($check_page->RecordCount() > MAX_DISPLAY_RESULTS_CATEGORIES) {
-                $check_count = 1;
+                $check_count = 0;
                 foreach ($check_page as $item) {
                   if ($item['products_id'] == $_GET['pID']) {
                     break;

--- a/admin/customers.php
+++ b/admin/customers.php
@@ -1215,9 +1215,9 @@ if (zen_not_null($action)) {
 
 // Split Page
 // reset page when page is unknown
-                  if (($_GET['page'] == '' || $_GET['page'] == '1') && !empty($_GET['cID'])) {
+                  if ((empty($_GET['page']) || $_GET['page'] == '1') && !empty($_GET['cID'])) {
                     $check_page = $db->Execute($customers_query_raw);
-                    $check_count = 1;
+                    $check_count = 0;
                     if ($check_page->RecordCount() > MAX_DISPLAY_SEARCH_RESULTS_CUSTOMER) {
                       foreach ($check_page as $item) {
                         if ($item['customers_id'] == $_GET['cID']) {

--- a/admin/ezpages.php
+++ b/admin/ezpages.php
@@ -561,7 +561,7 @@ if (zen_not_null($action)) {
 // reset page when page is unknown
                 if ((empty($_GET['page']) || $_GET['page'] == '1') && !empty($_GET['ezID'])) {
                   $check_page = $db->Execute($pages_query_raw);
-                  $check_count = 1;
+                  $check_count = 0;
                   if ($check_page->RecordCount() > MAX_DISPLAY_SEARCH_RESULTS_EZPAGE) {
                     foreach ($check_page as $item) {
                       if ($item['pages_id'] == $_GET['ezID']) {

--- a/admin/featured.php
+++ b/admin/featured.php
@@ -347,11 +347,11 @@ if (zen_not_null($action)) {
 
                     // Split Page
                     // reset page when page is unknown
-                    if ((isset($_GET['page']) && ($_GET['page'] == '1' || $_GET['page'] == '')) && isset($_GET['fID']) && $_GET['fID'] != '') {
+                    if ((empty($_GET['page']) || $_GET['page'] == '1') && !empty($_GET['fID'])) {
                         $old_page = $_GET['page'];
                         $check_page = $db->Execute($featured_query_raw);
                         if ($check_page->RecordCount() > MAX_DISPLAY_SEARCH_RESULTS_FEATURED_ADMIN) {
-                            $check_count = 1;
+                            $check_count = 0;
                             foreach ($check_page as $item) {
                                 if ((int)$item['featured_id'] === (int)$_GET['fID']) {
                                     break;

--- a/admin/geo_zones.php
+++ b/admin/geo_zones.php
@@ -198,9 +198,9 @@ if (zen_not_null($action)) {
                                       ORDER BY c.countries_name, association_id";
 // Split Page
 // reset page when page is unknown
-                  if ((!isset($_GET['spage']) or $_GET['spage'] == '' or $_GET['spage'] == '1') && !empty($_GET['sID'])) {
+                  if ((empty($_GET['spage']) || $_GET['spage'] == '1') && !empty($_GET['sID'])) {
                     $check_page = $db->Execute($zones_query_raw);
-                    $check_count = 1;
+                    $check_count = 0;
                     if ($check_page->RecordCount() > MAX_DISPLAY_SEARCH_RESULTS) {
                       foreach ($check_page as $item) {
                         if ($item['association_id'] == $_GET['sID']) {
@@ -267,9 +267,9 @@ if (zen_not_null($action)) {
                                         ORDER BY geo_zone_name";
 // Split Page
 // reset page when page is unknown
-                    if ((!isset($_GET['zpage']) or $_GET['zpage'] == '' or $_GET['zpage'] == '1') && !empty($_GET['zID'])) {
+                    if ((empty($_GET['zpage']) ||$_GET['zpage'] == '1') && !empty($_GET['zID'])) {
                       $check_page = $db->Execute($zones_query_raw);
-                      $check_count = 1;
+                      $check_count = 0;
                       if ($check_page->RecordCount() > MAX_DISPLAY_SEARCH_RESULTS) {
                         foreach ($check_page as $item) {
                           if ($item['geo_zone_id'] == $_GET['zID']) {

--- a/admin/group_pricing.php
+++ b/admin/group_pricing.php
@@ -115,7 +115,7 @@ if ($query->fields['count'] > 0 && (!defined('MODULE_ORDER_TOTAL_GROUP_PRICING_S
 // reset page when page is unknown
                 if ((empty($_GET['page']) || $_GET['page'] == '1') && !empty($_GET['gID'])) {
                   $check_page = $db->Execute($groups_query_raw);
-                  $check_count = 1;
+                  $check_count = 0;
                   if ($check_page->RecordCount() > MAX_DISPLAY_SEARCH_RESULTS) {
                     foreach ($check_page as $item) {
                       if ($item['group_id'] == $_GET['gID']) {

--- a/admin/manufacturers.php
+++ b/admin/manufacturers.php
@@ -167,7 +167,7 @@ if (zen_not_null($action)) {
 // reset page when page is unknown
                 if ((empty($_GET['page']) || $_GET['page'] == '1') && !empty($_GET['mID'])) {
                   $check_page = $db->Execute($manufacturers_query_raw);
-                  $check_count = 1;
+                  $check_count = 0;
                   if ($check_page->RecordCount() > MAX_DISPLAY_SEARCH_RESULTS) {
                     foreach ($check_page as $item) {
                       if ($item['manufacturers_id'] == $_GET['mID']) {

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -1200,9 +1200,9 @@ if (zen_not_null($action) && $order_exists == true) {
 
 // Split Page
 // reset page when page is unknown
-                  if (($_GET['page'] == '' or $_GET['page'] <= 1) && !empty($_GET['oID'])) {
+                  if ((empty($_GET['page']) || $_GET['page'] <= 1) && !empty($_GET['oID'])) {
                     $check_page = $db->Execute($orders_query_raw);
-                    $check_count = 1;
+                    $check_count = 0;
                     if ($check_page->RecordCount() > MAX_DISPLAY_SEARCH_RESULTS_ORDERS) {
                       while (!$check_page->EOF) {
                         if ($check_page->fields['orders_id'] == $_GET['oID']) {

--- a/admin/reviews.php
+++ b/admin/reviews.php
@@ -265,7 +265,7 @@ if (zen_not_null($action)) {
 // reset page when page is unknown
                   if ((empty($_GET['page']) || $_GET['page'] == '1') && !empty($_GET['rID'])) {
                     $check_page = $db->Execute($reviews_query_raw);
-                    $check_count = 1;
+                    $check_count = 0;
                     if ($check_page->RecordCount() > MAX_DISPLAY_SEARCH_RESULTS) {
                       foreach ($check_page as $item) {
                         if ($item['reviews_id'] == $_GET['rID']) {

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -421,11 +421,11 @@ if (zen_not_null($action)) {
 
                     // Split Page
                     // reset page when page is unknown
-                    if ((isset($_GET['page']) && ($_GET['page'] == '1' || $_GET['page'] == '')) && isset($_GET['sID']) && $_GET['sID'] != '') {
+                    if ((empty($_GET['page']) || $_GET['page'] == '1') && !empty($_GET['sID'])) {
                         $old_page = $_GET['page'];
                         $check_page = $db->Execute($specials_query_raw);
                         if ($check_page->RecordCount() > MAX_DISPLAY_SEARCH_RESULTS) {
-                            $check_count = 1;
+                            $check_count = 0;
                             foreach ($check_page as $item) {
                                 if ((int)$item['specials_id'] === (int)$_GET['sID']) {
                                     break;


### PR DESCRIPTION
Begin numbering so that all items on first page area always selectable.

Through observation this counter needs to begin at a value of 0 so that
when a quantity spans more than one page, that the last item on the first
page can be selected allowing the page to reload with it selected and
editable. There may be other arrangements, but this fixes the issue with
the code continuing to exist here.
