### PR TITLE
ZC158, admin, manufacturers: PHP Fatal error: Uncaught TypeError: substr() expects parameter 1 to be string, null given

### DIFF
--- a/admin/manufacturers.php
+++ b/admin/manufacturers.php
@@ -253,7 +253,7 @@ if (!empty($action)) {
               $contents[] = ['text' => '<label class="checkbox-inline">' . zen_draw_checkbox_field('featured', '1', $mInfo->featured) . TEXT_MANUFACTURER_FEATURED_LABEL . '</label>'];
               $contents[] = ['text' => zen_draw_label(TEXT_MANUFACTURERS_IMAGE, 'manufacturers_image', 'class="control-label"') . zen_draw_file_field('manufacturers_image', '', ' class="form-control" id="manufacturers_image"') . '<br>' . $mInfo->manufacturers_image];
               $dir_info = zen_build_subdirectories_array(DIR_FS_CATALOG_IMAGES);
-              $default_directory = substr($mInfo->manufacturers_image, 0, strpos($mInfo->manufacturers_image ?? '', '/') + 1);
+              $default_directory = empty($mInfo->manufacturers_image) ? $mInfo->manufacturers_image = '' : substr($mInfo->manufacturers_image, 0, strpos($mInfo->manufacturers_image ?? '', '/') + 1);
 
               $contents[] = ['text' => zen_draw_label(TEXT_PRODUCTS_IMAGE_DIR, 'img_dir', 'class="control-label"') . zen_draw_pull_down_menu('img_dir', $dir_info, $default_directory, 'class="form-control" id="img_dir"')];
 


### PR DESCRIPTION
Add 
declare(strict_types=1);
at start of file.

Add a new manufacturer.
Do not set an image.
Save and open again:
PHP Fatal error:  Uncaught TypeError: substr() expects parameter 1 to be string, null given in ADMIN\manufacturers.php:257

https://github.com/zencart/zencart/blob/35b347e7b04903ed50b4c1272f957bec3a53307f/admin/manufacturers.php#L256

Database default is null. This PR just sets that value in the object to an empty string as part of the check as the value is used again a few lines later.