### PR TITLE
ZC158, php warning when action not set: assign value to action when not set

### DIFF
--- a/includes/modules/pages/redirect/header_php.php
+++ b/includes/modules/pages/redirect/header_php.php
@@ -11,6 +11,7 @@
 if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
 }
+$_GET['action'] = $_GET['action'] ?? '';
 switch ($_GET['action']) {
   case 'product':
     if (!empty($_GET['products_id'])) {


### PR DESCRIPTION
```
--> PHP Warning: Undefined array key "action" in .
.../includes/modules/pages/redirect/header_php.php on line 15.
```

I've had a couple of times for urls missing the action, eg:

> ... index.php?main_page=redirect&products_id=1575
> ,.. index.php?main_page=redirect&manufacturers_id=5

