### PR TITLE
improve query performance #4500

### DIFF
--- a/admin/orders.php
+++ b/admin/orders.php
@@ -904,7 +904,7 @@ if (!empty($action) && $order_exists == true) {
                 $orders_history = $db->Execute("SELECT *
                                               FROM " . TABLE_ORDERS_STATUS_HISTORY . "
                                               WHERE orders_id = " . zen_db_input($oID) . "
-                                              ORDER BY date_added");
+                                              ORDER BY orders_status_history_id");
 
                 if ($orders_history->RecordCount() > 0) {
                   $first = true;


### PR DESCRIPTION
the sort still needs to be there as `$db->Execute` returns the results in a reverse order which is different than running the query in a mysql session.  

this results in faster response with same results.
