### PR TITLE
add a common search form; fix missing closing tag

### DIFF
--- a/admin/featured.php
+++ b/admin/featured.php
@@ -211,7 +211,12 @@ if (!empty($action)) {
 //            $featured_array[] = $item['products_id'];
 //          }
         }
-        ?>
+
+          if ($action === 'new') {
+              $form = addSearchKeywordForm(FILENAME_FEATURED, $action);
+              echo $form;
+          }
+          ?>
         <div class="row">
           <?php echo zen_draw_form('new_featured', FILENAME_FEATURED, zen_get_all_get_params(['action', 'info', 'fID']) . 'action=' . $form_action . (!empty($_GET['go_back']) ? '&go_back=' . $_GET['go_back'] : ''), 'post', 'class="form-horizontal"'); ?>
           <?php
@@ -252,6 +257,7 @@ if (!empty($action)) {
               </div>
             </div>
           <?php } ?>
+        </div>
           <?php echo zen_draw_hidden_field('update_products_id', $fInfo->products_id); ?>
           <div class="form-group">
             <?php echo zen_draw_label(TEXT_FEATURED_AVAILABLE_DATE, 'featured_date_available', 'class="col-sm-3 control-label"'); ?>

--- a/admin/includes/functions/html_output.php
+++ b/admin/includes/functions/html_output.php
@@ -502,3 +502,31 @@ function zen_draw_date_selector($fieldname_prefix, $default_date='') {
     $date_selector .= '</select>';
     return $date_selector;
 }
+
+function addSearchKeywordForm($filename, $action) {
+    $keywords_products = (isset($_POST['keywords']) && zen_not_null($_POST['keywords'])) ? zen_db_input(zen_db_prepare_input($_POST['keywords'])) : '';
+    $form = '
+        <div class="row">
+            <div class="col-sm-offset-2 col-sm-4">' . zen_draw_form('keywords', $filename, 'action=' . $action, 'post', 'class="form-horizontal"') .
+        '<div class="form-group">' .
+        zen_draw_label(HEADING_TITLE_SEARCH_DETAIL_REPORTS_NAME_MODEL, 'keywords', 'class="control-label col-sm-3"') .
+        '<div class="col-sm-9">' .
+        zen_draw_input_field('keywords', '', 'class="form-control" id="keywords"') .
+        '</div>
+                </div>' . zen_hide_session_id();
+    if (!empty($keywords_products)) {
+        $form .= '<div class="form-group">
+                      <div class="col-sm-3">
+                          <p class="control-label">' . TEXT_INFO_SEARCH_DETAIL_FILTER . '</p>
+                      </div>
+                      <div class="col-sm-9 text-right">' .
+            zen_output_string_protected($keywords_products) . ' <a href="' . zen_href_link($filename, 'action=' . $action) . '" class="btn btn-default" role="button">' . IMAGE_RESET . '</a>
+                      </div>
+                  </div>';
+    }
+    $form .= '
+                </form>
+            </div>
+        </div>';
+    return $form;
+}

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -283,6 +283,10 @@ if (!empty($action)) {
 //            $specials_array[] = $item['products_id'];
 //          }
         }
+          if ($action === 'new') {
+              $form = addSearchKeywordForm(FILENAME_SPECIALS, $action);
+              echo $form;
+          }
         ?>
         <div class="row">
           <?php echo zen_draw_form('new_special', FILENAME_SPECIALS, zen_get_all_get_params(['action', 'info', 'sID']) . 'action=' . $form_action . (!empty($_GET['go_back']) ? '&go_back=' . $_GET['go_back'] : ''), 'post', 'class="form-horizontal"'); ?>
@@ -324,6 +328,7 @@ if (!empty($action)) {
               </div>
             </div>
           <?php } ?>
+        </div>
           <?php echo zen_draw_hidden_field('products_priced_by_attribute', $sInfo->products_priced_by_attribute); ?>
           <?php echo zen_draw_hidden_field('products_price', (!empty($sInfo->products_price) ? $sInfo->products_price : '')); ?>
           <?php echo zen_draw_hidden_field('update_products_id', $sInfo->products_id); ?>


### PR DESCRIPTION
i decided to use a common function for building the search form.  i'm hopeful of potentially using it in additional places.  it still provides this functionality to the specials and featured pages on the admin side:

![image](https://user-images.githubusercontent.com/1095136/148625009-1697c7de-f494-4abd-b6e9-c29f3ebd7511.png)

in addition, both scripts were missing a closing div tag which i added.