### PR TITLE
Fixes #4535 Demo images not present - ZipArchive not found on install of 1.5.8 zen cart

### DIFF
--- a/zc_install/includes/languages/en_us/main.php
+++ b/zc_install/includes/languages/en_us/main.php
@@ -139,6 +139,7 @@ return [
 'TEXT_ERROR_MYSQL_SUPPORT' => 'Problems with your MySQL (mysqli) support. Your server appears to be missing the mysqli extension for PHP, and without it we cannot connect to your database. Talk to your hosting company for assistance.',
 'TEXT_ERROR_PDOMYSQL_SUPPORT' => 'Problems with your MySQL (pdo_mysql) support. Your server appears to be missing the pdo_mysql extension for PHP, and without it we cannot connect to your database. Talk to your hosting company for assistance.',
 'TEXT_ERROR_PDOSQLITE_SUPPORT' => 'Your server appears to be missing the pdo_sqlite extension for PHP which is used for small temporary storage and for application testing. Talk to your hosting company for assistance.',
+'TEXT_ERROR_PHPZIP_SUPPORT' => 'Your server appears to be missing the php-zip extension for PHP which is used for unpacking zip files when installing the Demo data Images. Talk to your hosting company for assistance.',
 'TEXT_ERROR_LOG_FOLDER' => DIR_FS_LOGS . ' folder is not writeable',
 'TEXT_ERROR_CACHE_FOLDER' => DIR_FS_SQL_CACHE . ' folder is not writeable',
 'TEXT_ERROR_IMAGES_FOLDER' => '/images/ folder is not writeable',

--- a/zc_install/includes/systemChecks.yml
+++ b/zc_install/includes/systemChecks.yml
@@ -91,6 +91,14 @@ systemChecks:
       checkExtension:
         parameters:
           extension: pdo_sqlite
+  phpzipExt:
+    runLevel: always
+    errorLevel: WARN
+    mainErrorText: <?php echo TEXT_ERROR_PHPZIP_SUPPORT .PHP_EOL; ?>
+    methods:
+      checkExtension:
+        parameters:
+          extension: zip
   logFolder:
     runLevel: always
     errorLevel: FAIL


### PR DESCRIPTION
Fixes #4535
Add check to see if php-zip is installed

Add error message TEXT_ERROR_PHPZIP_SUPPORT to main.php

Add now critical error to check zip module installed to systemChecks.yml

Tested against php 8.0