### PR TITLE
add missing TABLE_HEADING_OPTION_NAME

### DIFF
--- a/admin/includes/languages/english/lang.options_name_manager.php
+++ b/admin/includes/languages/english/lang.options_name_manager.php
@@ -16,6 +16,7 @@ $define = [
     'TEXT_WARNING_DUPLICATE_OPTION_NAME' => 'Option ID#%1$u: Duplicate Option Name Added: "%2$s" (%3$s)',
     'TEXT_ORDER_BY' => 'Order by',
     'TEXT_SORT_ORDER' => 'Sort Order',
+    'TABLE_HEADING_OPTION_NAME' => 'Option Name',
     'TABLE_HEADING_OPTION_TYPE' => 'Option Type',
     'TABLE_HEADING_OPTION_NAME_SIZE' => 'Size',
     'TABLE_HEADING_OPTION_NAME_MAX' => 'Max',


### PR DESCRIPTION
fixes:

> PHP Fatal error: Uncaught Error: Undefined constant "TABLE_HEADING_OPTION_NAME" in D:\GitHub\zencart\admin\options_name_manager.php:530

on Edit Option Name.