### PR TITLE
replace strftime w php date function #4449

### DIFF
--- a/admin/banner_statistics.php
+++ b/admin/banner_statistics.php
@@ -18,7 +18,7 @@ $months_array = array();
 for ($i = 1; $i < 13; $i++) {
   $months_array[] = array(
     'id' => $i,
-    'text' => strftime('%B', mktime(0, 0, 0, $i)));
+    'text' => date('F', mktime(0, 0, 0, $i)));
 }
 $type_array = array(array(
     'id' => 'daily',
@@ -297,7 +297,8 @@ $opts = array(
 <?php
   $stats = zen_get_banner_data_daily($banner_id, (isset($_GET['year']) ? (int)$_GET['year'] : ''), (isset($_GET['month']) ? (int)$_GET['month'] : ''));
   $data = array(array('label'=>TEXT_BANNERS_BANNER_VIEWS, 'data'=>$stats[0]), array('label'=>TEXT_BANNERS_BANNER_CLICKS, 'data'=>$stats[1]));
-  $title = sprintf(TEXT_BANNERS_DAILY_STATISTICS, $banner->fields['banners_title'], strftime('%B', mktime(0,0,0,(isset($_GET['month']) ? (int)$_GET['month'] : date('n')))), (isset($_GET['year']) ? (int)$_GET['year'] : date('Y')));
+  $title = sprintf(TEXT_BANNERS_DAILY_STATISTICS, $banner->fields['banners_title'], date('F', mktime(0,0,0,(isset($_GET['month']) ? (int)$_GET['month'] : date('n')))), (isset($_GET['year']) ? (int)
+  $_GET['year'] : date('Y')));
 ?>
 
       <div class="row">

--- a/admin/includes/classes/stats_sales_report_graph.php
+++ b/admin/includes/classes/stats_sales_report_graph.php
@@ -202,18 +202,18 @@ class statsSalesReportGraph {
       $tmpStart = $this->startDate - $tmpShift + $tmpUnit;
       $tmpEnd = $this->startDate - $tmpUnit;
       if ($tmpStart >= $this->globalStartDate || $this->mode == self::MONTHLY_VIEW) {
-        //echo strftime("%T %x", $tmpStart). " - " . strftime("%T %x", $tmpEnd) . "<br>";
+        //echo date(PHP_DATE_TIME_FORMAT, $tmpStart). " - " . date(PHP_DATE_TIME_FORMAT, $tmpEnd) . "<br>";
         $this->previous = "report=" . $this->mode . "&startDate=" . $tmpStart . "&endDate=" . $tmpEnd;
       }
       $tmpStart = $this->endDate;
       $tmpEnd = $this->endDate + $tmpShift - 2 * $tmpUnit;
       if ($tmpEnd < mktime(0, 0, 0, date("m"), date("d"), date("Y"))) {
-        //echo strftime("%T %x", $tmpStart). " - " . strftime("%T %x", $tmpEnd);
+        //echo date(PHP_DATE_TIME_FORMAT, $tmpStart). " - " . date(PHP_DATE_TIME_FORMAT, $tmpEnd);
         $this->next = "report=" . $this->mode . "&startDate=" . $tmpStart . "&endDate=" . $tmpEnd;
       } else {
         if ($tmpEnd - $tmpDiff < mktime(0, 0, 0, date("m"), date("d"), date("Y"))) {
           $tmpEnd = mktime(0, 0, 0, date("m"), date("d"), date("Y"));
-          //echo strftime("%T %x", $tmpStart). " - " . strftime("%T %x", $tmpEnd);
+          //echo date(PHP_DATE_TIME_FORMAT, $tmpStart). " - " . date(PHP_DATE_TIME_FORMAT, $tmpEnd);
           $this->next = "report=" . $this->mode . "&startDate=" . $tmpStart . "&endDate=" . $tmpEnd;
         }
       }
@@ -242,7 +242,7 @@ class statsSalesReportGraph {
     $this->filter = $tmp1;
     $this->filter_link = "report=" . $this->mode . "&startDate=" . $startDate . "&endDate=" . $endDate;
     // if ($dateGiven) {
-    //  echo "<br>" . strftime("%H %x", $this->startDate). " - " . strftime("%H %x", $this->endDate);
+//      echo "<br>" . date('H ' . PHP_DATE_FORMAT, $this->startDate). " - " . date('H ' . PHP_DATE_FORMAT, $this->endDate);
     //} else {
       $this->query();
     //}
@@ -257,24 +257,24 @@ class statsSalesReportGraph {
       $report = $db->Execute($tmp_query . " AND o.date_purchased >= '" . zen_db_input(date("Y-m-d\TH:i:s", $this->startDates[$i])) . "' AND o.date_purchased < '" . zen_db_input(date("Y-m-d\TH:i:s", $this->endDates[$i])) . "'", false,true, 1800);
       //$GLOBALS['report_test'] = $report;
 
-      $this->info[$i]['sum'] = $report->fields['value'];
-      $this->info[$i]['avg'] = $report->fields['avg'];
+      $this->info[$i]['sum'] = $report->fields['value'] ?? 0;
+      $this->info[$i]['avg'] = $report->fields['avg'] ?? 0;
       $this->info[$i]['count'] = $report->fields['count'];
       switch ($this->mode) {
       case self::HOURLY_VIEW:
-          $this->info[$i]['text'] = strftime("%H", $this->startDates[$i]) . " - " . strftime("%H", $this->endDates[$i]);
+          $this->info[$i]['text'] = date('H', $this->startDates[$i]) . " - " . date('H', $this->endDates[$i]);
           $this->info[$i]['link'] = '';
           break;
       case self::DAILY_VIEW:
-          $this->info[$i]['text'] = strftime("%x", $this->startDates[$i]);
+          $this->info[$i]['text'] = date(PHP_DATE_FORMAT, $this->startDates[$i]);
           $this->info[$i]['link'] = "report=" . self::HOURLY_VIEW . "&startDate=" . $this->startDates[$i] . "&endDate=" . mktime(0, 0, 0, date("m", $this->endDates[$i]), date("d", $this->endDates[$i]) + 1, date("Y", $this->endDates[$i]));
           break;
       case self::WEEKLY_VIEW:
-          $this->info[$i]['text'] = strftime("%x", $this->startDates[$i]) . " - " . strftime("%x", mktime(0, 0, 0, date("m", $this->endDates[$i]), date("d", $this->endDates[$i]) - 1, date("Y", $this->endDates[$i])));
+          $this->info[$i]['text'] = date(PHP_DATE_FORMAT, $this->startDates[$i]) . " - " . date(PHP_DATE_FORMAT, mktime(0, 0, 0, date("m", $this->endDates[$i]), date("d", $this->endDates[$i]) - 1, date("Y", $this->endDates[$i])));
           $this->info[$i]['link'] = "report=" . self::DAILY_VIEW . "&startDate=" . $this->startDates[$i] . "&endDate=" . mktime(0, 0, 0, date("m", $this->endDates[$i]), date("d", $this->endDates[$i]) - 1, date("Y", $this->endDates[$i]));
           break;
       case self::MONTHLY_VIEW:
-          $this->info[$i]['text'] = strftime("%b %y", $this->startDates[$i]);
+          $this->info[$i]['text'] = date('M y', $this->startDates[$i]);
           $this->info[$i]['link'] = "report=" . self::WEEKLY_VIEW . "&startDate=" . $this->startDates[$i] . "&endDate=" . mktime(0, 0, 0, date("m", $this->endDates[$i]), date("d", $this->endDates[$i]) - 1, date("Y", $this->endDates[$i]));
           break;
       case self::YEARLY_VIEW:

--- a/admin/includes/functions/functions_banner_graphs.php
+++ b/admin/includes/functions/functions_banner_graphs.php
@@ -57,7 +57,7 @@
     if ((int)$year == 0) $year = date('Y');
     $set1 = $set2 = $stats = $months = array();
     for ($i=1; $i<13; $i++) {
-      $m = strftime('%b', mktime(0,0,0,$i));
+      $m = date('M', mktime(0,0,0,$i));
       $months[] = array((int)$i, $m);
       $set1[] = $set2[] = $stats[] = array($i, 0);
     }

--- a/admin/includes/header.php
+++ b/admin/includes/header.php
@@ -200,7 +200,8 @@ if (defined('MODULE_ORDER_TOTAL_GV_SHOW_QUEUE_IN_ADMIN') && MODULE_ORDER_TOTAL_G
     </div>
     <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6">
         <?php
-        echo((strtoupper(substr(PHP_OS, 0, 3)) == 'WIN') ? iconv('ISO-8859-1', 'UTF-8', strftime(ADMIN_NAV_DATE_TIME_FORMAT, time())) : strftime(ADMIN_NAV_DATE_TIME_FORMAT, time())); //windows does not "do" UTF-8...so a manual conversion is necessary
+        echo((strtoupper(substr(PHP_OS, 0, 3)) == 'WIN') ? iconv('ISO-8859-1', 'UTF-8', date(PHP_ADMIN_NAV_DATE_TIME_FORMAT, time())) : date(PHP_ADMIN_NAV_DATE_TIME_FORMAT, time())); //windows
+            // does not "do" UTF-8...so a manual conversion is necessary
         echo '&nbsp;' . date("O", time()) . ' GMT';  // time zone
         echo '&nbsp;[' . $_SERVER['REMOTE_ADDR'] . ']'; // current admin user's IP address
         echo '<br>';

--- a/admin/includes/modules/dashboard_widgets/BaseStatisticsDashboardWidget.php
+++ b/admin/includes/modules/dashboard_widgets/BaseStatisticsDashboardWidget.php
@@ -32,7 +32,7 @@ $result = $db->Execute("SELECT startdate, counter FROM " . TABLE_COUNTER, false,
 if ($result->RecordCount()) {
     $counter_startdate = $result->fields['startdate'];
     $counter = $result->fields['counter'];
-    $counter_startdate_formatted = strftime(DATE_FORMAT_SHORT, mktime(0, 0, 0, substr($counter_startdate, 4, 2), substr($counter_startdate, -2), substr($counter_startdate, 0, 4)));
+    $counter_startdate_formatted = date(PHP_DATE_FORMAT, mktime(0, 0, 0, substr($counter_startdate, 4, 2), substr($counter_startdate, -2), substr($counter_startdate, 0, 4)));
 }
 
 

--- a/admin/includes/modules/dashboard_widgets/TrafficDashboardWidget.php
+++ b/admin/includes/modules/dashboard_widgets/TrafficDashboardWidget.php
@@ -20,13 +20,13 @@ $counterData = '';
 foreach ($visits as $data) {
     // table
     $countdate = $data['startdate'];
-    $visit_date = strftime(DATE_FORMAT_SHORT, mktime(0, 0, 0, substr($countdate, 4, 2), substr($countdate, -2), substr($countdate, 0, 4)));
+    $visit_date = date(PHP_DATE_FORMAT, mktime(0, 0, 0, substr($countdate, 4, 2), substr($countdate, -2), substr($countdate, 0, 4)));
     $visit_history[] = array('date' => $visit_date, 'sessions' => $data['session_counter'], 'count' => $data['counter']);
     // graph
     if ($i > 0) {
         $counterData = "," . $counterData;
     }
-    $date = strftime('%a %d', mktime(0, 0, 0, substr($data['startdate'], 4, 2), substr($data['startdate'], -2)));
+    $date = date('D d', mktime(0, 0, 0, substr($data['startdate'], 4, 2), substr($data['startdate'], -2)));
     $counterData = "['$date'," . $data['session_counter'] . "," . $data['counter'] . "]" . $counterData;
     $i++;
 }

--- a/admin/stats_sales_report_graphs.php
+++ b/admin/stats_sales_report_graphs.php
@@ -254,7 +254,7 @@ for ($i = 0; $i < $report->size; $i++) {
                   </td>
                   <td>&nbsp;</td>
                   <td colspan="2" class="text-right">
-                      <?php if (strlen($report->next) > 0) { ?>
+                      <?php if (!empty($report->next) && strlen($report->next) > 0) { ?>
                       <a href="<?php echo zen_href_link(FILENAME_STATS_SALES_REPORT_GRAPHS, $report->next); ?>"><?php echo TEXT_NEXT_LINK; ?></a>
                     <?php } ?>
                   </td>

--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -1137,7 +1137,7 @@ class order extends base
             EMAIL_THANKS_FOR_SHOPPING . "\n" . EMAIL_DETAILS_FOLLOW . "\n" .
             EMAIL_SEPARATOR . "\n" .
             EMAIL_TEXT_ORDER_NUMBER . ' ' . $zf_insert_id . "\n" .
-            EMAIL_TEXT_DATE_ORDERED . ' ' . strftime(DATE_FORMAT_LONG) . "\n" .
+            EMAIL_TEXT_DATE_ORDERED . ' ' . date(PHP_DATE_FORMAT_LONG) . "\n" .
             EMAIL_TEXT_INVOICE_URL . ' ' . zen_href_link(FILENAME_ACCOUNT_HISTORY_INFO, 'order_id=' . $zf_insert_id, 'SSL', false) . "\n\n";
 
         $html_msg['EMAIL_TEXT_HEADER'] = EMAIL_TEXT_HEADER;
@@ -1148,7 +1148,7 @@ class order extends base
         $html_msg['INTRO_ORDER_NUM_TITLE'] = EMAIL_TEXT_ORDER_NUMBER;
         $html_msg['INTRO_ORDER_NUMBER'] = $zf_insert_id;
         $html_msg['INTRO_DATE_TITLE'] = EMAIL_TEXT_DATE_ORDERED;
-        $html_msg['INTRO_DATE_ORDERED'] = strftime(DATE_FORMAT_LONG);
+        $html_msg['INTRO_DATE_ORDERED'] = date(PHP_DATE_FORMAT_LONG);
         $html_msg['INTRO_URL_TEXT'] = EMAIL_TEXT_INVOICE_URL_CLICK;
         $html_msg['INTRO_URL_VALUE'] = zen_href_link(FILENAME_ACCOUNT_HISTORY_INFO, 'order_id=' . $zf_insert_id, 'SSL', false);
         $html_msg['EMAIL_CUSTOMER_PHONE'] = $this->customer['telephone'];

--- a/includes/classes/traits/NotifierManager.php
+++ b/includes/classes/traits/NotifierManager.php
@@ -121,7 +121,7 @@ trait NotifierManager
                 $output .= print_r($paramArray, true);
             }
         }
-        error_log(strftime("%Y-%m-%d %H:%M:%S") . ' [main_page=' . $main_page . '] ' . $eventID . $output . "\n", 3, $file);
+        error_log(date(DATE_RSS) . ' [main_page=' . $main_page . '] ' . $eventID . $output . "\n", 3, $file);
     }
 
     private function eventIdHasAlias($eventId)

--- a/includes/counter.php
+++ b/includes/counter.php
@@ -50,4 +50,4 @@ if ($counter->RecordCount() <= 0) {
   $db->Execute($sql);
 }
 
-$counter_startdate_formatted = strftime(DATE_FORMAT_LONG, mktime(0, 0, 0, substr($counter_startdate, 4, 2), substr($counter_startdate, -2), substr($counter_startdate, 0, 4)));
+$counter_startdate_formatted = date(PHP_DATE_FORMAT_LONG, mktime(0, 0, 0, substr($counter_startdate, 4, 2), substr($counter_startdate, -2), substr($counter_startdate, 0, 4)));

--- a/includes/functions/functions_dates.php
+++ b/includes/functions/functions_dates.php
@@ -50,7 +50,7 @@ function zen_date_long($raw_date)
     $minute = (int)substr($raw_date, 14, 2);
     $second = (int)substr($raw_date, 17, 2);
 
-    $retVal = strftime(DATE_FORMAT_LONG, mktime($hour, $minute, $second, $month, $day, $year));
+    $retVal = date(PHP_DATE_FORMAT_LONG, mktime($hour, $minute, $second, $month, $day, $year));
     if (stristr(PHP_OS, 'win')) return utf8_encode($retVal);
     return $retVal;
 }
@@ -95,7 +95,7 @@ function zen_datetime_short($raw_datetime)
     $minute = (int)substr($raw_datetime, 14, 2);
     $second = (int)substr($raw_datetime, 17, 2);
 
-    return strftime(DATE_TIME_FORMAT, mktime($hour, $minute, $second, $month, $day, $year));
+    return date(PHP_DATE_TIME_FORMAT, mktime($hour, $minute, $second, $month, $day, $year));
 }
 
 /**

--- a/includes/functions/functions_files.php
+++ b/includes/functions/functions_files.php
@@ -318,7 +318,7 @@ function get_logs_data($maxToList = 'count')
                 $logs[$i]['filename'] = $logfile;
                 $logs[$i]['filesize'] = @filesize($filename);
                 $logs[$i]['unixtime'] = @filemtime($filename);
-                $logs[$i]['datetime'] = strftime(DATE_TIME_FORMAT, $logs[$i]['unixtime']);
+                $logs[$i]['datetime'] = date(PHP_DATE_TIME_FORMAT, $logs[$i]['unixtime']);
             }
             $i++;
             if ($maxToList != 'count' && $i >= $maxToList) break;

--- a/includes/modules/new_products.php
+++ b/includes/modules/new_products.php
@@ -84,9 +84,9 @@ if ($num_products_count > 0) {
   if ($new_products->RecordCount() > 0) {
     if (!empty($new_products_category_id)) {
       $category_title = zen_get_category_name((int)$new_products_category_id);
-      $title = '<h2 class="centerBoxHeading">' . sprintf(TABLE_HEADING_NEW_PRODUCTS, strftime('%B')) . ($category_title != '' ? ' - ' . $category_title : '' ) . '</h2>';
+      $title = '<h2 class="centerBoxHeading">' . sprintf(TABLE_HEADING_NEW_PRODUCTS, date('F')) . ($category_title != '' ? ' - ' . $category_title : '' ) . '</h2>';
     } else {
-      $title = '<h2 class="centerBoxHeading">' . sprintf(TABLE_HEADING_NEW_PRODUCTS, strftime('%B')) . '</h2>';
+      $title = '<h2 class="centerBoxHeading">' . sprintf(TABLE_HEADING_NEW_PRODUCTS, date('F')) . '</h2>';
     }
     $zc_show_new_products = true;
   }

--- a/includes/modules/payment/authorizenet.php
+++ b/includes/modules/payment/authorizenet.php
@@ -197,12 +197,12 @@ class authorizenet extends base {
     global $order;
 
     for ($i=1; $i<13; $i++) {
-      $expires_month[] = array('id' => sprintf('%02d', $i), 'text' => strftime('%B - (%m)',mktime(0,0,0,$i,1,2000)));
+      $expires_month[] = array('id' => sprintf('%02d', $i), 'text' => date('F - (m)',mktime(0,0,0,$i,1,2000)));
     }
 
     $today = getdate();
     for ($i=$today['year']; $i < $today['year']+10; $i++) {
-      $expires_year[] = array('id' => strftime('%y',mktime(0,0,0,1,1,$i)), 'text' => strftime('%Y',mktime(0,0,0,1,1,$i)));
+      $expires_year[] = array('id' => date('y',mktime(0,0,0,1,1,$i)), 'text' => date('Y',mktime(0,0,0,1,1,$i)));
     }
 
     $onFocus = ' onfocus="methodSelect(\'pmt-' . $this->code . '\')"';
@@ -220,7 +220,7 @@ class authorizenet extends base {
                                                'field' => zen_draw_input_field('authorizenet_cc_number', '', 'id="'.$this->code.'-cc-number"' . $onFocus . ' autocomplete="off"'),
                                                'tag' => $this->code.'-cc-number'),
                                          array('title' => MODULE_PAYMENT_AUTHORIZENET_TEXT_CREDIT_CARD_EXPIRES,
-                                               'field' => zen_draw_pull_down_menu('authorizenet_cc_expires_month', $expires_month, strftime('%m'), 'id="'.$this->code.'-cc-expires-month"' . $onFocus) . '&nbsp;' . zen_draw_pull_down_menu('authorizenet_cc_expires_year', $expires_year, '', 'id="'.$this->code.'-cc-expires-year"' . $onFocus),
+                                               'field' => zen_draw_pull_down_menu('authorizenet_cc_expires_month', $expires_month, date('m'), 'id="'.$this->code.'-cc-expires-month"' . $onFocus) . '&nbsp;' . zen_draw_pull_down_menu('authorizenet_cc_expires_year', $expires_year, '', 'id="'.$this->code.'-cc-expires-year"' . $onFocus),
                                                'tag' => $this->code.'-cc-expires-month')));
       if (MODULE_PAYMENT_AUTHORIZENET_USE_CVV == 'True') {
         $selection['fields'][] = array('title' => MODULE_PAYMENT_AUTHORIZENET_TEXT_CVV,
@@ -280,7 +280,7 @@ class authorizenet extends base {
                                               array('title' => MODULE_PAYMENT_AUTHORIZENET_TEXT_CREDIT_CARD_NUMBER,
                                                     'field' => substr($this->cc_card_number, 0, 4) . str_repeat('X', (strlen($this->cc_card_number) - 8)) . substr($this->cc_card_number, -4)),
                                               array('title' => MODULE_PAYMENT_AUTHORIZENET_TEXT_CREDIT_CARD_EXPIRES,
-                                                    'field' => strftime('%B, %Y', mktime(0,0,0,$_POST['authorizenet_cc_expires_month'], 1, '20' . $_POST['authorizenet_cc_expires_year'])))));
+                                                    'field' => date('F Y', mktime(0,0,0,$_POST['authorizenet_cc_expires_month'], 1, '20' . $_POST['authorizenet_cc_expires_year'])))));
     } else {
       $confirmation = array(); //array('title' => $this->title);
     }

--- a/includes/modules/payment/authorizenet_aim.php
+++ b/includes/modules/payment/authorizenet_aim.php
@@ -207,12 +207,12 @@ class authorizenet_aim extends base {
     global $order;
 
     for ($i=1; $i<13; $i++) {
-      $expires_month[] = array('id' => sprintf('%02d', $i), 'text' => strftime('%B - (%m)',mktime(0,0,0,$i,1,2000)));
+      $expires_month[] = array('id' => sprintf('%02d', $i), 'text' => date('F - (m)',mktime(0,0,0,$i,1,2000)));
     }
 
     $today = getdate();
     for ($i=$today['year']; $i < $today['year']+15; $i++) {
-      $expires_year[] = array('id' => strftime('%y',mktime(0,0,0,1,1,$i)), 'text' => strftime('%Y',mktime(0,0,0,1,1,$i)));
+      $expires_year[] = array('id' => date('y',mktime(0,0,0,1,1,$i)), 'text' => date('Y',mktime(0,0,0,1,1,$i)));
     }
     $onFocus = ' onfocus="methodSelect(\'pmt-' . $this->code . '\')"';
 
@@ -225,7 +225,7 @@ class authorizenet_aim extends base {
                                                'field' => zen_draw_input_field('authorizenet_aim_cc_number', '', 'id="'.$this->code.'-cc-number"' . $onFocus . ' autocomplete="off"'),
                                                'tag' => $this->code.'-cc-number'),
                                          array('title' => MODULE_PAYMENT_AUTHORIZENET_AIM_TEXT_CREDIT_CARD_EXPIRES,
-                                               'field' => zen_draw_pull_down_menu('authorizenet_aim_cc_expires_month', $expires_month, strftime('%m'), 'id="'.$this->code.'-cc-expires-month"' . $onFocus) . '&nbsp;' . zen_draw_pull_down_menu('authorizenet_aim_cc_expires_year', $expires_year, '', 'id="'.$this->code.'-cc-expires-year"' . $onFocus),
+                                               'field' => zen_draw_pull_down_menu('authorizenet_aim_cc_expires_month', $expires_month, date('m'), 'id="'.$this->code.'-cc-expires-month"' . $onFocus) . '&nbsp;' . zen_draw_pull_down_menu('authorizenet_aim_cc_expires_year', $expires_year, '', 'id="'.$this->code.'-cc-expires-year"' . $onFocus),
                                                'tag' => $this->code.'-cc-expires-month')));
     if (MODULE_PAYMENT_AUTHORIZENET_AIM_USE_CVV == 'True') {
       $selection['fields'][] = array('title' => MODULE_PAYMENT_AUTHORIZENET_AIM_TEXT_CVV,
@@ -283,7 +283,7 @@ class authorizenet_aim extends base {
                                             array('title' => MODULE_PAYMENT_AUTHORIZENET_AIM_TEXT_CREDIT_CARD_NUMBER,
                                                   'field' => substr($this->cc_card_number, 0, 4) . str_repeat('X', (strlen($this->cc_card_number) - 8)) . substr($this->cc_card_number, -4)),
                                             array('title' => MODULE_PAYMENT_AUTHORIZENET_AIM_TEXT_CREDIT_CARD_EXPIRES,
-                                                  'field' => strftime('%B, %Y', mktime(0,0,0,$_POST['authorizenet_aim_cc_expires_month'], 1, '20' . $_POST['authorizenet_aim_cc_expires_year']))) ));
+                                                  'field' => date('F Y', mktime(0,0,0,$_POST['authorizenet_aim_cc_expires_month'], 1, '20' . $_POST['authorizenet_aim_cc_expires_year']))) ));
     return $confirmation;
   }
   /**

--- a/includes/modules/payment/paypaldp.php
+++ b/includes/modules/payment/paypaldp.php
@@ -305,12 +305,12 @@ class paypaldp extends base {
     $expires_year = array();
     $issue_year = array();
     for ($i = 1; $i < 13; $i++) {
-      $expires_month[] = array('id' => sprintf('%02d', $i), 'text' => strftime('%B - (%m)',mktime(0,0,0,$i,1,2000)));
+      $expires_month[] = array('id' => sprintf('%02d', $i), 'text' => date('F - (m)',mktime(0,0,0,$i,1,2000)));
     }
 
     $today = getdate();
     for ($i = $today['year']; $i < $today['year'] + 15; $i++) {
-      $expires_year[] = array('id' => strftime('%y', mktime(0,0,0,1,1,$i)), 'text' => strftime('%Y',mktime(0,0,0,1,1,$i)));
+      $expires_year[] = array('id' => date('y', mktime(0,0,0,1,1,$i)), 'text' => date('Y',mktime(0,0,0,1,1,$i)));
     }
 
     $onFocus = ' onfocus="methodSelect(\'pmt-' . $this->code . '\')"';
@@ -330,7 +330,7 @@ class paypaldp extends base {
                            'field' => zen_draw_input_field('paypalwpp_cc_number', '', 'id="'.$this->code.'-cc-number"' . $onFocus . ' autocomplete="off"'),
                            'tag' => $this->code.'-cc-number');
     $fieldsArray[] = array('title' => MODULE_PAYMENT_PAYPALDP_TEXT_CREDIT_CARD_EXPIRES,
-                           'field' => zen_draw_pull_down_menu('paypalwpp_cc_expires_month', $expires_month, strftime('%m'), 'id="'.$this->code.'-cc-expires-month"' . $onFocus) . '&nbsp;' . zen_draw_pull_down_menu('paypalwpp_cc_expires_year', $expires_year, '', 'id="'.$this->code.'-cc-expires-year"' . $onFocus),
+                           'field' => zen_draw_pull_down_menu('paypalwpp_cc_expires_month', $expires_month, date('m'), 'id="'.$this->code.'-cc-expires-month"' . $onFocus) . '&nbsp;' . zen_draw_pull_down_menu('paypalwpp_cc_expires_year', $expires_year, '', 'id="'.$this->code.'-cc-expires-year"' . $onFocus),
                            'tag' => $this->code.'-cc-expires-month');
     $fieldsArray[] = array('title' => MODULE_PAYMENT_PAYPALDP_TEXT_CREDIT_CARD_CHECKNUMBER,
                            'field' => zen_draw_input_field('paypalwpp_cc_checkcode', '', 'size="4" maxlength="4"' . ' id="'.$this->code.'-cc-cvv"' . $onFocus . ' autocomplete="off"') . '&nbsp;<small>' . MODULE_PAYMENT_PAYPALDP_TEXT_CREDIT_CARD_CHECKNUMBER_LOCATION . '</small><script type="text/javascript">paypalwpp_cc_type_check();</script>',
@@ -343,7 +343,7 @@ class paypaldp extends base {
     if (MODULE_PAYMENT_PAYPALDP_MERCHANT_COUNTRY == 'UK' && (CC_ENABLED_MAESTRO=='1' || CC_ENABLED_SOLO=='1')) {
       // add extra fields for UK cards
       for ($i = $today['year'] - 10; $i <= $today['year']; $i++) {
-        $issue_year[] = array('id' => strftime('%y',mktime(0,0,0,1,1,$i)), 'text' => strftime('%Y',mktime(0,0,0,1,1,$i)));
+        $issue_year[] = array('id' => date('y',mktime(0,0,0,1,1,$i)), 'text' => date('Y',mktime(0,0,0,1,1,$i)));
       }
       array_splice($selection['fields'], 4, 0,
                    array(array('title' => MODULE_PAYMENT_PAYPALDP_TEXT_CREDIT_CARD_ISSUE,
@@ -550,7 +550,7 @@ class paypaldp extends base {
                                             array('title' => MODULE_PAYMENT_PAYPALDP_TEXT_CREDIT_CARD_NUMBER,
                                                   'field' => substr($_POST['paypalwpp_cc_number'], 0, 4) . str_repeat('X', (strlen($_POST['paypalwpp_cc_number']) - 8)) . substr($_POST['paypalwpp_cc_number'], -4)),
                                             array('title' => MODULE_PAYMENT_PAYPALDP_TEXT_CREDIT_CARD_EXPIRES,
-                                                  'field' => strftime('%B, %Y', mktime(0,0,0,$_POST['paypalwpp_cc_expires_month'], 1, '20' . $_POST['paypalwpp_cc_expires_year'])),
+                                                  'field' => date('F Y', mktime(0,0,0,$_POST['paypalwpp_cc_expires_month'], 1, '20' . $_POST['paypalwpp_cc_expires_year'])),
                                             (isset($_POST['paypalwpp_cc_issuenumber']) ? array('title' => MODULE_PAYMENT_PAYPALDP_TEXT_ISSUE_NUMBER,
                                                   'field' => $_POST['paypalwpp_cc_issuenumber']) : '')
                                             )));

--- a/includes/modules/specials_index.php
+++ b/includes/modules/specials_index.php
@@ -85,7 +85,7 @@ if ($num_products_count > 0) {
   }
 
   if ($specials_index->RecordCount() > 0) {
-    $title = '<h2 class="centerBoxHeading">' . sprintf(TABLE_HEADING_SPECIALS_INDEX, strftime('%B')) . '</h2>';
+    $title = '<h2 class="centerBoxHeading">' . sprintf(TABLE_HEADING_SPECIALS_INDEX, date('F')) . '</h2>';
     $zc_show_specials = true;
   }
 }


### PR DESCRIPTION
these are the constants that are needed (provided in both formats).  hopefully they load on the storefront as well as the admin side.

```
    define('PHP_DATE_FORMAT', 'm/d/Y');
    define('PHP_DATE_FORMAT_LONG', 'l d F, Y');
    define('PHP_DATE_TIME_FORMAT', PHP_DATE_FORMAT . ' H:i:s');
    define('PHP_ADMIN_NAV_DATE_TIME_FORMAT', DATE_COOKIE);

    $sample = [
        'PHP_DATE_FORMAT' => 'm/d/Y',
        'PHP_DATE_FORMAT_LONG' => 'l d F, Y',
        'PHP_DATE_TIME_FORMAT' => PHP_DATE_FORMAT . ' H:i:s',
        'PHP_ADMIN_NAV_DATE_TIME_FORMAT' => DATE_COOKIE,
    ];
```