### PR TITLE
Remove config settings related to Tell a Friend

### DIFF
--- a/zc_install/sql/updates/mysql_upgrade_zencart_158.sql
+++ b/zc_install/sql/updates/mysql_upgrade_zencart_158.sql
@@ -135,6 +135,14 @@ UPDATE configuration SET configuration_description = 'Do you want create debug-l
 UPDATE configuration SET configuration_description = 'Do you want create debug-log files for <b>all</b> PHP errors, even warnings, that occur during your Zen Cart store\'s processing?  If you want to log all PHP errors <b>except</b> duplicate-language definitions, choose <em>IgnoreDups</em>.<br /><br /><strong>Note:</strong> Choosing \'Yes\' is not suggested for a <em>live</em> store, since it will reduce performance significantly!', set_function = 'zen_cfg_select_option(array(\'Yes\', \'No\', \'IgnoreDups\'),' WHERE configuration_key = 'REPORT_ALL_ERRORS_STORE';
 ############
 
+## Remove remnants of tell a friend 
+DELETE FROM configuration WHERE configuration_key = 'SHOW_PRODUCT_INFO_TELL_A_FRIEND';
+DELETE FROM configuration WHERE configuration_key = 'SHOW_PRODUCT_MUSIC_INFO_TELL_A_FRIEND';
+DELETE FROM configuration WHERE configuration_key = 'SHOW_DOCUMENT_GENERAL_INFO_TELL_A_FRIEND';
+DELETE FROM configuration WHERE configuration_key = 'SHOW_DOCUMENT_PRODUCT_INFO_TELL_A_FRIEND';
+DELETE FROM configuration WHERE configuration_key = 'SHOW_PRODUCT_FREE_SHIPPING_INFO_TELL_A_FRIEND';
+DELETE FROM configuration WHERE configuration_key = 'SEND_EXTRA_TELL_A_FRIEND_EMAILS_TO';
+DELETE FROM configuration WHERE configuration_key = 'ALLOW_GUEST_TO_TELL_A_FRIEND';
 
 #### VERSION UPDATE STATEMENTS
 ## THE FOLLOWING 2 SECTIONS SHOULD BE THE "LAST" ITEMS IN THE FILE, so that if the upgrade fails prematurely, the version info is not updated.


### PR DESCRIPTION
Tell a Friend has been deprecated for a long time but these settings are still lying around. 