### PR TITLE
Current address should match payment, not shipping

### DIFF
--- a/includes/templates/template_default/templates/tpl_modules_checkout_address_book.php
+++ b/includes/templates/template_default/templates/tpl_modules_checkout_address_book.php
@@ -18,6 +18,9 @@ require(DIR_WS_MODULES . zen_get_module_directory('checkout_address_book.php'));
 <?php
   foreach ($addresses as $address) {
     $selected = ($address['address_book_id'] == $_SESSION['sendto']);
+    if ($current_page_base === FILENAME_CHECKOUT_PAYMENT_ADDRESS) {
+       $selected = ($address['address_book_id'] == $_SESSION['billto']); 
+    } 
 ?>
     <div <?php echo ($selected) ? 'id="defaultSelected" class="moduleRowSelected"' : 'class="moduleRow"'; ?>>
     <div class="back"><?php echo zen_draw_radio_field('address', $address['address_book_id'], $selected, 'id="name-' . $address['address_book_id'] . '"'); ?></div>


### PR DESCRIPTION
If you select a different shipping address from your billing address, the billing address should show up as the selected one when you try to change the payment address. 

See also https://github.com/lat9/ZCA-Bootstrap-Template/pull/106