### PR TITLE
Pagination should be different for search

### DIFF
--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -17,7 +17,10 @@ $search_result = isset($_GET['search']) && zen_not_null($_GET['search']);
 
 $search_parameter = $search_result ? '&search=' . $_GET['search'] : '';
 $keywords = $search_result ? zen_db_input(zen_db_prepare_input($_GET['search'])) : '';
-
+$max_results = MAX_DISPLAY_RESULTS_CATEGORIES; 
+if (!empty($search_parameter)) {
+   $max_results = MAX_DISPLAY_SEARCH_RESULTS; 
+}
 if (isset($_GET['page'])) {
   $_GET['page'] = (int)$_GET['page'];
 }
@@ -782,7 +785,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
             if ((empty($_GET['page']) || $_GET['page'] == '1') && !empty($_GET['pID'])) {
               $old_page = $_GET['page'];
               $check_page = $db->Execute($products_query_raw);
-              if ($check_page->RecordCount() > MAX_DISPLAY_RESULTS_CATEGORIES) {
+              if ($check_page->RecordCount() > $max_results) {
                 $check_count = 0;
                 foreach ($check_page as $item) {
                   if ($item['products_id'] == $_GET['pID']) {
@@ -790,7 +793,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
                   }
                   $check_count++;
                 }
-                $_GET['page'] = round((($check_count / MAX_DISPLAY_RESULTS_CATEGORIES) + (fmod_round($check_count, MAX_DISPLAY_RESULTS_CATEGORIES) != 0 ? .5 : 0)), 0);
+                $_GET['page'] = round((($check_count / $max_results) + (fmod_round($check_count, $max_results) != 0 ? .5 : 0)), 0);
                 $page = $_GET['page'];
                 if ($old_page != $_GET['page']) {
 //      zen_redirect(zen_href_link(FILENAME_CATEGORIES, 'cPath=' . $_GET['cPath'] . '&pID=' . $_GET['pID'] . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '')));
@@ -799,7 +802,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
                 $_GET['page'] = 1;
               }
             }
-            $products_split = new splitPageResults($_GET['page'], MAX_DISPLAY_RESULTS_CATEGORIES, $products_query_raw, $products_query_numrows);
+            $products_split = new splitPageResults($_GET['page'], $max_results, $products_query_raw, $products_query_numrows);
             $products = $db->Execute($products_query_raw);
 // Split Page
 
@@ -1200,7 +1203,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
           <?php
 // Split Page
           if ($products_query_numrows > 0) {
-            echo $products_split->display_count($products_query_numrows, MAX_DISPLAY_RESULTS_CATEGORIES, $_GET['page'], TEXT_DISPLAY_NUMBER_OF_PRODUCTS) . '<br>' . $products_split->display_links($products_query_numrows, MAX_DISPLAY_RESULTS_CATEGORIES, MAX_DISPLAY_PAGE_LINKS, $_GET['page'], zen_get_all_get_params(array('page', 'info', 'x', 'y', 'pID')));
+            echo $products_split->display_count($products_query_numrows, $max_results, $_GET['page'], TEXT_DISPLAY_NUMBER_OF_PRODUCTS) . '<br>' . $products_split->display_links($products_query_numrows, $max_results, MAX_DISPLAY_PAGE_LINKS, $_GET['page'], zen_get_all_get_params(array('page', 'info', 'x', 'y', 'pID')));
           }
           ?>
         </div>


### PR DESCRIPTION
Fixes #4480.
Use `MAX_DISPLAY_RESULTS_CATEGORIES` for pagination only if not searching; otherwise use `MAX_DISPLAY_SEARCH_RESULTS`.