### PR TITLE
admin, option values manager, correct text

### DIFF
--- a/admin/includes/languages/english/lang.options_values_manager.php
+++ b/admin/includes/languages/english/lang.options_values_manager.php
@@ -60,7 +60,7 @@ $define = [
     'TEXT_SELECT_DELETE_OPTION_VALUES_FROM' => 'Option Value to match:',
     'ERROR_OPTION_VALUES_DELETE_MISMATCH' => 'Error: Mismatched Option Name and Option Value selected',
     'SUCCESS_OPTION_VALUES_DELETE' => 'Successful: Deletion of: ',
-    'LABEL_FILTER' => 'Select Option Value to filter',
+    'LABEL_FILTER' => 'Select Option Name to filter Values',
     'TEXT_DISPLAY_NUMBER_OF_OPTION_VALUES' => 'Displaying <b>%d</b> to <b>%d</b> (of <b>%d</b> Option Values)',
     'TEXT_SHOW_ALL' => 'Show All',
 ];


### PR DESCRIPTION
the filter is based on selecting the Name not the Value.

Also, I was looking at this text and think it is wrong/pointless/can be removed. 
![Clipboard03](https://user-images.githubusercontent.com/4391026/153032953-749af10c-17e9-4d7e-a667-5ad4f8c6e8f6.gif)

Also I believe Default Order should be Sort Order.
