### PR TITLE
Record admin id if Place Order was used when an OSH record is being added 

### DIFF
--- a/admin/includes/functions/admin_access.php
+++ b/admin/includes/functions/admin_access.php
@@ -275,21 +275,6 @@ function zen_read_user($name)
 }
 
 /**
- * Lookup admin user name based on admin id
- * @param int $id
- * @return string
- */
-function zen_get_admin_name($id = null)
-{
-    global $db;
-    if (empty($id)) $id = $_SESSION['admin_id'];
-    $sql = "SELECT admin_name FROM " . TABLE_ADMIN . " WHERE admin_id = :adminid: LIMIT 1";
-    $sql = $db->bindVars($sql, ':adminid:', $id, 'integer');
-    $result = $db->Execute($sql);
-    return $result->RecordCount() ? $result->fields['admin_name'] : null;
-}
-
-/**
  * Verify login according to security requirements
  * @param string $admin_name
  * @param string $admin_pass
@@ -911,15 +896,6 @@ function zen_deregister_admin_pages($pages)
         $db->Execute($sql);
         zen_record_admin_activity('Deleted admin pages for page keys: ' . print_r($pages, true), 'warning');
     }
-}
-
-function zen_updated_by_admin($admin_id = null)
-{
-    if (empty($admin_id)) {
-        $admin_id = $_SESSION['admin_id'];
-    }
-    $name = zen_get_admin_name($admin_id);
-    return ($name ?? 'Unknown Name') . " [$admin_id]";
 }
 
 function zen_admin_authorized_to_place_order()

--- a/includes/functions/functions_general_shared.php
+++ b/includes/functions/functions_general_shared.php
@@ -383,3 +383,27 @@ function request()
 {
     return \Zencart\Request\Request::getInstance();
 }
+
+function zen_updated_by_admin($admin_id = null)
+{
+    if (empty($admin_id)) {
+        $admin_id = $_SESSION['admin_id'];
+    }
+    $name = zen_get_admin_name($admin_id);
+    return ($name ?? 'Unknown Name') . " [$admin_id]";
+}
+
+/**
+ * Lookup admin user name based on admin id
+ * @param int $id
+ * @return string
+ */
+function zen_get_admin_name($id = null)
+{
+    global $db;
+    if (empty($id)) $id = $_SESSION['admin_id'];
+    $sql = "SELECT admin_name FROM " . TABLE_ADMIN . " WHERE admin_id = :adminid: LIMIT 1";
+    $sql = $db->bindVars($sql, ':adminid:', $id, 'integer');
+    $result = $db->Execute($sql);
+    return $result->RecordCount() ? $result->fields['admin_name'] : null;
+}

--- a/includes/functions/functions_osh_update.php
+++ b/includes/functions/functions_osh_update.php
@@ -175,6 +175,8 @@ function zen_update_orders_history($orders_id, $message = '', $updated_by = null
             if (empty($updated_by)) {
                 if (IS_ADMIN_FLAG === true && isset($_SESSION['admin_id'])) {
                     $updated_by = zen_updated_by_admin();
+                } else if (isset($_SESSION['emp_admin_id'])) {
+                   $updated_by = zen_updated_by_admin($_SESSION['emp_admin_id']);
                 } elseif (IS_ADMIN_FLAG === false && isset($_SESSION['customer_id'])) {
                     $updated_by = '';
                 } else {

--- a/not_for_release/testFramework/unittests/testsNotifiers/AdminLoggingTest.php
+++ b/not_for_release/testFramework/unittests/testsNotifiers/AdminLoggingTest.php
@@ -9,15 +9,6 @@ use org\bovigo\vfs\visitor\vfsStreamPrintVisitor;
 use org\bovigo\vfs\visitor\vfsStreamStructureVisitor;
 
 require_once(__DIR__ . '/../support/zcTestCase.php');
-/**
- * Test Dummy
- */
-if (!function_exists('zen_get_admin_name')) {
-    function zen_get_admin_name()
-    {
-        return 'TestAdminName';
-    }
-}
 
 /**
  * Testing Library


### PR DESCRIPTION
If zen_update_orders_history() is called on the storefront due to an action by an admin logged in using Place Order, the admin id should be recorded in the order status history table. 