### PR TITLE
low stock email: remove hard-coded text and rejig format

### DIFF
--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -897,8 +897,8 @@ class order extends base
 
                     // for low stock email
                     if ($stock_left <= STOCK_REORDER_LEVEL) {
-                        // WebMakers.com Added: add to low stock email
-                        $this->email_low_stock .= 'ID# ' . zen_get_prid($this->products[$i]['id']) . "\t\t" . $this->products[$i]['model'] . "\t\t" . $this->products[$i]['name'] . "\t\t" . ' Qty Left: ' . $stock_left . "\n";
+                        // add product to low stock email content
+                        $this->email_low_stock .= ($this->products[$i]['model'] === '' ? ''  : $this->products[$i]['model'] . "\t\t") . ' "' . $this->products[$i]['name'] . '" (#' . zen_get_prid($this->products[$i]['id']) . ')'. "\t\t" . ' ' . TEXT_PRODUCTS_QUANTITY . ' ' . $stock_left . "\n";
                     }
                 }
             }


### PR DESCRIPTION
Previously

> ID# 2        Matrox G400 32MB              Qty Left: 0

"Qty Left:" was hard-coded text.

Changed to:

> MG400-32MB		 "Matrox G400 32MB" (#2)		 In Stock:  0

Model displays only if used.