### PR TITLE
Admin, sql tool: texts, remove popup

### DIFF
--- a/admin/includes/languages/english/lang.sqlpatch.php
+++ b/admin/includes/languages/english/lang.sqlpatch.php
@@ -8,14 +8,14 @@
 
 $define = [
     'HEADING_TITLE' => 'SQL Query Executor',
-    'HEADING_WARNING' => 'BE SURE TO BACKUP YOUR DATABASE AND VERIFY THAT BACKUP, BEFORE RUNNING SCRIPTS HERE',
-    'HEADING_WARNING2' => 'If you are installing 3rd-party contributions, note that you do so at your own risk.<br>Zen Cart&reg; makes no warranty as to the safety of scripts supplied by 3rd-party contributors. Test on a development server before using on your live database!',
-    'HEADING_WARNING_INSTALLSCRIPTS' => 'NOTE: Zen Cart database-upgrade scripts should NOT be run from this page.<br>Please upload the new <strong>zc_install</strong> folder and run the upgrade from there instead for better reliability.',
+    'HEADING_INFO' => 'The SQL Query Executor allows you to run SQL queries directly on the database by pasting a script into the textarea or uploading a text file containing the script. It is intended for the manual installation of fields for Plugins and your own corrections/additions.',
+    'HEADING_WARNING_INSTALLSCRIPTS' => 'This tool should <b>NOT</b> be used to execute Zen Cart database-upgrade scripts: use the Zen Cart Installer as per the documentation.',
+    'HEADING_WARNING' => '<p>BEFORE you perform ANY database operation using this tool, ensure you have a VERIFIED backup of your database and you know how to restore it.<br>If you are installing 3rd-party modifications/Plugins, note that you do so at your own risk. Zen Cart&reg; makes no warranty as to the safety of scripts supplied by 3rd-party contributors.</p><p>Always test every script on a DEVELOPMENT server before using on your live shop!</p>',
     'TEXT_QUERY_RESULTS' => 'Query Results:',
     'TEXT_ENTER_QUERY_STRING' => 'Enter the query<br>to be executed:&nbsp;&nbsp;<br><br>Ensure that each statement<br>ends with a semicolon ";"',
     'TEXT_QUERY_FILENAME' => 'Upload file:',
     'ERROR_NOTHING_TO_DO' => 'Error: Nothing to do - no query or query-file specified.',
-    'SQLPATCH_HELP_TEXT' => 'The SQLPATCH tool lets you install system patches by pasting SQL code directly into the textarea ',
+    'SQLPATCH_HELP_TEXT' => 'The SQL Query Executor allows you to run SQL queries directly by pasting a script into the textarea or uploading a text file containing the script.',
     'REASON_TABLE_ALREADY_EXISTS' => 'Cannot create table %s because it already exists',
     'REASON_TABLE_DOESNT_EXIST' => 'Cannot drop table %s because it does not exist.',
     'REASON_TABLE_NOT_FOUND' => 'Cannot execute because table %s does not exist.',

--- a/admin/sqlpatch.php
+++ b/admin/sqlpatch.php
@@ -793,14 +793,11 @@ if (!empty($action)) {
         $messageStack->add(ERROR_NOTHING_TO_DO, 'error');
       }
       break;
-    case 'help':
-      break;
     default:
       break;
   }
 }
 ?>
-<?php if ($action != 'help') { ?>
   <!doctype html>
   <html <?php echo HTML_PARAMS; ?>>
     <head>
@@ -810,9 +807,6 @@ if (!empty($action)) {
       <link rel="stylesheet" href="includes/cssjsmenuhover.css" media="all" id="hoverJS">
       <script src="includes/menu.js"></script>
       <script>
-        function popupHelpWindow(url) {
-            window.open(url, 'popupImageWindow', 'toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=no,resizable=yes,copyhistory=no,width=100,height=100,screenX=150,screenY=150,top=150,left=150,noreferrer')
-        }
         function init() {
             cssjsmenu('navbar');
             if (document.getElementById) {
@@ -830,11 +824,11 @@ if (!empty($action)) {
         <!-- body //-->
 
         <h1 class="pageHeading"><?php echo HEADING_TITLE; ?></h1>
+          <div class="row">
+              <div class="col-sm-12"><?php echo HEADING_INFO; ?></div>
+          </div>
         <div class="row">
-          <div class="col-sm-12 text-danger"><?php echo HEADING_WARNING; ?></div>
-        </div>
-        <div class="row">
-          <div class="col-sm-12 text-danger"><strong><?php echo HEADING_WARNING2; ?></strong></div>
+          <div class="col-sm-12 text-danger font-weight-bold"><?php echo HEADING_WARNING; ?></div>
         </div>
         <?php
         if ($action == 'execute' && !empty($_POST['query_string'])) {
@@ -878,9 +872,6 @@ if (!empty($action)) {
         </div>
   <?php echo '</form>'; ?>
 
-        <div class="row">
-          <div class="col-sm-12 text-right"><a href="<?php echo zen_href_link(FILENAME_SQLPATCH, 'action=help'); ?>" target="_blank" class="btn btn-info" role="button"><?php echo IMAGE_DETAILS; ?></a></div>
-        </div>
         <!-- body_text_eof //-->
       </div>
       <!-- body_eof //-->
@@ -891,32 +882,3 @@ if (!empty($action)) {
   </html>
   <?php require(DIR_WS_INCLUDES . 'application_bottom.php'); ?>
 
-<?php } elseif ($action == 'help') { ?>
-  <!doctype html>
-  <html  <?php echo HTML_PARAMS; ?>>
-    <head>
-      <meta charset="<?php echo CHARSET; ?>">
-      <title>HELP - <?php echo HEADING_TITLE; ?> - Zen Cart&reg;</title>
-      <link rel="stylesheet" href="includes/stylesheet.css">
-    </head>
-    <body id="popup">
-      <div class="container-fluid">
-        <div id="popup_header">
-          <h1><?php echo 'Zen Cart&reg; ' . HEADING_TITLE; ?></h1>
-        </div>
-        <div id="popup_content">
-          <span class="txt-red font-weight-bold"><?php echo HEADING_WARNING; ?></span><br>
-          <?php
-          echo SQLPATCH_HELP_TEXT;
-          echo '<br><br>';
-          ?>
-          <span class="txt-red font-weight-bold"><?php echo HEADING_WARNING; ?></span><br>
-          <span class="txt-red font-weight-bold"><?php echo HEADING_WARNING2; ?></span><br>
-        </div>
-        <div class="row text-center">
-          <a href="javascript:window.close()"><?php echo TEXT_CLOSE_WINDOW; ?></a>
-        </div>
-      </div>
-    </body>
-  </html>
-<?php } ?>


### PR DESCRIPTION
**Before**

![SQL path before](https://user-images.githubusercontent.com/4391026/155000133-0ee71165-9de9-4af6-a340-c8248a124bde.gif)

I found the "details" button did not popup/it showed a new page, and only repeated most of the text on the main page.
So I merged the texts into one warning for the main page, and removed the popup.


**After**

![SQL path after](https://user-images.githubusercontent.com/4391026/155001727-a025b8e3-6646-4ac7-bfcc-643e7096bd22.gif)

<strike>
And, deep breath....I changed the name from "Install SQL Patches" to "SQL Query Executor" as per the page title as that seems more accurate and does not imply that installing patches is a common thing to do.
</strike>

