### PR TITLE
move  TEXT_APPROVAL_REQUIRED to main language file

### DIFF
--- a/includes/languages/english/lang.product_reviews_write.php
+++ b/includes/languages/english/lang.product_reviews_write.php
@@ -6,7 +6,6 @@ $define = [
     'SUB_TITLE_RATING' => 'Choose a ranking for this item. 1 star is the worst and 5 stars is the best.',
     'TEXT_NO_HTML' => '<strong>NOTE:</strong>  HTML tags are not allowed.',
     'TEXT_BAD' => 'Worst',
-    'TEXT_APPROVAL_REQUIRED' => '<strong>NOTE:</strong>  Reviews require prior approval before they will be displayed',
     'EMAIL_REVIEW_PENDING_SUBJECT' => 'Product Review Pending Approval: %s',
     'EMAIL_PRODUCT_REVIEW_CONTENT_INTRO' => 'A Product Review for %s has been submitted and requires your approval.' . "\n\n",
     'EMAIL_PRODUCT_REVIEW_CONTENT_DETAILS' => 'Review Details: %s',

--- a/includes/languages/lang.english.php
+++ b/includes/languages/lang.english.php
@@ -355,6 +355,7 @@ $define = [
     'TEXT_ALL_CATEGORIES' => 'All Categories',
     'TEXT_ALL_MANUFACTURERS' => 'All Manufacturers',
     'TEXT_ALSO_PURCHASED_PRODUCTS' => 'Customers who bought this product also purchased...',
+    'TEXT_APPROVAL_REQUIRED' => '<strong>NOTE:</strong>  Reviews require prior approval before they will be displayed.',
     'TEXT_ASCENDINGLY' => 'ascendingly',
     'TEXT_ATTRIBUTES_PRICE_WAS' => ' [was: ',
     'TEXT_ATTRIBUTES_QTY_PRICES_HELP' => 'Option Quantity Discounts',


### PR DESCRIPTION
This constant is used on the initial review page and the post-submission page, but is only declared for the initial review page.
So, after submitting a review:

> PHP Fatal error: Uncaught Error: Undefined constant "TEXT_APPROVAL_REQUIRED" in ...zencart\includes\templates\responsive_classic\templates\tpl_product_reviews_default.php:87

This PR moves this constant to the main language file.