### PR TITLE
Admin, developer email diversion message: add transport info

### DIFF
--- a/admin/includes/init_includes/init_errors.php
+++ b/admin/includes/init_includes/init_errors.php
@@ -28,12 +28,12 @@ if (!defined('IS_ADMIN_FLAG')) {
     $messageStack->add(WARNING_EMAIL_SYSTEM_DISABLED, 'error');
   }
 // check if email sending has been disabled by developer switch
-  if (defined('DEVELOPER_OVERRIDE_EMAIL_STATUS') && DEVELOPER_OVERRIDE_EMAIL_STATUS == 'false') {
-      $messageStack->add(WARNING_EMAIL_SYSTEM_DEVELOPER_OVERRIDE, 'info');
+if (defined('DEVELOPER_OVERRIDE_EMAIL_STATUS') && DEVELOPER_OVERRIDE_EMAIL_STATUS === 'false') {
+    $messageStack->add(WARNING_EMAIL_SYSTEM_DEVELOPER_OVERRIDE, 'info');
 // check if email destinations have been diverted by developer switch
-  } elseif (defined('DEVELOPER_OVERRIDE_EMAIL_ADDRESS') && DEVELOPER_OVERRIDE_EMAIL_ADDRESS != '') {
-      $messageStack->add(sprintf(zen_output_string_protected(WARNING_EMAIL_SYSTEM_DEVELOPER_EMAIL), DEVELOPER_OVERRIDE_EMAIL_ADDRESS), 'info');
-  }
+} elseif (defined('DEVELOPER_OVERRIDE_EMAIL_ADDRESS') && DEVELOPER_OVERRIDE_EMAIL_ADDRESS !== '') {
+    $messageStack->add(sprintf(WARNING_EMAIL_SYSTEM_DEVELOPER_EMAIL, DEVELOPER_OVERRIDE_EMAIL_ADDRESS, EMAIL_TRANSPORT), 'info');
+}
 
   // this will let the admin know that the website is DOWN FOR MAINTENANCE to the public
   if (DOWN_FOR_MAINTENANCE == 'true') {

--- a/admin/includes/languages/lang.english.php
+++ b/admin/includes/languages/lang.english.php
@@ -623,7 +623,7 @@ $define = [
     'WARNING_COULD_NOT_LOCATE_LANG_FILE' => 'WARNING: Could not locate language file: ',
     'WARNING_DATABASE_VERSION_OUT_OF_DATE' => 'Your database appears to need patching to a higher level. See Tools->' . '%%BOX_TOOLS_SERVER_INFO%%' . ' to review patch levels.',
     'WARNING_DOWNLOAD_DIRECTORY_NON_EXISTENT' => 'Warning: The downloadable products directory does not exist: ' . DIR_FS_DOWNLOAD . '. Downloadable products will not work until this directory is valid.',
-    'WARNING_EMAIL_SYSTEM_DEVELOPER_EMAIL' => 'WARNING: ALL emails will be sent to %s (as defined in "DEVELOPER_OVERRIDE_EMAIL_ADDRESS").',
+    'WARNING_EMAIL_SYSTEM_DEVELOPER_EMAIL' => 'WARNING: ALL emails will be sent to %1$s (as defined in "DEVELOPER_OVERRIDE_EMAIL_ADDRESS") using EMAIL_TRANSPORT=%2$s.',
     'WARNING_EMAIL_SYSTEM_DEVELOPER_OVERRIDE' => 'WARNING: The sending of emails has been disabled as developer switch "DEVELOPER_OVERRIDE_EMAIL_STATUS" is set to "false".',
     'WARNING_EMAIL_SYSTEM_DISABLED' => 'WARNING: The email subsystem is disabled. No emails will be sent until it is re-enabled in Admin->Configuration->Email Options.',
     'WARNING_FILE_UPLOADS_DISABLED' => 'Warning: File uploads are disabled in the php.ini configuration file.',


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4391026/155496082-e9c5dd02-cd53-47d6-b5ed-b83042e24d64.png)

1) The constant was wrapped with zen_output_string_protected: I couldn't see why.
2) The additional info is useful after importing a real db for local use and forgetting to change to suit the local server transport method.