### PR TITLE
Guard against first comment being blank

### DIFF
--- a/includes/templates/template_default/templates/tpl_account_history_info_default.php
+++ b/includes/templates/template_default/templates/tpl_account_history_info_default.php
@@ -114,10 +114,12 @@ if (!empty($order->statuses)) {
     if (!empty($statuses['comments'])) {
       if ($first) {
          echo nl2br(zen_output_string_protected($statuses['comments']));
-         $first = false;
       } else {
          echo nl2br(zen_output_string($statuses['comments']));
       }
+    }
+    if ($first) {
+       $first = false;
     }
 ?>
        </td>


### PR DESCRIPTION
Set first false even if initial order comment is blank. 