### PR TITLE
Remove instructional text from html_includes

### DIFF
--- a/includes/languages/english/html_includes/classic/define_checkout_success.php
+++ b/includes/languages/english/html_includes/classic/define_checkout_success.php
@@ -1,4 +1,0 @@
-<p><strong>Checkout Success Sample Text ...</strong></p><p>A few words about the approximate shipping time or your processing policy would be put here. </p>
-<p>This section of text is from the Define Pages Editor located under Tools in the Admin.</p>
-<p>This file is located in<code> /languages/english/html_includes/classic/</code></p>
-<p><strong>NOTE: Always backup the files in<code> /languages/english/html_includes/your_template</code></strong></p>

--- a/includes/languages/english/html_includes/classic/define_conditions.php
+++ b/includes/languages/english/html_includes/classic/define_conditions.php
@@ -1,4 +1,0 @@
-<p><strong>Conditions of Use Sample Text ...</strong></p><p>This section of text is from the Define Pages Editor located under Tools in the Admin.</p>
-<p>To remove this section of the text, delete it from the Define Pages Editor.</p>
-<p>This file is located in<code> /languages/english/html_includes/classic/</code></p>
-<p><strong>NOTE: Always backup the files in<code> /languages/english/html_includes/your_template</code></strong></p>

--- a/includes/languages/english/html_includes/classic/define_contact_us.php
+++ b/includes/languages/english/html_includes/classic/define_contact_us.php
@@ -1,5 +1,0 @@
-<p><strong>Contact Us Sample Text ...</strong></p>
-<p>This section of text is from the Define Pages Editor located under Tools in the Admin.</p>
-<p>To remove this section of the text, delete it from the Define Pages Editor.</p>
-<p>This file is located in<code> /languages/english/html_includes/classic/</code></p>
-<p><strong>NOTE: Always backup the files in<code> /languages/english/html_includes/your_template</code></strong></p>

--- a/includes/languages/english/html_includes/classic/define_discount_coupon.php
+++ b/includes/languages/english/html_includes/classic/define_discount_coupon.php
@@ -1,5 +1,0 @@
-<p><strong>Discount Coupon Sample Text ...</strong></p>
-<p>This section of text is from the Define Pages Editor located under Tools in the Admin.</p>
-<p>To remove this section of the text, delete it from the Define Pages Editor.</p>
-<p>This file is located in<code> /languages/english/html_includes/classic/</code></p>
-<p><strong>NOTE: Always backup the files in<code> /languages/english/html_includes/your_template</code></strong></p>

--- a/includes/languages/english/html_includes/classic/define_main_page.php
+++ b/includes/languages/english/html_includes/classic/define_main_page.php
@@ -1,4 +1,0 @@
-<a href="https://docs.zen-cart.com/user/" target="_blank" rel="noopener"><img src="images/large/zencart-docs.jpg" alt="Zen Cart Documentation" title="View the online Zen Cart documentation!" class="home-image" width="100%"></a>
-<p>This text is located in the file at: <code> /languages/english/html_includes/classic/define_main_page.php</code></p>
-<p>You can quickly edit this content (and remove this image) via Admin->Tools->Define Pages Editor, and select define_main_page from the pulldown.</p>
-<p><strong>NOTE: Always backup the files in<code> /languages/english/html_includes/your_template</code></strong></p>

--- a/includes/languages/english/html_includes/classic/define_page_2.php
+++ b/includes/languages/english/html_includes/classic/define_page_2.php
@@ -1,5 +1,0 @@
-<p><strong>Page 2 Sample Text ...</strong></p>
-<p>This section of text is from the Define Pages Editor located under Tools in the Admin.</p>
-<p>To remove this section of the text, delete it from the Define Pages Editor.</p>
-<p>This file is located in<code> /languages/english/html_includes/classic/</code></p>
-<p><strong>NOTE: Always backup the files in<code> /languages/english/html_includes/your_template</code></strong></p>

--- a/includes/languages/english/html_includes/classic/define_page_3.php
+++ b/includes/languages/english/html_includes/classic/define_page_3.php
@@ -1,5 +1,0 @@
-<p><strong>Page 3 Sample Text ...</strong></p>
-<p>This section of text is from the Define Pages Editor located under Tools in the Admin.</p>
-<p>To remove this section of the text, delete it from the Define Pages Editor.</p>
-<p>This file is located in<code> /languages/english/html_includes/classic/</code></p>
-<p><strong>NOTE: Always backup the files in<code> /languages/english/html_includes/your_template</code></strong></p>

--- a/includes/languages/english/html_includes/classic/define_page_4.php
+++ b/includes/languages/english/html_includes/classic/define_page_4.php
@@ -1,5 +1,0 @@
-<p><strong>Page 4 Sample Text ...</strong></p>
-<p>This section of text is from the Define Pages Editor located under Tools in the Admin.</p>
-<p>To remove this section of the text, delete it from the Define Pages Editor.</p>
-<p>This file is located in<code> /languages/english/html_includes/classic/</code></p>
-<p><strong>NOTE: Always backup the files in<code> /languages/english/html_includes/your_template</code></strong></p>

--- a/includes/languages/english/html_includes/classic/define_page_not_found.php
+++ b/includes/languages/english/html_includes/classic/define_page_not_found.php
@@ -1,4 +1,0 @@
-<p><strong>Custom 404 Error Page with Site Map Sample Text ...</strong></p>
-<p>Put your custom "page not found" message here.  You can change this text in the Define Pages Editor located under Tools in the Admin.</p>
-<p>This file is located in<code> /languages/english/html_includes/classic/</code></p>
-<p><strong>NOTE: Always backup the files in<code> /languages/english/html_includes/your_template</code></strong></p>

--- a/includes/languages/english/html_includes/classic/define_privacy.php
+++ b/includes/languages/english/html_includes/classic/define_privacy.php
@@ -1,5 +1,0 @@
-<p><strong>Privacy Sample Text ...</strong></p>
-<p>This section of text is from the Define Pages Editor located under Tools in the Admin.</p>
-<p>To remove this section of the text, delete it from the Define Pages Editor.</p>
-<p>This file is located in<code> /languages/english/html_includes/classic/</code></p>
-<p><strong>NOTE: Always backup the files in<code> /languages/english/html_includes/your_template</code></strong></p>

--- a/includes/languages/english/html_includes/classic/define_shippinginfo.php
+++ b/includes/languages/english/html_includes/classic/define_shippinginfo.php
@@ -1,5 +1,0 @@
-<p><strong>Shipping Sample Text ...</strong></p>
-<p>This section of text is from the Define Pages Editor located under Tools in the Admin.</p>
-<p>To remove this section of the text, delete it from the Define Pages Editor.</p>
-<p>This file is located in<code> /languages/english/html_includes/classic/</code></p>
-<p><strong>NOTE: Always backup the files in<code> /languages/english/html_includes/your_template</code></strong></p>

--- a/includes/languages/english/html_includes/classic/define_shopping_cart.php
+++ b/includes/languages/english/html_includes/classic/define_shopping_cart.php
@@ -1,2 +1,0 @@
-<p>This file is found in includes/languages/english/html_includes/define_shopping_cart.php</p>
-<p>Edit this text (the one you are reading now) in Admin > Tools > Define Pages Editor to write your personal shopping cart message here</p>

--- a/includes/languages/english/html_includes/classic/define_site_map.php
+++ b/includes/languages/english/html_includes/classic/define_site_map.php
@@ -1,2 +1,0 @@
-<p><strong>To assist you in navigating our site, we have provided the following map.</strong></p>
-<p>If you are having difficulty in locating something on our site, please visit our <a href="<?php echo zen_href_link(FILENAME_CONTACT_US, '', 'SSL'); ?>">Contact Us </a> page and let us know! </p>

--- a/includes/languages/english/html_includes/define_about_us.php
+++ b/includes/languages/english/html_includes/define_about_us.php
@@ -1,3 +1,1 @@
-<p>We are much more interesting than this blank page!</p>
-<p>Please use the Contact-Us page to remind us to update this page.</p>
-<p class="small pt-5"><br><br><br>Storeowners: use the Define Pages editor in your Admin to update this text.</p>
+<p>Here are some details about us: </p>

--- a/includes/languages/english/html_includes/define_checkout_success.php
+++ b/includes/languages/english/html_includes/define_checkout_success.php
@@ -1,2 +1,1 @@
-<p><strong>Checkout Success Sample Text ...</strong></p><p>A few words about the approximate shipping time or your processing policy would be put here. </p>
-<p>This section of text is from the Define Pages Editor located under Tools in the Admin.</p>
+<p>Thank you for your order!</p>

--- a/includes/languages/english/html_includes/define_conditions.php
+++ b/includes/languages/english/html_includes/define_conditions.php
@@ -1,2 +1,1 @@
-<p><strong>Conditions of Use Sample Text ...</strong></p><p>This section of text is from the Define Pages Editor located under Tools in the Admin.</p>
-<p>To remove this section of the text, delete it from the Define Pages Editor.</p>
+<p>Here are our conditions of use: </p>

--- a/includes/languages/english/html_includes/define_contact_us.php
+++ b/includes/languages/english/html_includes/define_contact_us.php
@@ -1,3 +1,1 @@
-<p><strong>Contact Us Sample Text ...</strong></p>
-<p>This section of text is from the Define Pages Editor located under Tools in the Admin.</p>
-<p>To remove this section of the text, delete it from the Define Pages Editor.</p>
+<p>Thank you for contacting us.</p>

--- a/includes/languages/english/html_includes/define_discount_coupon.php
+++ b/includes/languages/english/html_includes/define_discount_coupon.php
@@ -1,3 +1,1 @@
-<p><strong>Discount Coupon Sample Text ...</strong></p>
-<p>This section of text is from the Define Pages Editor located under Tools in the Admin.</p>
-<p>To remove this section of the text, delete it from the Define Pages Editor.</p>
+<p>Here is some information about our coupons:</p>

--- a/includes/languages/english/html_includes/define_page_2.php
+++ b/includes/languages/english/html_includes/define_page_2.php
@@ -1,3 +1,0 @@
-<p><strong>Page 2 Sample Text ...</strong></p>
-<p>This section of text is from the Define Pages Editor located under Tools in the Admin.</p>
-<p>To remove this section of the text, delete it from the Define Pages Editor.</p>

--- a/includes/languages/english/html_includes/define_page_3.php
+++ b/includes/languages/english/html_includes/define_page_3.php
@@ -1,3 +1,0 @@
-<p><strong>Page 3 Sample Text ...</strong></p>
-<p>This section of text is from the Define Pages Editor located under Tools in the Admin.</p>
-<p>To remove this section of the text, delete it from the Define Pages Editor.</p>

--- a/includes/languages/english/html_includes/define_page_4.php
+++ b/includes/languages/english/html_includes/define_page_4.php
@@ -1,3 +1,0 @@
-<p><strong>Page 4 Sample Text ...</strong></p>
-<p>This section of text is from the Define Pages Editor located under Tools in the Admin.</p>
-<p>To remove this section of the text, delete it from the Define Pages Editor.</p>

--- a/includes/languages/english/html_includes/define_page_not_found.php
+++ b/includes/languages/english/html_includes/define_page_not_found.php
@@ -1,2 +1,0 @@
-<p><strong>Custom 404 Error Page with Site Map Sample Text ...</strong></p>
-<p>Put your custom "page not found" message here.  You can change this text in the Define Pages Editor located under Tools in the Admin.</p>

--- a/includes/languages/english/html_includes/define_privacy.php
+++ b/includes/languages/english/html_includes/define_privacy.php
@@ -1,3 +1,1 @@
-<p><strong>Privacy Sample Text ...</strong></p>
-<p>This section of text is from the Define Pages Editor located under Tools in the Admin.</p>
-<p>To remove this section of the text, delete it from the Define Pages Editor.</p>
+<p>Here is our privacy policy:</p>

--- a/includes/languages/english/html_includes/define_shippinginfo.php
+++ b/includes/languages/english/html_includes/define_shippinginfo.php
@@ -1,3 +1,1 @@
-<p><strong>Shipping Sample Text ...</strong></p>
-<p>This section of text is from the Define Pages Editor located under Tools in the Admin.</p>
-<p>To remove this section of the text, delete it from the Define Pages Editor.</p>
+<p>Here is our shipping policy:</p>

--- a/includes/languages/english/html_includes/responsive_classic/define_about_us.php
+++ b/includes/languages/english/html_includes/responsive_classic/define_about_us.php
@@ -1,3 +1,0 @@
-<p>We are much more interesting than this blank page!</p>
-<p>Please use the Contact-Us page to remind us to update this page.</p>
-<p class="small pt-5"><br><br><br>Storeowners: use the Define Pages editor in your Admin to update this text.</p>

--- a/includes/languages/english/html_includes/responsive_classic/define_checkout_success.php
+++ b/includes/languages/english/html_includes/responsive_classic/define_checkout_success.php
@@ -1,3 +1,0 @@
-<p><strong>Checkout Success Sample Text ...</strong></p
-><p>A few words about the approximate shipping time or our processing policy should be put here. </p>
-<p>We haven't updated this page yet. Please use the Contact Us form to let us know!</p>

--- a/includes/languages/english/html_includes/responsive_classic/define_conditions.php
+++ b/includes/languages/english/html_includes/responsive_classic/define_conditions.php
@@ -1,2 +1,0 @@
-<p><strong>Conditions of Use Sample Text ...</strong></p>
-<p>We haven't updated this page yet. Please use the Contact Us form to let us know!</p>

--- a/includes/languages/english/html_includes/responsive_classic/define_contact_us.php
+++ b/includes/languages/english/html_includes/responsive_classic/define_contact_us.php
@@ -1,2 +1,0 @@
-<p><strong>Contact Us Sample Text ...</strong></p>
-<p>We haven't updated this custom text yet. Please use form below to let us know!</p>

--- a/includes/languages/english/html_includes/responsive_classic/define_discount_coupon.php
+++ b/includes/languages/english/html_includes/responsive_classic/define_discount_coupon.php
@@ -1,2 +1,0 @@
-<p><strong>Discount Coupon Sample Text ...</strong></p>
-<p>We haven't updated this page yet. Please use the Contact Us form to let us know!</p>

--- a/includes/languages/english/html_includes/responsive_classic/define_main_page.php
+++ b/includes/languages/english/html_includes/responsive_classic/define_main_page.php
@@ -1,9 +1,0 @@
-<a href="https://docs.zen-cart.com/user/" target="_blank" rel="noopener"><img src="images/large/zencart-docs.jpg" alt="Zen Cart Documentation" title="View the online Zen Cart documentation!" class="home-image" width="100%"></a>
-<p class="biggerText">The template package uses PHP Mobile Detect to serve up the optimized layout based on device.  
-    If you are on a Desktop and want to view the Tablet layout <a class="red" href="index.php?main_page=index&amp;layoutType=tablet">use this link.</a>  
-    If you want to view the Mobile layout <a class="red" href="index.php?main_page=index&amp;layoutType=mobile">use this link.</a>  
-    To switch back to a Desktop <a class="red" href="index.php?main_page=index&amp;layoutType=default">use this link.</a></p>
-    
-<p>This text is located in the file at: <code> /languages/english/html_includes/YOUR_TEMPLATE/define_main_page.php</code></p>
-<p>You can quickly edit this content (and remove this image) via Admin->Tools->Define Pages Editor, and select define_main_page from the pulldown.</p>
-<p><strong>NOTE: Always backup the files in<code> /languages/english/html_includes/your_template</code></strong></p>

--- a/includes/languages/english/html_includes/responsive_classic/define_page_2.php
+++ b/includes/languages/english/html_includes/responsive_classic/define_page_2.php
@@ -1,2 +1,0 @@
-<p><strong>Page 2 Sample Text ...</strong></p>
-<p>We haven't updated this page yet. Please use the Contact Us form to let us know!</p>

--- a/includes/languages/english/html_includes/responsive_classic/define_page_3.php
+++ b/includes/languages/english/html_includes/responsive_classic/define_page_3.php
@@ -1,2 +1,0 @@
-<p><strong>Page 3 Sample Text ...</strong></p>
-<p>We haven't updated this page yet. Please use the Contact Us form to let us know!</p>

--- a/includes/languages/english/html_includes/responsive_classic/define_page_4.php
+++ b/includes/languages/english/html_includes/responsive_classic/define_page_4.php
@@ -1,2 +1,0 @@
-<p><strong>Page 4 Sample Text ...</strong></p>
-<p>We haven't updated this page yet. Please use the Contact Us form to let us know!</p>

--- a/includes/languages/english/html_includes/responsive_classic/define_page_not_found.php
+++ b/includes/languages/english/html_includes/responsive_classic/define_page_not_found.php
@@ -1,2 +1,0 @@
-<p><strong>Custom 404 Error Page Sample Text ...</strong></p>
-<p>We haven't updated this page yet. Please use the Contact Us form to let us know!</p>

--- a/includes/languages/english/html_includes/responsive_classic/define_privacy.php
+++ b/includes/languages/english/html_includes/responsive_classic/define_privacy.php
@@ -1,2 +1,0 @@
-<p><strong>Privacy Policy</strong></p>
-<p>We haven't updated this page yet. Please use the Contact Us form to let us know!</p>

--- a/includes/languages/english/html_includes/responsive_classic/define_shippinginfo.php
+++ b/includes/languages/english/html_includes/responsive_classic/define_shippinginfo.php
@@ -1,2 +1,0 @@
-<p><strong>Shipping Information</strong></p>
-<p>We haven't updated this page yet. Please use the Contact Us form to let us know!</p>

--- a/includes/languages/english/html_includes/responsive_classic/define_shopping_cart.php
+++ b/includes/languages/english/html_includes/responsive_classic/define_shopping_cart.php
@@ -1,7 +1,0 @@
-<p>
-    Your shopping cart contents are shown below. You may update quantities or remove items by clicking on the related buttons.
-    
-    If relevant, Shipping, Taxes and Discounts will be determined and displayed during Checkout.
-    
-    You may of course add more items to your cart!
-</p>

--- a/includes/languages/english/html_includes/responsive_classic/define_site_map.php
+++ b/includes/languages/english/html_includes/responsive_classic/define_site_map.php
@@ -1,2 +1,0 @@
-<p><strong>To assist you in navigating our site, we have provided the following map.</strong></p>
-<p>If you are having difficulty in locating something on our site, please visit our <a href="<?php echo zen_href_link(FILENAME_CONTACT_US, '', 'SSL'); ?>">Contact Us </a> page and let us know! </p>


### PR DESCRIPTION
The default versions of these files are replicated in triplicate and full of content that the storeowner has to delete.  Let's improve this. 