### PR TITLE
Restore public scope on shopping_cart::get_cart_id

### DIFF
--- a/includes/classes/shopping_cart.php
+++ b/includes/classes/shopping_cart.php
@@ -1429,7 +1429,7 @@ class shoppingCart extends base
      * @param int $length length of ID to generate
      * @return string cart ID
      */
-    protected function generate_cart_id($length = 5)
+    public function generate_cart_id($length = 5)
     {
         return zen_create_random_value($length, 'digits');
     }


### PR DESCRIPTION
Fixes #4681 