### PR TITLE
responsive_classic mobile menu needs !zen_in_guest_checkout

### DIFF
--- a/includes/templates/responsive_classic/templates/tpl_modules_mobile_menu.php
+++ b/includes/templates/responsive_classic/templates/tpl_modules_mobile_menu.php
@@ -17,7 +17,7 @@
 <?php  } ?>
     <li><?php echo '<a href="' . zen_href_link(FILENAME_ABOUT_US) . '">' . BOX_INFORMATION_ABOUT_US . '</a>'; ?></li>
 
-<?php if (zen_is_logged_in()) { ?>
+<?php if (zen_is_logged_in() && !zen_in_guest_checkout()) { ?>
     <li><a href="<?php echo zen_href_link(FILENAME_LOGOFF, '', 'SSL'); ?>"><?php echo HEADER_TITLE_LOGOFF; ?></a></li>
     <li><a href="<?php echo zen_href_link(FILENAME_ACCOUNT, '', 'SSL'); ?>"><?php echo HEADER_TITLE_MY_ACCOUNT; ?></a></li>
 <?php


### PR DESCRIPTION
... as identified in [this](https://www.zen-cart.com/showthread.php?228741-One-page-payment-and-default-responsive_classic-template-issue) Zen-Cart support-thread posting.  Otherwise, the "Logoff" and "Account" links are shown instead of "Login" when a customer is in the middle of a guest-checkout.