### PR TITLE
Correcting admin/orders.php performance issue when orders have a larg…

### DIFF
--- a/admin/orders.php
+++ b/admin/orders.php
@@ -1304,28 +1304,28 @@ if (!empty($action) && $order_exists === true) {
 
                     $show_payment_type = $orders->fields['payment_module_code'] . '<br>' . $orders->fields['shipping_module_code'];
 
-                    $sql = "SELECT op.orders_products_id, op.products_quantity AS qty, op.products_name AS name, op.products_model AS model
-                            FROM " . TABLE_ORDERS_PRODUCTS . " op
-                            WHERE op.orders_id = " . (int)$orders->fields['orders_id'];
-                    $orderProducts = $db->Execute($sql, false, true, 1800);
                     $product_details = '';
                     if ($includeAttributesInProductDetailRows) {
-                    foreach($orderProducts as $product) {
-                        $product_details .= $product['qty'] . ' x ' . $product['name'] . (!empty($product['model']) ? ' (' . $product['model'] . ')' :'') . "\n";
-                        $sql = "SELECT products_options, products_options_values
-                            FROM " .  TABLE_ORDERS_PRODUCTS_ATTRIBUTES . "
-                            WHERE orders_products_id = " . (int)$product['orders_products_id'] . " ORDER BY orders_products_attributes_id ASC";
-                        $productAttributes = $db->Execute($sql, false, true, 1800);
-                        foreach ($productAttributes as $attr) {
-                          if (!empty($attr['products_options'])) {
-                             $product_details .= '&nbsp;&nbsp;- ' . $attr['products_options'] . ': ' . zen_output_string_protected($attr['products_options_values']) . "\n";
-                          }
+                        $sql = "SELECT op.orders_products_id, op.products_quantity AS qty, op.products_name AS name, op.products_model AS model
+                                FROM " . TABLE_ORDERS_PRODUCTS . " op
+                                WHERE op.orders_id = " . (int)$orders->fields['orders_id'];
+                        $orderProducts = $db->Execute($sql, false, true, 1800);
+                        foreach($orderProducts as $product) {
+                            $product_details .= $product['qty'] . ' x ' . $product['name'] . (!empty($product['model']) ? ' (' . $product['model'] . ')' :'') . "\n";
+                            $sql = "SELECT products_options, products_options_values
+                                FROM " .  TABLE_ORDERS_PRODUCTS_ATTRIBUTES . "
+                                WHERE orders_products_id = " . (int)$product['orders_products_id'] . " ORDER BY orders_products_attributes_id ASC";
+                            $productAttributes = $db->Execute($sql, false, true, 1800);
+                            foreach ($productAttributes as $attr) {
+                              if (!empty($attr['products_options'])) {
+                                 $product_details .= '&nbsp;&nbsp;- ' . $attr['products_options'] . ': ' . zen_output_string_protected($attr['products_options_values']) . "\n";
+                              }
+                            }
+                            $product_details .= '<hr>'; // add HR
                         }
-                        $product_details .= '<hr>'; // add HR
-                    }
-                    $product_details = rtrim($product_details);
-                    $product_details = preg_replace('~<hr>$~', '', $product_details); // remove last HR
-                    $product_details = nl2br($product_details);
+                        $product_details = rtrim($product_details);
+                        $product_details = preg_replace('~<hr>$~', '', $product_details); // remove last HR
+                        $product_details = nl2br($product_details);
                     }
                     ?>
                 <td class="dataTableContent text-center"><?php echo $show_difference . $orders->fields['orders_id']; ?></td>

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -1305,21 +1305,23 @@ if (!empty($action) && $order_exists === true) {
                     $show_payment_type = $orders->fields['payment_module_code'] . '<br>' . $orders->fields['shipping_module_code'];
 
                     $product_details = '';
-                    if ($includeAttributesInProductDetailRows) {
+                    if ($quick_view_popover_enabled) {
                         $sql = "SELECT op.orders_products_id, op.products_quantity AS qty, op.products_name AS name, op.products_model AS model
                                 FROM " . TABLE_ORDERS_PRODUCTS . " op
                                 WHERE op.orders_id = " . (int)$orders->fields['orders_id'];
                         $orderProducts = $db->Execute($sql, false, true, 1800);
-                        foreach($orderProducts as $product) {
+                        foreach ($orderProducts as $product) {
                             $product_details .= $product['qty'] . ' x ' . $product['name'] . (!empty($product['model']) ? ' (' . $product['model'] . ')' :'') . "\n";
-                            $sql = "SELECT products_options, products_options_values
-                                FROM " .  TABLE_ORDERS_PRODUCTS_ATTRIBUTES . "
-                                WHERE orders_products_id = " . (int)$product['orders_products_id'] . " ORDER BY orders_products_attributes_id ASC";
-                            $productAttributes = $db->Execute($sql, false, true, 1800);
-                            foreach ($productAttributes as $attr) {
-                              if (!empty($attr['products_options'])) {
-                                 $product_details .= '&nbsp;&nbsp;- ' . $attr['products_options'] . ': ' . zen_output_string_protected($attr['products_options_values']) . "\n";
-                              }
+                            if ($includeAttributesInProductDetailRows) {
+                                $sql = "SELECT products_options, products_options_values
+                                    FROM " .  TABLE_ORDERS_PRODUCTS_ATTRIBUTES . "
+                                    WHERE orders_products_id = " . (int)$product['orders_products_id'] . " ORDER BY orders_products_attributes_id ASC";
+                                $productAttributes = $db->Execute($sql, false, true, 1800);
+                                foreach ($productAttributes as $attr) {
+                                  if (!empty($attr['products_options'])) {
+                                     $product_details .= '&nbsp;&nbsp;- ' . $attr['products_options'] . ': ' . zen_output_string_protected($attr['products_options_values']) . "\n";
+                                  }
+                                }
                             }
                             $product_details .= '<hr>'; // add HR
                         }


### PR DESCRIPTION
…e number of products.

Essentially, the orders' listing display takes **_forever_** (and sometimes times out) on stores with (a) a large number of orders, think > 100,000 and (b) orders with a large number of products (like 154).

This is due to the addition made by [this](https://github.com/zencart/zencart/commit/61d2abb213be78e0f1a4e74d439b9a67a45b0856) commit and isn't helped by the addition of the `$includeAttributesInProductDetailRows` flag, since the order-products' gathering query is still performed even if that flag is set to `(bool)false`.

This change moves the product-gathering query so that it's only run when the above flag is set.