### PR TITLE
Fixes #4156

### DIFF
--- a/includes/auto_loaders/config.core.php
+++ b/includes/auto_loaders/config.core.php
@@ -105,6 +105,15 @@ if (!defined('USE_PCONNECT')) define('USE_PCONNECT', 'false');
   $autoLoadConfig[50][] = array('autoType'=>'init_script',
                                 'loadFile'=> 'init_sefu.php');
 /**
+ * Breakpoint 55.
+ *
+ * require('includes/init_includes/init_common_elements.php');
+ */
+$autoLoadConfig[55][] = [
+'autoType' => 'init_script',
+'loadFile' => 'init_common_elements.php',
+];
+/**
  * Breakpoint 60.
  *
  * require('includes/init_includes/init_general_funcs.php');

--- a/includes/extra_datafiles/dist-site_specific_overrides.php
+++ b/includes/extra_datafiles/dist-site_specific_overrides.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * A collection of site-specific overrides for the storefront operation.
+ *
+ * There are some features in the base Zen Cart processing that can be overridden for a specific
+ * site, as identified in this module.
+ *
+ * For use on YOUR site, make a copy of this file (which has all entries commented-out) to /includes/extra_datafiles/site_specific_overrides.php
+ * and make your edits there.  Otherwise, your overrides might get "lost" on a future Zen Cart upgrade.  The 'base' Zen Cart definitions
+ * of these variables are set by /includes/init_includes/init_common_elements.php.
+ *
+ * @copyright Copyright 2003-2022 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: lat9 2022 Apr 30 Modified in v1.5.8 $
+ */
+//-For use on YOUR site, remove the following block-comment start!
+/*
+// -----
+// Identify whether the link to the 'brands' page (added in Zen Cart 1.5.8) is included in the "Information" sidebox.
+//
+// true ...... Always show in the sidebox.
+// false ..... Never show in the sidebox.
+// Not set ... (i.e. leave the variable commented-out), the link shows if there are manufacturers with active products (default).
+//
+$flag_show_brand_sidebox_link = false;
+
+//-For use on YOUR site, remove the following block-comment end!
+*/

--- a/includes/init_includes/init_common_elements.php
+++ b/includes/init_includes/init_common_elements.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Set some common processing flags, overridable via site-specific /extra_datafiles processing.  See
+ * /includes/extra_datafiles/dist-site_specific_overrides.php.
+ *
+ * @package initSystem
+ * @copyright Copyright 2003-2022 Zen Cart Development Team
+ * @copyright Portions Copyright 2003 osCommerce
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ */
+if (!defined('IS_ADMIN_FLAG')) {
+    die('Illegal Access');
+}
+
+// -----
+// Sets the processing flag (used by /includes/modules/sideboxes/information.php) that
+// indicates whether or not a link to the "Brands" page should be included.
+//
+if (isset($flag_show_brand_sidebox_link)) {
+    $flag_show_brand_sidebox_link = (bool)$flag_show_brand_sidebox_link;
+} else {
+    // -----
+    // Setting a flag for use in the 'information' sidebox.
+    //
+    $brand_check = $db->Execute(
+        "SELECT m.manufacturers_id
+           FROM " . TABLE_MANUFACTURERS . " m
+                LEFT JOIN " . TABLE_PRODUCTS . " p
+                    ON p.manufacturers_id = m.manufacturers_id
+          WHERE p.products_status = 1
+          LIMIT 1"
+    );
+    $flag_show_brand_sidebox_link = !$brand_check->EOF;
+    unset($brand_check);
+}

--- a/includes/modules/sideboxes/information.php
+++ b/includes/modules/sideboxes/information.php
@@ -12,7 +12,13 @@ $information = [];
 
 $information[] = '<a href="' . zen_href_link(FILENAME_ABOUT_US) . '">' . BOX_INFORMATION_ABOUT_US . '</a>';
 
-$information[] = '<a href="' . zen_href_link(FILENAME_BRANDS) . '">' . BOX_HEADING_BRANDS . '</a>';
+// -----
+// The following flag is set by /includes/init_includes/init_common_elements.php; refer to that module's
+// comments for the way to override this setting.
+//
+if ($flag_show_brand_sidebox_link === true) {
+    $information[] = '<a href="' . zen_href_link(FILENAME_BRANDS) . '">' . BOX_HEADING_BRANDS . '</a>';
+}
 
 if (DEFINE_SHIPPINGINFO_STATUS <= 1) {
     $information[] = '<a href="' . zen_href_link(FILENAME_SHIPPING) . '">' . BOX_INFORMATION_SHIPPING . '</a>';


### PR DESCRIPTION
Creates an initialization file that sets some "soft" configuration settings, overridable via variables present in a site-specific extra_datafiles module.

Starting with a flag that controls whether/not to display the "Brands" page's link in the information sidebox.