### PR TITLE
V158 freeoptions updates

### DIFF
--- a/includes/modules/shipping/freeoptions.php
+++ b/includes/modules/shipping/freeoptions.php
@@ -5,257 +5,253 @@
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: Scott C Wilson 2020 Apr 09 Modified in v1.5.7 $
  */
+class freeoptions extends base
+ {
+    public
+        $code,
+        $title,
+        $description,
+        $icon,
+        $enabled,
+        $debug = [];
 
-  class freeoptions extends base {
-    var $code, $title, $description, $icon, $enabled;
-    var $ck_freeoptions_total, $ck_freeoptions_weight, $ck_freeoptions_items;
+    public function __construct()
+    {
+        $this->code = 'freeoptions';
+        $this->title = MODULE_SHIPPING_FREEOPTIONS_TEXT_TITLE;
+        $this->description = MODULE_SHIPPING_FREEOPTIONS_TEXT_DESCRIPTION;
+        $this->sort_order = defined('MODULE_SHIPPING_FREEOPTIONS_SORT_ORDER') ? MODULE_SHIPPING_FREEOPTIONS_SORT_ORDER : null;
+        if (null === $this->sort_order) return false;
 
-    function __construct() {
-      $this->code = 'freeoptions';
-      $this->title = MODULE_SHIPPING_FREEOPTIONS_TEXT_TITLE;
-      $this->description = MODULE_SHIPPING_FREEOPTIONS_TEXT_DESCRIPTION;
-      $this->sort_order = defined('MODULE_SHIPPING_FREEOPTIONS_SORT_ORDER') ? MODULE_SHIPPING_FREEOPTIONS_SORT_ORDER : null;
-      if (null === $this->sort_order) return false;
+        $this->icon = '';
+        $this->tax_class = MODULE_SHIPPING_FREEOPTIONS_TAX_CLASS;
+        $this->tax_basis = MODULE_SHIPPING_FREEOPTIONS_TAX_BASIS;
 
-      $this->icon = '';
-      $this->tax_class = MODULE_SHIPPING_FREEOPTIONS_TAX_CLASS;
-      $this->tax_basis = MODULE_SHIPPING_FREEOPTIONS_TAX_BASIS;
-
-      // disable only when entire cart is free shipping
-      if (zen_get_shipping_enabled($this->code)) {
-          $this->enabled = ((MODULE_SHIPPING_FREEOPTIONS_STATUS == 'True') ? true : false);
-      }
-
-      $this->update_status();
-    }
-
-  /**
-   * Perform various checks to see whether this module should be visible
-   */
-    function update_status() {
-      global $order, $db;
-      if (!$this->enabled) return;
-      if (IS_ADMIN_FLAG === true) return;
-
-      if ((int)MODULE_SHIPPING_FREEOPTIONS_ZONE > 0) {
-        $check_flag = false;
-        $check = $db->Execute("SELECT zone_id FROM " . TABLE_ZONES_TO_GEO_ZONES . " WHERE geo_zone_id = '" . MODULE_SHIPPING_FREEOPTIONS_ZONE . "' AND zone_country_id = '" . $order->delivery['country']['id'] . "' ORDER BY zone_id");
-        while (!$check->EOF) {
-          if ($check->fields['zone_id'] < 1) {
-            $check_flag = true;
-            break;
-          } elseif ($check->fields['zone_id'] == $order->delivery['zone_id']) {
-            $check_flag = true;
-            break;
-          }
-          $check->MoveNext();
+        // disable only when entire cart is free shipping
+        if (zen_get_shipping_enabled($this->code)) {
+            $this->enabled = ((MODULE_SHIPPING_FREEOPTIONS_STATUS == 'True') ? true : false);
         }
 
-        if ($check_flag == false) {
-          $this->enabled = false;
-        }
-      }
-
-      if ($this->enabled === true) {
-          $this->checkForFreeOptions();
-      }
+        $this->update_status();
     }
 
+    /**
+     * Perform various checks to see whether this module should be visible
+     */
+    public function update_status()
+    {
+        global $order, $db;
+        if ($this->enabled === false || IS_ADMIN_FLAG === true) {
+            return;
+        }
+
+        if ((int)MODULE_SHIPPING_FREEOPTIONS_ZONE > 0) {
+            $check_flag = false;
+            $check = $db->Execute(
+                "SELECT zone_id
+                   FROM " . TABLE_ZONES_TO_GEO_ZONES . "
+                  WHERE geo_zone_id = " . (int)MODULE_SHIPPING_FREEOPTIONS_ZONE . "
+                    AND zone_country_id = " . $order->delivery['country']['id'] . "
+                  ORDER BY zone_id"
+            );
+            foreach ($check as $next_zone) {
+                if ($next_zone['zone_id'] < 1 || $next_zone['zone_id'] == $order->delivery['zone_id']) {
+                    $check_flag = true;
+                    break;
+                }
+            }
+
+            if ($check_flag === false) {
+                $this->enabled = false;
+            }
+        }
+
+        // -----
+        // If still enabled, check to see if any "Free Options" should be presented to the customer.
+        //
+        if ($this->enabled === true) {
+            $this->checkForFreeOptions();
+        }
+    }
+
+    // -----
+    // This function checks to see if the order's total, weight or number-of-items qualifies for the
+    // Free Options shipping method.
+    //
     protected function checkForFreeOptions()
     {
-      global $order;
-      $order_weight = round($_SESSION['cart']->show_weight(),9);
+        global $order;
 
-      // check if anything is configured for total, weight or item
-      if ((MODULE_SHIPPING_FREEOPTIONS_TOTAL_MIN !='' or MODULE_SHIPPING_FREEOPTIONS_TOTAL_MAX !='')) {
-        $this->ck_freeoptions_total = true;
-      } else {
-        $this->ck_freeoptions_total = false;
-      }
-      if ((MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MIN !='' or MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MAX !='')) {
-        $this->ck_freeoptions_weight = true;
-      } else {
-        $this->ck_freeoptions_weight = false;
-      }
-      if ((MODULE_SHIPPING_FREEOPTIONS_ITEMS_MIN !='' or MODULE_SHIPPING_FREEOPTIONS_ITEMS_MAX !='')) {
-        $this->ck_freeoptions_items = true;
-      } else {
-        $this->ck_freeoptions_items = false;
-      }
-      if ($this->ck_freeoptions_total or $this->ck_freeoptions_weight or $this->ck_freeoptions_items) {
-        $this->enabled = true;
-      } else {
-        $this->enabled = false;
-      }
+        // -----
+        // First, see if any of the 3 options for free shipping are configured.  If none are configured, there's no quote
+        // to be returned.
+        //
+        $freeoptions_total = (MODULE_SHIPPING_FREEOPTIONS_TOTAL_MIN !== '' || MODULE_SHIPPING_FREEOPTIONS_TOTAL_MAX !== '');
+        $freeoptions_weight = (MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MIN !== '' || MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MAX !== '');
+        $freeoptions_items  = (MODULE_SHIPPING_FREEOPTIONS_ITEMS_MIN !== '' || MODULE_SHIPPING_FREEOPTIONS_ITEMS_MAX !== '');
+        $this->debug[] = [$freeoptions_total, $freeoptions_weight, $freeoptions_items];
 
-      // disabled if nothing validates for total, weight or item
-      if ($this->enabled) {
-        if ($this->ck_freeoptions_total) {
-          switch (true) {
-          case ((MODULE_SHIPPING_FREEOPTIONS_TOTAL_MIN !='' and MODULE_SHIPPING_FREEOPTIONS_TOTAL_MAX !='')):
-// free shipping total should not need adjusting
-//            if (($_SESSION['cart']->show_total() - $_SESSION['cart']->free_shipping_prices()) >= MODULE_SHIPPING_FREEOPTIONS_TOTAL_MIN and ($_SESSION['cart']->show_total() - $_SESSION['cart']->free_shipping_prices()) <= MODULE_SHIPPING_FREEOPTIONS_TOTAL_MAX) {
-            if (($_SESSION['cart']->show_total()) >= MODULE_SHIPPING_FREEOPTIONS_TOTAL_MIN and ($_SESSION['cart']->show_total()) <= MODULE_SHIPPING_FREEOPTIONS_TOTAL_MAX) {
-              $this->ck_freeoptions_total = true;
-            } else {
-              $this->ck_freeoptions_total = false;
-            }
-            break;
-          case ((MODULE_SHIPPING_FREEOPTIONS_TOTAL_MIN !='')):
-//            if (($_SESSION['cart']->show_total() - $_SESSION['cart']->free_shipping_prices()) >= MODULE_SHIPPING_FREEOPTIONS_TOTAL_MIN) {
-            if (($_SESSION['cart']->show_total()) >= MODULE_SHIPPING_FREEOPTIONS_TOTAL_MIN) {
-              $this->ck_freeoptions_total = true;
-            } else {
-              $this->ck_freeoptions_total = false;
-            }
-            break;
-          case ((MODULE_SHIPPING_FREEOPTIONS_TOTAL_MAX !='')):
-//            if (($_SESSION['cart']->show_total() - $_SESSION['cart']->free_shipping_prices()) <= MODULE_SHIPPING_FREEOPTIONS_TOTAL_MAX) {
-            if (($_SESSION['cart']->show_total()) <= MODULE_SHIPPING_FREEOPTIONS_TOTAL_MAX) {
-              $this->ck_freeoptions_total = true;
-            } else {
-              $this->ck_freeoptions_total = false;
-            }
-            break;
-          }
+        $this->enabled = ($freeoptions_total === true || $freeoptions_weight === true || $freeoptions_items === true);
+        if ($this->enabled === false) {
+            return;
         }
 
-        if ($this->ck_freeoptions_weight) {
-          switch (true) {
-          case ((MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MIN !='' and MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MAX !='')):
-            if ($order_weight >= MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MIN and $order_weight <= MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MAX) {
-              $this->ck_freeoptions_weight = true;
+        // -----
+        // If freeoptions on the order's total is requested ...
+        //
+        if ($freeoptions_total === true) {
+            $cart_total = $_SESSION['cart']->show_total();
+            if (MODULE_SHIPPING_FREEOPTIONS_TOTAL_MIN !== '' && MODULE_SHIPPING_FREEOPTIONS_TOTAL_MAX !== '') {
+                $freeoptions_total = ($cart_total >= MODULE_SHIPPING_FREEOPTIONS_TOTAL_MIN && $cart_total <= MODULE_SHIPPING_FREEOPTIONS_TOTAL_MAX);
+            } elseif (MODULE_SHIPPING_FREEOPTIONS_TOTAL_MIN !== '') {
+                $freeoptions_total = ($cart_total >= MODULE_SHIPPING_FREEOPTIONS_TOTAL_MIN);
             } else {
-              $this->ck_freeoptions_weight = false;
+                $freeoptions_total = ($cart_total <= MODULE_SHIPPING_FREEOPTIONS_TOTAL_MAX);
             }
-            break;
-          case ((MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MIN !='')):
-            if ($order_weight >= MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MIN) {
-              $this->ck_freeoptions_weight = true;
-            } else {
-              $this->ck_freeoptions_weight = false;
-            }
-            break;
-          case ((MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MAX !='')):
-            if ($order_weight <= MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MAX) {
-              $this->ck_freeoptions_weight = true;
-            } else {
-              $this->ck_freeoptions_weight = false;
-            }
-            break;
-          }
+            $this->debug[] = ['total', $cart_total, $freeoptions_total, MODULE_SHIPPING_FREEOPTIONS_TOTAL_MIN, MODULE_SHIPPING_FREEOPTIONS_TOTAL_MAX];
         }
 
-        if ($this->ck_freeoptions_items) {
-          switch (true) {
-          case ((MODULE_SHIPPING_FREEOPTIONS_ITEMS_MIN !='' and MODULE_SHIPPING_FREEOPTIONS_ITEMS_MAX !='')):
-// free shipping items should not need adjusting
-//            if (($_SESSION['cart']->count_contents() - $_SESSION['cart']->free_shipping_items()) >= MODULE_SHIPPING_FREEOPTIONS_ITEMS_MIN and ($_SESSION['cart']->count_contents() - $_SESSION['cart']->free_shipping_items()) <= MODULE_SHIPPING_FREEOPTIONS_ITEMS_MAX) {
-            if (($_SESSION['cart']->count_contents()) >= MODULE_SHIPPING_FREEOPTIONS_ITEMS_MIN and ($_SESSION['cart']->count_contents()) <= MODULE_SHIPPING_FREEOPTIONS_ITEMS_MAX) {
-              $this->ck_freeoptions_items = true;
+        // -----
+        // If freeoptions on the order's weight is requested ...
+        //
+        if ($freeoptions_weight === true) {
+            $order_weight = round($_SESSION['cart']->show_weight(), 9);
+            if (MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MIN !== '' && MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MAX !== '') {
+                $freeoptions_weight = ($order_weight >= MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MIN && $order_weight <= MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MAX);
+            } elseif (MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MIN !== '') {
+                $freeoptions_weight = ($order_weight >= MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MIN);
             } else {
-              $this->ck_freeoptions_items = false;
+                $freeoptions_weight = ($order_weight <= MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MAX);
             }
-            break;
-          case ((MODULE_SHIPPING_FREEOPTIONS_ITEMS_MIN !='')):
-//            if (($_SESSION['cart']->count_contents() - $_SESSION['cart']->free_shipping_items()) >= MODULE_SHIPPING_FREEOPTIONS_ITEMS_MIN) {
-            if (($_SESSION['cart']->count_contents()) >= MODULE_SHIPPING_FREEOPTIONS_ITEMS_MIN) {
-              $this->ck_freeoptions_items = true;
-            } else {
-              $this->ck_freeoptions_items = false;
-            }
-            break;
-          case ((MODULE_SHIPPING_FREEOPTIONS_ITEMS_MAX !='')):
-//            if (($_SESSION['cart']->count_contents() - $_SESSION['cart']->free_shipping_items())<= MODULE_SHIPPING_FREEOPTIONS_ITEMS_MAX) {
-            if (($_SESSION['cart']->count_contents())<= MODULE_SHIPPING_FREEOPTIONS_ITEMS_MAX) {
-              $this->ck_freeoptions_items = true;
-            } else {
-              $this->ck_freeoptions_items = false;
-            }
-            break;
-          }
+            $this->debug[] = ['weight', $order_weight, $freeoptions_weight, MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MIN, MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MAX];
         }
-      }
 
-// final check for display of Free Options
-      if ($this->ck_freeoptions_total or $this->ck_freeoptions_weight or $this->ck_freeoptions_items) {
-        $this->enabled = true;
-      } else {
-        $this->enabled = false;
-      }
+        // -----
+        // If freeoptions on the order's number of items is requested ...
+        //
+        if ($freeoptions_items === true) {
+            $num_items = $_SESSION['cart']->count_contents();
+            if (MODULE_SHIPPING_FREEOPTIONS_ITEMS_MIN !== '' && MODULE_SHIPPING_FREEOPTIONS_ITEMS_MAX !== '') {
+                $freeoptions_items = ($num_items >= MODULE_SHIPPING_FREEOPTIONS_ITEMS_MIN && $num_items <= MODULE_SHIPPING_FREEOPTIONS_ITEMS_MAX);
+            } elseif (MODULE_SHIPPING_FREEOPTIONS_ITEMS_MIN !== '') {
+                $freeoptions_items = ($num_items >= MODULE_SHIPPING_FREEOPTIONS_ITEMS_MIN);
+            } else {
+                $freeoptions_items = ($num_items <= MODULE_SHIPPING_FREEOPTIONS_ITEMS_MAX);
+            }
+            $this->debug[] = ['items', $num_items, $freeoptions_items, MODULE_SHIPPING_FREEOPTIONS_ITEMS_MIN, MODULE_SHIPPING_FREEOPTIONS_ITEMS_MAX];
+        }
+
+        // -----
+        // The 'freeoptions' shipping method is enabled if at least one of the 3 configured options
+        // are met.
+        //
+        $this->enabled = ($freeoptions_total === true || $freeoptions_weight === true || $freeoptions_items === true);
     }
 
-    function quote($method = '') {
-      global $order;
-      if ($this->enabled) {
-        $this->quotes = array('id' => $this->code,
-                              'module' => MODULE_SHIPPING_FREEOPTIONS_TEXT_TITLE,
-                              'methods' => array(array('id' => $this->code,
-                                                       'title' => MODULE_SHIPPING_FREEOPTIONS_TEXT_WAY,
-                                                       'cost'  => (float)MODULE_SHIPPING_FREEOPTIONS_COST + (float)MODULE_SHIPPING_FREEOPTIONS_HANDLING)));
+    // -----
+    // Return the "Free Options" quote, as requested.
+    //
+    public function quote($method = '')
+    {
+        global $order;
+        
+        // -----
+        // Note: Only requested by the shipping class if previous processing has indicated that the
+        // module is enabled!
+        //
+        $this->quotes = [
+            'id' => $this->code,
+            'module' => MODULE_SHIPPING_FREEOPTIONS_TEXT_TITLE,
+            'methods' => [
+                [
+                    'id' => $this->code,
+                    'title' => MODULE_SHIPPING_FREEOPTIONS_TEXT_WAY,
+                    'cost'  => (float)MODULE_SHIPPING_FREEOPTIONS_COST + (float)MODULE_SHIPPING_FREEOPTIONS_HANDLING
+                ]
+            ]
+        ];
 
-        if ($this->tax_class > 0) {
-          $this->quotes['tax'] = zen_get_tax_rate($this->tax_class, $order->delivery['country']['id'], $order->delivery['zone_id']);
+        if ($this->tax_class > '0') {
+            $this->quotes['tax'] = zen_get_tax_rate($this->tax_class, $order->delivery['country']['id'], $order->delivery['zone_id']);
         }
 
         if (!empty($this->icon)) $this->quotes['icon'] = zen_image($this->icon, $this->title);
-      }
 
-      return $this->quotes;
+        return $this->quotes;
     }
 
-    function check() {
-      global $db;
-      if (!isset($this->_check)) {
-        $check_query = $db->Execute("SELECT configuration_value FROM " . TABLE_CONFIGURATION . " WHERE configuration_key = 'MODULE_SHIPPING_FREEOPTIONS_STATUS'");
-        $this->_check = $check_query->RecordCount();
-      }
-      return $this->_check;
+    public function check()
+    {
+        global $db;
+        if (!isset($this->_check)) {
+            $check_query = $db->Execute("SELECT configuration_value FROM " . TABLE_CONFIGURATION . " WHERE configuration_key = 'MODULE_SHIPPING_FREEOPTIONS_STATUS'");
+            $this->_check = $check_query->RecordCount();
+        }
+        return $this->_check;
     }
 
-    function get_configuration_errors() {
-      if (!zen_check_for_misconfigured_downloads()) {
-         return TEXT_DOWNLOADABLE_PRODUCTS_MISCONFIGURED; 
-      }
+    public function get_configuration_errors()
+    {
+        if (!zen_check_for_misconfigured_downloads()) {
+            return TEXT_DOWNLOADABLE_PRODUCTS_MISCONFIGURED; 
+        }
     }
 
-    function install() {
-      global $db;
-      $db->Execute("INSERT INTO " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) VALUES ('Enable Free Options Shipping', 'MODULE_SHIPPING_FREEOPTIONS_STATUS', 'True', 'Free Options is used to display a Free Shipping option when other Shipping Modules are displayed.
+    public function install()
+    {
+        global $db;
+        $db->Execute("INSERT INTO " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) VALUES ('Enable Free Options Shipping', 'MODULE_SHIPPING_FREEOPTIONS_STATUS', 'True', 'Free Options is used to display a Free Shipping option when other Shipping Modules are displayed.
 It can be based on: Always show, Order Total, Order Weight or Order Item Count.
 The Free Options module does not show when Free Shipper is displayed.<br><br>
 Setting Total to >= 0.00 and <= nothing (leave blank) will activate this module to show with all shipping modules, except for Free Shipping - freeshipper.<br><br>
 NOTE: Leaving all settings for Total, Weight and Item count blank will deactivate this module.<br><br>
 NOTE: Free Shipping Options does not display if Free Shipping is used based on 0 weight is Free Shipping.
 See: freeshipper<br><br>Do you want to offer per freeoptions rate shipping?', '6', '0', 'zen_cfg_select_option(array(\'True\', \'False\'), ', now())");
-      $db->Execute("INSERT INTO " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) VALUES ('Shipping Cost', 'MODULE_SHIPPING_FREEOPTIONS_COST', '0.00', 'The shipping cost will be $0.00', '6', '0', now())");
-      $db->Execute("INSERT INTO " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) VALUES ('Handling Fee', 'MODULE_SHIPPING_FREEOPTIONS_HANDLING', '0', 'Handling fee for this shipping method.', '6', '0', now())");
+        $db->Execute("INSERT INTO " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) VALUES ('Shipping Cost', 'MODULE_SHIPPING_FREEOPTIONS_COST', '0.00', 'The shipping cost will be $0.00', '6', '0', now())");
+        $db->Execute("INSERT INTO " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) VALUES ('Handling Fee', 'MODULE_SHIPPING_FREEOPTIONS_HANDLING', '0', 'Handling fee for this shipping method.', '6', '0', now())");
 
-      $db->Execute("INSERT INTO " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) VALUES ('Total >=', 'MODULE_SHIPPING_FREEOPTIONS_TOTAL_MIN', '0.00', 'Free Shipping when Total >=', '6', '0', now())");
-      $db->Execute("INSERT INTO " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) VALUES ('Total <=', 'MODULE_SHIPPING_FREEOPTIONS_TOTAL_MAX', '', 'Free Shipping when Total <=', '6', '0', now())");
+        $db->Execute("INSERT INTO " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) VALUES ('Total >=', 'MODULE_SHIPPING_FREEOPTIONS_TOTAL_MIN', '0.00', 'Free Shipping when Total >=', '6', '0', now())");
+        $db->Execute("INSERT INTO " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) VALUES ('Total <=', 'MODULE_SHIPPING_FREEOPTIONS_TOTAL_MAX', '', 'Free Shipping when Total <=', '6', '0', now())");
 
-      $db->Execute("INSERT INTO " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) VALUES ('Weight >=', 'MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MIN', '', 'Free Shipping when Weight >=', '6', '0', now())");
-      $db->Execute("INSERT INTO " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) VALUES ('Weight <=', 'MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MAX', '', 'Free Shipping when Weight <=', '6', '0', now())");
+        $db->Execute("INSERT INTO " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) VALUES ('Weight >=', 'MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MIN', '', 'Free Shipping when Weight >=', '6', '0', now())");
+        $db->Execute("INSERT INTO " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) VALUES ('Weight <=', 'MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MAX', '', 'Free Shipping when Weight <=', '6', '0', now())");
 
-      $db->Execute("INSERT INTO " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) VALUES ('Item Count >=', 'MODULE_SHIPPING_FREEOPTIONS_ITEMS_MIN', '', 'Free Shipping when Item Count >=', '6', '0', now())");
-      $db->Execute("INSERT INTO " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) VALUES ('Item Count <=', 'MODULE_SHIPPING_FREEOPTIONS_ITEMS_MAX', '', 'Free Shipping when Item Count <=', '6', '0', now())");
+        $db->Execute("INSERT INTO " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) VALUES ('Item Count >=', 'MODULE_SHIPPING_FREEOPTIONS_ITEMS_MIN', '', 'Free Shipping when Item Count >=', '6', '0', now())");
+        $db->Execute("INSERT INTO " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) VALUES ('Item Count <=', 'MODULE_SHIPPING_FREEOPTIONS_ITEMS_MAX', '', 'Free Shipping when Item Count <=', '6', '0', now())");
 
-      $db->Execute("INSERT INTO " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, use_function, set_function, date_added) VALUES ('Tax Class', 'MODULE_SHIPPING_FREEOPTIONS_TAX_CLASS', '0', 'Use the following tax class on the shipping fee.', '6', '0', 'zen_get_tax_class_title', 'zen_cfg_pull_down_tax_classes(', now())");
-      $db->Execute("INSERT INTO " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) VALUES ('Tax Basis', 'MODULE_SHIPPING_FREEOPTIONS_TAX_BASIS', 'Shipping', 'On what basis is Shipping Tax calculated. Options are<br>Shipping - Based on customers Shipping Address<br>Billing Based on customers Billing address<br>Store - Based on Store address if Billing/Shipping Zone equals Store zone', '6', '0', 'zen_cfg_select_option(array(\'Shipping\', \'Billing\', \'Store\'), ', now())");
-      $db->Execute("INSERT INTO " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, use_function, set_function, date_added) VALUES ('Shipping Zone', 'MODULE_SHIPPING_FREEOPTIONS_ZONE', '0', 'If a zone is selected, only enable this shipping method for that zone.', '6', '0', 'zen_get_zone_class_title', 'zen_cfg_pull_down_zone_classes(', now())");
-      $db->Execute("INSERT INTO " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) VALUES ('Sort Order', 'MODULE_SHIPPING_FREEOPTIONS_SORT_ORDER', '0', 'Sort order of display.', '6', '0', now())");
+        $db->Execute("INSERT INTO " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, use_function, set_function, date_added) VALUES ('Tax Class', 'MODULE_SHIPPING_FREEOPTIONS_TAX_CLASS', '0', 'Use the following tax class on the shipping fee.', '6', '0', 'zen_get_tax_class_title', 'zen_cfg_pull_down_tax_classes(', now())");
+        $db->Execute("INSERT INTO " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) VALUES ('Tax Basis', 'MODULE_SHIPPING_FREEOPTIONS_TAX_BASIS', 'Shipping', 'On what basis is Shipping Tax calculated. Options are<br>Shipping - Based on customers Shipping Address<br>Billing Based on customers Billing address<br>Store - Based on Store address if Billing/Shipping Zone equals Store zone', '6', '0', 'zen_cfg_select_option(array(\'Shipping\', \'Billing\', \'Store\'), ', now())");
+        $db->Execute("INSERT INTO " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, use_function, set_function, date_added) VALUES ('Shipping Zone', 'MODULE_SHIPPING_FREEOPTIONS_ZONE', '0', 'If a zone is selected, only enable this shipping method for that zone.', '6', '0', 'zen_get_zone_class_title', 'zen_cfg_pull_down_zone_classes(', now())");
+        $db->Execute("INSERT INTO " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) VALUES ('Sort Order', 'MODULE_SHIPPING_FREEOPTIONS_SORT_ORDER', '0', 'Sort order of display.', '6', '0', now())");
     }
 
-    function help() {
-       return array('link' => 'https://docs.zen-cart.com/user/shipping/free_shipping/'); 
+    public function help()
+    {
+        return ['link' => 'https://docs.zen-cart.com/user/shipping/free_shipping/']; 
+    }
+    
+    public function remove()
+    {
+        global $db;
+        $db->Execute("DELETE FROM " . TABLE_CONFIGURATION . " WHERE configuration_key LIKE  'MODULE\_SHIPPING\_FREEOPTIONS\_%'");
     }
 
-   function remove() {
-     global $db;
-     $db->Execute("DELETE FROM " . TABLE_CONFIGURATION . " WHERE configuration_key LIKE  'MODULE\_SHIPPING\_FREEOPTIONS\_%'");
-   }
-
-    function keys() {
-      return array('MODULE_SHIPPING_FREEOPTIONS_STATUS', 'MODULE_SHIPPING_FREEOPTIONS_COST', 'MODULE_SHIPPING_FREEOPTIONS_HANDLING', 'MODULE_SHIPPING_FREEOPTIONS_TOTAL_MIN', 'MODULE_SHIPPING_FREEOPTIONS_TOTAL_MAX', 'MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MIN', 'MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MAX', 'MODULE_SHIPPING_FREEOPTIONS_ITEMS_MIN', 'MODULE_SHIPPING_FREEOPTIONS_ITEMS_MAX', 'MODULE_SHIPPING_FREEOPTIONS_TAX_CLASS', 'MODULE_SHIPPING_FREEOPTIONS_TAX_BASIS', 'MODULE_SHIPPING_FREEOPTIONS_ZONE', 'MODULE_SHIPPING_FREEOPTIONS_SORT_ORDER');
+    public function keys()
+    {
+        return [
+            'MODULE_SHIPPING_FREEOPTIONS_STATUS',
+            'MODULE_SHIPPING_FREEOPTIONS_COST',
+            'MODULE_SHIPPING_FREEOPTIONS_HANDLING',
+            'MODULE_SHIPPING_FREEOPTIONS_TOTAL_MIN',
+            'MODULE_SHIPPING_FREEOPTIONS_TOTAL_MAX',
+            'MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MIN',
+            'MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MAX',
+            'MODULE_SHIPPING_FREEOPTIONS_ITEMS_MIN',
+            'MODULE_SHIPPING_FREEOPTIONS_ITEMS_MAX',
+            'MODULE_SHIPPING_FREEOPTIONS_TAX_CLASS',
+            'MODULE_SHIPPING_FREEOPTIONS_TAX_BASIS',
+            'MODULE_SHIPPING_FREEOPTIONS_ZONE',
+            'MODULE_SHIPPING_FREEOPTIONS_SORT_ORDER'
+        ];
     }
-  }
+}

--- a/includes/modules/shipping/freeoptions.php
+++ b/includes/modules/shipping/freeoptions.php
@@ -55,9 +55,14 @@
           $this->enabled = false;
         }
       }
+
+      if ($this->enabled === true) {
+          $this->checkForFreeOptions();
+      }
     }
 
-    function quote($method = '') {
+    protected function checkForFreeOptions()
+    {
       global $order;
       $order_weight = round($_SESSION['cart']->show_weight(),9);
 
@@ -178,7 +183,10 @@
       } else {
         $this->enabled = false;
       }
+    }
 
+    function quote($method = '') {
+      global $order;
       if ($this->enabled) {
         $this->quotes = array('id' => $this->code,
                               'module' => MODULE_SHIPPING_FREEOPTIONS_TEXT_TITLE,


### PR DESCRIPTION
Fixes #4766.

- Moves the final "enabled" check into the `update_status` method, so a quote's only requested when (er) there's something to quote.
- Overall refactor of the code to (a) simplify, (b) improve performance and (c) use PHP strict comparisions.