### PR TITLE
v158: Enable site-specific override of 'about_us' page inclusion in "…

### DIFF
--- a/includes/extra_datafiles/dist-site_specific_overrides.php
+++ b/includes/extra_datafiles/dist-site_specific_overrides.php
@@ -7,12 +7,20 @@
  *
  * For use on YOUR site, make a copy of this file (which has all entries commented-out) to /includes/extra_datafiles/site_specific_overrides.php
  * and make your edits there.  Otherwise, your overrides might get "lost" on a future Zen Cart upgrade.  The 'base' Zen Cart definitions
- * of these variables are set by /includes/init_includes/init_common_elements.php.
+ * for most of these variables are set by /includes/init_includes/init_common_elements.php.
  *
  * @copyright Copyright 2003-2022 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: lat9 2022 Apr 30 Modified in v1.5.8 $
  */
+// -----
+// Idenfify whether the link to the 'about_us' page is included in the "Information" sidebox.
+//
+// true .... Show in the sidebox (default)
+// false ... Don't show in the sidebox
+//
+// $flag_show_about_us_sidebox_link = false;
+
 // -----
 // Identify whether the link to the 'brands' page (added in Zen Cart 1.5.8) is included in the "Information" sidebox.
 //
@@ -23,7 +31,8 @@
 //$flag_show_brand_sidebox_link = false;
 
 // -----
-// Identify whether the zcDate class' (added in Zen Cart 1.5.8) debug-output is initially enabled.
+// Identify whether the zcDate class' (added in Zen Cart 1.5.8) debug-output is initially enabled. Note that this
+// value is **not** managed by the init_common_elements.php module.
 //
 // true ...... The zcDate debug is enabled.
 // false ..... The zcDate debug is disabled (the default).

--- a/includes/init_includes/init_common_elements.php
+++ b/includes/init_includes/init_common_elements.php
@@ -14,6 +14,12 @@ if (!defined('IS_ADMIN_FLAG')) {
 
 // -----
 // Sets the processing flag (used by /includes/modules/sideboxes/information.php) that
+// indicates whether or not a link to the "About Us" page should be included.
+//
+$flag_show_about_us_sidebox_link = (isset($flag_show_about_us_sidebox_link)) ? (bool)$flag_show_about_us_sidebox_link : true;
+
+// -----
+// Sets the processing flag (used by /includes/modules/sideboxes/information.php) that
 // indicates whether or not a link to the "Brands" page should be included.
 //
 if (isset($flag_show_brand_sidebox_link)) {

--- a/includes/modules/sideboxes/information.php
+++ b/includes/modules/sideboxes/information.php
@@ -10,7 +10,13 @@
 
 $information = [];
 
-$information[] = '<a href="' . zen_href_link(FILENAME_ABOUT_US) . '">' . BOX_INFORMATION_ABOUT_US . '</a>';
+// -----
+// The following flag is set by /includes/init_includes/init_common_elements.php; refer to that module's
+// comments for the way to override this setting.
+//
+if ($flag_show_about_us_sidebox_link === true) {
+    $information[] = '<a href="' . zen_href_link(FILENAME_ABOUT_US) . '">' . BOX_INFORMATION_ABOUT_US . '</a>';
+}
 
 // -----
 // The following flag is set by /includes/init_includes/init_common_elements.php; refer to that module's


### PR DESCRIPTION
…Information" sidebox

Fixes #4764.