### PR TITLE
add zone_code and refactor admin.customers

### DIFF
--- a/admin/customers.php
+++ b/admin/customers.php
@@ -485,17 +485,13 @@ if (!empty($action)) {
               <div class="col-sm-9 col-md-6">
                 <?php
                 $entry_state = zen_get_zone_name((int)$cInfo->country_id, (int)$cInfo->zone_id, $cInfo->state);
-                if (count(zen_get_country_zones((int)$cInfo->country_id))) {
+                $zones_values = zen_get_country_zones((int)$cInfo->country_id);
+                if (count($zones_values)) {
                   $zones_array = [];
-                  $zones_values = $db->Execute("SELECT zone_name
-                                                FROM " . TABLE_ZONES . "
-                                                WHERE zone_country_id = " . (int)zen_db_input($cInfo->country_id) . "
-                                                ORDER BY zone_name");
-
                   foreach ($zones_values as $zones_value) {
                     $zones_array[] = [
-                      'id' => $zones_value['zone_name'],
-                      'text' => $zones_value['zone_name']
+                      'id' => $zones_value['text'],
+                      'text' => $zones_value['text']
                     ];
                   }
                   echo zen_draw_pull_down_menu('entry_state', $zones_array, $entry_state, 'class="form-control" id="entry_state"');

--- a/includes/functions/functions_addresses.php
+++ b/includes/functions/functions_addresses.php
@@ -124,12 +124,16 @@ function zen_get_country_zones($country_id)
 {
     global $db;
     $zones_array = array();
-    $zones = $db->Execute("SELECT zone_id, zone_name
+    $zones = $db->Execute("SELECT zone_id, zone_name, zone_code
                            FROM " . TABLE_ZONES . "
                            WHERE zone_country_id = " . (int)$country_id . "
                            ORDER BY zone_name");
     foreach ($zones as $zone) {
-        $zones_array[] = array('id' => $zone['zone_id'], 'text' => $zone['zone_name']);
+        $zones_array[] = [
+            'id' => $zone['zone_id'],
+            'text' => $zone['zone_name'],
+            'zone_code' => $zone['zone_code'],
+            ];
     }
 
     return $zones_array;


### PR DESCRIPTION
in researching `zen_get_country_zones` for adding of `zone_code` to the return array, it seems that we can reduce the db hits on the customers script by making use of the return values from said function.