### PR TITLE
shipping estimator template, change deprecated name to id

### DIFF
--- a/includes/templates/template_default/templates/tpl_modules_shipping_estimator.php
+++ b/includes/templates/template_default/templates/tpl_modules_shipping_estimator.php
@@ -9,7 +9,7 @@
  */
 ?>
 <div id="shippingEstimatorContent">
-<?php echo zen_draw_form('estimator', zen_href_link($show_in . '#view', '', $request_type), 'post'); ?>
+<?php echo zen_draw_form('estimator', zen_href_link($show_in . '#seView', '', $request_type), 'post'); ?>
 <?php if (is_array($selected_shipping)) {
     zen_draw_hidden_field('scid', $selected_shipping['id']);
 } ?>
@@ -54,7 +54,7 @@
 <?php echo zen_get_country_list('zone_country_id', $selected_country, 'id="country"' . (($flag_show_pulldown_states) ? ' onchange="update_zone(this.form);"' : '')); ?>
 <br class="clearBoth">
 
-<a name="view"></a>
+<a id="seView"></a>
 <label class="inputLabel" for="stateZone" id="zoneLabel"><?php echo ENTRY_STATE; ?></label>
 <?php
           if ($flag_show_pulldown_states) {


### PR DESCRIPTION
as referenced by the form action
`<?php echo zen_draw_form('estimator', zen_href_link($show_in . '#view', '', $request_type), 'post'); ?>`
