### PR TITLE
cast selected_country to integer

### DIFF
--- a/includes/modules/shipping_estimator.php
+++ b/includes/modules/shipping_estimator.php
@@ -156,7 +156,7 @@ if ($_SESSION['cart']->count_contents() > 0) {
     $quotes = $shipping_modules->quote();
 
     // set selections for displaying
-    $selected_country = $order->delivery['country']['id'];
+    $selected_country = (int)$order->delivery['country']['id'];
     $selected_address = $sendto;
     // eo shipping cost
     // check free shipping based on order $total


### PR DESCRIPTION
When the shipping estimator is first loaded, $selected_country is a string from

https://github.com/zencart/zencart/blob/14d292a970bd5c584636aabe7499f52f98723fd7/includes/modules/shipping_estimator.php#L159

but subsequently, after updating, $selected_country is an integer, from here

https://github.com/zencart/zencart/blob/14d292a970bd5c584636aabe7499f52f98723fd7/includes/modules/shipping_estimator.php#L19

This PR casts the first one to integer too.


