### PR TITLE
retrieve all fields from address_book

### DIFF
--- a/includes/modules/pages/address_book_process/header_php.php
+++ b/includes/modules/pages/address_book_process/header_php.php
@@ -255,9 +255,7 @@ if (isset($_POST['action']) && (($_POST['action'] == 'process') || ($_POST['acti
 }
 
 if (isset($_GET['edit']) && is_numeric($_GET['edit'])) {
-  $entry_query = "SELECT entry_gender, entry_company, entry_firstname, entry_lastname,
-                         entry_street_address, entry_suburb, entry_postcode, entry_city,
-                         entry_state, entry_zone_id, entry_country_id
+  $entry_query = "SELECT *
                   FROM   " . TABLE_ADDRESS_BOOK . "
                   WHERE  customers_id = :customersID
                   AND    address_book_id = :addressBookID";


### PR DESCRIPTION
Regarding extra-fields used in the address book table (such as in my case a telephone number per address),  
there are notifiers for adding extra-field validation and extra-field insertion, but not for retrieval.
The original sql pulls **all** the columns from the table anyway, by name. Changing this to SELECT * does the same but includes the extra-field(s).