### PR TITLE
alert_page: allow developer overrides to bypass checks

### DIFF
--- a/admin/alert_page.php
+++ b/admin/alert_page.php
@@ -6,12 +6,16 @@
  */
 require('includes/application_top.php');
 $adminDirectoryExists = $installDirectoryExists = false;
-if (substr(DIR_WS_ADMIN, -7) == '/admin/' || substr(DIR_WS_HTTPS_ADMIN, -7) == '/admin/') {
-    $adminDirectoryExists = true;
-}
-$check_path = dirname($_SERVER['SCRIPT_FILENAME']) . '/../zc_install';
-if (is_dir($check_path)) {
-    $installDirectoryExists = true;
+if (!(defined('ADMIN_BLOCK_WARNING_OVERRIDE') && ADMIN_BLOCK_WARNING_OVERRIDE === '1')) {
+    if (substr(DIR_WS_ADMIN, -7) === '/admin/' || substr(DIR_WS_HTTPS_ADMIN, -7) === '/admin/') {
+        $adminDirectoryExists = true;
+    }
+    if (!(defined('WARN_INSTALL_EXISTENCE') && WARN_INSTALL_EXISTENCE === 'false')) {
+        $check_path = dirname($_SERVER['SCRIPT_FILENAME']) . '/../zc_install';
+        if (is_dir($check_path)) {
+            $installDirectoryExists = true;
+        }
+    }
 }
 if (!$adminDirectoryExists && !$installDirectoryExists) {
     zen_redirect(zen_href_link(FILENAME_DEFAULT));


### PR DESCRIPTION
Regarding these constants which may optionally be defined for developer use.
```
define('ADMIN_BLOCK_WARNING_OVERRIDE', '1'); //bypasses checks in (admin) init_admin_auth to allow admin access when a) the admin folder has not been renamed and b) installer folder /zc_install exists.
define('WARN_INSTALL_EXISTENCE', 'false'); //bypasses check in (admin) init_errors: prevents a messageStack warning in the admin if the installer folder /zc_install exists.
```

This PR allows the alert page to be refreshed and continue to admin when these constants are defined as shown.
