### PR TITLE
v158: Correcting account-history unformatted totals

### DIFF
--- a/includes/classes/Customer.php
+++ b/includes/classes/Customer.php
@@ -487,7 +487,7 @@ class Customer extends base
     public function getOrderHistory(int $max_number_to_return = 0): array
     {
         $language = $_SESSION['languages_id'];
-        global $db;
+        global $db, $currencies;
         $sql = "SELECT o.orders_id, o.date_purchased, o.delivery_name,
                        o.order_total, o.currency, o.currency_value,
                        o.delivery_country, o.billing_name, o.billing_country,
@@ -532,7 +532,8 @@ class Customer extends base
                 'order_name' => $order_name,
                 'order_country' => $order_country,
                 'orders_status_name' => $result['orders_status_name'],
-                'order_total' => $result['order_total'],
+                'order_total' => $currencies->format($result['order_total'], false, $result['currency']),
+                'order_total_raw' => $result['order_total'],
                 'currency' => $result['currency'],
                 'currency_value' => $result['currency_value'],
                 'language_code' => $result['language_code'],

--- a/includes/templates/responsive_classic/templates/tpl_account_default.php
+++ b/includes/templates/responsive_classic/templates/tpl_account_default.php
@@ -43,7 +43,7 @@
     <td class="accountOrderId"><?php if ($display_as_mobile) { echo '<b class="hide">' . TABLE_HEADING_ORDER_NUMBER . '&#58;&nbsp;&nbsp;</b>'; }?><?php echo TEXT_NUMBER_SYMBOL . $orders['orders_id']; ?></td>
     <td class="accountOrderAddress"><?php if ($display_as_mobile) { echo '<b class="hide">' . TABLE_HEADING_SHIPPED_TO . '&#58;&nbsp;&nbsp;</b>'; }?><address><?php echo zen_output_string_protected($orders['order_name']) . '<br>' . $orders['order_country']; ?></address></td>
     <td class="accountOrderStatus"><?php if ($display_as_mobile) { echo '<b class="hide">' . TABLE_HEADING_STATUS . '&#58;&nbsp;&nbsp;</b>'; }?><?php echo $orders['orders_status_name']; ?></td>
-    <td class="accountOrderTotal alignRight"><?php if ($display_as_mobile) { echo '<b class="hide">' . TABLE_HEADING_TOTAL . '&#58;&nbsp;&nbsp;</b>'; }?><?php echo $currencies->format($orders['order_total'], false, $orders['currency']); ?></td>
+    <td class="accountOrderTotal alignRight"><?php if ($display_as_mobile) { echo '<b class="hide">' . TABLE_HEADING_TOTAL . '&#58;&nbsp;&nbsp;</b>'; }?><?php echo $orders['order_total']; ?></td>
     <td class="accountOrderViewButton alignCenter"><?php echo '<a href="' . zen_href_link(FILENAME_ACCOUNT_HISTORY_INFO, 'order_id=' . $orders['orders_id'], 'SSL') . '"> ' . zen_image_button(BUTTON_IMAGE_VIEW_SMALL, BUTTON_VIEW_SMALL_ALT) . '</a>'; ?></td>
   </tr>
 

--- a/includes/templates/template_default/templates/tpl_account_default.php
+++ b/includes/templates/template_default/templates/tpl_account_default.php
@@ -41,7 +41,7 @@
     <td class="accountOrderId"><?php echo TEXT_NUMBER_SYMBOL . $orders['orders_id']; ?></td>
     <td class="accountAddress"><address><?php echo zen_output_string_protected($orders['order_name']) . '<br>' . $orders['order_country']; ?></address></td>
     <td class="accountOrderStatus"><?php echo $orders['orders_status_name']; ?></td>
-    <td class="accountOrderTotal alignRight"><?php echo $currencies->format($orders['order_total'], false, $orders['currency']); ?></td>
+    <td class="accountOrderTotal alignRight"><?php echo $orders['order_total']; ?></td>
     <td class="accountOrderViewButton alignRight"><?php echo '<a href="' . zen_href_link(FILENAME_ACCOUNT_HISTORY_INFO, 'order_id=' . $orders['orders_id'], 'SSL') . '"> ' . zen_image_button(BUTTON_IMAGE_VIEW_SMALL, BUTTON_VIEW_SMALL_ALT) . '</a>'; ?></td>
   </tr>
 


### PR DESCRIPTION
Fixes #4813.

- Moving the formatting into the `Customers.php` class to address the changes required for both #4196 and #4813.
- Created a separate array element returned by the class' `getOrderHistory` method to also return the 'raw' value of each order's total.
- Removing the template-specific formatting introduced in #4813.