### PR TITLE
Fix null param deprecation in PHP 8.1 when testing for email templates

### DIFF
--- a/includes/functions/functions_email.php
+++ b/includes/functions/functions_email.php
@@ -579,7 +579,7 @@ use PHPMailer\PHPMailer\SMTP;
        );
     $found = FALSE;
     foreach($filesToTest as $val) {
-      if (file_exists($val)) {
+      if (!empty($val) && file_exists($val)) {
         $template_filename = $val;
         $found = TRUE;
         break;


### PR DESCRIPTION
[26-May-2022 22:25:27 UTC] Request URI: /gh_demo_158/admin/index.php?cmd=modules&set=ordertotal&action=install, IP address: ::1
#0 [internal function]: zen_debug_error_handler()
#1 /Users/scott/sites/gh_demo_158/includes/functions/functions_email.php(582): file_exists()
#2 /Users/scott/sites/gh_demo_158/includes/functions/functions_email.php(109): zen_build_html_email_from_template()
#3 /Users/scott/sites/gh_demo_158/admin/modules.php(108): zen_mail()
#4 /Users/scott/sites/gh_demo_158/admin/index.php(11): require('/Users/scott/si...')
--> PHP Deprecated: file_exists(): Passing null to parameter #1 ($filename) of type string is deprecated in /Users/scott/sites/gh_demo_158/includes/functions/functions_email.php on line 582.

