### PR TITLE
Fix log in PHP 8.1

### DIFF
--- a/includes/functions/functions_prices.php
+++ b/includes/functions/functions_prices.php
@@ -1171,6 +1171,7 @@ function zen_get_attributes_price_factor($price, $special, $factor, $offset)
  */
 function zen_get_attributes_qty_prices_onetime($string, $qty)
 {
+    if (empty($string)) return 0; 
     $attribute_qty = preg_split("/[:,]/", str_replace(' ', '', $string));
     $new_price = 0;
     $size = count($attribute_qty);


### PR DESCRIPTION
[26-May-2022 22:34:54 UTC] Request URI: /gh_demo_158/index.php?main_page=product_info&cPath=48_32&products_id=97, IP address: ::1
#0 [internal function]: zen_debug_error_handler()
#1 /Users/scott/sites/gh_demo_158/includes/functions/functions_prices.php(1174): str_replace()
#2 /Users/scott/sites/gh_demo_158/includes/functions/functions_prices.php(1235): zen_get_attributes_qty_prices_onetime()
#3 /Users/scott/sites/gh_demo_158/includes/modules/attributes.php(170): zen_get_attributes_price_final()
#4 /Users/scott/sites/gh_demo_158/includes/modules/pages/product_info/main_template_vars.php(50): require('/Users/scott/si...')
#5 /Users/scott/sites/gh_demo_158/includes/templates/responsive_classic/common/tpl_main_page.php(178): require('/Users/scott/si...')
#6 /Users/scott/sites/gh_demo_158/index.php(94): require('/Users/scott/si...')
--> PHP Deprecated: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /Users/scott/sites/gh_demo_158/includes/functions/functions_prices.php on line 1174.