### PR TITLE
Fix sqlpatch undefined array key notice in PHP 8.0

### DIFF
--- a/admin/sqlpatch.php
+++ b/admin/sqlpatch.php
@@ -84,6 +84,11 @@ function executeSql($lines, $database, $table_prefix = '') {
      $no_semi_line = rtrim($line, ';');
      $param = preg_split('/\s+/', $no_semi_line);
 
+     // Preset entries 0..5 if not set
+     for ($i = 0; $i <= 13; $i++) {
+        if (!isset($param[$i])) $param[$i] = ''; 
+     }
+
     // The following command checks to see if we're asking for a block of commands to be run at once.
     // Syntax: #NEXT_X_ROWS_AS_ONE_COMMAND:6     for running the next 6 commands together (commands denoted by a ;)
     if (substr($line, 0, 28) == '#NEXT_X_ROWS_AS_ONE_COMMAND:') {


### PR DESCRIPTION
[27-May-2022 10:42:25 UTC] Request URI: /gh_demo_158/admin/index.php?cmd=sqlpatch&action=uploadquery, IP address: ::1
#0 /Users/scott/sites/gh_demo_158/admin/sqlpatch.php(117): zen_debug_error_handler()
#1 /Users/scott/sites/gh_demo_158/admin/sqlpatch.php(771): executeSql()
#2 /Users/scott/sites/gh_demo_158/admin/index.php(11): require('/Users/scott/si...')
--> PHP Warning: Undefined array key 4 in /Users/scott/sites/gh_demo_158/admin/sqlpatch.php on line 117.