### PR TITLE
Fix for (some of) PHP Notice for malformed shipping 

### DIFF
--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -396,7 +396,7 @@ class order extends base
         //
         // If that's not the case, issue a PHP Notice and reset the shipping to its unselected state.
         //
-        if (isset($_SESSION['shipping'])) {
+        if (!empty($_SESSION['shipping'])) {
             if (!empty($_SESSION['shipping']['id']) && strpos((string)$_SESSION['shipping']['id'], '_')) {
                 $shipping_module_code = $_SESSION['shipping']['id'];
             } else {


### PR DESCRIPTION
PHP Notice:  Malformed value for session-based shipping module; customer will need to re-select: false in includes/classes/order.php on line 327
