### PR TITLE
Change color for icon when Quantity Discounts enabled

### DIFF
--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -939,7 +939,13 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
                         <a href="<?php echo zen_href_link(FILENAME_ATTRIBUTES_CONTROLLER, 'products_filter=' . $product['products_id'] . '&current_category_id=' . $current_category_id); ?>" class="btn btn-sm btn-default btn-attributes-off" role="button" title="<?php echo BOX_CATALOG_CATEGORIES_ATTRIBUTES_CONTROLLER; ?>"><strong>A</strong></a>
                       <?php } ?>
                       <?php if ($zc_products->get_allow_add_to_cart($product['products_id']) == "Y") { ?>
-                        <a href="<?php echo zen_href_link(FILENAME_PRODUCTS_PRICE_MANAGER, 'products_filter=' . $product['products_id'] . '&current_category_id=' . $current_category_id); ?>" class="btn btn-sm btn-default btn-pricemanager-on" role="button" title="<?php echo BOX_CATALOG_PRODUCTS_PRICE_MANAGER; ?>">
+<?php 
+                     $ppm_color = 'btn-pricemanager-on'; 
+                     if (zen_has_product_discounts($product['products_id']) === 'true') {
+                        $ppm_color = 'btn-pricemanager-on-enabled'; 
+                     }
+?>
+                        <a href="<?php echo zen_href_link(FILENAME_PRODUCTS_PRICE_MANAGER, 'products_filter=' . $product['products_id'] . '&current_category_id=' . $current_category_id) . '" class="btn btn-sm btn-default ' . $ppm_color . '" role="button" title="' . BOX_CATALOG_PRODUCTS_PRICE_MANAGER . '">'; ?>
                           <i class="fa fa-dollar fa-lg" aria-hidden="true"></i>
                         </a>
                       <?php } else { ?>

--- a/admin/includes/css/stylesheet.css
+++ b/admin/includes/css/stylesheet.css
@@ -679,6 +679,11 @@ a.btn-pricemanager-on {
     color: #eee;
 }
 
+a.btn-pricemanager-on-enabled {
+    background-color: #006400;
+    color: #eee;
+}
+
 a.btn-pricemanager-off {
     background-color: #d3d3d3;
     color: #eee;


### PR DESCRIPTION
Right now when viewing Admin > Catalog > Categories/Products, you cannot tell at a glance if a product has quantity discounts. If a product may be added to the cart, the icon is green.
<img width="287" alt="product_icons_old" src="https://user-images.githubusercontent.com/4391638/170840665-d59bb92a-8976-46c8-a051-c10637d95917.png">

This change makes the icon dark green if quantity discounts are present. 
<img width="281" alt="product_icons_new" src="https://user-images.githubusercontent.com/4391638/170840674-5607d986-1fff-49eb-9294-b745510cf07f.png">


