### PR TITLE
Disable continue if T&C not present

### DIFF
--- a/includes/modules/pages/checkout_payment/jscript_main.php
+++ b/includes/modules/pages/checkout_payment/jscript_main.php
@@ -11,7 +11,6 @@
 <script>
 var selected;
 var submitter = null;
-
 function popupWindow(url) {
   window.open(url,'popupWindow','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no,width=450,height=320,screenX=150,screenY=150,top=150,left=150')
 }
@@ -23,5 +22,23 @@ function submitFunction($gv,$total) {
     submitter = 1;
   }
 }
+function tAndCChange() {
+// function to disable continue if T&C present and not checked.
+  var conditionsElement = document.getElementById('conditions');
+  var paymentSubmitInputs = document.getElementById('paymentSubmit').getElementsByTagName('input'), i=0, e;
+  if(typeof(conditionsElement) != 'undefined' && conditionsElement != null){
+    while(e=paymentSubmitInputs[i++]){
+      e.disabled = ! conditionsElement.checked;
+    }
+  }
+}
+// Add listeners to initially disable the continue button and to reset when T&C changed
+document.addEventListener('DOMContentLoaded',  function () {
+  var conditionsElement = document.getElementById("conditions");
+  if(typeof(conditionsElement) != 'undefined' && conditionsElement != null){
+    conditionsElement.addEventListener('change', tAndCChange);
+    tAndCChange();
+  }
+});
 
 </script>

--- a/includes/templates/responsive_classic/css/stylesheet_colors.css
+++ b/includes/templates/responsive_classic/css/stylesheet_colors.css
@@ -42,6 +42,7 @@ span.cssButton.normal_button.button.button_logoff, span.cssButton.normal_button.
 .button_in_cart:hover{background-color:#000;}
 #docGeneralDisplay #pinfo-right, #popupShippingEstimator, #popupSearchHelp, #popupAdditionalImage, #popupImage, #popupCVVHelp, #popupCouponHelp, #popupAtrribsQuantityPricesHelp, #infoShoppingCart{background:none;}
 #navMain ul li a.navCartContentsIndicator {background: #ff662e;color:#000}
+input.submit_button:disabled, input.submit_button:disabled:hover, input.cssButtonHover:disabled{background:#808080;}
 
 /*bof border colors*/
 HR {border-bottom:1px solid #9a9a9a;}

--- a/includes/templates/template_default/css/stylesheet_css_buttons.css
+++ b/includes/templates/template_default/css/stylesheet_css_buttons.css
@@ -37,3 +37,4 @@ span.normal_button {
 span.normal_button:hover {
   background-color:#b4bc8b;  /* Hover color for link-related buttons */
 }
+input.submit_button:disabled, input.submit_button:disabled:hover, input.cssButtonHover:disabled{background:#808080;} /* Button disabled color */


### PR DESCRIPTION
Javascript to disable the continue button on the checkout payment page.
CSS changes to make button grey when disabled.