### PR TITLE
Fix multiplication issue in Customers class

### DIFF
--- a/includes/classes/Customer.php
+++ b/includes/classes/Customer.php
@@ -310,7 +310,7 @@ class Customer extends base
                     'language_code' => $result['language_code'],
                 ];
             }
-            $lifetime_value += ($result['order_total'] * $result['currency_value']);
+            $lifetime_value += ((float)$result['order_total'] * (float)$result['currency_value']);
         }
         $this->data['last_order'] = $last_order;
         $this->data['lifetime_value'] = $lifetime_value;


### PR DESCRIPTION
In PHP 8.1:
[29-May-2022 14:09:09 UTC] Request URI: /gh_demo_158/admin/index.php?cmd=customers, IP address: ::1
--> PHP Fatal error: Uncaught TypeError: Unsupported operand types: string * string in /Users/scott/sites/gh_demo_158/includes/classes/Customer.php:313

In PHP 8.0: 
--> PHP Warning: A non-numeric value encountered in /Users/scott/sites/gh_demo_158/includes/classes/Customer.php on line 313.