### PR TITLE
Fix issues on customer groups page

### DIFF
--- a/admin/customer_groups.php
+++ b/admin/customer_groups.php
@@ -55,11 +55,6 @@ if (!empty($action)) {
 <div class="container-fluid">
     <h1><?php echo HEADING_TITLE; ?></h1>
     <div class="row">
-        <div class="col-xs-12 col-sm-12 col-md-9 col-lg-9">
-            <?php echo TEXT_INFORMATION; ?>
-        </div>
-    </div>
-    <div class="row">
         <!-- body_text //-->
         <div class="col-xs-12 col-sm-12 col-md-9 col-lg-9 configurationColumnLeft">
             <table class="table table-hover">
@@ -125,13 +120,11 @@ if (!empty($action)) {
                         <td class="dataTableContent text-right"><div>
                             <?php echo '<a href="' . zen_href_link(FILENAME_CUSTOMER_GROUPS, $href_page_param . 'gID=' . $group['group_id'] . '&action=edit') . '" class="btn btn-primary" role="button">' . ICON_EDIT . '</a>'; ?>
                             <?php echo '<a href="' . zen_href_link(FILENAME_CUSTOMER_GROUPS, $href_page_param . 'gID=' . $group['group_id'] . '&action=delete') . '" class="btn btn-warning" role="button">' . ICON_DELETE . '</a>'; ?>
-                            <?php
-                                echo '<a href="' . zen_href_link(FILENAME_CUSTOMER_GROUPS, zen_get_all_get_params(['gID']) . 'gID=' . $group['group_id']) . '" class="btn btn-info" role="button">' . IMAGE_ICON_INFO;
-                                if (isset($gInfo) && is_object($gInfo) && ($group['group_id'] == $gInfo->group_id)) {
-                                    echo zen_image(DIR_WS_IMAGES . 'icon_arrow_right.gif', '');
-                                }
-                                echo '</a>';
-                            ?>
+                            <?php 
+                              if (!isset($gInfo) || (isset($gInfo) && is_object($gInfo) && ($group['group_id'] != $gInfo->group_id))) {
+                                 echo zen_image(DIR_WS_IMAGES . 'icon_arrow_right.gif', ''); 
+                              }
+                             ?>
                             </div>
                         </td>
                     </tr>

--- a/admin/includes/languages/english/lang.customer_groups.php
+++ b/admin/includes/languages/english/lang.customer_groups.php
@@ -12,7 +12,6 @@ $define = [
     'TEXT_HEADING_ADD_GROUP' => 'Add Group',
     'TEXT_HEADING_EDIT_GROUP' => 'Edit Group',
     'TEXT_HEADING_DELETE_GROUP' => 'Delete Group',
-    'TEXT_INFORMATION' => 'You can create customer groups which can be used elsewhere in your store for various special permissions. Some payment modules also allow being enabled for only a certain customer group. Customers may belong to multiple groups; however you should review assignments regularly and prune them for optimal performance.',
     'TEXT_NO_GROUPS_FOUND' => 'No groups found. Click INSERT to create one.',
     'TEXT_NEW_INTRO' => 'Please describe the new group',
     'TEXT_DELETE_INTRO' => 'Are you sure you want to delete this group?',


### PR DESCRIPTION
a) Info button overlaid with right arrow icon looks wonky. 

<img width="279" alt="customer_groups_BUG" src="https://user-images.githubusercontent.com/4391638/171997838-5167499f-7e79-4d9b-ad9d-905041337d23.png">

Remove info button.  Displays right arrow when row is not the currently selected one. 

b) Remove help text at the top of page.  We have a separate help repository that is linked on the right. 