### PR TITLE
v158: Adding start/end page notifiers for `about_us` page.

### DIFF
--- a/includes/modules/pages/about_us/header_php.php
+++ b/includes/modules/pages/about_us/header_php.php
@@ -7,8 +7,13 @@
  * @version $Id:  New in v1.5.8 $
  */
 
+// This should be first line of the script:
+$zco_notifier->notify('NOTIFY_HEADER_START_ABOUT_US');
 
 require DIR_WS_MODULES . zen_get_module_directory('require_languages.php');
 $breadcrumb->add(NAVBAR_TITLE);
 
 $define_page = zen_get_file_directory(DIR_WS_LANGUAGES . $_SESSION['language'] . '/html_includes/', FILENAME_DEFINE_ABOUT_US, 'false');
+
+// This should be last line of the script:
+$zco_notifier->notify('NOTIFY_HEADER_END_ABOUT_US');


### PR DESCRIPTION
Fixes #4849