### PR TITLE
Add comment_position field to products_options

### DIFF
--- a/admin/includes/languages/english/lang.options_name_manager.php
+++ b/admin/includes/languages/english/lang.options_name_manager.php
@@ -16,6 +16,7 @@ $define = [
     'TEXT_WARNING_DUPLICATE_OPTION_NAME' => 'Option ID#%1$u: Duplicate Option Name Added: "%2$s" (%3$s)',
     'TEXT_ORDER_BY' => 'Order by',
     'TEXT_OPTION_NAME_COMMENTS' => 'Comment (displayed next to Option Name)',
+    'TEXT_OPTION_NAME_COMMENTS_POSITION' => 'Position for comment', 
     'TEXT_OPTION_ATTRIBUTE_IMAGES_PER_ROW' => 'Attribute Images per Row',
     'TEXT_OPTION_ATTRIBUTE_IMAGES_STYLE' => 'Attribute Image Layout Style (for Checkbox/Radio Buttons only)',
     'TEXT_OPTION_ATTRIBUTE_LAYOUTS_EXAMPLE' => 'View Examples',

--- a/admin/options_name_manager.php
+++ b/admin/options_name_manager.php
@@ -96,6 +96,7 @@ if (!empty($action)) {
 
             $products_options_length_array = $_POST['products_options_length'];
             $products_options_comment_array = $_POST['products_options_comment'];
+            $products_options_comment_position_array = $_POST['products_options_comment_position'];
             $products_options_size_array = $_POST['products_options_size'];
 
             $products_options_images_per_row_array = $_POST['products_options_images_per_row'];
@@ -109,6 +110,7 @@ if (!empty($action)) {
 
                 $products_options_length = zen_db_prepare_input($products_options_length_array[$languages[$i]['id']]);
                 $products_options_comment = zen_db_prepare_input($products_options_comment_array[$languages[$i]['id']]);
+                $products_options_comment_position = zen_db_prepare_input($products_options_comment_position_array[$languages[$i]['id']]);
                 $products_options_size = zen_db_prepare_input($products_options_size_array[$languages[$i]['id']]);
 
                 $products_options_images_per_row = (int)$products_options_images_per_row_array[$languages[$i]['id']];
@@ -120,6 +122,7 @@ if (!empty($action)) {
                           products_options_type = '" . $option_type . "',
                           products_options_length = '" . zen_db_input($products_options_length) . "',
                           products_options_comment = '" . zen_db_input($products_options_comment) . "',
+                          products_options_comment_position = '" . zen_db_input($products_options_comment_position) . "',
                           products_options_size = '" . zen_db_input($products_options_size) . "',
                           products_options_sort_order = " . $products_options_sort_order . ",
                           products_options_images_per_row = " . $products_options_images_per_row . ",
@@ -522,7 +525,7 @@ function translate_type_to_name($opt_type)
                             $sort_order_input = '';
                             $inputs2 = '';
                             for ($i = 0, $n = count($languages); $i < $n; $i++) {
-                                $option_name = $db->Execute("SELECT products_options_name, products_options_sort_order, products_options_size, products_options_length, products_options_comment, products_options_images_per_row, products_options_images_style, products_options_rows
+                                $option_name = $db->Execute("SELECT products_options_name, products_options_sort_order, products_options_size, products_options_length, products_options_comment, products_options_comment_position, products_options_images_per_row, products_options_images_style, products_options_rows
                                                    FROM " . TABLE_PRODUCTS_OPTIONS . "
                                                    WHERE products_options_id = " . (int)$options_name['products_options_id'] . "
                                                    AND language_id = " . (int)$languages[$i]['id']);
@@ -540,6 +543,9 @@ function translate_type_to_name($opt_type)
                                 $inputs2 .= '<div class="col-sm-12">';
                                 $inputs2 .= zen_draw_label(TEXT_OPTION_NAME_COMMENTS . ':', 'products_options_comment[' . $languages[$i]['id'] . ']', 'class="control-label"');
                                 $inputs2 .= zen_draw_input_field('products_options_comment[' . $languages[$i]['id'] . ']', $option_name->fields['products_options_comment'], 'class="form-control" style="width:100%" id="products_options_comment[' . $languages[$i]['id'] . ']"');
+
+                                $inputs2 .= zen_draw_label(TEXT_OPTION_NAME_COMMENTS_POSITION. ':', 'products_options_comment_position[' . $languages[$i]['id'] . ']', 'class="control-label"');
+                                $inputs2 .= zen_draw_input_field('products_options_comment_position[' . $languages[$i]['id'] . ']', $option_name->fields['products_options_comment_position'], 'class="form-control" id="products_options_comment_position[' . $languages[$i]['id'] . ']"', '', 'number');
                                 $inputs2 .= '</div>';
                                 $inputs2 .= '</div>';
                                 $inputs2 .= '<div class="row">';

--- a/includes/modules/attributes.php
+++ b/includes/modules/attributes.php
@@ -50,7 +50,7 @@ if (PRODUCTS_OPTIONS_SORT_ORDER == '0') {
 }
 
 $sql = "SELECT DISTINCT popt.products_options_id, popt.products_options_name, popt.products_options_sort_order,
-            popt.products_options_type, popt.products_options_length, popt.products_options_comment,
+            popt.products_options_type, popt.products_options_length, popt.products_options_comment, popt.products_options_comment_position,
             popt.products_options_size,
             popt.products_options_images_per_row,
             popt.products_options_images_style,
@@ -116,10 +116,6 @@ while (!$products_options_names->EOF) {
     $i = 0;
 
     $zco_notifier->notify('NOTIFY_ATTRIBUTES_MODULE_START_OPTION', $products_options_names->fields);
-
-    if (!isset($products_options_names->fields['products_options_comment_position'])) {
-        $products_options_names->fields['products_options_comment_position'] = '0';
-    }
 
     // loop through each Attribute
     while (!$products_options->EOF) {

--- a/zc_install/sql/install/mysql_zencart.sql
+++ b/zc_install/sql/install/mysql_zencart.sql
@@ -1776,6 +1776,7 @@ CREATE TABLE products_options (
   products_options_type int(5) NOT NULL default '0',
   products_options_length smallint(2) NOT NULL default '32',
   products_options_comment varchar(256) default NULL,
+  products_options_comment_position smallint(2) NOT NULL default '0',
   products_options_size smallint(2) NOT NULL default '32',
   products_options_images_per_row int(2) default '5',
   products_options_images_style int(1) default '0',

--- a/zc_install/sql/updates/mysql_upgrade_zencart_158.sql
+++ b/zc_install/sql/updates/mysql_upgrade_zencart_158.sql
@@ -47,6 +47,7 @@ ALTER TABLE orders MODIFY customers_country varchar(64) NOT NULL default '';
 ALTER TABLE orders MODIFY delivery_country varchar(64) NOT NULL default '';
 ALTER TABLE orders MODIFY billing_country varchar(64) NOT NULL default '';
 
+ALTER TABLE products_options ADD products_options_comment_position smallint(2) NOT NULL default '0' AFTER products_options_comment; 
 # Remove greater-than sign in query_builder
 UPDATE query_builder SET query_name = 'Customers Dormant for 3+ months (Subscribers)' WHERE query_id = 3;
 


### PR DESCRIPTION
This field is referenced in code, but, as Cindy noted in a forum post 

not actually in the database.  This PR adds it to the database and handles it on the admin and storefront sides.

I added the comment "This is the color comment" to the Color attribute.  
Here it is in position 0

<img width="421" alt="color_pos_0" src="https://user-images.githubusercontent.com/4391638/172431790-77e3defa-e181-479e-bc83-660e319aaccf.png">


and here it is in position 1

<img width="200" alt="color_pos_1" src="https://user-images.githubusercontent.com/4391638/172431773-266729fe-6b45-46c7-be6f-761c637b8bc7.png">

