### PR TITLE
v158: Add previously-used variable for compatibility with current tem…

### DIFF
--- a/includes/modules/pages/account_history/header_php.php
+++ b/includes/modules/pages/account_history/header_php.php
@@ -22,6 +22,7 @@ $breadcrumb->add(NAVBAR_TITLE_2);
 
 $customer = new Customer;
 $accountHistory = $customer->getOrderHistory();
+$accountHasHistory = !empty($accountHistory);
 
 // This should be last line of the script:
 $zco_notifier->notify('NOTIFY_HEADER_END_ACCOUNT_HISTORY');


### PR DESCRIPTION
…plates

As identified in [this](https://github.com/lat9/ZCA-Bootstrap-Template/issues/123) issue raised against the Bootstrap template, update `includes/modules/pages/account_history/header_php.php` to include a variable that's been provided since zc155 (and possibly earlier) for compatibility with pre-existing templates.