### PR TITLE
Fix multi-page coupon search

### DIFF
--- a/admin/coupon_admin.php
+++ b/admin/coupon_admin.php
@@ -1226,10 +1226,16 @@ switch ($_GET['action']) {
                 <tbody>
                   <?php
                   if ($status != 'A') {
-                    $cc_query_raw = "SELECT *
+                     if (isset($_GET['cid'])) {
+                       $cc_query_raw = "SELECT *
+                                     FROM " . TABLE_COUPONS . "
+                                     WHERE coupon_id = " . (int)$_GET['cid'];
+                     } else {
+                       $cc_query_raw = "SELECT *
                                      FROM " . TABLE_COUPONS . "
                                      WHERE coupon_active = '" . zen_db_input($status) . "'
                                      AND coupon_type != 'G'";
+                     }
                   } else {
                     $cc_query_raw = "SELECT *
                                      FROM " . TABLE_COUPONS . "


### PR DESCRIPTION
This bug shows up if more than a page of coupons is shown when you go to
Admin > Discounts > Coupon Admin.

search for a coupon code from the second page (or greater).

you will get a URL like

http://localhost:8888/gh_demo_158/admin/index.php?cmd=coupon_admin&cid=48&status=Y

but the sidebar does not contain the coupon data:
<img width="351" alt="orig_coupon_search" src="https://user-images.githubusercontent.com/4391638/173455465-6c2493e4-49e1-40df-9455-10afca9084f7.png">

This change fixes it so the data is available for editing or accessing other screens.

<img width="339" alt="coupon_search_fixed" src="https://user-images.githubusercontent.com/4391638/173455553-67fe56b3-c50b-4be4-94d6-14ba60f8081e.png">



