### PR TITLE
Begin migration of non-language constants

### DIFF
--- a/admin/coupon_restrict.php
+++ b/admin/coupon_restrict.php
@@ -5,7 +5,6 @@
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: Scott C Wilson 2020 Apr 29 Modified in v1.5.7 $
  */
-//define('MAX_DISPLAY_RESTRICT_ENTRIES', 10);
 require('includes/application_top.php');
 
 // -----

--- a/admin/includes/extra_configures/flags.php
+++ b/admin/includes/extra_configures/flags.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @package initSystem
+ * @copyright Copyright 2003-2022 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: 
+ */
+
+require DIR_FS_CATALOG . DIR_WS_INCLUDES . 'extra_configures/flags.php'; 
+
+if (!defined('MAX_DISPLAY_RESTRICT_ENTRIES')) {
+   define('MAX_DISPLAY_RESTRICT_ENTRIES', 10);
+}

--- a/admin/includes/languages/english/lang.coupon_restrict.php
+++ b/admin/includes/languages/english/lang.coupon_restrict.php
@@ -18,7 +18,6 @@ $define = [
     'TABLE_HEADING_RESTRICT_REMOVE' => 'Remove',
     'IMAGE_REMOVE' => 'Remove this restriction',
     'TEXT_ALL_CATEGORIES' => 'All Categories',
-    'MAX_DISPLAY_RESTRICT_ENTRIES' => 20,
     'TEXT_ALL_PRODUCTS_ADD' => 'Add All Category Products',
     'TEXT_ALL_PRODUCTS_REMOVE' => 'Remove All Category Products',
     'TEXT_INFO_ADD_DENY_ALL' => '<strong>For Add all Category Products, only Products not already set for restrictions will be added.<br>

--- a/admin/includes/languages/lang.english.php
+++ b/admin/includes/languages/lang.english.php
@@ -636,7 +636,6 @@ $define = [
     'WARNING_SQL_CACHE_DIRECTORY_NON_EXISTENT' => 'Warning: The SQL cache directory does not exist: ' . DIR_FS_SQL_CACHE . '. SQL caching will not work until this directory is created.',
     'WARNING_SQL_CACHE_DIRECTORY_NOT_WRITEABLE' => 'Warning: I am not able to write to the SQL cache directory: ' . DIR_FS_SQL_CACHE . '. SQL caching will not work until the right user permissions are set.',
     'WARNING_WELCOME_DISCOUNT_COUPON_EXPIRES_IN' => 'WARNING! Welcome Email Discount Coupon expires in %s days',
-    'WARN_DATABASE_VERSION_PROBLEM' => 'true',
     'WHOS_ONLINE_ACTIVE_NO_CART_TEXT' => 'Active no cart',
     'WHOS_ONLINE_ACTIVE_TEXT' => 'Active cart',
     'WHOS_ONLINE_INACTIVE_NO_CART_TEXT' => 'Inactive no cart',

--- a/includes/extra_configures/flags.php
+++ b/includes/extra_configures/flags.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @package initSystem
+ * @copyright Copyright 2003-2022 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: 
+ */
+if (!defined('CART_SHIPPING_METHOD_ZIP_REQUIRED')) {
+   define('CART_SHIPPING_METHOD_ZIP_REQUIRED','true');
+}
+if (!defined('WARN_DATABASE_VERSION_PROBLEM')) {
+   define('WARN_DATABASE_VERSION_PROBLEM','true');
+}

--- a/includes/languages/lang.english.php
+++ b/includes/languages/lang.english.php
@@ -72,7 +72,6 @@ $define = [
     'CART_SHIPPING_METHOD_RATES' => 'Rates',
     'CART_SHIPPING_METHOD_TEXT' => 'Available Shipping Methods',
     'CART_SHIPPING_METHOD_TO' => 'Ship to: ',
-    'CART_SHIPPING_METHOD_ZIP_REQUIRED' => 'true',
     'CART_SHIPPING_OPTIONS' => 'Estimate Shipping Costs',
     'CART_SHIPPING_QUOTE_CRITERIA' => 'Shipping quotes are based on the address information you selected:',
     'CATEGORIES_BOX_HEADING_FEATURED_PRODUCTS' => 'Featured Products ...',


### PR DESCRIPTION
Establishes a mechanism for setting non-language constants that were in language files in prior releases. 

Fixes #4649
Fixes #3126
Fixes #4633 

This PR is not intended to address all constants everywhere, it's just the first step.  Additional constants can be moved in future PRs. 
