### PR TITLE
function zen_create_coupon_code: remove type hint from parameter SECURITY_CODE_LENGTH

### DIFF
--- a/includes/functions/functions_gvcoupons.php
+++ b/includes/functions/functions_gvcoupons.php
@@ -74,7 +74,7 @@ function zen_user_has_gv_account(int $customer_id)
  * @param string $prefix - include a prefix string if you want to force the generated code to start with a specific string
  * @return string (new coupon code) (will be blank if the function failed)
  */
-function zen_create_coupon_code(string $salt = "secret", int $length = SECURITY_CODE_LENGTH, string $prefix = '')
+function zen_create_coupon_code(string $salt = "secret", $length = SECURITY_CODE_LENGTH, string $prefix = '')
 {
     global $db;
     $length = (int)$length;


### PR DESCRIPTION
as discussed here https://github.com/zencart/zencart/issues/4317
