### PR TITLE
v158: Correcting PHP Fatal error for configurationValidation

### DIFF
--- a/admin/includes/classes/configurationValidation.php
+++ b/admin/includes/classes/configurationValidation.php
@@ -16,12 +16,14 @@ if (!defined('IS_ADMIN_FLAG')) {
 
 class configurationValidation extends base
 {
-    static public function sanitizeEmailNullOK(&$val) {
-        if (empty($val)) {
-          return true;
+    static public function sanitizeEmailNullOK(&$val)
+    {
+        if ($val === '') {
+            return true;
         }
-        return $this->sanitizeEmail($val); 
+        return configurationValidation::sanitizeEmail($val); 
     }
+
     static public function sanitizeEmail(&$val) {
         $results = array();
         $send_email_array = array();


### PR DESCRIPTION
With the recently merged addition of `configurationValidation::sanitizeEmailNullOK`, I'm met with a couple of issues:

1. A Fatal PHP error:
```

[19-Jun-2022 06:40:04 America/New_York] PHP Fatal error:  Uncaught Error: Using $this when not in object context in C:\xampp\htdocs\zc158\hoisT-PYL-teAch\includes\classes\configurationValidation.php:23
Stack trace:
#0 [internal function]: configurationValidation::sanitizeEmailNullOK('0')
#1 C:\xampp\htdocs\zc158\hoisT-PYL-teAch\includes\functions\configuration_checks.php(53): filter_var('0', 1024, Array)
#2 C:\xampp\htdocs\zc158\hoisT-PYL-teAch\configuration.php(22): zen_validate_configuration_entry('0', '{"error":"TEXT_...')
#3 C:\xampp\htdocs\zc158\hoisT-PYL-teAch\index.php(11): require('C:\\xampp\\htdocs...')
#4 {main}
  thrown in C:\xampp\htdocs\zc158\hoisT-PYL-teAch\includes\classes\configurationValidation.php on line 23
```
2. When that's corrected, an optional email address entered as `0` is accepted as valid