### PR TITLE
fix: move missing image check after handle_image

### DIFF
--- a/includes/functions/html_output.php
+++ b/includes/functions/html_output.php
@@ -195,10 +195,7 @@ function zen_catalog_href_link($page = '', $parameters = '', $connection = 'NONS
     if (!file_exists($src)) {
       $src = str_replace(DIR_WS_TEMPLATES . $template_dir, DIR_WS_TEMPLATES . 'template_default', $src);
     }
-    //image is defined but is missing
-    if (PRODUCTS_IMAGE_NO_IMAGE_STATUS === '1' && !file_exists($src)) {
-        $src = DIR_WS_IMAGES . PRODUCTS_IMAGE_NO_IMAGE;
-      }
+
     // hook for handle_image() function such as Image Handler etc
     if (function_exists('handle_image')) {
       $newimg = handle_image($src, $alt, $width, $height, $parameters);
@@ -206,6 +203,11 @@ function zen_catalog_href_link($page = '', $parameters = '', $connection = 'NONS
       $zco_notifier->notify('NOTIFY_HANDLE_IMAGE', array($newimg));
     }
 
+    //image is defined but is missing
+    if (PRODUCTS_IMAGE_NO_IMAGE_STATUS === '1' && !file_exists($src)) {
+      $src = DIR_WS_IMAGES . PRODUCTS_IMAGE_NO_IMAGE;
+    }
+    
     $zco_notifier->notify('NOTIFY_OPTIMIZE_IMAGE', $template_dir, $src, $alt, $width, $height, $parameters);
 
     // Convert width/height to int for proper validation.


### PR DESCRIPTION
sites with handled images do not use the SIZE suffixes: will always fail.
Check for image source should be post handle_image.
