### PR TITLE
admin, collect_info: change alt tag for product from category_name to product_name

### DIFF
--- a/admin/includes/modules/product/collect_info.php
+++ b/admin/includes/modules/product/collect_info.php
@@ -354,7 +354,7 @@ if (zen_get_categories_status($current_category_id) == 0 && $pInfo->products_sta
     if (!empty($pInfo->products_image)) { ?>
         <div class="form-group">
             <div class="col-sm-offset-3 col-sm-9 col-md-6">
-                <?php echo zen_info_image($pInfo->products_image, $pInfo->categories_name); ?>
+                <?php echo zen_info_image($pInfo->products_image, $pInfo->products_name); ?>
                 <br>
                 <?php echo $pInfo->products_image; ?>
             </div>


### PR DESCRIPTION
ZC158, php 8.1.7.
Admin->Catalog->Edit product triggers debug. 

The main image defined for the product is shown on the edit page using this:
`<?php echo zen_info_image($pInfo->products_image, $pInfo->categories_name); ?>`

But categories_name is not in $pInfo.

Consequently this not-set parameter is passed to zen_image:
`$image = '<img src="' . $src . '" alt="' . zen_output_string($alt) . '"';`

then zen_output_string
`return strtr($string, ['"' => '&quot;']);`

where it triggers:
`--> PHP Deprecated: strtr(): Passing null to parameter #1 ($string) of type string is deprecated in ...\includes\functions\functions_strings.php on line 24.`

This PR corrects the alt tag to use the product name.