### PR TITLE
Fix alignment of GV Balance header on customers

### DIFF
--- a/admin/customers.php
+++ b/admin/customers.php
@@ -807,7 +807,7 @@ if (!empty($action)) {
                   </th>
 
                   <?php if (defined('MODULE_ORDER_TOTAL_GV_STATUS') && MODULE_ORDER_TOTAL_GV_STATUS == 'true') { ?>
-                    <th class="dataTableHeadingContent">
+                    <th class="dataTableHeadingContent text-right">
                       <?php echo (($_GET['list_order'] == 'gv_balance-asc' or $_GET['list_order'] == 'gv_balance-desc') ? '<span class="SortOrderHeader">' . TABLE_HEADING_GV_AMOUNT . '</span>' : TABLE_HEADING_GV_AMOUNT); ?><br>
                       <a href="<?php echo zen_href_link(basename($PHP_SELF), zen_get_all_get_params(array('list_order', 'page')) . 'list_order=gv_balance-asc', 'NONSSL'); ?>"><?php echo ($_GET['list_order'] == 'gv_balance-asc' ? '<span class="SortOrderHeader">' . TEXT_ASC . '</span>' : '<span class="SortOrderHeaderLink">' . TEXT_ASC . '</span>'); ?></a>&nbsp;
                       <a href="<?php echo zen_href_link(basename($PHP_SELF), zen_get_all_get_params(array('list_order', 'page')) . 'list_order=gv_balance-desc', 'NONSSL'); ?>"><?php echo ($_GET['list_order'] == 'gv_balance-desc' ? '<span class="SortOrderHeader">' . TEXT_DESC . '</span>' : '<span class="SortOrderHeaderLink">' . TEXT_DESC . '</span>'); ?></a>


### PR DESCRIPTION
Data is right aligned so header should be as well. 

Before: 
<img width="141" alt="gv_bal_before" src="https://user-images.githubusercontent.com/4391638/175082779-1c09b105-b863-4871-86bc-bd6a21be4ed9.png">


After: 

<img width="108" alt="gv_bal_after" src="https://user-images.githubusercontent.com/4391638/175082829-b712a31e-d871-41df-9a3f-c47acc4b9d2f.png">

