### PR TITLE
Add name= to Ambiguous Links in Define_Main_Page

### DIFF
--- a/includes/languages/english/html_includes/responsive_classic/define_main_page.php
+++ b/includes/languages/english/html_includes/responsive_classic/define_main_page.php
@@ -1,8 +1,8 @@
 <a href="https://docs.zen-cart.com/user/" target="_blank" rel="noopener"><img src="images/large/zencart-docs.jpg" alt="Zen Cart Documentation" title="View the online Zen Cart documentation!" class="home-image"></a>
 <p class="biggerText">The template package uses PHP Mobile Detect to serve up the optimized layout based on device.  
-    If you are on a Desktop, you can also view the site in the <a class="red" href="index.php?main_page=index&amp;layoutType=tablet" name="Tablet Layout View">Tablet Layout</a>.  
-    Clicking on <a class="red" href="index.php?main_page=index&amp;layoutType=mobile" name="Mobile Layout View">Mobile layout</a> shows how the site will look on a mobile device. 
-    Click on <a class="red" href="index.php?main_page=index&amp;layoutType=default" name="Desktop Layout View">Desktop view</a> to switch back to the Desktop view.</p>
+    If you are on a Desktop, you can also view the site in the <a class="red" href="index.php?main_page=index&amp;layoutType=tablet" title="Tablet Layout View">Tablet Layout</a>.  
+    Clicking on <a class="red" href="index.php?main_page=index&amp;layoutType=mobile" title="Mobile Layout View">Mobile layout</a> shows how the site will look on a mobile device. 
+    Click on <a class="red" href="index.php?main_page=index&amp;layoutType=default" title="Desktop Layout View">Desktop view</a> to switch back to the Desktop view.</p>
     
 <p>This text is located in the file at: <code> /languages/english/html_includes/YOUR_TEMPLATE/define_main_page.php</code></p>
 <p>You can quickly edit this content (and remove this image) via Admin->Tools->Define Pages Editor, and select define_main_page from the pulldown.</p>

--- a/includes/languages/english/html_includes/responsive_classic/define_main_page.php
+++ b/includes/languages/english/html_includes/responsive_classic/define_main_page.php
@@ -1,8 +1,8 @@
 <a href="https://docs.zen-cart.com/user/" target="_blank" rel="noopener"><img src="images/large/zencart-docs.jpg" alt="Zen Cart Documentation" title="View the online Zen Cart documentation!" class="home-image"></a>
 <p class="biggerText">The template package uses PHP Mobile Detect to serve up the optimized layout based on device.  
-    If you are on a Desktop and want to view the Tablet layout <a class="red" href="index.php?main_page=index&amp;layoutType=tablet">use this link.</a>  
-    If you want to view the Mobile layout <a class="red" href="index.php?main_page=index&amp;layoutType=mobile">use this link.</a>  
-    To switch back to a Desktop <a class="red" href="index.php?main_page=index&amp;layoutType=default">use this link.</a></p>
+    If you are on a Desktop, you can also view the site in the <a class="red" href="index.php?main_page=index&amp;layoutType=tablet" name="Tablet Layout View">Tablet Layout</a>.  
+    Clicking on <a class="red" href="index.php?main_page=index&amp;layoutType=mobile" name="Mobile Layout View">Mobile layout</a> shows how the site will look on a mobile device. 
+    Click on <a class="red" href="index.php?main_page=index&amp;layoutType=default" name="Desktop Layout View">Desktop view</a> to switch back to the Desktop view.</p>
     
 <p>This text is located in the file at: <code> /languages/english/html_includes/YOUR_TEMPLATE/define_main_page.php</code></p>
 <p>You can quickly edit this content (and remove this image) via Admin->Tools->Define Pages Editor, and select define_main_page from the pulldown.</p>


### PR DESCRIPTION
It's a minor infraction to use "use this link" for the three template-viewing options in the includes/languages/english/html_includes/responsive_classic/define_main_page.php.

These three link fixes get us closer to removing the 14 link alerts on the default home page.