### PR TITLE
Finalizing Color Contrast in stylesheet_colors.css

### DIFF
--- a/includes/templates/responsive_classic/css/stylesheet_colors.css
+++ b/includes/templates/responsive_classic/css/stylesheet_colors.css
@@ -1,49 +1,52 @@
+/**
+ * CSS Stylesheet for Colors
+ *
+ * @copyright Copyright 2003-2020 Zen Cart Development Team
+ * @copyright Portions Copyright 2003 osCommerce
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: dbltoe 2022 June 25 Modified in v1.5.8 $
+ */
+
 /*bof font colors*/
-body, .messageStackSuccess, .messageStackCaution, #tagline, #productQuantityDiscounts table, .categoryListBoxContents a, h2.greeting a {color:#000000;}
-a:link, a:visited, #navEZPagesTOC ul li a, a:hover, #navEZPagesTOC ul li a:hover, fieldset fieldset legend, #siteinfoLegal a, .cartTotalDisplay, .cartOldItem, .specialsListBoxContents, .centerBoxContentsSpecials, .centerBoxContentsAlsoPurch, .centerBoxContentsFeatured, .centerBoxContentsNew, .list-price, .itemTitle a, h2.greeting, #icon, h1, .header .fa-bars {color:#364fb5;}
+body, .messageStackSuccess, .messageStackCaution, #tagline, #productQuantityDiscounts table, a:link, a:visited, #navEZPagesTOC ul li a, a:hover, #navEZPagesTOC ul li a:hover, fieldset fieldset h3.rightBoxHeading a:hover, h3.leftBoxHeading a:hover {color: #03A9D3;}
 .cat-count, .itemTitle a:hover, h2.greeting a:hover {color:#666;}
 h3.rightBoxHeading a:hover, h3.leftBoxHeading a:hover {color: #aaa}
+span.normal_button:hover {background: #666666;}
+span.button_back{font-size: 1.0em;}
+span.button_back:hover{font-size: 1.0em;}
 a:active {color:#0000ff;}
 h2, h3, .cartAttribsList, #cart-box {color:#000000;}
 #navMain ul li a:hover, #navSupp ul li a:hover{color:#03a5ce;}
 #navMain ul li a.navCartContentsIndicator:hover {color:#ffffff;}
 .alert {color: #8b0000;}
-legend, .specialsListBoxContents a, .centerBoxContentsAlsoPurch a, .centerBoxContentsFeatured a, .centerBoxContentsSpecials a, .centerBoxContentsNew a, .productPriceDiscount{color:#333;}
-.messageStackWarning, .messageStackError, #navMainWrapper, #navMain ul li a, #navCatTabsWrapper, #navCatTabs li a, #navCatTabs li a:hover, #navCatTabs li:hover, #navEZPagesTop, #navEZPagesTop li a, .pagination li a, #navSuppWrapper, #navSupp li a, #siteinfoIP, #siteinfoLegal, #bannerSix, #siteinfoLegal a:hover, h2.centerBoxHeading, h3.rightBoxHeading, h3.leftBoxHeading, h3.rightBoxHeading a, h3.leftBoxHeading a, .seDisplayedAddressLabel, TR.tableHeading, #shippingEstimatorContent h2, #shippingEstimatorContent th, #checkoutConfirmDefault .cartTableHeading, #filter-wrapper, .navSplitPagesLinks a, .current, .productListing-rowheading a, .productListing-rowheading a, .prod-list-wrap, #productQuantityDiscounts table tr:first-child td, #reviewsWriteHeading, #sendSpendWrapper h2, #accountDefault #sendSpendWrapper h2, #gvFaqDefaultSubHeading, #checkoutPayAddressDefaultAddress, #checkoutShipAddressDefaultAddress, #accountLinksWrapper h2, h2#addressBookDefaultPrimary, #myAccountPaymentInfo h3, #myAccountShipInfo h3, #myAccountPaymentInfo h4, #myAccountShipInfo h4, input.submit_button, input.submit_button:hover, input.cssButtonHover, span.normal_button{color: #ffffff;}
-.cartNewItem {color:#33cc33;}
+legend, .specialsListBoxContents a, .centerBoxContentsAlsoPurch a, .centerBoxContentsFeatured a, .messageStackWarning, .messageStackError, #navMainWrapper, #navMain ul li a, #navCatTabsWrapper, .cartNewItem {color:#DB3A00;}
 #orderhistoryContent ul li a i.fa,
-.productSpecialPrice, .productSalePrice, .productSpecialPriceSale, .productPriceDiscount {color:#900404;}
-.categoryListBoxContents a:hover, .categoryListBoxContents:hover a{color:#364fb5;}
+.productSpecialPrice, .productSalePrice, .productSpecialPriceSale, .productPriceDiscount .categoryListBoxContents a:hover, .categoryListBoxContents:hover a{color:#364fb5;}
 .list-more{color:#fff !important;}
-
+  
+/* Added by dbltoe for more accent on center page items.  Comment out any not wanted */
+.categoryListBoxContents:hover, centerBoxContentsListing:hover, .centerBoxContents:hover, 
 /*bof background colors*/
-body, #mainWrapper, #headerWrapper, #contentMainWrapper, #logoWrapper, #cartBoxListWrapper, #ezPageBoxList, #cartBoxListWrapper ul, #ezPageBoxList ul, #mainWrapper, #popupAdditionalImage, #contentMainWrapper, #headerWrapper, .sideBoxContent, .rightBoxContent, .rowOdd, #productQuantityDiscounts table, #accountLinksWrapper {background:#fff;}
-input:focus, select:focus, textarea:focus, #mainWrapper, .specialsListBoxContents:hover, .centerBoxContentsSpecials:hover, .centerBoxContentsAlsoPurch:hover, .centerBoxContentsFeatured:hover, .centerBoxContentsNew:hover, .centerBoxContentsProducts:hover, .categoryListBoxContents:hover, .sideBoxContentItem:hover, .productListing-odd, #pinfo-right, #sendSpendWrapper {background:#f4f4f4;}
-.messageStackCaution {background-color:#ffff66;}
+body, #mainWrapper, #headerWrapper, #contentMainWrapper, #logoWrapper, #cartBoxListWrapper, input:focus, select:focus, textarea:focus, #mainWrapper, .specialsListBoxContents:hover, .messageStackCaution {background-color:#ffff66;}
 .brandCell:hover,
-fieldset, .rowEven, #shippingEstimatorContent tr:nth-child(odd), #order-comments, ul.list-links li:hover, ol.list-links li:hover, #no-products, .listing-wrapper:nth-child(odd), #reviews-write-wrapper, #gvFaqDefaultContent, #checkoutPayAddressDefault .instructions, #checkoutShipAddressDefault .instructions, #addressBookDefault .instructions, #myAccountNotify, #myAccountGen, .reviews-wrapper, #accountHistInfo table td, #prevOrders td, #myAccountPaymentInfo, #myAccountShipInfo, #accountDefault #sendSpendWrapper{background:#eee;}
-.tableHeading{background-color:#e9e9e9;}
-#navEZPagesTOCWrapper, .cartBoxTotal, .productListing-even:hover, .productListing-odd:hover, #productQuantityDiscounts tr:nth-child(even) {background:#ddd;}
-#cartContentsDisplay .rowEven:hover, #cartContentsDisplay .rowOdd:hover {background:#e2e2e2;}
+fieldset, .rowEven, #shippingEstimatorContent tr:nth-child(odd), #order-comments, ul.list-links .tableHeading{background-color:#e9e9e9;}
+#navEZPagesTOCWrapper, .cartBoxTotal, .productListing-even:hover, .productListing-odd:hover, #cartContentsDisplay .rowEven:hover, #cartContentsDisplay .rowOdd:hover {background:#e2e2e2;}
 #orderTotals{background:#ccc;}
 legend, #cart-box{background:#bbb;}
-#navMainWrapper, #navSuppWrapper, #shippingEstimatorContent h2, #checkoutConfirmDefault .cartTableHeading, .navSplitPagesLinks a, .productListing-rowheading a:hover, .list-more, #sendSpendWrapper h2, #accountDefault #sendSpendWrapper h2, #gvFaqDefaultSubHeading, #checkoutPayAddressDefaultAddress, #checkoutShipAddressDefaultAddress, #accountLinksWrapper h2, h2#addressBookDefaultPrimary, #reviewsWriteHeading, #myAccountPaymentInfo h3, #myAccountShipInfo h3, span.cssButton.normal_button.button.button_more_reviews, .button_more_reviews:hover, span.cssButton.normal_button.button.button_read_reviews, .button_read_reviews:hover {background:#333;}
-#navSupp li a:hover, .rightBoxHeading, .leftBoxHeading, .centerBoxHeading {background:#444;}
-span.cssButton.normal_button.button.button_logoff, span.cssButton.normal_button.button.small_edit, #navEZPagesTop, .seDisplayedAddressLabel, TR.tableHeading, .prod-list-wrap, #myAccountPaymentInfo h4, #myAccountShipInfo h4 {background:#666;}
-#siteinfoIP, #siteinfoLegal, #bannerSix{background:#666665;}
-#navEZPagesTop li a:hover, .pagination li a:hover {background:#777;}
+#navMainWrapper, #navSuppWrapper, #shippingEstimatorContent h2, #checkoutConfirmDefault .rightBoxHeading, .leftBoxHeading, .centerBoxHeading {background:#444;}
+h3.rightBoxHeading a:hover, h3.leftBoxHeading a:hover {color: #03A9D3;}
+span.cssButton.normal_button.button.button_logoff, span.cssButton.normal_button.button.small_edit, #siteinfoIP, #siteinfoLegal, #bannerSix{background:#666665;}
+#navEZPagesTop li a:hover, .pagination li a:hover {color:#0eA9D3;}
+
 .messageStackWarning, .messageStackError {background-color:#8b0000;}
 .messageStackSuccess {background-color:#99ff99;}
-#shippingEstimatorContent th, .navSplitPagesLinks a:hover, .productListing-rowheading, #productQuantityDiscounts table tr:first-child td{background:#999;}
-#navCatTabsWrapper, .current, .productListing-rowheading a, .list-more:hover, input.submit_button, span.normal_button {background:#364fb5;}
-.button_goto_prod_details:hover{background:#05a5cb !important;}
+#shippingEstimatorContent th, .navSplitPagesLinks a:hover, .productListing-rowheading, #navCatTabsWrapper, .current, .productListing-rowheading a, .list-more:hover, input.submit_button, .button_goto_prod_details:hover{background:#05a5cb !important;}
 #navCatTabs li a:hover, input.submit_button:hover, input.cssButtonHover {background:#666666;}
-#filter-wrapper, span.normal_button:hover, span.cssButton.normal_button.button.button_goto_prod_details, .button_add_selected:hover{background:#000;}
-.button_in_cart:hover{background-color:#000;}
-#docGeneralDisplay #pinfo-right, #popupShippingEstimator, #popupSearchHelp, #popupAdditionalImage, #popupImage, #popupCVVHelp, #popupCouponHelp, #popupAtrribsQuantityPricesHelp, #infoShoppingCart{background:none;}
-#navMain ul li a.navCartContentsIndicator {background: #ff662e;color:#000}
-input.submit_button:disabled, input.submit_button:disabled:hover, input.cssButtonHover:disabled{background:#808080;}
-
+#filter-wrapper, span.normal_button:hover, .button_in_cart:hover{background-color:#000;}
+#docGeneralDisplay #pinfo-right, #popupShippingEstimator, #popupSearchHelp, #popupAdditionalImage, #navMain {background: #ff662e;color:#000}
+#navMain ul li a.navCartContentsIndicator:hover {color: #db3a00;background: #FFFFFF;font-weight: bold;}
+#navMain ul li a.navCartContentsIndicator {color: #000000;background: #ff662e;font-weight: bold;}
+input.submit_button:disabled, input.submit_button:disabled:hover, 
 /*bof border colors*/
 HR {border-bottom:1px solid #9a9a9a;}
 input, TEXTAREA{border:3px solid #ccc;}
@@ -63,6 +66,5 @@ ol.list-links li{border-bottom:1px solid #ddd;}
 #seQuoteResults td, .listBoxContentTable td, .tableBorder1 td {border: 1px solid #000;}
 
 /*bof placeholders*/
-::-moz-placeholder, :-moz-placeholder, ::-webkit-input-placeholder, :-ms-input-placeholder, :placeholder-shown {color: #D01;}
-
+::-moz-placeholder, :-moz-placeholder, ::-webkit-input-placeholder, :-ms-input-placeholder, 
 #siteinfoLegal a{color:#ffffff;}


### PR DESCRIPTION
Most ADA/WCAG testers cannot check if a hover is done correctly.

This fix addresses those hovers and their components that were missing, did not comply with minimum color contrast, are needed to match other color combinations of similar items on a page like the _back_ and _search_ buttons on the search page.

As far as I can tell, this fixes all color contrast on all pages but, I welcome any gems you may find.

I did add new lines 32 and 33 simply for a little pizzazz when someone is viewing a new install.