### PR TITLE
Check output before referencing

### DIFF
--- a/includes/classes/order_total.php
+++ b/includes/classes/order_total.php
@@ -63,6 +63,9 @@ class order_total extends base {
         $class = substr($value, 0, strrpos($value, '.'));
         if (!isset($GLOBALS[$class])) continue;
         $GLOBALS[$class]->process();
+        if (empty($GLOBALS[$class]->output)) {
+           continue; 
+        }
         for ($i=0, $n=sizeof($GLOBALS[$class]->output); $i<$n; $i++) {
           if (zen_not_null($GLOBALS[$class]->output[$i]['title']) && zen_not_null($GLOBALS[$class]->output[$i]['text'])) {
             $order_total_array[] = array('code' => $GLOBALS[$class]->code,


### PR DESCRIPTION
Fixes this log, seen during `index.php?main_page=checkout_process`: 
```
--> PHP Warning: sizeof(): Parameter must be an array or an object that implements Countable in /var/www/html/myaccount/mystore.com/shop/includes/classes/order_total.php on line 66.
```