### PR TITLE
admin, customers, addresses: parameter passed to zen_get_customers_address_primary must be integer

### DIFF
--- a/admin/customers.php
+++ b/admin/customers.php
@@ -656,7 +656,7 @@ if (!empty($action)) {
              */
             foreach ($addressArray as $addresses) {
               ?>
-              <h3 class="addressBookDefaultName"><?php echo zen_output_string_protected($addresses['firstname'] . ' ' . $addresses['lastname']); ?><?php echo ($addresses['address_book_id'] == zen_get_customers_address_primary($_GET['cID']) ? '&nbsp;' . PRIMARY_ADDRESS : ''); ?></h3>
+              <h3 class="addressBookDefaultName"><?php echo zen_output_string_protected($addresses['firstname'] . ' ' . $addresses['lastname']); ?><?php echo ((int)$addresses['address_book_id'] === zen_get_customers_address_primary((int)$_GET['cID']) ? '&nbsp;' . PRIMARY_ADDRESS : ''); ?></h3>
               <address><?php echo zen_address_format($addresses['format_id'], $addresses['address'], true, ' ', '<br>'); ?></address>
 
               <br class="clearBoth">


### PR DESCRIPTION
If customers file has `declare(strict_types=1);` set, (which I usually add to get a heads-up), opening the customer address book (when there is more than one), triggers this error.
`PHP Fatal error:  Uncaught TypeError: zen_get_customers_address_primary(): Argument #1 ($customer_id) must be of type int, string given, called in D:\GitHub\zencart\admin\customers.php on line 660 and defined in ...zencart\includes\functions\functions_customers.php:44`

So parameter needs to be cast. I also made the comparison strict (to annoy someone).
