### PR TITLE
v158: Correcting PHP warnings when $_GET['manufacturers_id'] is inval…

### DIFF
--- a/includes/modules/pages/index/main_template_vars.php
+++ b/includes/modules/pages/index/main_template_vars.php
@@ -14,9 +14,9 @@ $zco_notifier->notify('NOTIFY_HEADER_START_INDEX_MAIN_TEMPLATE_VARS');
 
 // release manufacturers_id when nothing is there so a blank filter is not setup.
 // this will result in the home page, if used
-if (isset($_GET['manufacturers_id']) && $_GET['manufacturers_id'] <= 0) {
-  unset($_GET['manufacturers_id']);
-  unset($manufacturers_id);
+if (isset($_GET['manufacturers_id']) && (int)$_GET['manufacturers_id'] <= 0) {
+    unset($_GET['manufacturers_id']);
+    $manufacturers_id = '';
 }
 
 // release music_genre_id when nothing is there so a blank filter is not setup.


### PR DESCRIPTION
…id or empty.

Fixes #4933