### PR TITLE
Fix filename LEDs

### DIFF
--- a/admin/downloads_manager.php
+++ b/admin/downloads_manager.php
@@ -179,7 +179,7 @@ if (!empty($action)) {
                   <td><?php echo zen_values_name($products_downloads['options_values_id']); ?></td>
                   <td>
                     <div class="fa-stack fa-fw">
-                      <i class="fa fa-circle fa-stack-1x<?php echo (!zen_orders_products_downloads($products_downloads['products_attributes_filename']) ? ' txt-red' : ' txt-lime'); ?>;"></i>
+                      <i class="fa fa-circle fa-stack-1x<?php echo (!zen_orders_products_downloads($products_downloads['products_attributes_filename']) ? ' txt-red' : ' txt-lime'); ?>"></i>
                       <i class="fa fa-circle-o fa-stack-1x txt-black"></i>
                     </div>
                     <?php echo $products_downloads['products_attributes_filename']; ?></td>


### PR DESCRIPTION
Typo in class - stray semicolon.   

Before: 
<img width="800" alt="orig_dl_mgr" src="https://user-images.githubusercontent.com/4391638/176942612-9af9cd70-1518-4326-b4fe-d7878a0b79a5.png">

After: 
<img width="800" alt="new_dl_manager" src="https://user-images.githubusercontent.com/4391638/176942657-41f410e1-7a0d-4a5c-b36d-3863efdbcb26.png">


