### PR TITLE
admin, collect_info: handle $pInfo->products_name as array or string

### DIFF
--- a/admin/includes/modules/product/collect_info.php
+++ b/admin/includes/modules/product/collect_info.php
@@ -354,7 +354,7 @@ if (zen_get_categories_status($current_category_id) == 0 && $pInfo->products_sta
     if (!empty($pInfo->products_image)) { ?>
         <div class="form-group">
             <div class="col-sm-offset-3 col-sm-9 col-md-6">
-                <?php echo zen_info_image($pInfo->products_image, $pInfo->products_name); ?>
+                <?php echo zen_info_image($pInfo->products_image, (is_array($pInfo->products_name) ? $pInfo->products_name[$_SESSION['languages_id']] : $pInfo->products_name)); ?>
                 <br>
                 <?php echo $pInfo->products_image; ?>
             </div>


### PR DESCRIPTION
Fix for problem 

> PHP Fatal error: Uncaught TypeError: strtr(): Argument https://github.com/zencart/zencart/pull/1 ($string) must be of type string, array given

as reported here: 
https://github.com/zencart/zencart/issues/4946
