### PR TITLE
Fix zen_get_orders_comments and calls to it

### DIFF
--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -700,14 +700,10 @@ function zen_geo_zones_pull_down_coupon($parameters, $selected = '')
 }
 
 /**
- * @TODO - refactor associated code
- * @deprecated -- consider using $order->getStatusHistory() instead
  * get first customer comment record for an order (usually contains their special instructions)
  */
 function zen_get_orders_comments($orders_id)
 {
-//    trigger_error('Call to deprecated function zen_get_orders_comments. Use order->getStatusHistory instead', E_USER_DEPRECATED);
-
     global $db;
     $orders_comments_query = "SELECT osh.comments
                               FROM " . TABLE_ORDERS_STATUS_HISTORY . " osh

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -1358,8 +1358,16 @@ if (!empty($action) && $order_exists === true) {
 <?php } ?>
                 <td class="dataTableContent text-center"><?php echo zen_datetime_short($orders->fields['date_purchased']); ?></td>
                 <td class="dataTableContent text-right"><?php echo ($orders->fields['orders_status_name'] !== '' ? $orders->fields['orders_status_name'] : TEXT_INVALID_ORDER_STATUS); ?></td>
-                <?php $order_comments = zen_output_string_protected(zen_get_orders_comments($orders->fields['orders_id'])); ?>
-                <td class="dataTableContent text-center"<?php if (!empty($order_comments)) echo ' title="' . $order_comments . '"'; ?>><?php if (!empty($order_comments)) echo zen_image(DIR_WS_IMAGES . 'icon_yellow_on.gif', '', 16, 16); ?></td>
+                <?php 
+                   $order_comments = zen_output_string_protected(zen_get_orders_comments($orders->fields['orders_id'])); 
+                   if (!empty($order_comments)) { 
+                      echo '<td class="dataTableContent text-center" title="' . $order_comments . '">'; 
+                      echo zen_image(DIR_WS_IMAGES . 'icon_yellow_on.gif', '', 16, 16); 
+                      echo '</td>'; 
+                   } else {
+                     echo '<td class="dataTableContent text-center"></td>'; 
+                   }
+                ?>
 <?php
   // -----
   // A watching observer can provide an associative array in the form:


### PR DESCRIPTION
This function should not have been deprecated; it's much faster than calling getStatusHistory.
References to the return value need to be simplified for readability.