### PR TITLE
v158: Move page-specific language-loading to `require_languages.php`

### DIFF
--- a/includes/classes/ResourceLoaders/LanguageLoader.php
+++ b/includes/classes/ResourceLoaders/LanguageLoader.php
@@ -55,6 +55,19 @@ class LanguageLoader
         return true; 
     }
 
+    /**
+     * Used on the catalog-side to set the current page for the language-load, since it's not necessarily
+     * available during the autoload process (e.g. for AJAX handlers).
+     *
+     * @param string $currentPage
+     * @return void
+     */
+    public function setCurrentPage($currentPage)
+    {
+        $this->arrayLoader->currentPage = $currentPage;
+        $this->fileLoader->currentPage = $currentPage;
+    }
+
     public function loadLanguageForView()
     {
         $this->arrayLoader->loadLanguageForView();

--- a/includes/modules/require_languages.php
+++ b/includes/modules/require_languages.php
@@ -1,14 +1,14 @@
 <?php
 /**
- * loads template specific language override files
+ * loads template- and page-specific language override files
  *
  * @copyright Copyright 2003-2020 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: Scott C Wilson 2019 Jul 23 Modified in v1.5.7 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
-  die('Illegal Access');
+    die('Illegal Access');
 }
 
+$languageLoader->setCurrentPage($current_page);
 $languageLoader->loadLanguageForView();
-


### PR DESCRIPTION
... to correct missing constant errors for AJAX-loaded language constants.

Fixes #4983.