### PR TITLE
emailed_to length in coupon_email_track table

### DIFF
--- a/zc_install/sql/install/mysql_zencart.sql
+++ b/zc_install/sql/install/mysql_zencart.sql
@@ -431,7 +431,7 @@ CREATE TABLE coupon_email_track (
   customer_id_sent int(11) NOT NULL default '0',
   sent_firstname varchar(32) default NULL,
   sent_lastname varchar(32) default NULL,
-  emailed_to varchar(32) default NULL,
+  emailed_to varchar(96) default NULL,
   date_sent datetime NOT NULL default '0001-01-01 00:00:00',
   PRIMARY KEY  (unique_id),
   KEY idx_coupon_id_zen (coupon_id)

--- a/zc_install/sql/updates/mysql_upgrade_zencart_158.sql
+++ b/zc_install/sql/updates/mysql_upgrade_zencart_158.sql
@@ -48,6 +48,8 @@ ALTER TABLE orders MODIFY delivery_country varchar(64) NOT NULL default '';
 ALTER TABLE orders MODIFY billing_country varchar(64) NOT NULL default '';
 
 ALTER TABLE products_options ADD products_options_comment_position smallint(2) NOT NULL default '0' AFTER products_options_comment;
+
+ALTER TABLE coupon_email_track MODIFY emailed_to varchar(96) default NULL;
 # Remove greater-than sign in query_builder
 UPDATE query_builder SET query_name = 'Customers Dormant for 3+ months (Subscribers)' WHERE query_id = 3;
 


### PR DESCRIPTION
Increase length to varchar(96) to be consistent with other zen cart
email address fields.

fixes #5004 