### PR TITLE
Refactor T&C

### DIFF
--- a/includes/classes/ajax/zcAjaxPayment.php
+++ b/includes/classes/ajax/zcAjaxPayment.php
@@ -73,9 +73,7 @@ class zcAjaxPayment extends base
     $_SESSION['comments'] = $_POST['comments'];
 
     if (DISPLAY_CONDITIONS_ON_CHECKOUT=='true') {
-      if (!isset ($_POST['conditions'])||($_POST['conditions']!='1')) {
-        $messageStack->add_session ('checkout_payment', ERROR_CONDITIONS_NOT_ACCEPTED, 'error');
-      }
+        $_SESSION['conditions'] = $_POST['conditions'] ?? NULL;
     }
     // load the selected payment module
     require (DIR_WS_CLASSES.'payment.php');

--- a/includes/languages/lang.english.php
+++ b/includes/languages/lang.english.php
@@ -168,7 +168,7 @@ $define = [
     'ENTRY_TELEPHONE_NUMBER_TEXT' => '*',
     'ERROR_AT_LEAST_ONE_INPUT' => 'At least one of the fields in the search form must be entered.',
     'ERROR_CART_UPDATE' => '<strong>Please update your order.</strong> ',
-    'ERROR_CONDITIONS_NOT_ACCEPTED' => 'Please confirm the terms and conditions bound to this order by ticking the box below.',
+    'ERROR_CONDITIONS_NOT_ACCEPTED' => 'Please confirm you have read and agree to the terms and conditions bound to this order by ticking this box.',
     'ERROR_CORRECTIONS_HEADING' => 'Please correct the following: <br>',
     'ERROR_CUSTOMERS_ID_INVALID' => 'Customer information cannot be validated!<br>Please login or recreate your account ...',
     'ERROR_DATABASE_MAINTENANCE_NEEDED' => '<a href="https://docs.zen-cart.com/user/troubleshooting/error_71_maintenance_required/" rel="noopener" target="_blank">ERROR 0071 There appears to be a problem with the database. Maintenance is required.</a>',

--- a/includes/modules/pages/checkout_confirmation/header_php.php
+++ b/includes/modules/pages/checkout_confirmation/header_php.php
@@ -53,9 +53,7 @@ $_SESSION['comments'] = !empty($_POST['comments']) ? $_POST['comments'] : '';
 
 
 if (DISPLAY_CONDITIONS_ON_CHECKOUT == 'true') {
-  if (!isset($_POST['conditions']) || ($_POST['conditions'] != '1')) {
-    $messageStack->add_session('checkout_payment', ERROR_CONDITIONS_NOT_ACCEPTED, 'error');
-  }
+    $_SESSION['conditions'] = $_POST['conditions'] ?? NULL;
 }
 //echo $messageStack->size('checkout_payment');
 

--- a/includes/modules/pages/checkout_payment/jscript_main.php
+++ b/includes/modules/pages/checkout_payment/jscript_main.php
@@ -22,23 +22,5 @@ function submitFunction($gv,$total) {
     submitter = 1;
   }
 }
-function tAndCChange() {
-// function to disable continue if T&C present and not checked.
-  var conditionsElement = document.getElementById('conditions');
-  var paymentSubmitInputs = document.getElementById('paymentSubmit').getElementsByTagName('input'), i=0, e;
-  if(typeof(conditionsElement) != 'undefined' && conditionsElement != null){
-    while(e=paymentSubmitInputs[i++]){
-      e.disabled = ! conditionsElement.checked;
-    }
-  }
-}
-// Add listeners to initially disable the continue button and to reset when T&C changed
-document.addEventListener('DOMContentLoaded',  function () {
-  var conditionsElement = document.getElementById("conditions");
-  if(typeof(conditionsElement) != 'undefined' && conditionsElement != null){
-    conditionsElement.addEventListener('change', tAndCChange);
-    tAndCChange();
-  }
-});
 
 </script>

--- a/includes/templates/responsive_classic/css/stylesheet_colors.css
+++ b/includes/templates/responsive_classic/css/stylesheet_colors.css
@@ -61,7 +61,6 @@ span.cssButton.normal_button.button.button_logoff, span.cssButton.normal_button.
 #docGeneralDisplay #pinfo-right, #popupShippingEstimator, #popupSearchHelp, #popupAdditionalImage, #popupImage, #popupCVVHelp, #popupCouponHelp, #popupAtrribsQuantityPricesHelp, #infoShoppingCart{background:none;}
 #navMain ul li a.navCartContentsIndicator:hover {color: #db3a00;background: #FFFFFF;font-weight: bold;}
 #navMain ul li a.navCartContentsIndicator {color: #000000;background: #ff662e;font-weight: bold;}
-input.submit_button:disabled, input.submit_button:disabled:hover, input.cssButtonHover:disabled{background:#808080;}
 
 /*bof border colors*/
 HR {border-bottom:1px solid #9a9a9a;}

--- a/includes/templates/template_default/css/stylesheet_css_buttons.css
+++ b/includes/templates/template_default/css/stylesheet_css_buttons.css
@@ -37,4 +37,3 @@ span.normal_button {
 span.normal_button:hover {
   background-color:#b4bc8b;  /* Hover color for link-related buttons */
 }
-input.submit_button:disabled, input.submit_button:disabled:hover, input.cssButtonHover:disabled{background:#808080;} /* Button disabled color */

--- a/includes/templates/template_default/templates/tpl_checkout_payment_default.php
+++ b/includes/templates/template_default/templates/tpl_checkout_payment_default.php
@@ -196,7 +196,7 @@
 <fieldset>
 <legend><?php echo TABLE_HEADING_CONDITIONS; ?></legend>
 <div><?php echo TEXT_CONDITIONS_DESCRIPTION;?></div>
-<?php echo  zen_draw_checkbox_field('conditions', '1', false, 'id="conditions"');?>
+<?php echo  zen_draw_checkbox_field('conditions', '1', (isset($_SESSION['conditions']) && ($_SESSION['conditions'] === '1')), 'id="conditions" required  oninput="this.setCustomValidity(\'\')" oninvalid="this.setCustomValidity(\'' . ERROR_CONDITIONS_NOT_ACCEPTED . '\')"');?>
 <label class="checkboxLabel" for="conditions"><?php echo TEXT_CONDITIONS_CONFIRM; ?></label>
 </fieldset>
 <?php


### PR DESCRIPTION
Reworked terms and conditions to make a required field and sticky.
Changed error message to be relevent to new working.
Removed javascript and css changes from PR #4833 
Fixes #2344

I have reworked this to use required. There is still some javascript to issue the custom error message and reset the message on input. 
I have tested it on 1.5.8 and php 8.0.
I have tested with coupons and gift vouchers.

You now have to agree to the terms and conditions prior to clicking the continue button for any action. If the action requires you to return to the checkout_payment page, the status of T&C is remembered. If you leave the page and return later, the T&C status is remembered for the session.

Don't know what the implications are for OPC or Checkout as guest.