### PR TITLE
Remove check for empty tags

### DIFF
--- a/admin/categories.php
+++ b/admin/categories.php
@@ -141,10 +141,9 @@ if (!empty($action)) {
         $categories_description_array = $_POST['categories_description'];
         $language_id = $languages[$i]['id'];
 
-        // clean $categories_description of empty tags
         $sql_data_array = [
           'categories_name' => zen_db_prepare_input($categories_name_array[$language_id]),
-          'categories_description' => empty(trim(strip_tags($categories_description_array[$language_id]))) ? '' : zen_db_prepare_input($categories_description_array[$language_id])
+          'categories_description' => zen_db_prepare_input($categories_description_array[$language_id]),
         ];
 
         if ($action === 'insert_category') {


### PR DESCRIPTION
This will empty out a category description if tags were improperly entered. 

This issue will only show up if CKEditor is not used when editing the category page.  CKEditor will correct improper tags.