### PR TITLE
v158: Correcting spam detection on `contact_us` page

### DIFF
--- a/includes/classes/observers/auto.non_captcha_observer.php
+++ b/includes/classes/observers/auto.non_captcha_observer.php
@@ -39,7 +39,7 @@ class zcObserverNonCaptchaObserver extends base
     public function updateNotifyContactUsCaptchaCheck(&$class, $eventID, $paramsArray)
     {
         // sanitize the contact-us name field more aggressively
-        $GLOBALS['name'] = zen_db_prepare_input(zen_sanitize_string($_POST['contactname']));
+        $GLOBALS['name'] = zen_db_prepare_input(zen_sanitize_string($_POST['contactname'] ?? ''));
 
         // fire default tests
         $this->update($class, $eventID, $paramsArray);
@@ -71,7 +71,7 @@ class zcObserverNonCaptchaObserver extends base
         // Simple regex to identify presence of an (unwanted) URL
         $regexPattern = '~(https?|ftps?):/~';
 
-        $fields = array(
+        $fields = [
             'firstname',
             'lastname',
             'contactname',
@@ -91,7 +91,7 @@ class zcObserverNonCaptchaObserver extends base
             'passwordhintA',
             'review_text', // comment-out if you actually want to allow URLs for this
             'enquiry',     // comment-out if you actually want to allow URLs for this
-        );
+        ];
 
         // prepare for inspection
         foreach ($fields as $field) {
@@ -110,4 +110,3 @@ class zcObserverNonCaptchaObserver extends base
         }
     }
 }
-


### PR DESCRIPTION
Fixes #4987

Changes were required to both the `contact_us` page's header and the SPAM observer class.  The page-header has also been updated to 'not collect' customer information for the page's display when guest-checkout is active, using exactly-equal-to where relevant and removing a redundant `elseif` clause.