### PR TITLE
v158: Removing FILTER_SANITIZE_STRING use during zc_install

### DIFF
--- a/zc_install/ajaxValidateAdminCredentials.php
+++ b/zc_install/ajaxValidateAdminCredentials.php
@@ -10,19 +10,18 @@ define('IS_ADMIN_FLAG', false);
 define('DIR_FS_INSTALL', __DIR__ . '/');
 define('DIR_FS_ROOT', realpath(__DIR__ . '/../') . '/');
 
-require(DIR_FS_INSTALL . 'includes/application_top.php');
+require DIR_FS_INSTALL . 'includes/application_top.php';
 
-$error          = FALSE;
-$postParams     = filter_input_array(INPUT_POST, FILTER_SANITIZE_STRING);
-$systemChecker  = new systemChecker();
+$error = false;
+$systemChecker = new systemChecker();
 $adminCandidate = $systemChecker->validateAdminCredentials(
-  trim($postParams['admin_user']),
-  trim($postParams['admin_password'])
+    trim(stripslashes($_POST['admin_user'])),
+    trim(stripslashes($_POST['admin_password']))
 );
 
 if (!is_int($adminCandidate)) {
-  $error = !$adminCandidate;
-  $adminCandidate = '';
+    $error = !$adminCandidate;
+    $adminCandidate = '';
 }
 
 echo json_encode(compact('error', 'adminCandidate'));


### PR DESCRIPTION
Partial correction for #4449

Noting that (as with zc157) a password mismatch will be indicated on an upgrade from zc155/zc156 (or unsuffixed zc157) if the upgrading admin's password contains one or more 'htmlspecialchars': `&<>"`.