### PR TITLE
v158: `??=` not introduced until PHP 7.4

### DIFF
--- a/includes/templates/template_default/templates/tpl_gv_send_default.php
+++ b/includes/templates/template_default/templates/tpl_gv_send_default.php
@@ -17,7 +17,7 @@
 <?php
 $action = $_GET['action'] ?? '';
 $to_name = (isset($_POST['to_name'])) ? zen_output_string_protected($_POST['to_name']) : '';
-$error ??= false;
+$error = $error ?? false;
 if ($gv_result->fields['amount'] > 0 && $action === 'doneprocess') {
 ?>
         <p><?php echo TEXT_SEND_ANOTHER; ?></p>


### PR DESCRIPTION
Change to use `$error = $error ?? false;` instead of `$error ??= false`.