### PR TITLE
z158 fix: All Products listings extra/missing brackets

### DIFF
--- a/includes/templates/responsive_classic/templates/tpl_modules_products_all_listing.php
+++ b/includes/templates/responsive_classic/templates/tpl_modules_products_all_listing.php
@@ -82,7 +82,7 @@
 // more info in place of buy now
       if (PRODUCT_ALL_BUY_NOW != '0' and zen_get_products_allow_add_to_cart($products_all->fields['products_id']) == 'Y') {
         if (zen_has_product_attributes($products_all->fields['products_id'])) {
-          $link = '<a class="list-more" href="' . zen_href_link(zen_get_info_page($products_all->fields['products_id']), 'cPath=' . zen_get_generated_category_path_rev($products_all->fields['master_categories_id']) . '&products_id=' . $products_all->fields['products_id']) . '" title="' . $products_all->fields['products_id']) . '">' . MORE_INFO_TEXT . '</a>';
+          $link = '<a class="list-more" href="' . zen_href_link(zen_get_info_page($products_all->fields['products_id']), 'cPath=' . zen_get_generated_category_path_rev($products_all->fields['master_categories_id']) . '&products_id=' . $products_all->fields['products_id']) . '" title="' . $products_all->fields['products_id'] . '">' . MORE_INFO_TEXT . '</a>';
         } else {
 //          $link= '<a href="' . zen_href_link(FILENAME_PRODUCTS_ALL, zen_get_all_get_params(array('action')) . 'action=buy_now&products_id=' . $products_all->fields['products_id']) . '">' . zen_image_button(BUTTON_IMAGE_IN_CART, BUTTON_IN_CART_ALT) . '</a>';
           if (PRODUCT_ALL_LISTING_MULTIPLE_ADD_TO_CART > 0 && $products_all->fields['products_qty_box_status'] != 0) {

--- a/includes/templates/template_default/templates/tpl_modules_products_all_listing.php
+++ b/includes/templates/template_default/templates/tpl_modules_products_all_listing.php
@@ -28,7 +28,7 @@
         if ($products_all->fields['products_image'] == '' and PRODUCTS_IMAGE_NO_IMAGE_STATUS == 0) {
           $display_products_image = str_repeat('<br class="clearBoth">', substr(PRODUCT_ALL_LIST_IMAGE, 3, 1));
         } else {
-          $display_products_image = '<a href="' . zen_href_link(zen_get_info_page($products_all->fields['products_id']), 'cPath=' . zen_get_generated_category_path_rev($products_all->fields['master_categories_id']) . '&products_id=' . $products_all->fields['products_id'] . '">' . zen_image(DIR_WS_IMAGES . $products_all->fields['products_image'], $products_all->fields['products_name'], IMAGE_PRODUCT_ALL_LISTING_WIDTH, IMAGE_PRODUCT_ALL_LISTING_HEIGHT) . '</a>' . str_repeat('<br class="clearBoth">', substr(PRODUCT_ALL_LIST_IMAGE, 3, 1));
+          $display_products_image = '<a href="' . zen_href_link(zen_get_info_page($products_all->fields['products_id']), 'cPath=' . zen_get_generated_category_path_rev($products_all->fields['master_categories_id']) . '&products_id=' . $products_all->fields['products_id']) . '">' . zen_image(DIR_WS_IMAGES . $products_all->fields['products_image'], $products_all->fields['products_name'], IMAGE_PRODUCT_ALL_LISTING_WIDTH, IMAGE_PRODUCT_ALL_LISTING_HEIGHT) . '</a>' . str_repeat('<br class="clearBoth">', substr(PRODUCT_ALL_LIST_IMAGE, 3, 1));
         }
       } else {
         $display_products_image = '';


### PR DESCRIPTION
as seen when viewing All Products

> [03-Aug-2022 14:28:53 UTC] PHP Parse error:  Unclosed '{' on line 84 does not match ')' in zencart\includes\templates\responsive_classic\templates\tpl_modules_products_all_listing.php on line 85
> [03-Aug-2022 14:28:53 UTC] Request URI: /zencart/index.php?main_page=products_all, IP address: 127.0.0.1
> --> PHP Parse error: Unclosed '{' on line 84 does not match ')' in zencart\includes\templates\responsive_classic\templates\tpl_modules_products_all_listing.php on line 85.
