### PR TITLE
Make admin HTML5 compliant

### DIFF
--- a/admin/admin_page_registration.php
+++ b/admin/admin_page_registration.php
@@ -108,47 +108,47 @@ foreach ($menu_titles as $id => $title) {
       <h1><?php echo HEADING_TITLE ?></h1>
       <?php echo zen_draw_form('admin_page_registration_form', FILENAME_ADMIN_PAGE_REGISTRATION, 'action=insert', 'post', 'class="form-horizontal" id="adminPageRegistrationForm"'); ?>
       <div class="form-group">
-          <?php echo zen_draw_label(TEXT_PAGE_KEY, 'page_key', 'class="col-sm-3 control-label"'); ?>
+          <?php echo zen_draw_label(TEXT_PAGE_KEY, 'pageKey', 'class="col-sm-3 control-label"'); ?>
         <div class="col-sm-9 col-md-6">
             <?php echo zen_draw_input_field('page_key', $page_key, 'class="form-control" id="pageKey" required autofocus'); ?>
           <span class="help-block"><?php echo TEXT_EXAMPLE_PAGE_KEY ?></span>
         </div>
       </div>
       <div class="form-group">
-          <?php echo zen_draw_label(TEXT_LANGUAGE_KEY, 'language_key', 'class="col-sm-3 control-label"'); ?>
+          <?php echo zen_draw_label(TEXT_LANGUAGE_KEY, 'languageKey', 'class="col-sm-3 control-label"'); ?>
         <div class="col-sm-9 col-md-6">
             <?php echo zen_draw_input_field('language_key', $language_key, 'class="form-control" id="languageKey" required'); ?>
           <span class="help-block"><?php echo TEXT_EXAMPLE_LANGUAGE_KEY ?></span>
         </div>
       </div>
       <div class="form-group">
-          <?php echo zen_draw_label(TEXT_MAIN_PAGE, 'main_page', 'class="col-sm-3 control-label"'); ?>
+          <?php echo zen_draw_label(TEXT_MAIN_PAGE, 'mainPage', 'class="col-sm-3 control-label"'); ?>
         <div class="col-sm-9 col-md-6">
             <?php echo zen_draw_input_field('main_page', $main_page, 'class="form-control" id="mainPage" required'); ?>
           <span class="help-block"><?php echo TEXT_EXAMPLE_MAIN_PAGE ?></span>
         </div>
       </div>
       <div class="form-group">
-          <?php echo zen_draw_label(TEXT_PAGE_PARAMS, 'page_params', 'class="col-sm-3 control-label"'); ?>
+          <?php echo zen_draw_label(TEXT_PAGE_PARAMS, 'pageParams', 'class="col-sm-3 control-label"'); ?>
         <div class="col-sm-9 col-md-6">
             <?php echo zen_draw_input_field('page_params', $page_params, 'class="form-control" id="pageParams"'); ?>
           <span class="help-block"><?php echo TEXT_EXAMPLE_PAGE_PARAMS ?></span>
         </div>
       </div>
       <div class="form-group">
-          <?php echo zen_draw_label(TEXT_MENU_KEY, 'menu_key', 'class="col-sm-3 control-label"'); ?>
+          <?php echo zen_draw_label(TEXT_MENU_KEY, 'menuKey', 'class="col-sm-3 control-label"'); ?>
         <div class="col-sm-9 col-md-6">
             <?php echo zen_draw_pull_down_menu('menu_key', $menu_options, $menu_key, 'class="form-control" id="menuKey" required'); ?>
         </div>
       </div>
       <div class="form-group">
-          <?php echo zen_draw_label(TEXT_DISPLAY_ON_MENU, 'display_on_menu', 'class="col-sm-3 control-label"'); ?>
+          <?php echo zen_draw_label(TEXT_DISPLAY_ON_MENU, 'displayOnMenu', 'class="col-sm-3 control-label"'); ?>
         <div class="col-sm-9 col-md-6">
           <input type="checkbox" name="display_on_menu" id="displayOnMenu" <?php echo $checked ?>>
         </div>
       </div>
       <div class="form-group">
-          <?php echo zen_draw_label(TEXT_SORT_ORDER, 'sort_order', 'class="col-sm-3 control-label"'); ?>
+          <?php echo zen_draw_label(TEXT_SORT_ORDER, 'sortOrder', 'class="col-sm-3 control-label"'); ?>
         <div class="col-sm-3 col-md-1">
             <?php echo zen_draw_input_field('sort_order', $sort_order, 'class="form-control" id="sortOrder" required', false, 'number'); ?>
         </div>

--- a/admin/banner_manager.php
+++ b/admin/banner_manager.php
@@ -399,7 +399,7 @@ if (!empty($action)) {
           <div class="form-group">
             <?php echo zen_draw_label(TEXT_BANNERS_HTML_TEXT, 'banners_html_text', 'class="col-sm-3 control-label"'); ?>
             <div class="col-sm-9 col-md-6">
-              <?php echo '<p>' . TEXT_BANNERS_HTML_TEXT_INFO . '</p>' . zen_draw_textarea_field('banners_html_text', 'soft', '80', '10', htmlspecialchars($bInfo->banners_html_text, ENT_COMPAT, CHARSET, TRUE), 'class="editorHook form-control" id="banners_htm_text"'); ?>
+              <?php echo '<p>' . TEXT_BANNERS_HTML_TEXT_INFO . '</p>' . zen_draw_textarea_field('banners_html_text', 'soft', '80', '10', htmlspecialchars($bInfo->banners_html_text, ENT_COMPAT, CHARSET, TRUE), 'class="editorHook form-control" id="banners_html_text"'); ?>
             </div>
           </div>
           <div class="form-group">
@@ -456,7 +456,7 @@ if (!empty($action)) {
         ?>
         <div class="row">
           <div class="col-xs-12 col-sm-12 col-md-9 col-lg-9 configurationColumnLeft">
-            <table class="table table-hover table-striped">
+            <table class="table table-hover table-striped" role="listbox">
               <thead>
                 <tr class="dataTableHeadingRow">
                   <th class="dataTableHeadingContent"><?php echo TABLE_HEADING_BANNERS; ?></th>
@@ -511,11 +511,11 @@ if (!empty($action)) {
 
                   if (isset($bInfo) && is_object($bInfo) && ($banner['banners_id'] == $bInfo->banners_id)) {
                     ?>
-                    <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href = '<?php echo zen_href_link(FILENAME_BANNER_MANAGER, 'page=' . $_GET['page'] . '&bID=' . $bInfo->banners_id . '&action=new'); ?>'" role="button">
+                    <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href = '<?php echo zen_href_link(FILENAME_BANNER_MANAGER, 'page=' . $_GET['page'] . '&bID=' . $bInfo->banners_id . '&action=new'); ?>'" role="option" aria-selected="true">
                       <?php
                     } else {
                       ?>
-                    <tr class="dataTableRow" onclick="document.location.href = '<?php echo zen_href_link(FILENAME_BANNER_MANAGER, 'page=' . $_GET['page'] . '&bID=' . $banner['banners_id']); ?>'" role="button">
+                    <tr class="dataTableRow" onclick="document.location.href = '<?php echo zen_href_link(FILENAME_BANNER_MANAGER, 'page=' . $_GET['page'] . '&bID=' . $banner['banners_id']); ?>'" role="option" aria-selected="false">
                       <?php
                     }
                     ?>

--- a/admin/configuration.php
+++ b/admin/configuration.php
@@ -104,7 +104,7 @@ if ($gID == 7) {
       <div class="row">
         <div class="col-xs-12 col-sm-12 col-md-9 col-lg-9 configurationColumnLeft">
 
-          <table class="table table-hover">
+          <table class="table table-hover" role="listbox">
             <thead>
               <tr class="dataTableHeadingRow">
                 <th class="dataTableHeadingContent"><?php echo TABLE_HEADING_CONFIGURATION_TITLE; ?></th>
@@ -157,9 +157,9 @@ if ($gID == 7) {
                   }
 
                   if ((isset($cInfo) && is_object($cInfo)) && ($item['configuration_id'] == $cInfo->configuration_id)) {
-                    echo '                  <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href=\'' . zen_href_link(FILENAME_CONFIGURATION, 'gID=' . $_GET['gID'] . '&cID=' . $cInfo->configuration_id . '&action=edit') . '\'" role="button">' . "\n";
+                    echo '                  <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href=\'' . zen_href_link(FILENAME_CONFIGURATION, 'gID=' . $_GET['gID'] . '&cID=' . $cInfo->configuration_id . '&action=edit') . '\'" role="option" aria-selected="true">' . "\n";
                   } else {
-                    echo '                  <tr class="dataTableRow" onclick="document.location.href=\'' . zen_href_link(FILENAME_CONFIGURATION, 'gID=' . $_GET['gID'] . '&cID=' . $item['configuration_id'] . '&action=edit') . '\'" role="button">' . "\n";
+                    echo '                  <tr class="dataTableRow" onclick="document.location.href=\'' . zen_href_link(FILENAME_CONFIGURATION, 'gID=' . $_GET['gID'] . '&cID=' . $item['configuration_id'] . '&action=edit') . '\'" role="option" aria-selected="false">' . "\n";
                   }
                   ?>
                   <?php
@@ -189,7 +189,7 @@ if ($gID == 7) {
                   if ((isset($cInfo) && is_object($cInfo)) && ($item['configuration_id'] == $cInfo->configuration_id)) {
                     echo zen_image(DIR_WS_IMAGES . 'icon_arrow_right.gif', '');
                   } else {
-                    echo '<a href="' . zen_href_link(FILENAME_CONFIGURATION, 'gID=' . $_GET['gID'] . '&cID=' . $item['configuration_id']) . '" name="link_' . $item['configuration_key'] . '">' . zen_image(DIR_WS_IMAGES . 'icon_info.gif', IMAGE_ICON_INFO) . '</a>';
+                      echo  '<a href="' . zen_href_link(FILENAME_CONFIGURATION, 'gID=' . $_GET['gID'] . '&cID=' . $item['configuration_id']) . '" id="link_' . $item['configuration_key'] . '">' . zen_image(DIR_WS_IMAGES . 'icon_info.gif', IMAGE_ICON_INFO) . '</a>';
                   }
                   ?>&nbsp;</td>
               </tr>

--- a/admin/countries.php
+++ b/admin/countries.php
@@ -95,10 +95,10 @@ if (!empty($action)) {
       <!-- body_text //-->
       <div class="row">
         <div class="col-xs-12 col-sm-12 col-md-9 col-lg-9 configurationColumnLeft">
-          <table class="table table-hover">
+          <table class="table table-hover" role="listbox">
             <thead>
               <tr class="dataTableHeadingRow">
-                <th class="dataTableHeadingContent" width="50%"><?php echo TABLE_HEADING_COUNTRY_NAME; ?></th>
+                <th class="dataTableHeadingContent col-sm-6"><?php echo TABLE_HEADING_COUNTRY_NAME; ?></th>
                 <th class="dataTableHeadingContent text-center" colspan="2"><?php echo TABLE_HEADING_COUNTRY_CODES; ?></th>
                 <th class="dataTableHeadingContent text-center"><?php echo TABLE_HEADING_COUNTRY_STATUS; ?></th>
                 <th class="dataTableHeadingContent text-right"><?php echo TABLE_HEADING_ACTION; ?></th>
@@ -118,11 +118,11 @@ if (!empty($action)) {
 
                 if (isset($cInfo) && is_object($cInfo) && ($country['countries_id'] == $cInfo->countries_id)) {
                   ?>
-                  <tr id="defaultSelected" class="dataTableRowSelected" onclick = "document.location.href = '<?php echo zen_href_link(FILENAME_COUNTRIES, 'page=' . $_GET['page'] . '&cID=' . $cInfo->countries_id . '&action=edit'); ?>'" role="button">
+                  <tr id="defaultSelected" class="dataTableRowSelected" onclick = "document.location.href = '<?php echo zen_href_link(FILENAME_COUNTRIES, 'page=' . $_GET['page'] . '&cID=' . $cInfo->countries_id . '&action=edit'); ?>'" role="option" aria-selected="true">
                   <?php } else { ?>
-                  <tr class="dataTableRow country-listing-row" onclick="document.location.href = '<?php echo zen_href_link(FILENAME_COUNTRIES, zen_get_all_get_params(array('cID', 'action')) . 'cID=' . $country['countries_id']); ?>'" data-cid="<?php echo $country['countries_id']; ?>">
+                  <tr class="dataTableRow country-listing-row" onclick="document.location.href = '<?php echo zen_href_link(FILENAME_COUNTRIES, zen_get_all_get_params(array('cID', 'action')) . 'cID=' . $country['countries_id']); ?>'" data-cid="<?php echo $country['countries_id']; ?>" aria-selected="false">
                   <?php } ?>
-                  <td class="dataTableContent" width="50%"><?php echo zen_output_string_protected($country['countries_name']); ?></td>
+                  <td class="dataTableContent col-sm-6"><?php echo zen_output_string_protected($country['countries_name']); ?></td>
                   <td class="dataTableContent text-center"><?php echo $country['countries_iso_code_2']; ?></td>
                   <td class="dataTableContent text-center"><?php echo $country['countries_iso_code_3']; ?></td>
                   <td class="dataTableContent text-center dataTableButtonCell">

--- a/admin/coupon_admin.php
+++ b/admin/coupon_admin.php
@@ -550,7 +550,7 @@ switch ($_GET['action']) {
                       <td class="dataTableContent text-right">
                         <?php
                         if ((isset($cInfo)) && ($item['unique_id'] == $cInfo->unique_id)) {
-                          echo '<i class="fa fa-caret-right fa-fw fa-2x align-middle">';
+                          echo '<i class="fa fa-caret-right fa-fw fa-2x align-middle"></i>';
                         } else {
                           echo '<a href="' . zen_href_link(FILENAME_COUPON_ADMIN, 'reports_page=' . $_GET['reports_page'] . '&cid=' . $item['coupon_id']) . '"><i class="fa fa-info-circle fa-fw fa-2x align-middle"></i></a>';
                         }
@@ -623,7 +623,7 @@ switch ($_GET['action']) {
                   $cc_list = $db->Execute($cc_query_raw);
 
                   foreach ($cc_list as $item) {
-                    if (((!$_GET['uid']) || (@$_GET['uid'] == $item['unique_id'])) && (!$cInfo)) {
+                    if ((empty($_GET['uid']) || ($_GET['uid'] == $item['unique_id'])) && (empty($cInfo))) {
                       $cInfo = new objectInfo($item);
                     }
                     if ((isset($cInfo)) && ($item['unique_id'] == $cInfo->unique_id)) {
@@ -646,7 +646,7 @@ switch ($_GET['action']) {
                       <td class="dataTableContent text-right">
                         <?php
                         if ((isset($cInfo)) && ($item['unique_id'] == $cInfo->unique_id)) {
-                          echo '<i class="fa fa-caret-right fa-fw fa-2x align-middle">';
+                          echo '<i class="fa fa-caret-right fa-fw fa-2x align-middle"></i>';
                         } else {
                           echo '<a href="' . zen_href_link(FILENAME_COUPON_ADMIN, 'reports_page=' . $_GET['reports_page'] . '&cid=' . $item['coupon_id']) . '"><i class="fa fa-info-circle fa-fw fa-2x align-middle"></i></a>';
                         }
@@ -701,7 +701,7 @@ switch ($_GET['action']) {
             ?>
             <table class="table">
               <tr>
-                <td width="25%" class="text-right"><b><?php echo TEXT_CUSTOMER; ?></b></td>
+                <td class="col-sm-3 text-right"><b><?php echo TEXT_CUSTOMER; ?></b></td>
                 <td><?php echo $mail_sent_to; ?></td>
               </tr>
               <tr>
@@ -724,7 +724,7 @@ switch ($_GET['action']) {
               <?php } ?>
               <tr>
                 <td class="text-right"><b><?php echo TEXT_MESSAGE; ?></b></td>
-                <td><tt><?php echo nl2br(htmlspecialchars(stripslashes($_POST['message']), ENT_COMPAT, CHARSET, TRUE)); ?></tt></td>
+                <td><span class="tt"><?php echo nl2br(htmlspecialchars(stripslashes($_POST['message']), ENT_COMPAT, CHARSET, TRUE)); ?></span></td>
               </tr>
               <tr>
                 <td>
@@ -783,7 +783,7 @@ switch ($_GET['action']) {
             <?php if (EMAIL_USE_HTML == 'true') { ?>
               <div class="form-group">
                 <?php echo zen_draw_label(TEXT_RICH_TEXT_MESSAGE, 'message_html', 'class="control-label col-sm-3"'); ?>
-                <div class="col-sm-9 col-md-6"><?php echo zen_draw_textarea_field('message_html', 'soft', '100%', '25', htmlspecialchars(empty($_POST['message_html']) ? TEXT_COUPON_ANNOUNCE : stripslashes($_POST['message_html']), ENT_COMPAT, CHARSET, TRUE), 'id="message_html" class="editorHook form-control" id="message_html"'); ?></div>
+                <div class="col-sm-9 col-md-6"><?php echo zen_draw_textarea_field('message_html', 'soft', '100%', '25', htmlspecialchars(empty($_POST['message_html']) ? TEXT_COUPON_ANNOUNCE : stripslashes($_POST['message_html']), ENT_COMPAT, CHARSET, TRUE), 'id="message_html" class="editorHook form-control"'); ?></div>
               </div>
             <?php } ?>
             <div class="form-group">
@@ -800,10 +800,31 @@ switch ($_GET['action']) {
             break;
           case 'update_preview':
             echo zen_draw_form('coupon', FILENAME_COUPON_ADMIN, 'action=update_confirm&oldaction=' . $_GET['oldaction'] . '&cid=' . $_GET['cid'] . (isset($_GET['page']) ? '&page=' . $_GET['page'] : ''));
+            for ($i = 0, $n = count($languages); $i < $n; $i++) {
+                $language_id = $languages[$i]['id'];
+                echo zen_draw_hidden_field('coupon_name[' . $languages[$i]['id'] . ']', stripslashes($_POST['coupon_name'][$language_id]));
+                echo zen_draw_hidden_field('coupon_desc[' . $languages[$i]['id'] . ']', stripslashes($_POST['coupon_desc'][$language_id]));
+            }
+            echo zen_draw_hidden_field('coupon_amount', $_POST['coupon_amount']);
+            echo zen_draw_hidden_field('coupon_product_count', (int)$_POST['coupon_product_count']);
+            echo zen_draw_hidden_field('coupon_min_order', $_POST['coupon_min_order']);
+            echo zen_draw_hidden_field('coupon_free_ship', (!empty($_POST['coupon_free_ship']) ? $_POST['coupon_free_ship'] : ''));
+            $c_code = !empty($_POST['coupon_code']) ? $_POST['coupon_code'] : $coupon_code;
+            echo zen_draw_hidden_field('coupon_code', stripslashes($c_code));
+            echo zen_draw_hidden_field('coupon_uses_coupon', $_POST['coupon_uses_coupon']);
+            echo zen_draw_hidden_field('coupon_uses_user', $_POST['coupon_uses_user']);
+            echo zen_draw_hidden_field('coupon_products', (!empty($_POST['coupon_products']) ? $_POST['coupon_products'] : ''));
+            echo zen_draw_hidden_field('coupon_categories', (!empty($_POST['coupon_categories']) ? $_POST['coupon_categories'] : ''));
+            echo zen_draw_hidden_field('coupon_startdate', date('Y-m-d', mktime(0, 0, 0, $_POST['coupon_startdate_month'], $_POST['coupon_startdate_day'], $_POST['coupon_startdate_year'])));
+            echo zen_draw_hidden_field('coupon_finishdate', date('Y-m-d', mktime(0, 0, 0, $_POST['coupon_finishdate_month'], $_POST['coupon_finishdate_day'], $_POST['coupon_finishdate_year'])));
+            echo zen_draw_hidden_field('coupon_zone_restriction', $_POST['coupon_zone_restriction']);
+            echo zen_draw_hidden_field('coupon_order_limit', $_POST['coupon_order_limit']);
+            echo zen_draw_hidden_field('coupon_calc_base', (int)$_POST['coupon_calc_base']);
+            echo zen_draw_hidden_field('coupon_is_valid_for_sales', (int)$_POST['coupon_is_valid_for_sales']);
             ?>
             <table class="table">
               <tr>
-                <td width="25%" class="main"><?php echo COUPON_ZONE_RESTRICTION; ?></td>
+                <td class="main col-sm-3"><?php echo COUPON_ZONE_RESTRICTION; ?></td>
                 <td class="main"><?php echo zen_get_geo_zone_name($_POST['coupon_zone_restriction']); ?>
               </tr>
               <tr>
@@ -876,29 +897,6 @@ switch ($_GET['action']) {
                 <?php $finish_date = date(DATE_FORMAT, mktime(0, 0, 0, $_POST['coupon_finishdate_month'], $_POST['coupon_finishdate_day'], $_POST['coupon_finishdate_year'])); ?>
                 <td><?php echo $finish_date; ?></td>
               </tr>
-              <?php
-              for ($i = 0, $n = count($languages); $i < $n; $i++) {
-                $language_id = $languages[$i]['id'];
-                echo zen_draw_hidden_field('coupon_name[' . $languages[$i]['id'] . ']', stripslashes($_POST['coupon_name'][$language_id]));
-                echo zen_draw_hidden_field('coupon_desc[' . $languages[$i]['id'] . ']', stripslashes($_POST['coupon_desc'][$language_id]));
-              }
-              echo zen_draw_hidden_field('coupon_amount', $_POST['coupon_amount']);
-              echo zen_draw_hidden_field('coupon_product_count', (int)$_POST['coupon_product_count']);
-              echo zen_draw_hidden_field('coupon_min_order', $_POST['coupon_min_order']);
-              echo zen_draw_hidden_field('coupon_free_ship', (!empty($_POST['coupon_free_ship']) ? $_POST['coupon_free_ship'] : ''));
-              $c_code = !empty($_POST['coupon_code']) ? $_POST['coupon_code'] : $coupon_code;
-              echo zen_draw_hidden_field('coupon_code', stripslashes($c_code));
-              echo zen_draw_hidden_field('coupon_uses_coupon', $_POST['coupon_uses_coupon']);
-              echo zen_draw_hidden_field('coupon_uses_user', $_POST['coupon_uses_user']);
-              echo zen_draw_hidden_field('coupon_products', (!empty($_POST['coupon_products']) ? $_POST['coupon_products'] : ''));
-              echo zen_draw_hidden_field('coupon_categories', (!empty($_POST['coupon_categories']) ? $_POST['coupon_categories'] : ''));
-              echo zen_draw_hidden_field('coupon_startdate', date('Y-m-d', mktime(0, 0, 0, $_POST['coupon_startdate_month'], $_POST['coupon_startdate_day'], $_POST['coupon_startdate_year'])));
-              echo zen_draw_hidden_field('coupon_finishdate', date('Y-m-d', mktime(0, 0, 0, $_POST['coupon_finishdate_month'], $_POST['coupon_finishdate_day'], $_POST['coupon_finishdate_year'])));
-              echo zen_draw_hidden_field('coupon_zone_restriction', $_POST['coupon_zone_restriction']);
-              echo zen_draw_hidden_field('coupon_order_limit', $_POST['coupon_order_limit']);
-              echo zen_draw_hidden_field('coupon_calc_base', (int)$_POST['coupon_calc_base']);
-              echo zen_draw_hidden_field('coupon_is_valid_for_sales', (int)$_POST['coupon_is_valid_for_sales']);
-              ?>
               <tr>
                 <td class="text-right">
                   <button type="submit" class="btn btn-primary"><?php echo COUPON_BUTTON_CONFIRM; ?></button>&nbsp;<a href="<?php echo zen_href_link(FILENAME_COUPON_ADMIN, 'cid=' . $_GET['cid'] . (isset($_GET['status']) ? '&status=' . $_GET['status'] : '') . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '')); ?>" class="btn btn-default" role="button"><?php echo TEXT_CANCEL; ?></a>
@@ -954,7 +952,7 @@ switch ($_GET['action']) {
             echo zen_draw_form('coupon', FILENAME_COUPON_ADMIN, 'action=update&oldaction=' . $_GET['action'] . '&cid=' . $_GET['cid'] . (isset($_GET['status']) ? '&status=' . $_GET['status'] : '') . (isset($_GET['page']) ? '&page=' . $_GET['page'] : ''), 'post', 'class="form-horizontal"');
             ?>
             <div class="form-group">
-              <?php echo zen_draw_label(COUPON_NAME, 'coupon_name[]', 'class="control-label col-sm-3"'); ?>
+              <?php echo zen_draw_label(COUPON_NAME, 'coupon_name[' . $languages[0]['id'] . ']', 'class="control-label col-sm-3"'); ?>
               <div class="col-sm-9 col-md-6">
                 <?php
                 for ($i = 0, $n = count($languages); $i < $n; $i++) {
@@ -976,7 +974,7 @@ switch ($_GET['action']) {
               </div>
             </div>
             <div class="form-group">
-              <?php echo zen_draw_label(COUPON_DESC, 'coupon_desc[]', 'class="control-label col-sm-3"'); ?>
+              <?php echo zen_draw_label(COUPON_DESC, 'coupon_desc[' . $languages[0]['id'] . ']', 'class="control-label col-sm-3"'); ?>
               <div class="col-sm-9 col-md-6">
                 <?php
                 for ($i = 0, $n = count($languages); $i < $n; $i++) {
@@ -1302,7 +1300,7 @@ switch ($_GET['action']) {
                       <td class="dataTableContent text-right">
                         <?php
                         if ((isset($cInfo)) && ($item['coupon_id'] == $cInfo->coupon_id)) {
-                          echo '<i class="fa fa-caret-right fa-fw fa-2x align-middle">';
+                          echo '<i class="fa fa-caret-right fa-fw fa-2x align-middle"></i>';
                         } else {
                           echo '<a href="' . zen_href_link(FILENAME_COUPON_ADMIN, (isset($_GET['page']) ? 'page=' . $_GET['page'] . '&' : '') . 'cid=' . $item['coupon_id'] . (isset($_GET['status']) ? '&status=' . $_GET['status'] : '')) . '"><i class="fa fa-info-circle fa-fw fa-2x align-middle"></i></a>';
                         }
@@ -1318,7 +1316,7 @@ switch ($_GET['action']) {
                   <td class="text-right"><?php echo $cc_split->display_links($cc_query_numrows, $maxDisplaySearchResults, MAX_DISPLAY_PAGE_LINKS, $_GET['page'], (isset($_GET['status']) ? 'status=' . $_GET['status'] : '')); ?></td>
                 </tr>
                 <tr>
-                  <td class="text-right" colspan="2"><a name="couponInsert" href="<?php echo zen_href_link(FILENAME_COUPON_ADMIN, (isset($_GET['page']) ? 'page=' . $_GET['page'] . '&' : '') . 'cid=' . (int)$cInfo->coupon_id . '&action=new'); ?>" class="btn btn-primary" role="button"><?php echo IMAGE_INSERT; ?></a></td>
+                  <td class="text-right" colspan="2"><a id="couponInsert" href="<?php echo zen_href_link(FILENAME_COUPON_ADMIN, (isset($_GET['page']) ? 'page=' . $_GET['page'] . '&' : '') . 'cid=' . (int)$cInfo->coupon_id . '&action=new'); ?>" class="btn btn-primary" role="button"><?php echo IMAGE_INSERT; ?></a></td>
                 </tr>
               </table>
             </div>
@@ -1365,7 +1363,7 @@ switch ($_GET['action']) {
                 $contents = array('form' => zen_draw_form('duplicate_coupon_delete', FILENAME_COUPON_ADMIN, 'action=confirmdeleteduplicate' . '&cid=' . $_GET['cid'] . (isset($_GET['status']) ? '&status=' . $_GET['status'] : '') . (isset($_GET['page']) ? '&page=' . $_GET['page'] : ''), 'post', 'enctype="multipart/form-data" class="form-horizontal"'));
 
                 $contents[] = array('text' => sprintf(TEXT_CONFIRM_DELETE_DUPLICATE, $chk_duplicate_delete->fields['coupon_code'], $chk_duplicate_delete->fields['coupon_code']));
-                $contents[] = array('text' => zen_draw_label(TEXT_COUPON_DELETE_DUPLICATE, 'coupon_delete_duplicate_code', 'class="control-label"') . zen_draw_input_field('coupon_delete_duplicate_code', $chk_duplicate_delete->fields['coupon_code'], 'class="form-control" id="coupon_copy_to_count"'));
+                $contents[] = array('text' => zen_draw_label(TEXT_COUPON_DELETE_DUPLICATE, 'coupon_delete_duplicate_code', 'class="control-label"') . zen_draw_input_field('coupon_delete_duplicate_code', $chk_duplicate_delete->fields['coupon_code'], 'class="form-control"'));
                 $contents[] = array('align' => 'text-center', 'text' => '<button type="submit" class="btn btn-danger">' . TEXT_DISCOUNT_COUPON_CONFIRM_DELETE . '</button>&nbsp;<a href="' . zen_href_link(FILENAME_COUPON_ADMIN, 'cid=' . $cInfo->coupon_id . (isset($_GET['status']) ? '&status=' . $_GET['status'] : '') . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '')) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>');
                 break;
               default:

--- a/admin/coupon_admin_export.php
+++ b/admin/coupon_admin_export.php
@@ -94,6 +94,7 @@ if ($action != '')
       { //process records
         $i = 0;
         // make a <table> tag if HTML output
+        $exporter_output = '';
         if ($format == "HTML")
         {
           $exporter_output .= '<table border="1">' . $NL;
@@ -282,15 +283,16 @@ if ($action != '')
             //open output file for readback
             $readback = file_get_contents(DIR_FS_COUPON_EXPORT . $file);
           }
+          unset($f);
           if ($readback !== FALSE && $readback == $exporter_output) {
             $messageStack->add_session(SUCCESS_EXPORT_DISCOUNT_COUPON_LOG . $file, 'success');
           } else {
             $messageStack->add_session(FAILURE_EXPORT_DISCOUNT_COUPON_LOG . $file, 'error');
           }
-          unset($f);
         } // endif $save_to_file
       } //end if $records for processing not 0
-      zen_redirect(zen_href_link(FILENAME_COUPON_ADMIN_EXPORT));
+      unset($_GET['action']);
+      zen_redirect(zen_href_link(FILENAME_COUPON_ADMIN_EXPORT,$_GET));
       break;
 
   } //end switch / case
@@ -310,17 +312,16 @@ require (DIR_WS_INCLUDES . 'header.php');
 <!-- header_eof //-->
 
 <!-- body //-->
-<table border="0" width="100%" cellspacing="2" cellpadding="2">
-  <tr>
+
     <!-- body_text //-->
-    <td width="100%" valign="top">
-    <table border="0" width="100%" cellspacing="0" cellpadding="0">
+
+    <table class="table">
       <tr>
-        <td width="100%">
-        <table border="0" width="100%" cellspacing="0" cellpadding="0">
+        <td >
+        <table class="table">
           <tr>
             <td class="pageHeading"><?php echo HEADING_TITLE; ?></td>
-            <td class="pageHeading" align="right"><?php echo zen_draw_separator('pixel_trans.gif', HEADING_IMAGE_WIDTH, HEADING_IMAGE_HEIGHT); ?></td>
+            <td class="pageHeading text-right"><?php echo zen_draw_separator('pixel_trans.gif', HEADING_IMAGE_WIDTH, HEADING_IMAGE_HEIGHT); ?></td>
           </tr>
         </table>
         </td>
@@ -330,24 +331,25 @@ require (DIR_WS_INCLUDES . 'header.php');
       </tr>
 
 <?php if ($action == '') { ?>
-      <tr><?php echo zen_draw_form('export', FILENAME_COUPON_ADMIN_EXPORT, 'action=save&codebase=' . $_GET['codebase'], 'post'); //, 'onsubmit="return check_form(export);"');   ?>
-        <td align="center">
-        <table border="0" cellspacing="0" cellpadding="2">
+      <tr>
+        <td>
+        <?php echo zen_draw_form('export', FILENAME_COUPON_ADMIN_EXPORT, 'action=save&codebase=' . $_GET['codebase'] . '&cid=' . $_GET['cid'], 'post'); //, 'onsubmit="return check_form(export);"');   ?>
+        <table class="details">
         <tr><td><h2><?php echo HEADING_SUB1 . ' - ' . $_GET['codebase']; ?></h2></td></tr>
           <tr>
-            <td class="main" colspan="2"><?php echo TEXT_INSTRUCTIONS; ?></td>
+            <td class="main" ><?php echo TEXT_INSTRUCTIONS; ?></td>
           </tr>
           <tr>
             <td class="main"><strong><?php echo TEXT_ACTIVITY_EXPORT_FORMAT; ?></strong><br><?php echo zen_draw_pull_down_menu('format', $available_export_formats, $format); ?></td>
           </tr>
           <tr>
-            <td colspan="2"><?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?></td>
+            <td ><?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?></td>
           </tr>
           <tr>
             <td class="main"><strong><?php echo TEXT_ACTIVITY_EXPORT_FILENAME; ?></strong><br><?php echo zen_draw_input_field('filename', htmlspecialchars($file, ENT_COMPAT, CHARSET, TRUE), ' size="60"'); ?></td>
           </tr>
           <tr>
-            <td colspan="2"><?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?></td>
+            <td ><?php echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?></td>
           </tr>
           <tr>
             <td class="main"><?php echo zen_draw_checkbox_field('savetofile', '1', $save_to_file_checked); ?> <strong><?php echo TEXT_ACTIVITY_EXPORT_SAVETOFILE; ?></strong><br>
@@ -355,11 +357,11 @@ require (DIR_WS_INCLUDES . 'header.php');
               </td>
           </tr>
           <tr>
-            <td class="main" align="right"><?php echo '<input type="submit" name="submit" value="'. (defined('BUTTON_TEXT_EXPORT') ? BUTTON_TEXT_EXPORT : IMAGE_GO) . '" id="export_btn" class="btn btn-danger">' . '&nbsp;&nbsp;<a href="' . zen_href_link(FILENAME_COUPON_ADMIN, 'cid=' . $_GET['cid'] . (isset($_GET['status']) ? '&status=' . $_GET['status'] : '') . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '')) . '" class="btn btn-warning" role="button">' . IMAGE_CANCEL . '</a>'; ?></td>
+            <td class="main text-right"><?php echo '<input type="submit" name="submit" value="'. (defined('BUTTON_TEXT_EXPORT') ? BUTTON_TEXT_EXPORT : IMAGE_GO) . '" id="export_btn" class="btn btn-danger">' . '&nbsp;&nbsp;<a href="' . zen_href_link(FILENAME_COUPON_ADMIN, 'cid=' . $_GET['cid'] . (isset($_GET['status']) ? '&status=' . $_GET['status'] : '') . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '')) . '" class="btn btn-warning" role="button">' . IMAGE_CANCEL . '</a>'; ?></td>
           </tr>
         </table>
-        </td>
-        </form>
+        <?php echo ' </form>'; ?>
+        </td>   
       </tr>
 
 
@@ -372,4 +374,4 @@ require (DIR_WS_INCLUDES . 'header.php');
 
 </body>
 </html>
-<?php require (DIR_WS_INCLUDES . 'application_bottom.php'); ?>
+<?php require (DIR_WS_INCLUDES . 'application_bottom.php'); 

--- a/admin/coupon_restrict.php
+++ b/admin/coupon_restrict.php
@@ -306,7 +306,7 @@ $cr_list = $db->Execute($cr_query_raw);
 ?>
     <div class="row">
         <h4><?php echo HEADING_TITLE_CATEGORY; ?></h4>
-        <table class="table table-hover">
+        <table class="table table-hover t1">
 <?php
 if ($cr_list->EOF) {
 ?>
@@ -371,16 +371,7 @@ $pr_list = $db->Execute($pr_query_raw);
     <div class="row">
         <h4><?php echo HEADING_TITLE_PRODUCT; ?></h4>
         <table class="table table-hover">
-<?php
-if ($pr_list->EOF) {
-?>
-            <tr class="dataTableHeadingRow">
-                <td colspan="6" class="dataTableHeadingContent text-center"><?php echo TEXT_NO_PRODUCT_RESTRICTIONS; ?></td>
-            </tr>
-<?php
-} else {
-?>
-            <tr class="dataTableHeadingRow">
+        <tr class="dataTableHeadingRow">
                 <td class="dataTableHeadingContent text-center"><?php echo TABLE_HEADING_PRODUCT_ID; ?></td>
                 <td class="dataTableHeadingContent text-center"><?php echo TABLE_HEADING_STATUS; ?></td>
                 <td class="dataTableHeadingContent text-left"><?php echo TABLE_HEADING_MODEL; ?></td>
@@ -389,6 +380,14 @@ if ($pr_list->EOF) {
                 <td class="dataTableHeadingContent text-center"><?php echo TABLE_HEADING_RESTRICT_REMOVE; ?></td>
             </tr>
 <?php
+if ($pr_list->EOF) {
+?>
+            <tr class="dataTableHeadingRow">
+                <td colspan="6" class="dataTableHeadingContent text-center"><?php echo TEXT_NO_PRODUCT_RESTRICTIONS; ?></td>
+            </tr>
+<?php
+} else {
+
     $products_status_disabled = zen_image(DIR_WS_IMAGES . 'icon_red_on.gif', IMAGE_ICON_STATUS_OFF);
     $products_status_enabled = zen_image(DIR_WS_IMAGES . 'icon_green_on.gif', IMAGE_ICON_STATUS_ON);
     while (!$pr_list->EOF) {

--- a/admin/currencies.php
+++ b/admin/currencies.php
@@ -121,7 +121,7 @@ if (!empty($action)) {
       <div class="row">
         <!-- body_text //-->
         <div class="col-xs-12 col-sm-12 col-md-9 col-lg-9 configurationColumnLeft">
-          <table class="table table-hover">
+          <table class="table table-hover" role="listbox">
             <thead>
               <tr class="dataTableHeadingRow">
                 <th class="dataTableHeadingContent"><?php echo TABLE_HEADING_CURRENCY_NAME; ?></th>
@@ -144,9 +144,9 @@ if (!empty($action)) {
                   }
 
                   if (isset($cInfo) && is_object($cInfo) && ($currency['currencies_id'] == $cInfo->currencies_id)) {
-                    echo '              <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href=\'' . zen_href_link(FILENAME_CURRENCIES, 'page=' . $_GET['page'] . '&cID=' . $cInfo->currencies_id . '&action=edit') . '\'" role="button">' . "\n";
+                    echo '              <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href=\'' . zen_href_link(FILENAME_CURRENCIES, 'page=' . $_GET['page'] . '&cID=' . $cInfo->currencies_id . '&action=edit') . '\'" role="option" aria-selected="true">' . "\n";
                   } else {
-                    echo '              <tr class="dataTableRow" onclick="document.location.href=\'' . zen_href_link(FILENAME_CURRENCIES, 'page=' . $_GET['page'] . '&cID=' . $currency['currencies_id']) . '\'" role="button">' . "\n";
+                    echo '              <tr class="dataTableRow" onclick="document.location.href=\'' . zen_href_link(FILENAME_CURRENCIES, 'page=' . $_GET['page'] . '&cID=' . $currency['currencies_id']) . '\'" role="option" aria-selected="true">' . "\n";
                   }
 
                   if (DEFAULT_CURRENCY == $currency['code']) {

--- a/admin/customer_groups.php
+++ b/admin/customer_groups.php
@@ -57,7 +57,7 @@ if (!empty($action)) {
     <div class="row">
         <!-- body_text //-->
         <div class="col-xs-12 col-sm-12 col-md-9 col-lg-9 configurationColumnLeft">
-            <table class="table table-hover">
+            <table class="table table-hover" role="listbox">
                 <thead>
                 <tr class="dataTableHeadingRow">
                     <th class="dataTableHeadingContent text-center"><?php echo TABLE_HEADING_ID; ?></th>
@@ -106,23 +106,25 @@ if (!empty($action)) {
                     if ((!isset($_GET['gID']) || (isset($_GET['gID']) && ($_GET['gID'] == $group['group_id']))) && !isset($gInfo) && (substr($action, 0, 3) != 'new')) {
                         $gInfo = new objectInfo($group);
                     }
-
-                    $class_and_id = 'class="dataTableRow"';
                     if (isset($gInfo) && is_object($gInfo) && ($group['group_id'] == $gInfo->group_id)) {
-                        $class_and_id = 'id="defaultSelected" class="dataTableRowSelected"';
+                        $class_and_id = 'id="defaultSelected" class="dataTableRowSelected" aria-selected="true"';
+                    } else {
+                        $class_and_id = 'class="dataTableRow" aria-selected="false"';
                     }
                     ?>
-                    <tr <?php echo $class_and_id; ?> onclick="document.location.href='<?php echo zen_href_link(FILENAME_CUSTOMER_GROUPS, $href_page_param . 'gID=' . $group['group_id'] . '&action=edit'); ?>'" role="button">
+                    <tr <?php echo $class_and_id; ?> onclick="document.location.href='<?php echo zen_href_link(FILENAME_CUSTOMER_GROUPS, $href_page_param . 'gID=' . $group['group_id']  . '&action=edit'); ?>'" role="option">
                         <td class="dataTableContent text-center"><?php echo $group['group_id']; ?></td>
                         <td class="dataTableContent"><?php echo $group['group_name']; ?></td>
                         <td class="dataTableContent text-center"><?php echo $group['customer_count']; ?></td>
                         <td class="dataTableContent"><?php echo $group['group_comment']; ?></td>
                         <td class="dataTableContent text-right"><div>
-                            <?php echo '<a href="' . zen_href_link(FILENAME_CUSTOMER_GROUPS, $href_page_param . 'gID=' . $group['group_id'] . '&action=edit') . '" class="btn btn-primary" role="button">' . ICON_EDIT . '</a>'; ?>
-                            <?php echo '<a href="' . zen_href_link(FILENAME_CUSTOMER_GROUPS, $href_page_param . 'gID=' . $group['group_id'] . '&action=delete') . '" class="btn btn-warning" role="button">' . ICON_DELETE . '</a>'; ?>
+                            <?php echo '<a href="' . zen_href_link(FILENAME_CUSTOMER_GROUPS, $href_page_param . 'gID=' . $group['group_id'] . '&action=edit') . '">' . zen_image(DIR_WS_IMAGES . 'icon_edit.gif', ICON_EDIT) . '</a>'; ?>
+                            <?php echo '<a href="' . zen_href_link(FILENAME_CUSTOMER_GROUPS, $href_page_param . 'gID=' . $group['group_id'] . '&action=delete') . '">' . zen_image(DIR_WS_IMAGES . 'icon_delete.gif', ICON_DELETE ) . '</a>'; ?>
                             <?php 
-                              if (!isset($gInfo) || (isset($gInfo) && is_object($gInfo) && ($group['group_id'] != $gInfo->group_id))) {
+                              if (isset($gInfo) && is_object($gInfo) && ($group['group_id'] == $gInfo->group_id)) {
                                  echo zen_image(DIR_WS_IMAGES . 'icon_arrow_right.gif', ''); 
+                              } else {
+                                  echo '<a href="' . zen_href_link(FILENAME_CUSTOMER_GROUPS, zen_get_all_get_params(array('gID')) . 'gID=' . $group['group_id']) . '">' . zen_image(DIR_WS_IMAGES . 'icon_info.gif', IMAGE_ICON_INFO) . '</a>';
                               }
                              ?>
                             </div>
@@ -146,7 +148,7 @@ if (!empty($action)) {
                     $contents = ['form' => zen_draw_form('group_add', FILENAME_CUSTOMER_GROUPS, 'action=insert', 'post', 'class="form-horizontal"')];
                     $contents[] = ['text' => TEXT_NEW_INTRO];
                     $contents[] = ['text' => '<br>' . zen_draw_label(TEXT_GROUP_NAME, 'group_name', 'class="control-label"') . zen_draw_input_field('group_name', '', zen_set_field_length(TABLE_CUSTOMER_GROUPS, 'group_name') . ' class="form-control"')];
-                    $contents[] = ['text' => '<br>' . zen_draw_label(TEXT_GROUP_COMMENT, 'group_comment', 'class="control-label"') . zen_draw_input_field('group_comment', '', zen_set_field_length(TABLE_CUSTOMER_GROUPS, 'group_comment') . 'class="form-control"')];
+                    $contents[] = ['text' => '<br>' . zen_draw_label(TEXT_GROUP_COMMENT, 'group_comment', 'class="control-label"') . zen_draw_input_field('group_comment', '', zen_set_field_length(TABLE_CUSTOMER_GROUPS, 'group_comment') . ' class="form-control"')];
                     $contents[] = ['align' => 'text-center', 'text' => '<br><button type="submit" class="btn btn-primary">' . IMAGE_SAVE . '</button> <a href="' . zen_href_link(FILENAME_CUSTOMER_GROUPS, $href_page_param . (!empty($_GET['gID']) ? 'gID=' . $_GET['gID'] : '')) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>'];
                     break;
                 case 'edit':
@@ -155,7 +157,7 @@ if (!empty($action)) {
                     $contents = ['form' => zen_draw_form('group_edit', FILENAME_CUSTOMER_GROUPS, $href_page_param . 'gID=' . $gInfo->group_id . '&action=save', 'post', 'class="form-horizontal"')];
                     $contents[] = ['text' => TEXT_INFO_EDIT_INTRO];
                     $contents[] = ['text' => '<br>' . zen_draw_label(TEXT_GROUP_NAME, 'group_name', 'class="control-label"') . zen_draw_input_field('group_name', htmlspecialchars($gInfo->group_name, ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_CUSTOMER_GROUPS, 'group_name') . ' class="form-control"')];
-                    $contents[] = ['text' => '<br>' . zen_draw_label(TEXT_GROUP_COMMENT, 'group_comment', 'class="control-label"') . zen_draw_input_field('group_comment', zen_output_string_protected($gInfo->group_comment), zen_set_field_length(TABLE_CUSTOMER_GROUPS, 'group_comment') . 'class="form-control"')];
+                    $contents[] = ['text' => '<br>' . zen_draw_label(TEXT_GROUP_COMMENT, 'group_comment', 'class="control-label"') . zen_draw_input_field('group_comment', zen_output_string_protected($gInfo->group_comment), zen_set_field_length(TABLE_CUSTOMER_GROUPS, 'group_comment') . ' class="form-control"')];
                     $contents[] = ['align' => 'text-center', 'text' => '<br><button type="submit" class="btn btn-primary">' . IMAGE_SAVE . '</button> <a href="' . zen_href_link(FILENAME_CUSTOMER_GROUPS, $href_page_param . 'gID=' . $gInfo->group_id) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>'];
                     break;
                 case 'delete':
@@ -177,7 +179,7 @@ if (!empty($action)) {
                     if (isset($gInfo) && is_object($gInfo) && !empty($gInfo->group_name)) {
                         $heading[] = ['text' => '<h4>' . $gInfo->group_name . '</h4>'];
 
-                        $contents[] = ['align' => 'text-center', 'text' => '<a href="' . zen_href_link(FILENAME_CUSTOMER_GROUPS, $href_page_param . 'gID=' . $gInfo->group_id . '&action=edit') . '"class="btn btn-primary" role="button">' . IMAGE_EDIT . '</a>
+                        $contents[] = ['align' => 'text-center', 'text' => '<a href="' . zen_href_link(FILENAME_CUSTOMER_GROUPS, $href_page_param . 'gID=' . $gInfo->group_id . '&action=edit') . '" class="btn btn-primary" role="button">' . IMAGE_EDIT . '</a>
                                 <a href="' . zen_href_link(FILENAME_CUSTOMER_GROUPS, $href_page_param . 'gID=' . $gInfo->group_id . '&action=delete') . '" class="btn btn-warning" role="button">' . IMAGE_DELETE . '</a>'];
                         $contents[] = ['text' => '<br>' . TEXT_INFO_DATE_ADDED . ' ' . zen_date_short($gInfo->date_added)];
                         if (!empty($gInfo->last_modified)) $contents[] = ['text' => TEXT_INFO_LAST_MODIFIED . ' ' . zen_date_short($gInfo->last_modified)];

--- a/admin/customers.php
+++ b/admin/customers.php
@@ -722,7 +722,7 @@ if (!empty($action)) {
         ?>
         <div class="row">
           <div class="col-xs-12 col-sm-12 col-md-9 col-lg-9 configurationColumnLeft">
-            <table class="table table-hover">
+            <table class="table table-hover" role="listbox">
               <thead>
                 <tr class="dataTableHeadingRow">
                   <th class="dataTableHeadingContent text-right">
@@ -886,9 +886,9 @@ if (!empty($action)) {
 
                   if (isset($cInfo) && is_object($cInfo) && ($customer['customers_id'] == $cInfo->customers_id)) {
                     ?>
-                    <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href = '<?php echo zen_href_link(FILENAME_CUSTOMERS, zen_get_all_get_params(['cID', 'action']) . 'cID=' . $cInfo->customers_id . '&action=edit'); ?>'" role="button">
+                    <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href = '<?php echo zen_href_link(FILENAME_CUSTOMERS, zen_get_all_get_params(['cID', 'action']) . 'cID=' . $cInfo->customers_id . '&action=edit'); ?>'" role="option" aria-selected="true">
                     <?php } else { ?>
-                    <tr class="dataTableRow" onclick="document.location.href = '<?php echo zen_href_link(FILENAME_CUSTOMERS, zen_get_all_get_params(['cID', 'action']) . 'cID=' . $customer['customers_id']); ?>'" role="button">
+                    <tr class="dataTableRow" onclick="document.location.href = '<?php echo zen_href_link(FILENAME_CUSTOMERS, zen_get_all_get_params(['cID', 'action']) . 'cID=' . $customer['customers_id']); ?>'" role=option aria-selected="false">
                       <?php
                     }
 
@@ -946,13 +946,13 @@ if (!empty($action)) {
                     <?php } ?>
                     <td class="dataTableContent text-center">
                       <?php echo zen_draw_form('set_status_' . (int)$customer['customers_id'], FILENAME_CUSTOMERS, 'action=status&cID=' . $customer['customers_id'] . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')); ?>
-                      <button type="submit" class="btn btn-status">
+                        <button type="submit" class="btn btn-status">
                         <?php if ($customer['customers_authorization'] == 0) { ?>
                           <i class="fa fa-square txt-status-on" title="<?php echo IMAGE_ICON_STATUS_ON; ?>"></i>
                         <?php } else { ?>
                           <i class="fa fa-square txt-status-off" title="<?php echo IMAGE_ICON_STATUS_OFF; ?>"></i>
                         <?php } ?>
-                      </button>
+                        </button>
                       <?php echo zen_draw_hidden_field('current_status', strval($customer['customers_authorization'])); ?>
                       <?php echo '</form>'; ?>
                     </td>

--- a/admin/denied.php
+++ b/admin/denied.php
@@ -9,7 +9,7 @@
 require('includes/application_top.php');
 
 ?>
-<!doctype html public "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!doctype html >
 <html <?php echo HTML_PARAMS; ?>>
 <head>
     <?php require DIR_WS_INCLUDES . 'admin_html_head.php'; ?>

--- a/admin/downloads_manager.php
+++ b/admin/downloads_manager.php
@@ -105,7 +105,7 @@ if (!empty($action)) {
         <div class="col-xs-12 col-sm-12 col-md-9 col-lg-9 configurationColumnLeft">
           <!-- body_text //-->
           <!-- downloads by product_name//-->
-          <table class="table table-hover">
+          <table class="table table-hover" role="listbox">
             <thead>
               <tr class="dataTableHeadingRow">
                 <th class="dataTableHeadingContent text-right"><?php echo TABLE_HEADING_ATTRIBUTES_ID; ?></th>
@@ -174,9 +174,9 @@ if (!empty($action)) {
                 $file_check = zen_orders_products_downloads($products_downloads['products_attributes_filename']); 
                 ?>
                 <?php if (isset($padInfo) && is_object($padInfo) && ($products_downloads['products_attributes_id'] == $padInfo->products_attributes_id)) { ?>
-                  <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href = '<?php echo zen_href_link(FILENAME_DOWNLOADS_MANAGER, zen_get_all_get_params(array('padID', 'action', 'page')) . ($currentPage != 0 ? 'page=' . $currentPage . '&' : '') . 'padID=' . $padInfo->products_attributes_id . '&action=edit'); ?>'" role="button">
+                  <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href = '<?php echo zen_href_link(FILENAME_DOWNLOADS_MANAGER, zen_get_all_get_params(array('padID', 'action', 'page')) . ($currentPage != 0 ? 'page=' . $currentPage . '&' : '') . 'padID=' . $padInfo->products_attributes_id . '&action=edit'); ?>'" role="option" aria-selected="true">
                   <?php } else { ?>
-                  <tr class="dataTableRow" onclick="document.location.href = '<?php echo zen_href_link(FILENAME_DOWNLOADS_MANAGER, zen_get_all_get_params(array('padID', 'action', 'page')) . ($currentPage != 0 ? 'page=' . $currentPage . '&' : '') . 'padID=' . $products_downloads['products_attributes_id']); ?>'" role="button">
+                  <tr class="dataTableRow" onclick="document.location.href = '<?php echo zen_href_link(FILENAME_DOWNLOADS_MANAGER, zen_get_all_get_params(array('padID', 'action', 'page')) . ($currentPage != 0 ? 'page=' . $currentPage . '&' : '') . 'padID=' . $products_downloads['products_attributes_id']); ?>'" role="option" aria-selected="false">
                   <?php } ?>
 
                   <td class="text-right"><?php echo $products_downloads['products_attributes_id']; ?></td>
@@ -212,7 +212,7 @@ if (!empty($action)) {
                       <a href="<?php echo zen_href_link(FILENAME_DOWNLOADS_MANAGER, zen_get_all_get_params(array('padID')) . ($currentPage != 0 ? 'page=' . $currentPage . '&' : '') . 'padID=' . $products_downloads['products_attributes_id']); ?>" title="<?php echo IMAGE_ICON_INFO; ?>" role="button">
                         <i class="fa fa-info-circle fa-2x fa-fw txt-black align-middle"></i>
                       </a>
-                    <?php } ?>
+                     <?php } ?>
                   </td>
                 </tr>
               <?php } ?>

--- a/admin/ezpages.php
+++ b/admin/ezpages.php
@@ -243,7 +243,7 @@ if (!empty($action)) {
             <?php echo '</form>'; ?>
           <?php } ?>
         </div>
-      </div>
+      
       <?php
       if ($action == 'new') {
         $form_action = 'insert';
@@ -357,21 +357,21 @@ if (!empty($action)) {
         <div class="form-group">
           <?php echo zen_draw_label(TABLE_HEADING_PAGE_OPEN_NEW_WINDOW, 'page_open_new_window', 'class="col-sm-3 control-label"'); ?>
           <div class="col-sm-9 col-md-6">
-            <label class="radio-inline"><?php echo zen_draw_radio_field('page_open_new_window', '1', ($ezInfo->page_open_new_window == 1)) . TEXT_YES; ?></label>
+            <label class="radio-inline"><?php echo zen_draw_radio_field('page_open_new_window', '1', ($ezInfo->page_open_new_window == 1),'','id="page_open_new_window"') . TEXT_YES; ?></label>
             <label class="radio-inline"><?php echo zen_draw_radio_field('page_open_new_window', '0', ($ezInfo->page_open_new_window == 0)) . TEXT_NO; ?></label>
           </div>
         </div>
         <div class="form-group">
           <?php echo zen_draw_label(TABLE_HEADING_PAGE_IS_SSL, 'page_is_ssl', 'class="col-sm-3 control-label"'); ?>
           <div class="col-sm-9 col-md-6">
-            <label class="radio-inline"><?php echo zen_draw_radio_field('page_is_ssl', '1', ($ezInfo->page_is_ssl == 1)) . TEXT_YES; ?></label>
+            <label class="radio-inline"><?php echo zen_draw_radio_field('page_is_ssl', '1', ($ezInfo->page_is_ssl == 1),'','id="page_is_ssl"') . TEXT_YES; ?></label>
             <label class="radio-inline"><?php echo zen_draw_radio_field('page_is_ssl', '0', ($ezInfo->page_is_ssl == 0)) . TEXT_NO; ?></label>
           </div>
         </div>
         <div class="form-group">
           <?php echo zen_draw_label(TABLE_HEADING_PAGE_IS_VISIBLE, 'page_is_visible', 'class="col-sm-3 control-label"'); ?>
           <div class="col-sm-9 col-md-6">
-            <label class="radio-inline"><?php echo zen_draw_radio_field('status_visible', '1', ($ezInfo->status_visible == 1)) . TEXT_YES; ?></label>
+            <label class="radio-inline"><?php echo zen_draw_radio_field('status_visible', '1', ($ezInfo->status_visible == 1),'','id="page_is_visible"') . TEXT_YES; ?></label>
             <label class="radio-inline"><?php echo zen_draw_radio_field('status_visible', '0', ($ezInfo->status_visible == 0)) . TEXT_NO; ?></label>
             <br><br><?php echo TABLE_HEADING_PAGE_IS_VISIBLE_EXPLANATION; ?>
           </div>
@@ -398,7 +398,7 @@ if (!empty($action)) {
             <p class="control-label"><?php echo zen_draw_label(TABLE_HEADING_STATUS_SIDEBOX, 'status_sidebox', 'class="control-label"'); ?></p>
           </div>
           <div class="col-sm-9 col-md-6">
-            <label class="radio-inline"><?php echo zen_draw_radio_field('status_sidebox', '1', ($ezInfo->status_sidebox == 1)) . TEXT_YES; ?></label>
+            <label class="radio-inline"><?php echo zen_draw_radio_field('status_sidebox', '1', ($ezInfo->status_sidebox == 1),'','id="status_sidebox"') . TEXT_YES; ?></label>
             <label class="radio-inline"><?php echo zen_draw_radio_field('status_sidebox', '0', ($ezInfo->status_sidebox == 0)) . TEXT_NO; ?></label>
           </div>
         </div>
@@ -419,9 +419,9 @@ if (!empty($action)) {
           </div>
         </div>
         <div class="form-group">
-          <?php echo zen_draw_label(TEXT_FOOTER_SORT_ORDER, 'status_footer', 'class="control-label col-sm-3"'); ?>
+          <?php echo zen_draw_label(TEXT_FOOTER_SORT_ORDER, 'footer_sort_order', 'class="control-label col-sm-3"'); ?>
           <div class="col-sm-2">
-            <?php echo zen_draw_input_field('footer_sort_order', $ezInfo->footer_sort_order, zen_set_field_length(TABLE_EZPAGES, 'footer_sort_order') . ' class="form-control" id="footer_sort_order"'); ?>
+            <?php echo zen_draw_input_field('footer_sort_order', $ezInfo->footer_sort_order, zen_set_field_length(TABLE_EZPAGES, 'footer_sort_order') . ' class="form-control"'); ?>
           </div>
         </div>
         <hr>
@@ -507,7 +507,7 @@ if (!empty($action)) {
       <?php } else { ?>
         <div class="row">
           <div class="col-xs-12 col-sm-12 col-md-9 col-lg-9 configurationColumnLeft">
-            <table class="table table-hover">
+            <table class="table table-hover" role="listbox">
               <thead>
                 <tr class="dataTableHeadingRow">
                   <th class="dataTableHeadingContent text-center"><?php echo TABLE_HEADING_ID; ?></th>
@@ -594,9 +594,9 @@ if (!empty($action)) {
                   }
                   if (isset($ezInfo) && is_object($ezInfo) && ($page['pages_id'] == $ezInfo->pages_id)) {
                     ?>
-                    <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href = '<?php echo zen_href_link(FILENAME_EZPAGES_ADMIN, ($currentPage != 0 ? 'page=' . $currentPage . '&' : '') . 'ezID=' . $page['pages_id']); ?>'" role="button">
+                    <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href = '<?php echo zen_href_link(FILENAME_EZPAGES_ADMIN, ($currentPage != 0 ? 'page=' . $currentPage . '&' : '') . 'ezID=' . $page['pages_id']); ?>'" role="option" aria-selected="true">
                     <?php } else { ?>
-                    <tr class="dataTableRow" onclick="document.location.href = '<?php echo zen_href_link(FILENAME_EZPAGES_ADMIN, ($currentPage != 0 ? 'page=' . $currentPage . '&' : '') . 'ezID=' . $page['pages_id']); ?>'" role="button">
+                    <tr class="dataTableRow" onclick="document.location.href = '<?php echo zen_href_link(FILENAME_EZPAGES_ADMIN, ($currentPage != 0 ? 'page=' . $currentPage . '&' : '') . 'ezID=' . $page['pages_id']); ?>'" role="option" aria-selected="false">
                     <?php } ?>
                     <td class="dataTableContent text-right"><?php echo ($zv_link_method_cnt > 1 ? zen_image(DIR_WS_IMAGES . 'icon_status_red.gif', IMAGE_ICON_STATUS_RED_EZPAGES, 10, 10) : '') . '&nbsp;' . $page['pages_id']; ?></td>
                     <td class="dataTableContent"><?php echo $page['pages_title']; ?></td>

--- a/admin/featured.php
+++ b/admin/featured.php
@@ -503,7 +503,7 @@ if (!empty($action)) {
                         $contents[] = ['text' => TEXT_INFO_PRE_ADD_INTRO];
                         $result = $db->Execute("SELECT MAX(products_id) AS lastproductid FROM " . TABLE_PRODUCTS);
                         $max_product_id = $result->fields['lastproductid'];
-                        $contents[] = ['text' => zen_draw_label(TEXT_PRE_ADD_PRODUCTS_ID, 'pre_add_products_id', 'class="control-label"') . zen_draw_input_field('pre_add_products_id', '', zen_set_field_length(TABLE_FEATURED, 'products_id') . 'class="form-control" id="pre_add_products_id" required max="' . $max_product_id . '"', '', 'number')];
+                        $contents[] = ['text' => zen_draw_label(TEXT_PRE_ADD_PRODUCTS_ID, 'pre_add_products_id', 'class="control-label"') . zen_draw_input_field('pre_add_products_id', '', zen_set_field_length(TABLE_FEATURED, 'products_id') . ' class="form-control" id="pre_add_products_id" required max="' . $max_product_id . '"', '', 'number')];
                         $contents[] = ['align' => 'text-center', 'text' => '<button type="submit" class="btn btn-primary">' . IMAGE_CONFIRM . '</button> <a href="' . zen_href_link(FILENAME_FEATURED, (!empty($fInfo->featured_id) ? '&fID=' . $fInfo->featured_id : '') . ($currentPage != 0 ? '&page=' . $currentPage : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : '')) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>'];
                         break;
 

--- a/admin/group_pricing.php
+++ b/admin/group_pricing.php
@@ -83,7 +83,7 @@ if ($query->fields['count'] > 0 && (!defined('MODULE_ORDER_TOTAL_GROUP_PRICING_S
       <div class="row">
         <!-- body_text //-->
         <div class="col-xs-12 col-sm-12 col-md-9 col-lg-9 configurationColumnLeft">
-          <table class="table table-hover">
+          <table class="table table-hover" role="listbox">
             <thead>
               <tr class="dataTableHeadingRow">
                 <th class="dataTableHeadingContent"><?php echo TABLE_HEADING_ID; ?></th>
@@ -127,9 +127,9 @@ if ($query->fields['count'] > 0 && (!defined('MODULE_ORDER_TOTAL_GROUP_PRICING_S
                   }
 
                   if (isset($gInfo) && is_object($gInfo) && ($group['group_id'] == $gInfo->group_id)) {
-                    echo '              <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href=\'' . zen_href_link(FILENAME_GROUP_PRICING, 'page=' . $_GET['page'] . '&gID=' . $group['group_id'] . '&action=edit') . '\'" role="button">' . "\n";
+                    echo '              <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href=\'' . zen_href_link(FILENAME_GROUP_PRICING, 'page=' . $_GET['page'] . '&gID=' . $group['group_id'] . '&action=edit') . '\'" role="option" aria-selected="true">' . "\n";
                   } else {
-                    echo '              <tr class="dataTableRow" onclick="document.location.href=\'' . zen_href_link(FILENAME_GROUP_PRICING, 'page=' . $_GET['page'] . '&gID=' . $group['group_id'] . '&action=edit') . '\'" role="button">' . "\n";
+                    echo '              <tr class="dataTableRow" onclick="document.location.href=\'' . zen_href_link(FILENAME_GROUP_PRICING, 'page=' . $_GET['page'] . '&gID=' . $group['group_id'] . '&action=edit') . '\'" role="option" aria-selected="false">' . "\n";
                   }
                   ?>
               <td class="dataTableContent"><?php echo $group['group_id']; ?></td>
@@ -195,7 +195,7 @@ if ($query->fields['count'] > 0 && (!defined('MODULE_ORDER_TOTAL_GROUP_PRICING_S
                 if (isset($gInfo) && is_object($gInfo)) {
                   $heading[] = array('text' => '<h4>' . $gInfo->group_name . '</h4>');
 
-                  $contents[] = array('align' => 'text-center', 'text' => '<a href="' . zen_href_link(FILENAME_GROUP_PRICING, 'page=' . $_GET['page'] . '&gID=' . $gInfo->group_id . '&action=edit') . '"class="btn btn-primary" role="button">' . IMAGE_EDIT . '</a> <a href="' . zen_href_link(FILENAME_GROUP_PRICING, 'page=' . $_GET['page'] . '&gID=' . $gInfo->group_id . '&action=delete') . '" class="btn btn-warning" role="button">' . IMAGE_DELETE . '</a>');
+                  $contents[] = array('align' => 'text-center', 'text' => '<a href="' . zen_href_link(FILENAME_GROUP_PRICING, 'page=' . $_GET['page'] . '&gID=' . $gInfo->group_id . '&action=edit') . '" class="btn btn-primary" role="button">' . IMAGE_EDIT . '</a> <a href="' . zen_href_link(FILENAME_GROUP_PRICING, 'page=' . $_GET['page'] . '&gID=' . $gInfo->group_id . '&action=delete') . '" class="btn btn-warning" role="button">' . IMAGE_DELETE . '</a>');
                   $contents[] = array('text' => '<br>' . TEXT_INFO_DATE_ADDED . ' ' . zen_date_short($gInfo->date_added));
                   if (!empty($gInfo->last_modified))
                     $contents[] = array('text' => TEXT_INFO_LAST_MODIFIED . ' ' . zen_date_short($gInfo->last_modified));

--- a/admin/gv_mail.php
+++ b/admin/gv_mail.php
@@ -204,7 +204,7 @@ if (!empty($_GET['mail_sent_to']) && $_GET['mail_sent_to']) {
           <?php echo zen_draw_form('mail', FILENAME_GV_MAIL, 'action=send_email_to_user'); ?>
           <table class="table">
             <tr>
-              <td width="25%" class="text-right"><b><?php echo TEXT_FROM; ?></b></td>
+              <td class="text-right col-sm-3"><b><?php echo TEXT_FROM; ?></b></td>
               <td><?php echo htmlspecialchars(stripslashes($_POST['from']), ENT_COMPAT, CHARSET, true); ?></td>
             </tr>
             <tr>
@@ -256,9 +256,9 @@ if (!empty($_GET['mail_sent_to']) && $_GET['mail_sent_to']) {
                   <?php echo zen_draw_pull_down_menu('reset_editor', $editors_pulldown, $current_editor_key, 'onChange="this.form.submit();" class="form-control" id="reset_editor"'); ?>
                 </div>
                 <?php echo zen_hide_session_id(); ?>
-                <?php echo zen_draw_hidden_field('action', 'set_editor'); ?>
-                <?php echo'</form>'; ?>
+                <?php echo zen_draw_hidden_field('action', 'set_editor'); ?>          
               </div>
+            <?php echo'</form>'; ?>
             </div>
           </div>
           <?php

--- a/admin/gv_sent.php
+++ b/admin/gv_sent.php
@@ -47,10 +47,10 @@ $currencies = new currencies();
                 $gv_split = new splitPageResults($_GET['page'], MAX_DISPLAY_SEARCH_RESULTS, $gv_query_raw, $gv_query_numrows);
                 $gv_lists = $db->Execute($gv_query_raw);
                 foreach ($gv_lists as $gv_list) {
-                  if ((empty($_GET['gid']) || (@$_GET['gid'] == $gv_list['coupon_id'])) && !isset($gInfo)) {
+                  if ((empty($_GET['gid']) || ($_GET['gid'] == $gv_list['coupon_id'])) && empty($gInfo)) {
                     $gInfo = new objectInfo($gv_list);
                   }
-                  if (is_object($gInfo) && $gv_list['coupon_id'] == $gInfo->coupon_id) {
+                  if (!empty($ginfo) && is_object($gInfo) && $gv_list['coupon_id'] == $gInfo->coupon_id) {
                     ?>
                     <tr class="dataTableRowSelected" onclick="document.location.href = '<?php echo zen_href_link('gv_sent.php', zen_get_all_get_params(array('gid', 'action')) . 'gid=' . $gInfo->coupon_id . '&action=edit'); ?>'">
                     <?php } else { ?>
@@ -63,7 +63,7 @@ $currencies = new currencies();
                     <td class="dataTableContent text-right"><?php echo (empty($gv_list['redeem_date']) ? TEXT_INFO_NOT_REDEEMED : zen_date_short($gv_list['redeem_date'])); ?></td>
                     <td class="dataTableContent text-right">
                       <?php
-                      if ((is_object($gInfo)) && ($gv_list['coupon_id'] == $gInfo->coupon_id)) {
+                      if (!empty($gInfo) && (is_object($gInfo)) && ($gv_list['coupon_id'] == $gInfo->coupon_id)) {
                         echo zen_image(DIR_WS_IMAGES . 'icon_arrow_right.gif');
                       } else {
                         echo '<a href="' . zen_href_link(FILENAME_GV_SENT, 'page=' . $_GET['page'] . '&gid=' . $gv_list['coupon_id']) . '">' . zen_image(DIR_WS_IMAGES . 'icon_info.gif', IMAGE_ICON_INFO) . '</a>';

--- a/admin/includes/css/coupon_admin_export.css
+++ b/admin/includes/css/coupon_admin_export.css
@@ -1,0 +1,3 @@
+table.table tr td {border: 0; padding: 1px;}
+table.details {margin: auto;}
+table.details tr td.main {padding: 5px 2px;}

--- a/admin/includes/css/developers_tool_kit.css
+++ b/admin/includes/css/developers_tool_kit.css
@@ -14,3 +14,7 @@
 .dtk-contextline {font-family: Verdana, sans-serif;}
 .dtk-linenum {font-family: Verdana, sans-serif;}
 .dataTableGroupChange {border-top: 2px solid #000 !important;}
+table.table {border:2px solid;}
+table.blank {width:100%;}
+table.constantlink {border:3px solid;}
+table.constantlink td {border:1px solid;}

--- a/admin/includes/css/media_manager.css
+++ b/admin/includes/css/media_manager.css
@@ -1,0 +1,1 @@
+table.table, table.table tr, table.table tr td {border-top: 0; padding: 1px;} 

--- a/admin/includes/css/stylesheet.css
+++ b/admin/includes/css/stylesheet.css
@@ -839,6 +839,7 @@ input.faint {
 
 .control-label {/*for multiple inputs*/
     font-weight: 700;
+    font-size:inherit;
 }
 
 .txt-black {

--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -264,7 +264,7 @@ function zen_cfg_select_option($select_array, $key_value, $key = '')
     for ($i = 0, $n = count($select_array); $i < $n; $i++) {
         $name = (zen_not_null($key)) ? 'configuration[' . $key . ']' : 'configuration_value';
 
-        $string .= '<div class="radio"><label>' . zen_draw_radio_field($name, $select_array[$i], ($key_value == $select_array[$i] ? true : false), '', 'id="' . strtolower($select_array[$i] . '-' . $name) . '" class="inputSelect"') . $select_array[$i] . '</label></div>';
+        $string .= '<div class="radio"><label>' . zen_draw_radio_field($name, $select_array[$i], ($key_value == $select_array[$i] ? true : false), '', 'id="' . zen_make_id(strtolower($select_array[$i] . '-' . $name)) . '" class="inputSelect"') . $select_array[$i] . '</label></div>';
     }
 
     return $string;

--- a/admin/includes/modules/copy_product.php
+++ b/admin/includes/modules/copy_product.php
@@ -34,7 +34,7 @@ $contents[] = array('text' => zen_draw_label(TEXT_CATEGORIES, 'categories_id', '
 $contents[] = array(
     'text' => '<h5>' . TEXT_HOW_TO_COPY . '</h5>' .
         '<div class="radio h6"><label>' . zen_draw_radio_field('copy_as', 'link', true) . TEXT_COPY_AS_LINK . '</label></div>' .
-        zen_image(DIR_WS_IMAGES . 'pixel_black.gif', '', '', '1', 'style="width:100%"') .
+        zen_image(DIR_WS_IMAGES . 'pixel_black.gif', '', '100%', '1', '') .
         '<div class="radio h6"><label>' . zen_draw_radio_field('copy_as', 'duplicate') . TEXT_COPY_AS_DUPLICATE . '</label></div>'
 );
 
@@ -84,10 +84,10 @@ if (zen_has_product_discounts($pInfo->products_id) == 'true') {
     );
 }
 $contents[] = array('text' => '<label>' . zen_draw_checkbox_field('edit_duplicate', '1', true) . TEXT_COPY_EDIT_DUPLICATE . '</label>');
-$contents[] = array('text' => zen_image(DIR_WS_IMAGES . 'pixel_black.gif', '', '', '3', 'style="width:100%"'));
+$contents[] = array('text' => zen_image(DIR_WS_IMAGES . 'pixel_black.gif', '', '100%', '3', ''));
 $contents[] = array('align' => 'center', 'text' => '<button type="submit" class="btn btn-primary">' . IMAGE_COPY . '</button>
 <a href="' . zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING, 'cPath=' . $cPath . '&pID=' . $pInfo->products_id . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '')) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>'
 );
 
-$contents[] = array('text' => zen_image(DIR_WS_IMAGES . 'pixel_black.gif', '', '', '1', 'style="width:100%"'));
+$contents[] = array('text' => zen_image(DIR_WS_IMAGES . 'pixel_black.gif', '', '100%', '1', ''));
 $contents[] = array('align' => 'center', 'text' => '<a href="' . zen_href_link(FILENAME_PRODUCTS_TO_CATEGORIES, 'products_filter=' . $pInfo->products_id . '&current_category_id=' . $current_category_id) . '" class="btn btn-info" role="button">' . BUTTON_PRODUCTS_TO_CATEGORIES . '</a>');

--- a/admin/includes/modules/document_general/collect_info.php
+++ b/admin/includes/modules/document_general/collect_info.php
@@ -312,7 +312,7 @@ if (zen_get_categories_status($current_category_id) == 0 && $pInfo->products_sta
           <span class="input-group-addon">
               <?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']); ?>
           </span>
-          <?php echo zen_draw_input_field('products_url[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($products_url[$languages[$i]['id']]) ? $products_url[$languages[$i]['id']] : zen_get_products_url($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_PRODUCTS_DESCRIPTION, 'products_url') . ' class="form-control" inputtype="url"'); ?>
+          <?php echo zen_draw_input_field('products_url[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($products_url[$languages[$i]['id']]) ? $products_url[$languages[$i]['id']] : zen_get_products_url($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_PRODUCTS_DESCRIPTION, 'products_url') . ' class="form-control" inputmode="url"'); ?>
         </div>
         <br>
         <?php

--- a/admin/includes/modules/document_general/collect_info_metatags.php
+++ b/admin/includes/modules/document_general/collect_info_metatags.php
@@ -94,43 +94,43 @@ if (empty($pInfo->metatags_keywords) && empty($pInfo->metatags_description)) {
   <div class="form-group">
     <div class="col-sm-3 control-label"><?php echo TEXT_META_TAG_TITLE_INCLUDES; ?></div>
     <div class="col-sm-6">
-      <div class="form-group">
-          <?php echo zen_draw_label(TEXT_PRODUCTS_METATAGS_PRODUCTS_NAME_STATUS, 'metatags_products_name_status', 'class="col-sm-3 control-label"'); ?>
+      <fieldset class="form-group">
+          <legend class="col-sm-3 control-label"><?php echo TEXT_PRODUCTS_METATAGS_PRODUCTS_NAME_STATUS; ?></legend>
         <div class="col-sm-9">
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_products_name_status', '1', ($pInfo->metatags_products_name_status == '1')) . TEXT_YES; ?></label>
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_products_name_status', '0', ($pInfo->metatags_products_name_status == '0')) . TEXT_NO; ?></label>
         </div>
-      </div>
-      <div class="form-group">
-          <?php echo zen_draw_label(TEXT_PRODUCTS_METATAGS_TITLE_STATUS, 'metatags_title_status', 'class="col-sm-3 control-label"'); ?>
+      </fieldset>
+      <fieldset class="form-group">
+          <legend class="col-sm-3 control-label"><?php echo TEXT_PRODUCTS_METATAGS_TITLE_STATUS; ?></legend>
         <div class="col-sm-9 col-md-6">
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_title_status', '1', ($pInfo->metatags_title_status == '1')) . TEXT_YES; ?></label>
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_title_status', '0', ($pInfo->metatags_title_status == '0')) . TEXT_NO; ?></label>
         </div>
-      </div>
+      </fieldset>
 <!-- // not used for documents
-      <div class="form-group">
-          <?php echo zen_draw_label(TEXT_PRODUCTS_METATAGS_MODEL_STATUS, 'metatags_model_status', 'class="col-sm-3 control-label"'); ?>
+      <fieldset class="form-group">
+          <legend class="col-sm-3 control-label"><?php echo TEXT_PRODUCTS_METATAGS_MODEL_STATUS; ?></legend>
         <div class="col-sm-9 col-md-6">
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_model_status', '1', ($pInfo->metatags_model_status == '1')) . TEXT_YES; ?></label>
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_model_status', '0', ($pInfo->metatags_model_status == '0')) . TEXT_NO; ?></label>
         </div>
-      </div>
-      <div class="form-group">
-          <?php echo zen_draw_label(TEXT_PRODUCTS_METATAGS_PRICE_STATUS, 'metatags_price_status', 'class="col-sm-3 control-label"') ?>
+      </fieldset>
+      <fieldset class="form-group">
+          <legend class="col-sm-3 control-label"><?php echo TEXT_PRODUCTS_METATAGS_PRICE_STATUS; ?></legend>
         <div class="col-sm-9 col-md-6">
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_price_status', '1', ($pInfo->metatags_price_status == '1')) . TEXT_YES; ?></label>
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_price_status', '0', ($pInfo->metatags_price_status == '0')) . TEXT_NO; ?></label>
         </div>
-      </div>
+      </fieldset>
 -->
-      <div class="form-group">
-          <?php echo zen_draw_label(TEXT_PRODUCTS_METATAGS_TITLE_TAGLINE_STATUS, 'metatags_title_tagline_status', 'class="col-sm-3 control-label"'); ?>
+      <fieldset class="form-group">
+          <legend class="col-sm-3 control-label"><?php echo TEXT_PRODUCTS_METATAGS_TITLE_TAGLINE_STATUS; ?></legend>
         <div class="col-sm-9 col-md-6">
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_title_tagline_status', '1', ($pInfo->metatags_title_tagline_status == '1')) . TEXT_YES; ?></label>
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_title_tagline_status', '0', ($pInfo->metatags_title_tagline_status == '0')) . TEXT_NO; ?></label>
         </div>
-      </div>
+      </fieldset>
     </div>
   </div>
   <div class="form-group"><?php echo zen_draw_separator('pixel_black.gif', '100%', '3'); ?></div>
@@ -149,7 +149,7 @@ if (empty($pInfo->metatags_keywords) && empty($pInfo->metatags_description)) {
           <div class="form-group">
               <?php echo zen_draw_label(TEXT_META_TAGS_TITLE, 'metatags_title[' . $languages[$i]['id'] . ']', 'class="col-sm-3 control-label"'); ?>
             <div class="col-sm-9 col-md-6">
-                <?php echo zen_draw_input_field('metatags_title[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($metatags_title[$languages[$i]['id']]) ? stripslashes($metatags_title[$languages[$i]['id']]) : zen_get_product_metatag_fields($pInfo->products_id, $languages[$i]['id'], 'metatags_title'), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_META_TAGS_PRODUCTS_DESCRIPTION, 'metatags_title', '150', false) . 'class="form-control"'); //,'id="'.'metatags_title' . $languages[$i]['id'] . '"'); ?>
+                <?php echo zen_draw_input_field('metatags_title[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($metatags_title[$languages[$i]['id']]) ? stripslashes($metatags_title[$languages[$i]['id']]) : zen_get_product_metatag_fields($pInfo->products_id, $languages[$i]['id'], 'metatags_title'), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_META_TAGS_PRODUCTS_DESCRIPTION, 'metatags_title', '150', false) . ' class="form-control"'); //,'id="'.'metatags_title' . $languages[$i]['id'] . '"'); ?>
             </div>
           </div>
           <div class="form-group">

--- a/admin/includes/modules/document_general/preview_info_meta_tags.php
+++ b/admin/includes/modules/document_general/preview_info_meta_tags.php
@@ -46,32 +46,32 @@ $form_action = (isset($_GET['pID'])) ? 'update_product_meta_tags' : 'insert_prod
 
     <table class="table table-bordered">
       <tr>
-        <td class="main" valign="top">
+        <td class="main">
             <?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . '<strong>' . TEXT_PRODUCTS_NAME . '</strong>' . '&nbsp;' . ($pInfo->metatags_products_name_status == '1' ? zen_get_products_name($_GET['pID'], $languages[$i]['id']) : TEXT_META_EXCLUDED); ?>
         </td>
 <!-- // not used for documents
-            <td class="main" valign="top">
+            <td class="main">
                <?php echo '<strong>' . TEXT_PRODUCTS_MODEL . '</strong>&nbsp;' . ($pInfo->metatags_model_status == '1' ? $pInfo->products_model : TEXT_META_EXCLUDED); ?>
             </td>
-            <td class="main" valign="top">
+            <td class="main">
                <?php echo '<strong>' . TEXT_PRODUCTS_PRICE_INFO . '</strong>&nbsp;' . ($pInfo->metatags_price_status == '1' ? $currencies->format($pInfo->products_price_sorter) : TEXT_META_EXCLUDED); ?>
             </td>
 -->
-        <td class="main" valign="top">
+        <td class="main">
             <?php echo '<strong>' . TEXT_PRODUCTS_METATAGS_TITLE_TAGLINE_STATUS . '</strong>&nbsp;' . ($pInfo->metatags_title_tagline_status == '1' ? TEXT_TITLE_PLUS_TAGLINE : TEXT_META_EXCLUDED); ?>
         </td>
       </tr>
       <tr>
-        <td class="main" valign="top"><?php echo TEXT_META_TAGS_TITLE; ?>&nbsp;</td>
-        <td class="main" colspan="3"><?php echo ($pInfo->metatags_title_status == '1' ? $pInfo->metatags_title : TEXT_META_EXCLUDED); ?></td>
+        <td class="main"><?php echo TEXT_META_TAGS_TITLE; ?>&nbsp;</td>
+        <td class="main"><?php echo ($pInfo->metatags_title_status == '1' ? $pInfo->metatags_title : TEXT_META_EXCLUDED); ?></td>
       </tr>
       <tr>
-        <td class="main" valign="top"><?php echo TEXT_META_TAGS_KEYWORDS; ?>&nbsp;</td>
-        <td class="main" colspan="3"><?php echo $pInfo->metatags_keywords; ?></td>
+        <td class="main"><?php echo TEXT_META_TAGS_KEYWORDS; ?>&nbsp;</td>
+        <td class="main"><?php echo $pInfo->metatags_keywords; ?></td>
       </tr>
       <tr>
-        <td class="main" valign="top"><?php echo TEXT_META_TAGS_DESCRIPTION; ?>&nbsp;</td>
-        <td class="main" colspan="3"><?php echo $pInfo->metatags_description; ?></td>
+        <td class="main"><?php echo TEXT_META_TAGS_DESCRIPTION; ?>&nbsp;</td>
+        <td class="main"><?php echo $pInfo->metatags_description; ?></td>
       </tr>
     </table>
     <?php

--- a/admin/includes/modules/document_product/collect_info.php
+++ b/admin/includes/modules/document_product/collect_info.php
@@ -409,7 +409,7 @@ if (zen_get_categories_status($current_category_id) == 0 && $pInfo->products_sta
           <span class="input-group-addon">
               <?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']); ?>
           </span>
-          <?php echo zen_draw_input_field('products_url[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($products_url[$languages[$i]['id']]) ? $products_url[$languages[$i]['id']] : zen_get_products_url($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_PRODUCTS_DESCRIPTION, 'products_url') . ' class="form-control" inputtype="url"'); ?>
+          <?php echo zen_draw_input_field('products_url[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($products_url[$languages[$i]['id']]) ? $products_url[$languages[$i]['id']] : zen_get_products_url($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_PRODUCTS_DESCRIPTION, 'products_url') . ' class="form-control" inputmode="url"'); ?>
         </div>
         <br>
         <?php

--- a/admin/includes/modules/document_product/collect_info_metatags.php
+++ b/admin/includes/modules/document_product/collect_info_metatags.php
@@ -94,41 +94,41 @@ if (empty($pInfo->metatags_keywords) && empty($pInfo->metatags_description)) {
   <div class="form-group">
     <div class="col-sm-3 control-label"><?php echo TEXT_META_TAG_TITLE_INCLUDES; ?></div>
     <div class="col-sm-6">
-      <div class="form-group">
-          <?php echo zen_draw_label(TEXT_PRODUCTS_METATAGS_PRODUCTS_NAME_STATUS, 'metatags_products_name_status', 'class="col-sm-3 control-label"'); ?>
+      <fieldset class="form-group">
+          <legend class="col-sm-3 control-label"><?php echo TEXT_PRODUCTS_METATAGS_PRODUCTS_NAME_STATUS; ?></legend>
         <div class="col-sm-9">
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_products_name_status', '1', ($pInfo->metatags_products_name_status == '1')) . TEXT_YES; ?></label>
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_products_name_status', '0', ($pInfo->metatags_products_name_status == '0')) . TEXT_NO; ?></label>
         </div>
-      </div>
-      <div class="form-group">
-          <?php echo zen_draw_label(TEXT_PRODUCTS_METATAGS_TITLE_STATUS, 'metatags_title_status', 'class="col-sm-3 control-label"'); ?>
+      </fieldset>
+      <fieldset class="form-group">
+          <legend class="col-sm-3 control-label"><?php echo TEXT_PRODUCTS_METATAGS_TITLE_STATUS; ?></legend>
         <div class="col-sm-9 col-md-6">
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_title_status', '1', ($pInfo->metatags_title_status == '1')) . TEXT_YES; ?></label>
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_title_status', '0', ($pInfo->metatags_title_status == '0')) . TEXT_NO; ?></label>
         </div>
-      </div>
-      <div class="form-group">
-          <?php echo zen_draw_label(TEXT_PRODUCTS_METATAGS_MODEL_STATUS, 'metatags_model_status', 'class="col-sm-3 control-label"'); ?>
+      </fieldset>
+      <fieldset class="form-group">
+          <legend class="col-sm-3 control-label"><?php echo TEXT_PRODUCTS_METATAGS_MODEL_STATUS; ?></legend>
         <div class="col-sm-9 col-md-6">
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_model_status', '1', ($pInfo->metatags_model_status == '1')) . TEXT_YES; ?></label>
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_model_status', '0', ($pInfo->metatags_model_status == '0')) . TEXT_NO; ?></label>
         </div>
-      </div>
-      <div class="form-group">
-          <?php echo zen_draw_label(TEXT_PRODUCTS_METATAGS_PRICE_STATUS, 'metatags_price_status', 'class="col-sm-3 control-label"') ?>
+      </fieldset>
+      <fieldset class="form-group">
+          <legend class="col-sm-3 control-label"><?php echo TEXT_PRODUCTS_METATAGS_PRICE_STATUS; ?></legend>
         <div class="col-sm-9 col-md-6">
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_price_status', '1', ($pInfo->metatags_price_status == '1')) . TEXT_YES; ?></label>
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_price_status', '0', ($pInfo->metatags_price_status == '0')) . TEXT_NO; ?></label>
         </div>
-      </div>
-      <div class="form-group">
-          <?php echo zen_draw_label(TEXT_PRODUCTS_METATAGS_TITLE_TAGLINE_STATUS, 'metatags_title_tagline_status', 'class="col-sm-3 control-label"'); ?>
+      </fieldset>
+      <fieldset class="form-group">
+          <legend class="col-sm-3 control-label"><?php echo TEXT_PRODUCTS_METATAGS_TITLE_TAGLINE_STATUS; ?></legend>
         <div class="col-sm-9 col-md-6">
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_title_tagline_status', '1', ($pInfo->metatags_title_tagline_status == '1')) . TEXT_YES; ?></label>
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_title_tagline_status', '0', ($pInfo->metatags_title_tagline_status == '0')) . TEXT_NO; ?></label>
         </div>
-      </div>
+      </fieldset>
     </div>
   </div>
   <div class="form-group"><?php echo zen_draw_separator('pixel_black.gif', '100%', '3'); ?></div>
@@ -147,7 +147,7 @@ if (empty($pInfo->metatags_keywords) && empty($pInfo->metatags_description)) {
           <div class="form-group">
               <?php echo zen_draw_label(TEXT_META_TAGS_TITLE, 'metatags_title[' . $languages[$i]['id'] . ']', 'class="col-sm-3 control-label"'); ?>
             <div class="col-sm-9 col-md-6">
-                <?php echo zen_draw_input_field('metatags_title[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($metatags_title[$languages[$i]['id']]) ? stripslashes($metatags_title[$languages[$i]['id']]) : zen_get_product_metatag_fields($pInfo->products_id, $languages[$i]['id'], 'metatags_title'), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_META_TAGS_PRODUCTS_DESCRIPTION, 'metatags_title', '150', false) . 'class="form-control"'); //,'id="'.'metatags_title' . $languages[$i]['id'] . '"'); ?>
+                <?php echo zen_draw_input_field('metatags_title[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($metatags_title[$languages[$i]['id']]) ? stripslashes($metatags_title[$languages[$i]['id']]) : zen_get_product_metatag_fields($pInfo->products_id, $languages[$i]['id'], 'metatags_title'), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_META_TAGS_PRODUCTS_DESCRIPTION, 'metatags_title', '150', false) . ' class="form-control"'); //,'id="'.'metatags_title' . $languages[$i]['id'] . '"'); ?>
             </div>
           </div>
           <div class="form-group">

--- a/admin/includes/modules/document_product/preview_info_meta_tags.php
+++ b/admin/includes/modules/document_product/preview_info_meta_tags.php
@@ -46,29 +46,29 @@ $form_action = (isset($_GET['pID'])) ? 'update_product_meta_tags' : 'insert_prod
 
     <table class="table table-bordered">
       <tr>
-        <td class="main" valign="top">
+        <td class="main">
             <?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . '<strong>' . TEXT_PRODUCTS_NAME . '</strong>' . '&nbsp;' . ($pInfo->metatags_products_name_status == '1' ? zen_get_products_name($_GET['pID'], $languages[$i]['id']) : TEXT_META_EXCLUDED); ?>
         </td>
-        <td class="main" valign="top">
+        <td class="main">
             <?php echo '<strong>' . TEXT_PRODUCTS_MODEL . '</strong>&nbsp;' . ($pInfo->metatags_model_status == '1' ? $pInfo->products_model : TEXT_META_EXCLUDED); ?>
         </td>
-        <td class="main" valign="top">
+        <td class="main">
             <?php echo '<strong>' . TEXT_PRODUCTS_PRICE_INFO . '</strong>&nbsp;' . ($pInfo->metatags_price_status == '1' ? $currencies->format($pInfo->products_price_sorter) : TEXT_META_EXCLUDED); ?>
         </td>
-        <td class="main" valign="top">
+        <td class="main">
             <?php echo '<strong>' . TEXT_PRODUCTS_METATAGS_TITLE_TAGLINE_STATUS . '</strong>&nbsp;' . ($pInfo->metatags_title_tagline_status == '1' ? TEXT_TITLE_PLUS_TAGLINE : TEXT_META_EXCLUDED); ?>
         </td>
       </tr>
       <tr>
-        <td class="main" valign="top"><?php echo TEXT_META_TAGS_TITLE; ?>&nbsp;</td>
+        <td class="main"><?php echo TEXT_META_TAGS_TITLE; ?>&nbsp;</td>
         <td class="main" colspan="3"><?php echo ($pInfo->metatags_title_status == '1' ? $pInfo->metatags_title : TEXT_META_EXCLUDED); ?></td>
       </tr>
       <tr>
-        <td class="main" valign="top"><?php echo TEXT_META_TAGS_KEYWORDS; ?>&nbsp;</td>
+        <td class="main"><?php echo TEXT_META_TAGS_KEYWORDS; ?>&nbsp;</td>
         <td class="main" colspan="3"><?php echo $pInfo->metatags_keywords; ?></td>
       </tr>
       <tr>
-        <td class="main" valign="top"><?php echo TEXT_META_TAGS_DESCRIPTION; ?>&nbsp;</td>
+        <td class="main"><?php echo TEXT_META_TAGS_DESCRIPTION; ?>&nbsp;</td>
         <td class="main" colspan="3"><?php echo $pInfo->metatags_description; ?></td>
       </tr>
     </table>

--- a/admin/includes/modules/newsletters/newsletter.php
+++ b/admin/includes/modules/newsletters/newsletter.php
@@ -68,7 +68,7 @@ class newsletter {
     $confirm_string .= zen_draw_separator() . PHP_EOL;
     $confirm_string .= '</div>' . PHP_EOL;
     $confirm_string .= '<div class="row">' . PHP_EOL;
-    $confirm_string .= '<div class="col-sm-12"><tt>' . nl2br($this->content) . '</tt></div>' . PHP_EOL;
+    $confirm_string .= '<div class="col-sm-12"><span class="tt">' . nl2br($this->content) . '</span></div>' . PHP_EOL;
     $confirm_string .= '</div>' . PHP_EOL;
     $confirm_string .= '<div class="row">' . PHP_EOL;
     $confirm_string .= zen_draw_separator() . PHP_EOL;

--- a/admin/includes/modules/newsletters/product_notification.php
+++ b/admin/includes/modules/newsletters/product_notification.php
@@ -162,7 +162,7 @@ function selectAll(FormName, SelectBox) {
     $confirm_string .= zen_draw_separator() . PHP_EOL;
     $confirm_string .= '</div>' . PHP_EOL;
     $confirm_string .= '<div class="row">' . PHP_EOL;
-    $confirm_string .= '<div class="col-sm-12"><tt>' . nl2br($this->content) . '</tt></div>' . PHP_EOL;
+    $confirm_string .= '<div class="col-sm-12"><span class="tt">' . nl2br($this->content) . '</span></div>' . PHP_EOL;
     $confirm_string .= '</div>' . PHP_EOL;
     $confirm_string .= '<div class="row">' . PHP_EOL;
     $confirm_string .= zen_draw_separator() . PHP_EOL;

--- a/admin/includes/modules/product/collect_info.php
+++ b/admin/includes/modules/product/collect_info.php
@@ -409,7 +409,7 @@ if (zen_get_categories_status($current_category_id) == 0 && $pInfo->products_sta
           <span class="input-group-addon">
               <?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']); ?>
           </span>
-          <?php echo zen_draw_input_field('products_url[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($products_url[$languages[$i]['id']]) ? $products_url[$languages[$i]['id']] : zen_get_products_url($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_PRODUCTS_DESCRIPTION, 'products_url') . ' class="form-control" inputtype="url"'); ?>
+          <?php echo zen_draw_input_field('products_url[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($products_url[$languages[$i]['id']]) ? $products_url[$languages[$i]['id']] : zen_get_products_url($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_PRODUCTS_DESCRIPTION, 'products_url') . ' class="form-control" inputmode="url"'); ?>
         </div>
         <br>
         <?php

--- a/admin/includes/modules/product/collect_info_metatags.php
+++ b/admin/includes/modules/product/collect_info_metatags.php
@@ -94,41 +94,41 @@ if (empty($pInfo->metatags_keywords) && empty($pInfo->metatags_description)) {
   <div class="form-group">
     <div class="col-sm-3 control-label"><?php echo TEXT_META_TAG_TITLE_INCLUDES; ?></div>
     <div class="col-sm-6">
-      <div class="form-group">
-          <?php echo zen_draw_label(TEXT_PRODUCTS_METATAGS_PRODUCTS_NAME_STATUS, 'metatags_products_name_status', 'class="col-sm-3 control-label"'); ?>
+      <fieldset class="form-group">
+          <legend class="col-sm-3 control-label"><?php echo TEXT_PRODUCTS_METATAGS_PRODUCTS_NAME_STATUS; ?></legend>
         <div class="col-sm-9">
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_products_name_status', '1', ($pInfo->metatags_products_name_status == '1')) . TEXT_YES; ?></label>
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_products_name_status', '0', ($pInfo->metatags_products_name_status == '0')) . TEXT_NO; ?></label>
         </div>
-      </div>
-      <div class="form-group">
-          <?php echo zen_draw_label(TEXT_PRODUCTS_METATAGS_TITLE_STATUS, 'metatags_title_status', 'class="col-sm-3 control-label"'); ?>
+      </fieldset>
+      <fieldset class="form-group">
+          <legend class="col-sm-3 control-label"><?php echo TEXT_PRODUCTS_METATAGS_TITLE_STATUS; ?></legend>
         <div class="col-sm-9 col-md-6">
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_title_status', '1', ($pInfo->metatags_title_status == '1')) . TEXT_YES; ?></label>
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_title_status', '0', ($pInfo->metatags_title_status == '0')) . TEXT_NO; ?></label>
         </div>
-      </div>
-      <div class="form-group">
-          <?php echo zen_draw_label(TEXT_PRODUCTS_METATAGS_MODEL_STATUS, 'metatags_model_status', 'class="col-sm-3 control-label"'); ?>
+      </fieldset>
+      <fieldset class="form-group">
+          <legend class="col-sm-3 control-label"><?php echo TEXT_PRODUCTS_METATAGS_MODEL_STATUS; ?></legend>
         <div class="col-sm-9 col-md-6">
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_model_status', '1', ($pInfo->metatags_model_status == '1')) . TEXT_YES; ?></label>
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_model_status', '0', ($pInfo->metatags_model_status == '0')) . TEXT_NO; ?></label>
         </div>
-      </div>
-      <div class="form-group">
-          <?php echo zen_draw_label(TEXT_PRODUCTS_METATAGS_PRICE_STATUS, 'metatags_price_status', 'class="col-sm-3 control-label"') ?>
+      </fieldset>
+      <fieldset class="form-group">
+          <legend class="col-sm-3 control-label"><?php echo TEXT_PRODUCTS_METATAGS_PRICE_STATUS; ?></legend>
         <div class="col-sm-9 col-md-6">
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_price_status', '1', ($pInfo->metatags_price_status == '1')) . TEXT_YES; ?></label>
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_price_status', '0', ($pInfo->metatags_price_status == '0')) . TEXT_NO; ?></label>
         </div>
-      </div>
-      <div class="form-group">
-          <?php echo zen_draw_label(TEXT_PRODUCTS_METATAGS_TITLE_TAGLINE_STATUS, 'metatags_title_tagline_status', 'class="col-sm-3 control-label"'); ?>
+      </fieldset>
+      <fieldset class="form-group">
+          <legend class="col-sm-3 control-label"><?php echo TEXT_PRODUCTS_METATAGS_TITLE_TAGLINE_STATUS; ?></legend>
         <div class="col-sm-9 col-md-6">
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_title_tagline_status', '1', ($pInfo->metatags_title_tagline_status == '1')) . TEXT_YES; ?></label>
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_title_tagline_status', '0', ($pInfo->metatags_title_tagline_status == '0')) . TEXT_NO; ?></label>
         </div>
-      </div>
+      </fieldset>
     </div>
   </div>
   <div class="form-group"><?php echo zen_draw_separator('pixel_black.gif', '100%', '3'); ?></div>
@@ -147,7 +147,7 @@ if (empty($pInfo->metatags_keywords) && empty($pInfo->metatags_description)) {
           <div class="form-group">
               <?php echo zen_draw_label(TEXT_META_TAGS_TITLE, 'metatags_title[' . $languages[$i]['id'] . ']', 'class="col-sm-3 control-label"'); ?>
             <div class="col-sm-9 col-md-6">
-                <?php echo zen_draw_input_field('metatags_title[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($metatags_title[$languages[$i]['id']]) ? stripslashes($metatags_title[$languages[$i]['id']]) : zen_get_product_metatag_fields($pInfo->products_id, $languages[$i]['id'], 'metatags_title'), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_META_TAGS_PRODUCTS_DESCRIPTION, 'metatags_title', '150', false) . 'class="form-control"'); //,'id="'.'metatags_title' . $languages[$i]['id'] . '"'); ?>
+                <?php echo zen_draw_input_field('metatags_title[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($metatags_title[$languages[$i]['id']]) ? stripslashes($metatags_title[$languages[$i]['id']]) : zen_get_product_metatag_fields($pInfo->products_id, $languages[$i]['id'], 'metatags_title'), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_META_TAGS_PRODUCTS_DESCRIPTION, 'metatags_title', '150', false) . ' class="form-control"'); //,'id="'.'metatags_title' . $languages[$i]['id'] . '"'); ?>
             </div>
           </div>
           <div class="form-group">

--- a/admin/includes/modules/product/preview_info_meta_tags.php
+++ b/admin/includes/modules/product/preview_info_meta_tags.php
@@ -46,29 +46,29 @@ $form_action = (isset($_GET['pID'])) ? 'update_product_meta_tags' : 'insert_prod
 
     <table class="table table-bordered">
       <tr>
-        <td class="main" valign="top">
+        <td class="main">
             <?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . '<strong>' . TEXT_PRODUCTS_NAME . '</strong>' . '&nbsp;' . ($pInfo->metatags_products_name_status == '1' ? zen_get_products_name($_GET['pID'], $languages[$i]['id']) : TEXT_META_EXCLUDED); ?>
         </td>
-        <td class="main" valign="top">
+        <td class="main">
             <?php echo '<strong>' . TEXT_PRODUCTS_MODEL . '</strong>&nbsp;' . ($pInfo->metatags_model_status == '1' ? $pInfo->products_model : TEXT_META_EXCLUDED); ?>
         </td>
-        <td class="main" valign="top">
+        <td class="main">
             <?php echo '<strong>' . TEXT_PRODUCTS_PRICE_INFO . '</strong>&nbsp;' . ($pInfo->metatags_price_status == '1' ? $currencies->format($pInfo->products_price_sorter) : TEXT_META_EXCLUDED); ?>
         </td>
-        <td class="main" valign="top">
+        <td class="main">
             <?php echo '<strong>' . TEXT_PRODUCTS_METATAGS_TITLE_TAGLINE_STATUS . '</strong>&nbsp;' . ($pInfo->metatags_title_tagline_status == '1' ? TEXT_TITLE_PLUS_TAGLINE : TEXT_META_EXCLUDED); ?>
         </td>
       </tr>
       <tr>
-        <td class="main" valign="top"><?php echo TEXT_META_TAGS_TITLE; ?>&nbsp;</td>
+        <td class="main"><?php echo TEXT_META_TAGS_TITLE; ?>&nbsp;</td>
         <td class="main" colspan="3"><?php echo ($pInfo->metatags_title_status == '1' ? $pInfo->metatags_title : TEXT_META_EXCLUDED); ?></td>
       </tr>
       <tr>
-        <td class="main" valign="top"><?php echo TEXT_META_TAGS_KEYWORDS; ?>&nbsp;</td>
+        <td class="main"><?php echo TEXT_META_TAGS_KEYWORDS; ?>&nbsp;</td>
         <td class="main" colspan="3"><?php echo $pInfo->metatags_keywords; ?></td>
       </tr>
       <tr>
-        <td class="main" valign="top"><?php echo TEXT_META_TAGS_DESCRIPTION; ?>&nbsp;</td>
+        <td class="main"><?php echo TEXT_META_TAGS_DESCRIPTION; ?>&nbsp;</td>
         <td class="main" colspan="3"><?php echo $pInfo->metatags_description; ?></td>
       </tr>
     </table>

--- a/admin/includes/modules/product_free_shipping/collect_info.php
+++ b/admin/includes/modules/product_free_shipping/collect_info.php
@@ -409,7 +409,7 @@ if (zen_get_categories_status($current_category_id) == 0 && $pInfo->products_sta
           <span class="input-group-addon">
               <?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']); ?>
           </span>
-          <?php echo zen_draw_input_field('products_url[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($products_url[$languages[$i]['id']]) ? $products_url[$languages[$i]['id']] : zen_get_products_url($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_PRODUCTS_DESCRIPTION, 'products_url') . ' class="form-control" inputtype="url"'); ?>
+          <?php echo zen_draw_input_field('products_url[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($products_url[$languages[$i]['id']]) ? $products_url[$languages[$i]['id']] : zen_get_products_url($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_PRODUCTS_DESCRIPTION, 'products_url') . ' class="form-control" inputmode="url"'); ?>
         </div>
         <br>
         <?php

--- a/admin/includes/modules/product_free_shipping/collect_info_metatags.php
+++ b/admin/includes/modules/product_free_shipping/collect_info_metatags.php
@@ -94,41 +94,41 @@ if (empty($pInfo->metatags_keywords) && empty($pInfo->metatags_description)) {
   <div class="form-group">
     <div class="col-sm-3 control-label"><?php echo TEXT_META_TAG_TITLE_INCLUDES; ?></div>
     <div class="col-sm-6">
-      <div class="form-group">
-          <?php echo zen_draw_label(TEXT_PRODUCTS_METATAGS_PRODUCTS_NAME_STATUS, 'metatags_products_name_status', 'class="col-sm-3 control-label"'); ?>
+      <fieldset class="form-group">
+          <legend class="col-sm-3 control-label"><?php echo TEXT_PRODUCTS_METATAGS_PRODUCTS_NAME_STATUS;?></legend>
         <div class="col-sm-9">
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_products_name_status', '1', ($pInfo->metatags_products_name_status == '1')) . TEXT_YES; ?></label>
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_products_name_status', '0', ($pInfo->metatags_products_name_status == '0')) . TEXT_NO; ?></label>
         </div>
-      </div>
-      <div class="form-group">
-          <?php echo zen_draw_label(TEXT_PRODUCTS_METATAGS_TITLE_STATUS, 'metatags_title_status', 'class="col-sm-3 control-label"'); ?>
+      </fieldset>
+      <fieldset class="form-group">
+          <legend class="col-sm-3 control-label"><?php echo TEXT_PRODUCTS_METATAGS_TITLE_STATUS;?></legend>
         <div class="col-sm-9 col-md-6">
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_title_status', '1', ($pInfo->metatags_title_status == '1')) . TEXT_YES; ?></label>
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_title_status', '0', ($pInfo->metatags_title_status == '0')) . TEXT_NO; ?></label>
         </div>
-      </div>
-      <div class="form-group">
-          <?php echo zen_draw_label(TEXT_PRODUCTS_METATAGS_MODEL_STATUS, 'metatags_model_status', 'class="col-sm-3 control-label"'); ?>
+      </fieldset>
+      <fieldset class="form-group">
+          <legend class="col-sm-3 control-label"><?php echo TEXT_PRODUCTS_METATAGS_MODEL_STATUS;?></legend>
         <div class="col-sm-9 col-md-6">
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_model_status', '1', ($pInfo->metatags_model_status == '1')) . TEXT_YES; ?></label>
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_model_status', '0', ($pInfo->metatags_model_status == '0')) . TEXT_NO; ?></label>
         </div>
-      </div>
-      <div class="form-group">
-          <?php echo zen_draw_label(TEXT_PRODUCTS_METATAGS_PRICE_STATUS, 'metatags_price_status', 'class="col-sm-3 control-label"') ?>
+      </fieldset>
+      <fieldset class="form-group">
+          <legend class="col-sm-3 control-label"><?php echo TEXT_PRODUCTS_METATAGS_PRICE_STATUS;?></legend>
         <div class="col-sm-9 col-md-6">
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_price_status', '1', ($pInfo->metatags_price_status == '1')) . TEXT_YES; ?></label>
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_price_status', '0', ($pInfo->metatags_price_status == '0')) . TEXT_NO; ?></label>
         </div>
-      </div>
-      <div class="form-group">
-          <?php echo zen_draw_label(TEXT_PRODUCTS_METATAGS_TITLE_TAGLINE_STATUS, 'metatags_title_tagline_status', 'class="col-sm-3 control-label"'); ?>
+      </fieldset>
+      <fieldset class="form-group">
+          <legend class="col-sm-3 control-label"><?php echo TEXT_PRODUCTS_METATAGS_TITLE_TAGLINE_STATUS;?></legend>
         <div class="col-sm-9 col-md-6">
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_title_tagline_status', '1', ($pInfo->metatags_title_tagline_status == '1')) . TEXT_YES; ?></label>
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_title_tagline_status', '0', ($pInfo->metatags_title_tagline_status == '0')) . TEXT_NO; ?></label>
         </div>
-      </div>
+      </fieldset>
     </div>
   </div>
   <div class="form-group"><?php echo zen_draw_separator('pixel_black.gif', '100%', '3'); ?></div>
@@ -147,7 +147,7 @@ if (empty($pInfo->metatags_keywords) && empty($pInfo->metatags_description)) {
           <div class="form-group">
               <?php echo zen_draw_label(TEXT_META_TAGS_TITLE, 'metatags_title[' . $languages[$i]['id'] . ']', 'class="col-sm-3 control-label"'); ?>
             <div class="col-sm-9 col-md-6">
-                <?php echo zen_draw_input_field('metatags_title[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($metatags_title[$languages[$i]['id']]) ? stripslashes($metatags_title[$languages[$i]['id']]) : zen_get_product_metatag_fields($pInfo->products_id, $languages[$i]['id'], 'metatags_title'), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_META_TAGS_PRODUCTS_DESCRIPTION, 'metatags_title', '150', false) . 'class="form-control"'); //,'id="'.'metatags_title' . $languages[$i]['id'] . '"'); ?>
+                <?php echo zen_draw_input_field('metatags_title[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($metatags_title[$languages[$i]['id']]) ? stripslashes($metatags_title[$languages[$i]['id']]) : zen_get_product_metatag_fields($pInfo->products_id, $languages[$i]['id'], 'metatags_title'), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_META_TAGS_PRODUCTS_DESCRIPTION, 'metatags_title', '150', false) . ' class="form-control"'); //,'id="'.'metatags_title' . $languages[$i]['id'] . '"'); ?>
             </div>
           </div>
           <div class="form-group">

--- a/admin/includes/modules/product_free_shipping/preview_info_meta_tags.php
+++ b/admin/includes/modules/product_free_shipping/preview_info_meta_tags.php
@@ -46,29 +46,29 @@ $form_action = (isset($_GET['pID'])) ? 'update_product_meta_tags' : 'insert_prod
 
     <table class="table table-bordered">
       <tr>
-        <td class="main" valign="top">
+        <td class="main">
             <?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . '<strong>' . TEXT_PRODUCTS_NAME . '</strong>' . '&nbsp;' . ($pInfo->metatags_products_name_status == '1' ? zen_get_products_name($_GET['pID'], $languages[$i]['id']) : TEXT_META_EXCLUDED); ?>
         </td>
-        <td class="main" valign="top">
+        <td class="main">
             <?php echo '<strong>' . TEXT_PRODUCTS_MODEL . '</strong>&nbsp;' . ($pInfo->metatags_model_status == '1' ? $pInfo->products_model : TEXT_META_EXCLUDED); ?>
         </td>
-        <td class="main" valign="top">
+        <td class="main">
             <?php echo '<strong>' . TEXT_PRODUCTS_PRICE_INFO . '</strong>&nbsp;' . ($pInfo->metatags_price_status == '1' ? $currencies->format($pInfo->products_price_sorter) : TEXT_META_EXCLUDED); ?>
         </td>
-        <td class="main" valign="top">
+        <td class="main">
             <?php echo '<strong>' . TEXT_PRODUCTS_METATAGS_TITLE_TAGLINE_STATUS . '</strong>&nbsp;' . ($pInfo->metatags_title_tagline_status == '1' ? TEXT_TITLE_PLUS_TAGLINE : TEXT_META_EXCLUDED); ?>
         </td>
       </tr>
       <tr>
-        <td class="main" valign="top"><?php echo TEXT_META_TAGS_TITLE; ?>&nbsp;</td>
+        <td class="main"><?php echo TEXT_META_TAGS_TITLE; ?>&nbsp;</td>
         <td class="main" colspan="3"><?php echo ($pInfo->metatags_title_status == '1' ? $pInfo->metatags_title : TEXT_META_EXCLUDED); ?></td>
       </tr>
       <tr>
-        <td class="main" valign="top"><?php echo TEXT_META_TAGS_KEYWORDS; ?>&nbsp;</td>
+        <td class="main"><?php echo TEXT_META_TAGS_KEYWORDS; ?>&nbsp;</td>
         <td class="main" colspan="3"><?php echo $pInfo->metatags_keywords; ?></td>
       </tr>
       <tr>
-        <td class="main" valign="top"><?php echo TEXT_META_TAGS_DESCRIPTION; ?>&nbsp;</td>
+        <td class="main"><?php echo TEXT_META_TAGS_DESCRIPTION; ?>&nbsp;</td>
         <td class="main" colspan="3"><?php echo $pInfo->metatags_description; ?></td>
       </tr>
     </table>

--- a/admin/includes/modules/product_music/collect_info.php
+++ b/admin/includes/modules/product_music/collect_info.php
@@ -442,7 +442,7 @@ if (zen_get_categories_status($current_category_id) == 0 && $pInfo->products_sta
           <span class="input-group-addon">
               <?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']); ?>
           </span>
-          <?php echo zen_draw_input_field('products_url[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($products_url[$languages[$i]['id']]) ? $products_url[$languages[$i]['id']] : zen_get_products_url($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_PRODUCTS_DESCRIPTION, 'products_url') . ' class="form-control" inputtype="url"'); ?>
+          <?php echo zen_draw_input_field('products_url[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($products_url[$languages[$i]['id']]) ? $products_url[$languages[$i]['id']] : zen_get_products_url($pInfo->products_id, $languages[$i]['id']), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_PRODUCTS_DESCRIPTION, 'products_url') . ' class="form-control" inputmode="url"'); ?>
         </div>
         <br>
         <?php

--- a/admin/includes/modules/product_music/collect_info_metatags.php
+++ b/admin/includes/modules/product_music/collect_info_metatags.php
@@ -94,41 +94,41 @@ if (empty($pInfo->metatags_keywords) && empty($pInfo->metatags_description)) {
   <div class="form-group">
     <div class="col-sm-3 control-label"><?php echo TEXT_META_TAG_TITLE_INCLUDES; ?></div>
     <div class="col-sm-6">
-      <div class="form-group">
-          <?php echo zen_draw_label(TEXT_PRODUCTS_METATAGS_PRODUCTS_NAME_STATUS, 'metatags_products_name_status', 'class="col-sm-3 control-label"'); ?>
+      <fieldset class="form-group">
+          <legend class="col-sm-3 control-label"><?php echo TEXT_PRODUCTS_METATAGS_PRODUCTS_NAME_STATUS;?></legend>
         <div class="col-sm-9">
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_products_name_status', '1', ($pInfo->metatags_products_name_status == '1')) . TEXT_YES; ?></label>
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_products_name_status', '0', ($pInfo->metatags_products_name_status == '0')) . TEXT_NO; ?></label>
         </div>
-      </div>
-      <div class="form-group">
-          <?php echo zen_draw_label(TEXT_PRODUCTS_METATAGS_TITLE_STATUS, 'metatags_title_status', 'class="col-sm-3 control-label"'); ?>
+      </fieldset>
+      <fieldset class="form-group">
+          <legend class="col-sm-3 control-label"><?php echo TEXT_PRODUCTS_METATAGS_TITLE_STATUS;?></legend>
         <div class="col-sm-9 col-md-6">
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_title_status', '1', ($pInfo->metatags_title_status == '1')) . TEXT_YES; ?></label>
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_title_status', '0', ($pInfo->metatags_title_status == '0')) . TEXT_NO; ?></label>
         </div>
-      </div>
-      <div class="form-group">
-          <?php echo zen_draw_label(TEXT_PRODUCTS_METATAGS_MODEL_STATUS, 'metatags_model_status', 'class="col-sm-3 control-label"'); ?>
+      </fieldset>
+      <fieldset class="form-group">
+          <legend class="col-sm-3 control-label"><?php echo TEXT_PRODUCTS_METATAGS_MODEL_STATUS;?></legend>
         <div class="col-sm-9 col-md-6">
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_model_status', '1', ($pInfo->metatags_model_status == '1')) . TEXT_YES; ?></label>
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_model_status', '0', ($pInfo->metatags_model_status == '0')) . TEXT_NO; ?></label>
         </div>
-      </div>
-      <div class="form-group">
-          <?php echo zen_draw_label(TEXT_PRODUCTS_METATAGS_PRICE_STATUS, 'metatags_price_status', 'class="col-sm-3 control-label"') ?>
+      </fieldset>
+      <fieldset class="form-group">
+          <legend class="col-sm-3 control-label"><?php echo TEXT_PRODUCTS_METATAGS_PRICE_STATUS;?></legend>
         <div class="col-sm-9 col-md-6">
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_price_status', '1', ($pInfo->metatags_price_status == '1')) . TEXT_YES; ?></label>
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_price_status', '0', ($pInfo->metatags_price_status == '0')) . TEXT_NO; ?></label>
         </div>
-      </div>
-      <div class="form-group">
-          <?php echo zen_draw_label(TEXT_PRODUCTS_METATAGS_TITLE_TAGLINE_STATUS, 'metatags_title_tagline_status', 'class="col-sm-3 control-label"'); ?>
+      </fieldset>
+      <fieldset class="form-group">
+          <legend class="col-sm-3 control-label"><?php echo TEXT_PRODUCTS_METATAGS_TITLE_TAGLINE_STATUS;?></legend>
         <div class="col-sm-9 col-md-6">
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_title_tagline_status', '1', ($pInfo->metatags_title_tagline_status == '1')) . TEXT_YES; ?></label>
           <label class="radio-inline"><?php echo zen_draw_radio_field('metatags_title_tagline_status', '0', ($pInfo->metatags_title_tagline_status == '0')) . TEXT_NO; ?></label>
         </div>
-      </div>
+      </fieldset>
     </div>
   </div>
   <div class="form-group"><?php echo zen_draw_separator('pixel_black.gif', '100%', '3'); ?></div>
@@ -147,7 +147,7 @@ if (empty($pInfo->metatags_keywords) && empty($pInfo->metatags_description)) {
           <div class="form-group">
               <?php echo zen_draw_label(TEXT_META_TAGS_TITLE, 'metatags_title[' . $languages[$i]['id'] . ']', 'class="col-sm-3 control-label"'); ?>
             <div class="col-sm-9 col-md-6">
-                <?php echo zen_draw_input_field('metatags_title[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($metatags_title[$languages[$i]['id']]) ? stripslashes($metatags_title[$languages[$i]['id']]) : zen_get_product_metatag_fields($pInfo->products_id, $languages[$i]['id'], 'metatags_title'), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_META_TAGS_PRODUCTS_DESCRIPTION, 'metatags_title', '150', false) . 'class="form-control"'); //,'id="'.'metatags_title' . $languages[$i]['id'] . '"'); ?>
+                <?php echo zen_draw_input_field('metatags_title[' . $languages[$i]['id'] . ']', htmlspecialchars(isset($metatags_title[$languages[$i]['id']]) ? stripslashes($metatags_title[$languages[$i]['id']]) : zen_get_product_metatag_fields($pInfo->products_id, $languages[$i]['id'], 'metatags_title'), ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_META_TAGS_PRODUCTS_DESCRIPTION, 'metatags_title', '150', false) . ' class="form-control"'); //,'id="'.'metatags_title' . $languages[$i]['id'] . '"'); ?>
             </div>
           </div>
           <div class="form-group">

--- a/admin/includes/modules/product_music/copy_product.php
+++ b/admin/includes/modules/product_music/copy_product.php
@@ -34,7 +34,7 @@ $contents[] = array('text' => zen_draw_label(TEXT_CATEGORIES, 'categories_id', '
 $contents[] = array(
     'text' => '<h5>' . TEXT_HOW_TO_COPY . '</h5>' .
         '<div class="radio h6"><label>' . zen_draw_radio_field('copy_as', 'link', true) . TEXT_COPY_AS_LINK . '</label></div>' .
-        zen_image(DIR_WS_IMAGES . 'pixel_black.gif', '', '', '1', 'style="width:100%"') .
+        zen_image(DIR_WS_IMAGES . 'pixel_black.gif', '', '100%', '1', '') .
         '<div class="radio h6"><label>' . zen_draw_radio_field('copy_as', 'duplicate') . TEXT_COPY_AS_DUPLICATE . '</label></div>'
 );
 $contents[] = array('text' => '<div class="checkbox"><label>'.zen_draw_checkbox_field('copy_media',true, true) . TEXT_COPY_MEDIA_MANAGER . '</label></div>');
@@ -84,10 +84,10 @@ if (zen_has_product_discounts($pInfo->products_id) == 'true') {
     );
 }
 $contents[] = array('text' => '<label>' . zen_draw_checkbox_field('edit_duplicate', '1', true) . TEXT_COPY_EDIT_DUPLICATE . '</label>');
-$contents[] = array('text' => zen_image(DIR_WS_IMAGES . 'pixel_black.gif', '', '', '3', 'style="width:100%"'));
+$contents[] = array('text' => zen_image(DIR_WS_IMAGES . 'pixel_black.gif', '', '100%', '3', ''));
 $contents[] = array('align' => 'center', 'text' => '<button type="submit" class="btn btn-primary">' . IMAGE_COPY . '</button>
 <a href="' . zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING, 'cPath=' . $cPath . '&pID=' . $pInfo->products_id . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '')) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>'
 );
 
-$contents[] = array('text' => zen_image(DIR_WS_IMAGES . 'pixel_black.gif', '', '', '1', 'style="width:100%"'));
+$contents[] = array('text' => zen_image(DIR_WS_IMAGES . 'pixel_black.gif', '', '100%', '1', '"'));
 $contents[] = array('align' => 'center', 'text' => '<a href="' . zen_href_link(FILENAME_PRODUCTS_TO_CATEGORIES, 'products_filter=' . $pInfo->products_id . '&current_category_id=' . $current_category_id) . '" class="btn btn-info" role="button">' . BUTTON_PRODUCTS_TO_CATEGORIES . '</a>');

--- a/admin/includes/modules/product_music/preview_info_meta_tags.php
+++ b/admin/includes/modules/product_music/preview_info_meta_tags.php
@@ -46,29 +46,29 @@ $form_action = (isset($_GET['pID'])) ? 'update_product_meta_tags' : 'insert_prod
 
     <table class="table table-bordered">
       <tr>
-        <td class="main" valign="top">
+        <td class="main">
             <?php echo zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '&nbsp;' . '<strong>' . TEXT_PRODUCTS_NAME . '</strong>' . '&nbsp;' . ($pInfo->metatags_products_name_status == '1' ? zen_get_products_name($_GET['pID'], $languages[$i]['id']) : TEXT_META_EXCLUDED); ?>
         </td>
-        <td class="main" valign="top">
+        <td class="main">
             <?php echo '<strong>' . TEXT_PRODUCTS_MODEL . '</strong>&nbsp;' . ($pInfo->metatags_model_status == '1' ? $pInfo->products_model : TEXT_META_EXCLUDED); ?>
         </td>
-        <td class="main" valign="top">
+        <td class="main">
             <?php echo '<strong>' . TEXT_PRODUCTS_PRICE_INFO . '</strong>&nbsp;' . ($pInfo->metatags_price_status == '1' ? $currencies->format($pInfo->products_price_sorter) : TEXT_META_EXCLUDED); ?>
         </td>
-        <td class="main" valign="top">
+        <td class="main">
             <?php echo '<strong>' . TEXT_PRODUCTS_METATAGS_TITLE_TAGLINE_STATUS . '</strong>&nbsp;' . ($pInfo->metatags_title_tagline_status == '1' ? TEXT_TITLE_PLUS_TAGLINE : TEXT_META_EXCLUDED); ?>
         </td>
       </tr>
       <tr>
-        <td class="main" valign="top"><?php echo TEXT_META_TAGS_TITLE; ?>&nbsp;</td>
+        <td class="main"><?php echo TEXT_META_TAGS_TITLE; ?>&nbsp;</td>
         <td class="main" colspan="3"><?php echo ($pInfo->metatags_title_status == '1' ? $pInfo->metatags_title : TEXT_META_EXCLUDED); ?></td>
       </tr>
       <tr>
-        <td class="main" valign="top"><?php echo TEXT_META_TAGS_KEYWORDS; ?>&nbsp;</td>
+        <td class="main"><?php echo TEXT_META_TAGS_KEYWORDS; ?>&nbsp;</td>
         <td class="main" colspan="3"><?php echo $pInfo->metatags_keywords; ?></td>
       </tr>
       <tr>
-        <td class="main" valign="top"><?php echo TEXT_META_TAGS_DESCRIPTION; ?>&nbsp;</td>
+        <td class="main"><?php echo TEXT_META_TAGS_DESCRIPTION; ?>&nbsp;</td>
         <td class="main" colspan="3"><?php echo $pInfo->metatags_description; ?></td>
       </tr>
     </table>

--- a/admin/includes/templates/table_view.php
+++ b/admin/includes/templates/table_view.php
@@ -28,7 +28,7 @@ use Zencart\Paginator\LaravelPaginator;
 
     <div class="row">
         <div class="col-xs-12 col-sm-12 col-md-9 col-lg-9 configurationColumnLeft">
-            <table class="table table-hover">
+            <table class="table table-hover" role="listbox">
                 <thead>
                 <tr class="dataTableHeadingRow">
                     <?php foreach ($formatter->getTableHeaders() as $colHeader) { ?>
@@ -42,11 +42,11 @@ use Zencart\Paginator\LaravelPaginator;
                 <?php foreach ($formatter->getTableData() as $tableData) { ?>
                     <?php if ($formatter->isRowSelected($tableData)) { ?>
                         <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href='<?php echo $formatter->getSelectedRowLink(
-                            $tableData); ?>'" role="button">
+                            $tableData); ?>'" role="option" aria-selected="true">
                     <?php } else { ?>
                         <tr class="dataTableRow" onclick="document.location.href='<?php echo
                         $formatter->getNotSelectedRowLink($tableData); ?>'"
-                        role="button">
+                        role="option" aria-selected="false">
                     <?php } ?>
                     <?php foreach ($tableData as $column) { ?>
                         <td class="<?php echo $column['class']; ?>">
@@ -81,9 +81,10 @@ use Zencart\Paginator\LaravelPaginator;
     <?php if ($formatter->hasButtonActions()) { ?>
     <div class="row">
         <?php foreach ($formatter->getButtonActions() as $buttonAction) { ?>
-            <a href="<?php echo zen_href_link($PHP_SELF, $buttonAction['hrefLink']); ?>">
-            <button class="btn <?php echo $buttonAction['buttonClass']; ?>" type="button"><?php echo $buttonAction['title']; ?></button>
+            <a href="<?php echo zen_href_link($PHP_SELF, $buttonAction['hrefLink'] ) . '" class="btn ' . $buttonAction['buttonClass'] . '" role="button'; ?>">
+            <?php echo $buttonAction['title']; ?>
             </a>
         <?php } ?>
     </div>
     <?php } ?>
+</div>

--- a/admin/invoice.php
+++ b/admin/invoice.php
@@ -67,7 +67,7 @@ if ($order->billing['street_address'] != $order->delivery['street_address']) {
       <table class="table">
         <tr>
           <td class="pageHeading"><?php echo nl2br(STORE_NAME_ADDRESS); ?></td>
-          <td class="pageHeading" align="right"><?php echo zen_image(DIR_WS_IMAGES . HEADER_LOGO_IMAGE, HEADER_ALT_TEXT); ?></td>
+          <td class="pageHeading text-right"><?php echo zen_image(DIR_WS_IMAGES . HEADER_LOGO_IMAGE, HEADER_ALT_TEXT); ?></td>
         </tr>
       </table>
       <div><?php echo zen_draw_separator(); ?></div>

--- a/admin/languages.php
+++ b/admin/languages.php
@@ -286,7 +286,7 @@ if (!empty($action)) {
       <div class="row">
         <!-- body_text //-->
         <div class="col-xs-12 col-sm-12 col-md-9 col-lg-9 configurationColumnLeft">
-          <table class="table table-hover">
+          <table class="table table-hover" role="listbox">
             <thead>
               <tr class="dataTableHeadingRow">
                 <th class="dataTableHeadingContent"><?php echo TABLE_HEADING_LANGUAGE_NAME; ?></th>
@@ -306,9 +306,9 @@ if (!empty($action)) {
                     $lInfo = new objectInfo($language);
                   }
                   if (isset($lInfo) && is_object($lInfo) && ($language['languages_id'] == $lInfo->languages_id)) {
-                    echo '                  <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href=\'' . zen_href_link(FILENAME_LANGUAGES, 'page=' . $_GET['page'] . '&lID=' . $lInfo->languages_id . '&action=edit') . '\'" role="button">' . "\n";
+                    echo '                  <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href=\'' . zen_href_link(FILENAME_LANGUAGES, 'page=' . $_GET['page'] . '&lID=' . $lInfo->languages_id . '&action=edit') . '\'" role="option" aria-selected="true">' . "\n";
                   } else {
-                    echo '                  <tr class="dataTableRow" onclick="document.location.href=\'' . zen_href_link(FILENAME_LANGUAGES, 'page=' . $_GET['page'] . '&lID=' . $language['languages_id']) . '\'" role="button">' . "\n";
+                    echo '                  <tr class="dataTableRow" onclick="document.location.href=\'' . zen_href_link(FILENAME_LANGUAGES, 'page=' . $_GET['page'] . '&lID=' . $language['languages_id']) . '\'" role="option" aria-selected="false">' . "\n";
                   }
                   if (DEFAULT_LANGUAGE == $language['code']) {
                     echo '                <td class="dataTableContent"><strong>' . $language['name'] . ' (' . TEXT_DEFAULT . ')</strong></td>' . "\n";

--- a/admin/mail.php
+++ b/admin/mail.php
@@ -22,7 +22,7 @@ $upload_file_name = $attachment_file = $attachment_filetype = '';
 if ($action == 'set_editor') {
   // Reset will be done by init_html_editor.php. Now we simply redirect to refresh page properly.
   $action = '';
-  zen_redirect(zen_href_link(FILENAME_MAIL));
+  zen_redirect(zen_href_link(FILENAME_MAIL, $_GET['calling_parameters'] ?? ''));
 }
 
 if (($action == 'send_email_to_user') && isset($_POST['customers_email_address']) && !isset($_POST['back'])) {
@@ -185,10 +185,11 @@ if ($action == 'preview') {
       <h1><?php echo HEADING_TITLE; ?></h1>
       <div class="row text-right">
           <?php
-          // toggle switch for editor
+          // toggle switch for editor add calling parameters so customer details are not lost.
           echo TEXT_EDITOR_INFO . zen_draw_form('set_editor_form', FILENAME_MAIL, '', 'get') . '&nbsp;&nbsp;' . zen_draw_pull_down_menu('reset_editor', $editors_pulldown, $current_editor_key, 'onChange="this.form.submit();"') .
           zen_hide_session_id() .
           zen_draw_hidden_field('action', 'set_editor') .
+          zen_draw_hidden_field('calling_parameters', strstr($_SERVER['QUERY_STRING'] ?? '' , '&')) .
           '</form>';
           ?>
       </div>
@@ -224,7 +225,7 @@ if ($action == 'preview') {
               $message_preview = (false !== stripos($message_preview, '<br') ? $message_preview : nl2br($message_preview));
               $message_preview = str_replace(array('<br>', '<br />'), "<br />\n", $message_preview);
               $message_preview = str_replace('</p>', "</p>\n", $message_preview);
-              echo '<tt>' . nl2br(htmlspecialchars(stripslashes(strip_tags($message_preview)), ENT_COMPAT, CHARSET, TRUE)) . '</tt>';
+              echo '<span class="tt">' . nl2br(htmlspecialchars(stripslashes(strip_tags($message_preview)), ENT_COMPAT, CHARSET, TRUE)) . '</span>';
               ?>
           </div>
           <div class="col-sm-12"><hr></div>
@@ -276,7 +277,12 @@ if ($action == 'preview') {
             <div class="col-sm-9"><?php echo zen_draw_input_field('subject', htmlspecialchars(isset($_POST['subject']) ? $_POST['subject'] : '', ENT_COMPAT, CHARSET, TRUE), 'size="50" class="form-control"'); ?></div>
           </div>
           <div class="form-group">
-            <?php echo zen_draw_label(TEXT_MESSAGE_HTML, 'message_html', 'class="col-sm-3 control-label"'); //HTML version   ?>
+            <?php  
+            if (EMAIL_USE_HTML == 'true') {
+                echo zen_draw_label(TEXT_MESSAGE_HTML, 'message_html', 'class="col-sm-3 control-label"'); //HTML version   
+            } else {
+                echo '<div class="col-sm-3 control-label">' . TEXT_MESSAGE_HTML . '</div>';
+            }?>
             <div class="col-sm-9">
                 <?php
                 if (EMAIL_USE_HTML == 'true') {
@@ -324,6 +330,10 @@ if ($action == 'preview') {
           <button type="submit" class="btn btn-primary"><?php echo IMAGE_PREVIEW; ?></button> <a href="<?php echo zen_href_link($origin, (!empty($_GET['cID']) ? 'cID=' . (int)$_GET['cID'] : ''), $request_type); ?>" class="btn btn-default"><?php echo IMAGE_CANCEL; ?></a>
         </div>
         <?php
+        echo '</form>'; 
+        ?>
+      </div>
+      <?php 
       }
       ?>
       <!-- body_text_eof //-->

--- a/admin/media_manager.php
+++ b/admin/media_manager.php
@@ -133,25 +133,25 @@
 <!-- header_eof //-->
 
 <!-- body //-->
-<table border="0" width="100%" cellspacing="2" cellpadding="2">
-  <tr>
+<table class="table">
+  <tr class="col-sx-12">
 <!-- body_text //-->
-    <td width="100%" valign="top"><table border="0" width="100%" cellspacing="0" cellpadding="2">
+    <td><table class="table">
       <tr>
-        <td width="100%"><table border="0" width="100%" cellspacing="0" cellpadding="0">
+        <td><table class="table">
           <tr>
             <td class="pageHeading"><?php echo HEADING_TITLE_MEDIA_MANAGER; ?></td>
-            <td class="pageHeading" align="right"><?php echo zen_draw_separator('pixel_trans.gif', HEADING_IMAGE_WIDTH, HEADING_IMAGE_HEIGHT); ?></td>
+            <td class="pageHeading text-right"><?php echo zen_draw_separator('pixel_trans.gif', HEADING_IMAGE_WIDTH, HEADING_IMAGE_HEIGHT); ?></td>
           </tr>
         </table></td>
       </tr>
       <tr>
-        <td><table border="0" width="100%" cellspacing="0" cellpadding="0">
+        <td><table class="table">
           <tr>
-            <td valign="top"><table border="0" width="100%" cellspacing="0" cellpadding="2">
+            <td ><table class="table">
               <tr class="dataTableHeadingRow">
                 <td class="dataTableHeadingContent"><?php echo TABLE_HEADING_MEDIA; ?></td>
-                <td class="dataTableHeadingContent" align="right"><?php echo TABLE_HEADING_ACTION; ?>&nbsp;</td>
+                <td class="dataTableHeadingContent text-right"><?php echo TABLE_HEADING_ACTION; ?>&nbsp;</td>
               </tr>
 <?php
   $media_query_raw = "SELECT * FROM " . TABLE_MEDIA_MANAGER . " ORDER BY media_name";
@@ -164,13 +164,13 @@
     }
 
     if (isset($mInfo) && is_object($mInfo) && ($media->fields['media_id'] == $mInfo->media_id)) {
-      echo '              <tr id="defaultSelected" class="dataTableRowSelected" onmouseover="rowOverEffect(this)" onmouseout="rowOutEffect(this)" onclick="document.location.href=\'' . zen_href_link(FILENAME_MEDIA_MANAGER, 'page=' . $_GET['page'] . '&mID=' . $media->fields['media_id']) . '\'">' . "\n";
+      echo '              <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href=\'' . zen_href_link(FILENAME_MEDIA_MANAGER, 'page=' . $_GET['page'] . '&mID=' . $media->fields['media_id']) . '\'">' . "\n";
     } else {
-      echo '              <tr class="dataTableRow" onmouseover="rowOverEffect(this)" onmouseout="rowOutEffect(this)" onclick="document.location.href=\'' . zen_href_link(FILENAME_MEDIA_MANAGER, 'page=' . $_GET['page'] . '&mID=' . $media->fields['media_id']) . '\'">' . "\n";
+      echo '              <tr class="dataTableRow" onclick="document.location.href=\'' . zen_href_link(FILENAME_MEDIA_MANAGER, 'page=' . $_GET['page'] . '&mID=' . $media->fields['media_id']) . '\'">' . "\n";
     }
 ?>
                 <td class="dataTableContent"><?php echo $media->fields['media_name']; ?></td>
-                <td class="dataTableContent" align="right">
+                <td class="dataTableContent text-right">
                   <?php echo '<a href="' . zen_href_link(FILENAME_MEDIA_MANAGER, 'page=' . $_GET['page'] . '&mID=' . $media->fields['media_id'] . '&action=edit') . '">' . zen_image(DIR_WS_IMAGES . 'icon_edit.gif', ICON_EDIT) . '</a>'; ?>
                   <?php echo '<a href="' . zen_href_link(FILENAME_MEDIA_MANAGER, 'page=' . $_GET['page'] . '&mID=' . $media->fields['media_id'] . '&action=delete') . '">' . zen_image(DIR_WS_IMAGES . 'icon_delete.gif', ICON_DELETE) . '</a>'; ?>
                   <?php if (isset($mInfo) && is_object($mInfo) && ($media->fields['media_id'] == $mInfo->media_id)) { echo zen_image(DIR_WS_IMAGES . 'icon_arrow_right.gif', ''); } else { echo '<a href="' . zen_href_link(FILENAME_MEDIA_MANAGER, zen_get_all_get_params(array('mID')) . 'mID=' . $media->fields['media_id']) . '">' . zen_image(DIR_WS_IMAGES . 'icon_info.gif', IMAGE_ICON_INFO) . '</a>'; } ?>
@@ -181,10 +181,10 @@
   }
 ?>
               <tr>
-                <td colspan="2"><table border="0" width="100%" cellspacing="0" cellpadding="2">
+                <td colspan="2"><table class="table">
                   <tr>
-                    <td class="smallText" valign="top"><?php echo $media_split->display_count($media_query_numrows, MAX_DISPLAY_SEARCH_RESULTS, $_GET['page'], TEXT_DISPLAY_NUMBER_OF_MEDIA); ?></td>
-                    <td class="smallText" align="right"><?php echo $media_split->display_links($media_query_numrows, MAX_DISPLAY_SEARCH_RESULTS, MAX_DISPLAY_PAGE_LINKS, $_GET['page']); ?></td>
+                    <td class="smallText" ><?php echo $media_split->display_count($media_query_numrows, MAX_DISPLAY_SEARCH_RESULTS, $_GET['page'], TEXT_DISPLAY_NUMBER_OF_MEDIA); ?></td>
+                    <td class="smallText text-right"><?php echo $media_split->display_links($media_query_numrows, MAX_DISPLAY_SEARCH_RESULTS, MAX_DISPLAY_PAGE_LINKS, $_GET['page']); ?></td>
                   </tr>
                 </table></td>
               </tr>
@@ -192,7 +192,7 @@
   if (empty($action)) {
 ?>
               <tr>
-                <td align="right" colspan="2" class="smallText"><?php echo '<a href="' . zen_href_link(FILENAME_MEDIA_MANAGER, 'page=' . $_GET['page'] . '&mID=' . $mInfo->media_id . '&action=new') . '" class="btn btn-primary" role="button">' . IMAGE_INSERT . '</a>'; ?></td>
+                <td colspan="2" class="smallText text-right"><?php echo '<a href="' . zen_href_link(FILENAME_MEDIA_MANAGER, 'page=' . $_GET['page'] . '&mID=' . $mInfo->media_id . '&action=new') . '" class="btn btn-primary" role="button">' . IMAGE_INSERT . '</a>'; ?></td>
               </tr>
 <?php
   }
@@ -205,46 +205,45 @@
   switch ($action) {
     case 'new':
       $heading[] = array('text' => '<strong>' . TEXT_HEADING_NEW_MEDIA_COLLECTION . '</strong>');
-
-      $contents[] = array('text' => zen_draw_form('collections', FILENAME_MEDIA_MANAGER, 'action=insert&page=' . $_GET['page'], 'post', 'enctype="multipart/form-data"'));
+      $contents = array('form' => zen_draw_form('collections', FILENAME_MEDIA_MANAGER, 'action=insert&page=' . $_GET['page'], 'post', 'enctype="multipart/form-data"'));
       $contents[] = array('text' => TEXT_NEW_INTRO);
       $contents[] = array('text' => '<br>' . TEXT_MEDIA_COLLECTION_NAME . '<br>' . zen_draw_input_field('media_name', '', zen_set_field_length(TABLE_MEDIA_MANAGER, 'media_name')));
 
       $contents[] = array('align' => 'center', 'text' => '<br>' . '<button type="submit" class="btn btn-primary">' . IMAGE_SAVE . '</button>' . ' <a href="' . zen_href_link(FILENAME_MEDIA_MANAGER, 'page=' . $_GET['page'] . '&mID=' . $_GET['mID']) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>');
       break;
     case 'edit':
-      $heading[] = array('text' => '<strong>' . TEXT_HEADING_EDIT_MEDIA_COLLECTION . '</strong>');
-
-      $contents[] = array('text' => zen_draw_form('collections', FILENAME_MEDIA_MANAGER, 'page=' . $_GET['page'] . '&mID=' . $mInfo->media_id . '&action=save', 'post', 'enctype="multipart/form-data"'));
-      $contents[] = array('text' => TEXT_INFO_EDIT_INTRO);
-      $contents[] = array('text' => '<br>' . TEXT_MEDIA_COLLECTION_NAME . '<br>' . zen_draw_input_field('media_name', htmlspecialchars($mInfo->media_name, ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_MEDIA_MANAGER, 'media_name')));
-      $contents[] = array('align' => 'center', 'text' => '<br>' . '<button type="submit" class="btn btn-primary">' . IMAGE_SAVE . '</button>' . ' <a href="' . zen_href_link(FILENAME_MEDIA_MANAGER, 'page=' . $_GET['page'] . '&mID=' . $mInfo->media_id) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>');
-
-      $contents[] = array('text' => zen_draw_separator('pixel_black.gif'));
-      $contents[] = array('text' => TEXT_MEDIA_EDIT_INSTRUCTIONS);
-      $contents[] = array('text' => zen_draw_separator('pixel_black.gif'));
-
-      $dir_info = zen_build_subdirectories_array(DIR_FS_CATALOG_MEDIA);
-      $contents[] = array('text' => '<br>' . TEXT_ADD_MEDIA_CLIP . zen_draw_file_field('clip_filename'));
-      $contents[] = array('text' => TEXT_MEDIA_CLIP_DIR . ' ' . zen_draw_pull_down_menu('media_dir', $dir_info));
-      $media_type_query = "SELECT type_id, type_name, type_ext FROM " . TABLE_MEDIA_TYPES;
-      $media_types = $db->Execute($media_type_query);
-      while (!$media_types->EOF) {
-        $media_types_array[] = array('id' => $media_types->fields['type_id'], 'text' => $media_types->fields['type_name'] . ' (' . $media_types->fields['type_ext'] . ')');
-        $media_types->MoveNext();
-      }
-      $contents[] = array('text' => TEXT_MEDIA_CLIP_TYPE . ' ' . zen_draw_pull_down_menu('media_type', $media_types_array));
-
-      $contents[] = array('text' => '<input type="submit" name="add_clip" value="' . TEXT_ADD . '">', 'align' => 'center');
-      $contents[] = array('text' => '</form>');
-      $clip_query = "SELECT * FROM " . TABLE_MEDIA_CLIPS . " WHERE media_id = '" . $mInfo->media_id . "'";
-      $clips = $db->Execute($clip_query);
-      if ($clips->RecordCount() > 0) $contents[] = array('text' => '<hr>');
-      while (!$clips->EOF) {
-        $contents[] = array('text'=>zen_draw_form('delete_clip', FILENAME_MEDIA_MANAGER, 'action=remove_clip') . '<input type="hidden" name="mID" value="' . $mInfo->media_id . '">' . '<input type="hidden" name="clip_id" value="' . $clips->fields['clip_id'] . '">' . '<button type="submit" class="btn btn-danger">' . IMAGE_DELETE . '</button>'. '&nbsp;' . $clips->fields['clip_filename'] . '<br>' . '</form>');
-        $clips->MoveNext();
-      }
-      break;
+        $heading[] = array('text' => '<strong>' . TEXT_HEADING_EDIT_MEDIA_COLLECTION . '</strong>');
+        
+        $contents[] = array('text' => zen_draw_form('collections', FILENAME_MEDIA_MANAGER, 'page=' . $_GET['page'] . '&mID=' . $mInfo->media_id . '&action=save', 'post', 'enctype="multipart/form-data"') . '<div>');
+        $contents[] = array('text' => TEXT_INFO_EDIT_INTRO);
+        $contents[] = array('text' => '<br>' . TEXT_MEDIA_COLLECTION_NAME . '<br>' . zen_draw_input_field('media_name', htmlspecialchars($mInfo->media_name, ENT_COMPAT, CHARSET, TRUE), zen_set_field_length(TABLE_MEDIA_MANAGER, 'media_name')));
+        $contents[] = array('align' => 'center', 'text' => '<br>' . '<button type="submit" class="btn btn-primary">' . IMAGE_SAVE . '</button>' . ' <a href="' . zen_href_link(FILENAME_MEDIA_MANAGER, 'page=' . $_GET['page'] . '&mID=' . $mInfo->media_id) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>');
+        
+        $contents[] = array('text' => zen_draw_separator('pixel_black.gif'));
+        $contents[] = array('text' => TEXT_MEDIA_EDIT_INSTRUCTIONS);
+        $contents[] = array('text' => zen_draw_separator('pixel_black.gif'));
+        
+        $dir_info = zen_build_subdirectories_array(DIR_FS_CATALOG_MEDIA);
+        $contents[] = array('text' => '<br>' . TEXT_ADD_MEDIA_CLIP . zen_draw_file_field('clip_filename'));
+        $contents[] = array('text' => TEXT_MEDIA_CLIP_DIR . ' ' . zen_draw_pull_down_menu('media_dir', $dir_info));
+        $media_type_query = "SELECT type_id, type_name, type_ext FROM " . TABLE_MEDIA_TYPES;
+        $media_types = $db->Execute($media_type_query);
+        while (!$media_types->EOF) {
+            $media_types_array[] = array('id' => $media_types->fields['type_id'], 'text' => $media_types->fields['type_name'] . ' (' . $media_types->fields['type_ext'] . ')');
+            $media_types->MoveNext();
+        }
+        $contents[] = array('text' => TEXT_MEDIA_CLIP_TYPE . ' ' . zen_draw_pull_down_menu('media_type', $media_types_array));
+        
+        $contents[] = array('text' => '<input type="submit" name="add_clip" value="' . TEXT_ADD . '">', 'align' => 'center');
+        $contents[] = array('text' => '</div></form>');
+        $clip_query = "SELECT * FROM " . TABLE_MEDIA_CLIPS . " WHERE media_id = '" . $mInfo->media_id . "'";
+        $clips = $db->Execute($clip_query);
+        if ($clips->RecordCount() > 0) $contents[] = array('text' => '<hr>');
+        while (!$clips->EOF) {
+            $contents[] = array('text'=>zen_draw_form('delete_clip', FILENAME_MEDIA_MANAGER, 'page=' . $_GET['page'] . '&action=remove_clip') . '<input type="hidden" name="mID" value="' . $mInfo->media_id . '">' . '<input type="hidden" name="clip_id" value="' . $clips->fields['clip_id'] . '">' . '<button type="submit" class="btn btn-danger">' . IMAGE_DELETE . '</button>'. '&nbsp;' . $clips->fields['clip_filename'] . '<br>' . '</form>');
+            $clips->MoveNext();
+        }
+        break;
     case 'delete':
       $heading[] = array('text' => '<strong>' . TEXT_HEADING_DELETE_MEDIA_COLLECTION . '</strong>');
 
@@ -262,8 +261,8 @@
     case 'products':
       $heading[] = array('text' => '<strong>' . TEXT_HEADING_ASSIGN_MEDIA_COLLECTION . '</strong>');
       $contents[] = array('text' => TEXT_PRODUCTS_INTRO . '<br><br>');
-      $contents[] = array('text' => zen_draw_form('new_category', FILENAME_MEDIA_MANAGER, '', 'get') . '&nbsp;&nbsp;' .
-                           zen_draw_pull_down_menu('current_category_id', zen_get_category_tree('', '', '0'), (isset($current_category_id)? $current_category_id : ''), 'onChange="this.form.submit();"') . zen_hide_session_id() . zen_draw_hidden_field('products_filter', $_GET['products_filter']) . zen_draw_hidden_field('action', 'new_cat') . zen_draw_hidden_field('mID', $mInfo->media_id) . zen_draw_hidden_field('page', $_GET['page']) . '&nbsp;&nbsp;</form>');
+      $contents[] = array('text' => zen_draw_form('new_category', FILENAME_MEDIA_MANAGER, '&page=' . $_GET['page'], 'get') . '&nbsp;&nbsp;' .
+                           zen_draw_pull_down_menu('current_category_id', zen_get_category_tree('', '', '0'), (isset($current_category_id)? $current_category_id : ''), 'onChange="this.form.submit();"') . zen_hide_session_id() . zen_draw_hidden_field('products_filter', (empty($_GET['products_filter']) ? '' :$_GET['products_filter'])) . zen_draw_hidden_field('action', 'new_cat') . zen_draw_hidden_field('mID', $mInfo->media_id) . zen_draw_hidden_field('page', $_GET['page']) . '&nbsp;&nbsp;</form>');
       // product_array should be products in this category that do not already 
       // have a media_to_products entry for this media id. 
      $products_query = "SELECT ptc.*, pd.products_name
@@ -282,8 +281,8 @@
             'text' => $product['products_name']
          );
       }
-      if ($product_array) {
-        $contents[] = array('text' => zen_draw_form('new_product', FILENAME_MEDIA_MANAGER, 'action=add_product&page=' . (isset($GET['page']) ? $_GET['page'] : ''), 'post') . '&nbsp;&nbsp;' .
+      if (!empty($product_array)) {
+        $contents[] = array('text' => zen_draw_form('new_product', FILENAME_MEDIA_MANAGER, 'action=add_product&page=' . (isset($_GET['page']) ? $_GET['page'] : ''), 'post') . '&nbsp;&nbsp;' .
                            zen_draw_pull_down_menu('current_product_id', $product_array) . '&nbsp;' . '<input type="submit" name="add_product" value="Add">' .
                            zen_draw_hidden_field('current_category_id', $current_category_id) .
                            zen_draw_hidden_field('mID', $mInfo->media_id) . '&nbsp;&nbsp;</form>');
@@ -319,7 +318,7 @@
   }
 
   if (!empty($heading) && !empty($contents)) {
-    echo '            <td width="25%" valign="top">' . "\n";
+    echo '            <td class="col-sm-3" >' . "\n";
 
     $box = new box;
     echo $box->infoBox($heading, $contents);

--- a/admin/media_types.php
+++ b/admin/media_types.php
@@ -92,7 +92,7 @@ if (!empty($action)) {
                     ?>
                   <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href='<?php echo zen_href_link(FILENAME_MEDIA_TYPES, 'page=' . $_GET['page'] . '&mID=' . $media_type['type_id'] . '&action=edit'); ?>'">
                     <?php } else { ?>
-                  <tr class="dataTableRow" onclick="document.location.href='<?php echo zen_href_link(FILENAME_MEDIA_TYPES, 'page=' . $_GET['page'] . '&mID=' . $media_type->fields['type_id'] . '&action=edit'); ?>'">
+                  <tr class="dataTableRow" onclick="document.location.href='<?php echo zen_href_link(FILENAME_MEDIA_TYPES, 'page=' . $_GET['page'] . '&mID=' . $media_type['type_id'] . '&action=edit'); ?>'">
                     <?php } ?>
                   <td class="dataTableContent"><?php echo $media_type['type_name']; ?></td>
                   <td class="dataTableContent"><?php echo $media_type['type_ext']; ?></td>
@@ -101,7 +101,7 @@ if (!empty($action)) {
                       if (isset($mInfo) && is_object($mInfo) && ($media_type['type_id'] == $mInfo->type_id)) {
                         echo zen_image(DIR_WS_IMAGES . 'icon_arrow_right.gif', '');
                       } else {
-                      echo '<a href="' . zen_href_link(FILENAME_MEDIA_TYPES, zen_get_all_get_params(array('mID')) . 'mID=' . $media_type->fields['type_id']) . '">' . zen_image(DIR_WS_IMAGES . 'icon_info.gif', IMAGE_ICON_INFO) . '</a>';
+                      echo '<a href="' . zen_href_link(FILENAME_MEDIA_TYPES, zen_get_all_get_params(array('mID')) . 'mID=' . $media_type['type_id']) . '">' . zen_image(DIR_WS_IMAGES . 'icon_info.gif', IMAGE_ICON_INFO) . '</a>';
                       }
                       ?>
                   </td>

--- a/admin/modules.php
+++ b/admin/modules.php
@@ -347,7 +347,7 @@ if (!empty($action)) {
                     if (method_exists($module, 'help')) { 
                        $help_text = $module->help();
                        if (isset($help_text['link'])) { 
-                          $help_button = array('align' => 'text-center', 'text' => '<a href="' . $help_text['link'] . '" target="_blank" rel="noreferrer noopener">' . '<button type="submit" class="btn btn-primary " id="helpButton">' . IMAGE_MODULE_HELP. '</button></a>'); 
+                          $help_button = array('align' => 'text-center', 'text' => '<a href="' . $help_text['link'] . '" target="_blank" rel="noreferrer noopener" class="btn btn-primary " id="helpButton">' . IMAGE_MODULE_HELP. '</a>'); 
                        } else if (isset($help_text['body'])) { 
                           $help_title = $module->title; 
                           $help_button = array('align' => 'text-center', 'text' => '<button type="button" class="btn btn-primary" data-toggle="modal" data-target="#helpModal">' . IMAGE_MODULE_HELP . '</button>');

--- a/admin/music_genre.php
+++ b/admin/music_genre.php
@@ -98,6 +98,7 @@ if (!empty($action)) {
 
                     $aInfo_array = array_merge($music_genre, $music_genre_products->fields);
                     $aInfo = new objectInfo($aInfo_array);
+                    $_GET['mID'] = $aInfo->music_genre_id;
                   }
 
                   if (isset($aInfo) && is_object($aInfo) && ($music_genre['music_genre_id'] == $aInfo->music_genre_id)) {

--- a/admin/newsletters.php
+++ b/admin/newsletters.php
@@ -15,7 +15,7 @@ if (!empty($action)) {
     case 'set_editor':
       // Reset will be done by init_html_editor.php. Now we simply redirect to refresh page properly.
       $action = '';
-      zen_redirect(zen_href_link(FILENAME_NEWSLETTERS, (isset($_GET['page']) ? 'page=' . $_GET['page'] . '&' : '') . 'nID=' . $newsletter_id));
+      zen_redirect(zen_href_link(FILENAME_NEWSLETTERS,  (isset($_GET['page']) ? 'page=' . $_GET['page'] : '') ));
       break;
     case 'insert':
     case 'update':
@@ -211,7 +211,7 @@ if (!empty($action)) {
         }
         ?>
         <div class="form-group">
-            <?php echo zen_draw_label(TEXT_NEWSLETTER_MODULE, 'modules', 'class="control-label col-sm-3"'); ?>
+            <?php echo zen_draw_label(TEXT_NEWSLETTER_MODULE, 'module', 'class="control-label col-sm-3"'); ?>
           <div class="col-sm-9 col-md-6">
               <?php echo zen_draw_pull_down_menu('module', $modules_array, $nInfo->module, 'class="form-control"'); ?>
           </div>
@@ -238,6 +238,7 @@ if (!empty($action)) {
           <button type="submit" class="btn btn-primary"><?php echo (($form_action == 'insert') ? IMAGE_SAVE : IMAGE_UPDATE); ?></button>&nbsp;<a href="<?php echo zen_href_link(FILENAME_NEWSLETTERS, (isset($_GET['page']) ? 'page=' . $_GET['page'] . '&' : '') . (isset($_GET['nID']) ? 'nID=' . $_GET['nID'] : '')); ?>" class="btn btn-default" role="button"><?php echo IMAGE_CANCEL; ?></a>
         </div>
         <?php
+        echo '</form>'; 
       } elseif ($action == 'preview') {
         $nID = zen_db_prepare_input($_GET['nID']);
 
@@ -253,11 +254,11 @@ if (!empty($action)) {
         <div class="row"><?php echo zen_draw_separator(); ?></div>
         <div class="row">
           <div class="col-sm-3"><?php echo zen_draw_label(strip_tags(TEXT_NEWSLETTER_CONTENT_HTML), '', 'class="control-label"'); ?></div>
-          <div class="col-sm-9 col-md-6"><?php echo nl2br($nInfo->content_html); ?></div>
+          <div class="col-sm-9 col-md-6" ><?php echo nl2br($nInfo->content_html); ?></div>
         </div>
         <div class="row">
           <div class="col-sm-3"><?php echo zen_draw_label(strip_tags(TEXT_NEWSLETTER_CONTENT), '', 'class="control-label"'); ?></div>
-          <div class="col-sm-9 col-md-6"><tt><?php echo nl2br($nInfo->content); ?></tt></div>
+          <div class="col-sm-9 col-md-6"><span class="tt"><?php echo nl2br($nInfo->content); ?></span></div>
         </div>
         <div class="row"><?php echo zen_draw_separator(); ?></div>
         <div class="row text-right">
@@ -329,8 +330,8 @@ if (!empty($action)) {
         <div class="row">
           <h1><span class="text-danger"><?php echo TEXT_FINISHED_SENDING_EMAILS; ?></span></h1>
         </div>
-        <div class="row">
-          <span class="text-danger"><?php echo sprintf(TEXT_AFTER_EMAIL_INSTRUCTIONS, $i); ?></span>
+        <div class="row text-danger" >
+          <?php echo sprintf(TEXT_AFTER_EMAIL_INSTRUCTIONS, $i); ?>
         </div>
         <div class="row text-center">
           <a href="<?php echo zen_href_link(FILENAME_NEWSLETTERS, 'page=' . $_GET['page'] . '&nID=' . $_GET['nID']); ?>" class="btn btn-default" role="button"><?php echo IMAGE_BACK; ?></a>
@@ -370,16 +371,16 @@ if (!empty($action)) {
                     <tr class="dataTableRow" onclick="document.location.href = '<?php echo zen_href_link(FILENAME_NEWSLETTERS, 'page=' . $_GET['page'] . '&nID=' . $newsletter['newsletters_id']); ?>'">
                       <?php } ?>
                     <td class="dataTableContent"><?php echo '<a href="' . zen_href_link(FILENAME_NEWSLETTERS, 'page=' . $_GET['page'] . '&nID=' . $newsletter['newsletters_id'] . '&action=preview') . '">' . zen_image(DIR_WS_ICONS . 'preview.gif', ICON_PREVIEW) . '</a>&nbsp;' . $newsletter['title']; ?></td>
-                    <td class="dataTableContent" align="right"><?php echo number_format($newsletter['content_length'] + $newsletter['content_html_length']) . ' bytes'; ?></td>
-                    <td class="dataTableContent" align="right"><?php echo $newsletter['module']; ?></td>
-                    <td class="dataTableContent" align="center"><?php
+                    <td class="dataTableContent text-right"><?php echo number_format($newsletter['content_length'] + $newsletter['content_html_length']) . ' bytes'; ?></td>
+                    <td class="dataTableContent text-right"><?php echo $newsletter['module']; ?></td>
+                    <td class="dataTableContent text-center"><?php
                         if ($newsletter['status'] == '1') {
                           echo zen_image(DIR_WS_ICONS . 'tick.gif', ICON_TICK);
                         } else {
                           echo zen_image(DIR_WS_ICONS . 'cross.gif', ICON_CROSS);
                         }
                         ?></td>
-                    <td class="dataTableContent" align="right"><?php
+                    <td class="dataTableContent text-right"><?php
                         if (isset($nInfo) && is_object($nInfo) && ($newsletter['newsletters_id'] == $nInfo->newsletters_id)) {
                           echo zen_image(DIR_WS_IMAGES . 'icon_arrow_right.gif', '');
                         } else {

--- a/admin/option_name.php
+++ b/admin/option_name.php
@@ -72,11 +72,11 @@ if ($_GET['action'] == "update_sort_order") {
         <table class="table table-condensed table-striped">
           <thead>
             <tr class="dataTableHeadingRow">
-              <th colspan="<?php echo ($_GET['lng_id'] == $_SESSION['languages_id'] ? '5' : '8'); ?>" class="dataTableHeadingContent text-center"><?php echo TEXT_EDIT_ALL; ?></th>
+              <th colspan="2" class="dataTableHeadingContent text-center"><?php echo TEXT_EDIT_ALL; ?></th>
             </tr>
             <tr class="dataTableHeadingRow">
-              <th colspan="3" class="dataTableHeadingContent text-center"><?php echo ($_GET['lng_id'] != $_SESSION['languages_id'] ? 'Current Language' : '&nbsp;'); ?></th>
-              <th colspan="<?php echo ($_GET['lng_id'] == $_SESSION['languages_id'] ? '2' : '5'); ?>" class="dataTableHeadingContent" class="text-center">
+              <th class="dataTableHeadingContent text-center col-sm-6"><?php echo ($_GET['lng_id'] != $_SESSION['languages_id'] ? 'Current Language' : '&nbsp;'); ?></th>
+              <th class="dataTableHeadingContent text-center col-sm-6">
                   <?php echo zen_draw_form('lng', FILENAME_PRODUCTS_OPTIONS_NAME, '', 'get'); ?>
                   <?php echo zen_hide_session_id(); ?>
                 <?php echo zen_draw_label(TEXT_SELECTED_LANGUAGE . zen_get_language_icon($_GET['lng_id']), 'lng_id', 'class="control-label"'); ?>&nbsp;&nbsp;&nbsp;
@@ -84,7 +84,12 @@ if ($_GET['action'] == "update_sort_order") {
                 <?php echo '</form>'; ?>
               </th>
             </tr>
+            </thead>
+            <tr>
+                <td colspan="2">
             <?php echo zen_draw_form('update', FILENAME_PRODUCTS_OPTIONS_NAME, 'action=update_sort_order&lng_id=' . $_GET['lng_id']); ?>
+                    <table class="table table-condensed table-striped">
+                        <thead>
             <tr class="dataTableHeadingRow">
                 <?php
                 if ($_GET['lng_id'] != $_SESSION['languages_id']) {
@@ -101,14 +106,13 @@ if ($_GET['action'] == "update_sort_order") {
             </tr>
           </thead>
           <tbody>
-            <tr>
+            
                 <?php
                 $options_types = $db->Execute("SELECT * FROM " . TABLE_PRODUCTS_OPTIONS_TYPES);
                 $options_types_names = array();
                 foreach ($options_types as $options_type) {
                     $options_types_names[$options_type['products_options_types_id']] = ' (' . strtoupper($options_type['products_options_types_name']) . ')';
                 }
-
                 $rows = $db->Execute("SELECT *
                                       FROM " . TABLE_PRODUCTS_OPTIONS . "
                                       WHERE language_id = '" . (int)$_GET['lng_id'] . "'
@@ -116,7 +120,9 @@ if ($_GET['action'] == "update_sort_order") {
                 foreach ($rows as $row) {
                   $option_type = $row['products_options_type'];
                   $the_attributes_type = (isset($options_types_names[$option_type])) ? $options_types_names[$option_type] : " (UNKNOWN: $option_type)";
-
+                  ?>
+                <tr>
+                  <?php 
                   if ($_GET['lng_id'] != $_SESSION['languages_id']) {
                     ?>
                   <td class="dataTableContent text-center"><?php echo zen_get_language_icon($_SESSION['languages_id']); ?></td>
@@ -140,9 +146,13 @@ if ($_GET['action'] == "update_sort_order") {
                 <button type="submit" class="btn btn-primary"><?php echo TEXT_UPDATE_SUBMIT; ?></button>
               </td>
             </tr>
-            <?php echo '</form>'; ?>
           </tbody>
+                    </table>
+         <?php echo '</form>'; ?>
+                </td>      
+          </tr>
         </table>
+        
         <!-- body_text_eof //-->
         <!-- body_eof //-->
       </div>

--- a/admin/option_values.php
+++ b/admin/option_values.php
@@ -95,7 +95,7 @@ switch ($_GET['action']) {
           <?php echo zen_draw_form('quick_jump', FILENAME_PRODUCTS_OPTIONS_VALUES, '', 'get', 'class="form-horizontal"'); ?>
           <table class="table table-condensed">
             <tr class="dataTableHeadingRow">
-              <td colspan="2" align="center" class="dataTableHeadingContent"><?php echo TEXT_UPDATE_OPTION_VALUES; ?></td>
+              <td colspan="2" class="dataTableHeadingContent text-center"><?php echo TEXT_UPDATE_OPTION_VALUES; ?></td>
             </tr>
             <tr class="dataTableHeadingRow">
               <td class="dataTableHeadingContent">

--- a/admin/options_name_manager.php
+++ b/admin/options_name_manager.php
@@ -748,7 +748,7 @@ function translate_type_to_name($opt_type)
                     echo zen_draw_hidden_field('form_wrapper_id', 'addOptionValuesOneWrapper'); ?>
                     <div>
                         <div class="col-sm-3">
-                            <?php echo zen_draw_label(TEXT_SELECT_OPTION, 'options_id', 'class="control-label"'); ?>
+                            <?php echo zen_draw_label(TEXT_SELECT_OPTION, 'addOptionValuesOne', 'class="control-label"'); ?>
                             <?php echo zen_draw_pull_down_menu('options_id', $optionsValuesArray, $selectedOptionId, 'class="form-control" id="addOptionValuesOne" onchange="this.form.submit();" required'); ?></div>
                         <div class="col-sm-7">
                             <?php
@@ -782,7 +782,7 @@ function translate_type_to_name($opt_type)
                     <div class="row">
                         <div class="col-sm-3">
                             <?php
-                            echo zen_draw_label(TEXT_SELECT_OPTION, 'options_id', 'class="control-label"');
+                            echo zen_draw_label(TEXT_SELECT_OPTION, 'addOptionValuesCategory', 'class="control-label"');
                             echo zen_draw_pull_down_menu('options_id', $optionsValuesArray, $selectedOptionId, 'class="form-control optionNameFilter" id="addOptionValuesCategory" onchange="this.form.submit();" required'); ?></div>
                         <div class="col-sm-7">
                             <?php
@@ -821,8 +821,8 @@ function translate_type_to_name($opt_type)
                     <div class="row">
                         <div class="col-sm-3">
                             <?php
-                            echo zen_draw_label(TEXT_SELECT_OPTION, 'options_id', 'class="control-label"');
-                            echo zen_draw_pull_down_menu('options_id', $optionsValuesArray, '', 'class="form-control" required'); ?>
+                            echo zen_draw_label(TEXT_SELECT_OPTION, 'delete_values_all', 'class="control-label"');
+                            echo zen_draw_pull_down_menu('options_id', $optionsValuesArray, '', 'class="form-control" id="delete_values_all" required'); ?>
                         </div>
                         <div class="col-sm-7">&nbsp;</div>
                         <div class="col-sm-2">
@@ -846,7 +846,7 @@ function translate_type_to_name($opt_type)
                     <div class="row">
                         <div class="col-sm-3">
                             <?php
-                            echo zen_draw_label(TEXT_SELECT_OPTION, 'options_id', 'class="control-label"');
+                            echo zen_draw_label(TEXT_SELECT_OPTION, 'deleteOptionValuesOne', 'class="control-label"');
                             echo zen_draw_pull_down_menu('options_id', $optionsValuesArray, $selectedOptionId, 'class="form-control optionNameFilter" id="deleteOptionValuesOne" onchange="this.form.submit(this.id);" required'); ?>
                         </div>
                         <div class="col-sm-7">
@@ -881,7 +881,7 @@ function translate_type_to_name($opt_type)
                     <div class="row">
                         <div class="col-sm-3">
                             <?php
-                            echo zen_draw_label(TEXT_SELECT_OPTION, 'options_id', 'class="control-label"');
+                            echo zen_draw_label(TEXT_SELECT_OPTION, 'deleteOptionValuesCategory', 'class="control-label"');
                             echo zen_draw_pull_down_menu('options_id', $optionsValuesArray, $selectedOptionId, 'class="form-control optionNameFilter" id="deleteOptionValuesCategory" onchange="this.form.submit();" required'); ?>
                         </div>
                         <div class="col-sm-7">

--- a/admin/options_values_manager.php
+++ b/admin/options_values_manager.php
@@ -680,11 +680,11 @@ if (!empty($action)) {
           <table class="table table-striped">
             <thead>
               <tr class="dataTableHeadingRow">
-                <th class="dataTableHeadingContent text-right"><?php echo TABLE_HEADING_ID; ?></th>
-                <th class="dataTableHeadingContent"><?php echo TABLE_HEADING_OPTION_NAME; ?></th>
-                <th class="dataTableHeadingContent"><?php echo TABLE_HEADING_OPTION_VALUE; ?></th>
-                <th class="dataTableHeadingContent text-right"><?php echo TABLE_HEADING_OPTION_VALUE_SORT_ORDER; ?></th>
-                <th class="dataTableHeadingContent text-right"><?php echo TABLE_HEADING_ACTION; ?></th>
+                <th class="dataTableHeadingContent text-right col-md-1"><?php echo TABLE_HEADING_ID; ?></th>
+                <th class="dataTableHeadingContent col-md-3"><?php echo TABLE_HEADING_OPTION_NAME; ?></th>
+                <th class="dataTableHeadingContent col-md-4"><?php echo TABLE_HEADING_OPTION_VALUE; ?></th>
+                <th class="dataTableHeadingContent text-right col-md-1"><?php echo TABLE_HEADING_OPTION_VALUE_SORT_ORDER; ?></th>
+                <th class="dataTableHeadingContent text-right col-md-3"><?php echo TABLE_HEADING_ACTION; ?></th>
               </tr>
             </thead>
             <tbody>
@@ -706,7 +706,24 @@ if (!empty($action)) {
                   <?php
 // edit option values
                   if (($action == 'update_option_value') && ($_GET['value_id'] == $values_value['products_options_values_id'])) {
-                    echo zen_draw_form('values', FILENAME_OPTIONS_VALUES_MANAGER, 'action=update_value' . ($currentPage !== 0 && $currentPage !== 1 ? '&page=' . $currentPage: '') . ($filter !== 0 ? '&set_filter=' . $filter : '') . ($max_search_results != 0 ? '&max_search_results=' . $max_search_results : ''), 'post', 'class="form-horizontal"');
+                  ?>
+                    <td colspan=5>
+                     <?php 
+                     echo zen_draw_form('values', FILENAME_OPTIONS_VALUES_MANAGER, 'action=update_value' . ($currentPage !== 0 && $currentPage !== 1 ? '&page=' . $currentPage: '') . ($filter !== 0 ? '&set_filter=' . $filter : '') . ($max_search_results != 0 ? '&max_search_results=' . $max_search_results : ''), 'post', 'class="form-horizontal"');
+                     ?>
+                        <table class="table">
+                            <thead>
+                                <tr class="dataTableHeadingRow">
+                                    <th class="dataTableHeadingContent text-right col-md-1"><?php echo TABLE_HEADING_ID; ?></th>
+                                    <th class="dataTableHeadingContent col-md-3"><?php echo TABLE_HEADING_OPTION_NAME; ?></th>
+                                    <th class="dataTableHeadingContent col-md-4"><?php echo TABLE_HEADING_OPTION_VALUE; ?></th>
+                                    <th class="dataTableHeadingContent text-right col-md-1"><?php echo TABLE_HEADING_OPTION_VALUE_SORT_ORDER; ?></th>
+                                    <th class="dataTableHeadingContent text-right col-md-3"><?php echo TABLE_HEADING_ACTION; ?></th>
+                                </tr>
+                            </thead>
+                            <tbody> 
+                                <tr>
+                  <?php 
                     $inputs = '';
                     for ($i = 0, $n = sizeof($languages); $i < $n; $i++) {
                       $value_name = $db->Execute("SELECT products_options_values_name
@@ -754,8 +771,13 @@ if (!empty($action)) {
                       <button type="submit" class="btn btn-primary"><?php echo IMAGE_UPDATE; ?></button>
                       <a href="<?php echo zen_href_link(FILENAME_OPTIONS_VALUES_MANAGER, ($currentPage !== 0 ? 'page=' . $currentPage . '&' : '') . ($filter !== 0 ? 'set_filter=' . $filter . '&' : '') . ($max_search_results != 0 ? 'max_search_results=' . $max_search_results : '')); ?>" class="btn btn-default" role="button"><?php echo IMAGE_CANCEL ?></a>
                     </td>
+                            </tbody>
+                        </table>
                     <?php
                     echo '</form>';
+                    ?>
+                    </td>
+                    <?php 
                   } else {
                     ?>
                     <td class="text-right"><?php echo $values_value["products_options_values_id"]; ?></td>
@@ -781,8 +803,10 @@ if (!empty($action)) {
               </tr>
               <?php if ($action != 'update_option_value') { ?>
                 <tr>
+                <td colspan="5">
+                
                   <?php echo zen_draw_form('values', FILENAME_OPTIONS_VALUES_MANAGER, 'action=add_product_option_values' . ($currentPage !== 0 && $currentPage !== 1 ? '&page=' . $currentPage : '') . ($filter !== 0 ? '&set_filter=' . $filter : '') . ($max_search_results != 0 ? '&max_search_results=' . $max_search_results : ''), 'post', 'class="form-horizontal"'); ?>
-                  <td colspan="4">
+                  
                     <?php
                     $options_values = $db->Execute("SELECT products_options_id, products_options_name, products_options_type
                                                     FROM " . TABLE_PRODUCTS_OPTIONS . "
@@ -798,12 +822,15 @@ if (!empty($action)) {
                         'text' => $options_value['products_options_name']);
                     }
                     ?>
-                    <div class="col-md-4">
+                    <div class="col-md-1"></div>
+                    <div class="col-md-3">
                       <div class="form-group">
-                        <?php echo zen_draw_pull_down_menu('option_id', $optionsValueArray, $filter, 'class="form-control"'); ?>
+                        <?php echo zen_draw_label(TABLE_HEADING_OPTION_NAME, 'insert_option_id', 'class="control-label"'); ?>
+                        <?php echo zen_draw_pull_down_menu('option_id', $optionsValueArray, $filter, 'class="form-control" id="insert_option_id"'); ?>
                       </div>
                     </div>
-                    <div class="col-md-6">
+                    <div class="col-md-4">
+                        <?php echo zen_draw_label(TABLE_HEADING_OPTION_VALUE, 'value_name[' . $languages[0]['id'] . ']', 'class="control-label"'); ?>
                       <?php for ($i = 0, $n = sizeof($languages); $i < $n; $i++) { ?>
                         <div class="form-group">
                           <div class="input-group">
@@ -813,20 +840,21 @@ if (!empty($action)) {
                         </div>
                       <?php } ?>
                     </div>
-                    <div class="col-md-2">
+                    <div class="col-md-1">
                       <div class="form-group">
-                        <?php echo zen_draw_label(TEXT_SORT, 'products_options_values_sort_order', 'class="control-label"'); ?>
+                        <?php echo zen_draw_label(TABLE_HEADING_OPTION_VALUE_SORT_ORDER, 'products_options_values_sort_order', 'class="control-label"'); ?>
                         <?php echo zen_draw_input_field('products_options_values_sort_order', '', 'size="4" class="form-control"'); ?>
                       </div>
                     </div>
-                  </td>
-                  <td class="text-right">
+                  <div class="col-md-3 text-right">
                     <?php echo zen_draw_hidden_field('value_id', $next_id); ?>
+                    <br>
                     <button type="submit" class="btn btn-primary"><?php echo IMAGE_INSERT; ?></button>
-                  </td>
+                  </div>
                   <?php
                   echo '</form>';
                   ?>
+                  </td>
                 </tr>
                 <tr>
                   <td colspan="5"><?php echo zen_black_line(); ?></td>
@@ -893,8 +921,6 @@ if (!empty($action)) {
 
         $option_values_to_dropdown = $option_values_from_dropdown;
 
-        $to_categories_id = zen_draw_label(TEXT_SELECT_OPTION_VALUES_TO_CATEGORIES_ID, 'copy_to_categories_id', 'class="control-label"') . zen_draw_input_field('copy_to_categories_id', '', 'size="4" class="form-control"');
-
         $options_id_from_products_id = zen_draw_label(TEXT_SELECT_OPTION_FROM_PRODUCTS_ID, 'copy_from_products_id', 'class="control-label"') . zen_draw_input_field('copy_from_products_id', '', 'size="4" class="form-control"');
 
         // eof: build dropdowns for delete and add
@@ -907,13 +933,16 @@ if (!empty($action)) {
         <div class="table-responsive" style="border: 2px solid #999;">
           <table class="table">
             <tr>
-              <td colspan="4"><?php echo TEXT_OPTION_VALUE_COPY_ALL; ?></td>
+              <td ><?php echo TEXT_OPTION_VALUE_COPY_ALL; ?></td>
             </tr>
             <tr>
-              <td colspan="4"><?php echo TEXT_INFO_OPTION_VALUE_COPY_ALL; ?></td>
+              <td ><?php echo TEXT_INFO_OPTION_VALUE_COPY_ALL; ?></td>
             </tr>
             <tr class="dataTableHeadingRow">
+            <td>
               <?php echo zen_draw_form('quick_jump', FILENAME_OPTIONS_VALUES_MANAGER, 'action=copy_options_values_one_to_another', 'post', 'class="form-horizontal"'); ?>
+              <table class="table">
+                  <tr>
               <td class="dataTableHeadingContent">
                 <?php echo zen_draw_label(TEXT_SELECT_OPTION_FROM, 'options_id_from', 'class="control-label"') . zen_draw_pull_down_menu('options_id_from', $option_from_dropdown, '', 'class="form-control"'); ?><br>
                 <?php echo zen_draw_label(TEXT_SELECT_OPTION_VALUES_FROM, 'options_values_values_id_from', 'class="control-label"') . zen_draw_pull_down_menu('options_values_values_id_from', $option_values_from_dropdown, '', 'class="form-control"'); ?>
@@ -922,11 +951,14 @@ if (!empty($action)) {
                 <?php echo zen_draw_label(TEXT_SELECT_OPTION_TO, 'options_id_to', 'class="control-label"') . zen_draw_pull_down_menu('options_id_to', $option_to_dropdown, '', 'class="form-control"'); ?><br>
                 <?php echo zen_draw_label(TEXT_SELECT_OPTION_VALUES_TO, 'options_values_values_id_to', 'class="control-label"') . zen_draw_pull_down_menu('options_values_values_id_to', $option_values_to_dropdown, '', 'class="form-control"'); ?>
               </td>
-              <td class="dataTableHeadingContent"><?php echo $to_categories_id; ?></td>
+              <td class="dataTableHeadingContent"><?php echo zen_draw_label(TEXT_SELECT_OPTION_VALUES_TO_CATEGORIES_ID, 'copy_to_categories_id', 'class="control-label"') . zen_draw_input_field('copy_to_categories_id', '', 'size="4" class="form-control"');; ?></td>
               <td class="dataTableHeadingContent text-center">
                 <button type="submit" class="btn btn-warning"><?php echo IMAGE_INSERT; ?></button>
               </td>
+                  </tr>
+              </table>
               <?php echo '</form>'; ?>
+              </td>
             </tr>
           </table>
         </div>
@@ -942,22 +974,28 @@ if (!empty($action)) {
         <div class="table-responsive" style="border: 2px solid #999;">
           <table class="table">
             <tr>
-              <td colspan="3"><?php echo TEXT_OPTION_VALUE_DELETE_ALL; ?></td>
+              <td><?php echo TEXT_OPTION_VALUE_DELETE_ALL; ?></td>
             </tr>
             <tr>
-              <td colspan="3"><?php echo TEXT_INFO_OPTION_VALUE_DELETE_ALL; ?></td>
+              <td><?php echo TEXT_INFO_OPTION_VALUE_DELETE_ALL; ?></td>
             </tr>
             <tr class="dataTableHeadingRow">
+            <td>
               <?php echo zen_draw_form('quick_jump', FILENAME_OPTIONS_VALUES_MANAGER, 'action=delete_options_values_of_option_name', 'post', 'class="form-horizontal"'); ?>
+                <table>
+                    <tr>
               <td class="dataTableHeadingContent">
-                <?php echo zen_draw_label(TEXT_SELECT_DELETE_OPTION_FROM, 'options_id_from', 'class="control-label"') . zen_draw_pull_down_menu('options_id_from', $option_from_dropdown, '', 'class="form-control"'); ?><br>
-                <?php echo zen_draw_label(TEXT_SELECT_DELETE_OPTION_VALUES_FROM, 'options_values_values_id_from', 'class="control-label"') . zen_draw_pull_down_menu('options_values_values_id_from', $option_values_from_dropdown, '', 'class="form-control"'); ?>
+                <?php echo zen_draw_label(TEXT_SELECT_DELETE_OPTION_FROM, 'options_id_delete_from', 'class="control-label"') . zen_draw_pull_down_menu('options_id_from', $option_from_dropdown, '', 'class="form-control" id="options_id_delete_from"'); ?><br>
+                <?php echo zen_draw_label(TEXT_SELECT_DELETE_OPTION_VALUES_FROM, 'options_values_values_id_delete_from', 'class="control-label"') . zen_draw_pull_down_menu('options_values_values_id_from', $option_values_from_dropdown, '', 'class="form-control" id="options_values_values_id_delete_from"'); ?>
               </td>
-              <td class="dataTableHeadingContent"><?php echo $to_categories_id; ?></td>
+              <td class="dataTableHeadingContent"><?php echo zen_draw_label(TEXT_SELECT_OPTION_VALUES_TO_CATEGORIES_ID, 'copy_to_categories_id_delete', 'class="control-label"') . zen_draw_input_field('copy_to_categories_id', '', 'size="4" class="form-control" id="copy_to_categories_id_delete"');; ?></td>
               <td class="dataTableHeadingContent text-center">
                 <button type="submit" class="btn btn-danger"><i class="fa fa-trash"></i> <?php echo IMAGE_DELETE; ?></button>
               </td>
+                  </tr>
+              </table>
               <?php echo '</form>'; ?>
+              </td>
             </tr>
           </table>
         </div>
@@ -973,23 +1011,26 @@ if (!empty($action)) {
         <div class="table-responsive" style="border: 2px solid #999;">
           <table class="table">
             <tr>
-              <td colspan="4"><?php echo TEXT_OPTION_VALUE_COPY_OPTIONS_TO; ?></td>
+              <td><?php echo TEXT_OPTION_VALUE_COPY_OPTIONS_TO; ?></td>
             </tr>
             <tr>
-              <td colspan="4"><?php echo TEXT_INFO_OPTION_VALUE_COPY_OPTIONS_TO; ?></td>
+              <td><?php echo TEXT_INFO_OPTION_VALUE_COPY_OPTIONS_TO; ?></td>
             </tr>
             <tr class="dataTableHeadingRow">
+            <td>
               <?php echo zen_draw_form('quick_jump', FILENAME_OPTIONS_VALUES_MANAGER, 'action=copy_options_values_one_to_another_options_id', 'post', 'class="form-horizontal"'); ?>
+                <table class="table">
+                    <tr>
               <td class="dataTableHeadingContent">
-                <?php echo zen_draw_label(TEXT_SELECT_OPTION_FROM_ADD, 'options_id_from', 'class="control-label"') . zen_draw_pull_down_menu('options_id_from', $option_from_dropdown, '', 'class="form-control"'); ?><br>
-                <?php echo zen_draw_label(TEXT_SELECT_OPTION_VALUES_FROM_ADD, 'options_values_values_id_from', 'class="control-label"') . zen_draw_pull_down_menu('options_values_values_id_from', $option_values_from_dropdown, '', 'class="form-control"'); ?><br>
+                <?php echo zen_draw_label(TEXT_SELECT_OPTION_FROM_ADD, 'options_id_add_from', 'class="control-label"') . zen_draw_pull_down_menu('options_id_from', $option_from_dropdown, '', 'class="form-control" id="options_id_add_from"'); ?><br>
+                <?php echo zen_draw_label(TEXT_SELECT_OPTION_VALUES_FROM_ADD, 'options_values_values_id_add_from', 'class="control-label"') . zen_draw_pull_down_menu('options_values_values_id_from', $option_values_from_dropdown, '', 'class="form-control" id="options_values_values_id_add_from"'); ?><br>
                 <?php echo $options_id_from_products_id; ?>
               </td>
               <td class="dataTableHeadingContent">
-                <?php echo zen_draw_label(TEXT_SELECT_OPTION_TO_ADD_TO, 'options_id_to', 'class="control-label"') . zen_draw_pull_down_menu('options_id_to', $option_to_dropdown, '', 'class="form-control"'); ?>
+                <?php echo zen_draw_label(TEXT_SELECT_OPTION_TO_ADD_TO, 'options_id_add_to', 'class="control-label"') . zen_draw_pull_down_menu('options_id_to', $option_to_dropdown, '', 'class="form-control" id="options_id_add_to"'); ?>
               </td>
               <td class="dataTableHeadingContent">
-                <?php echo $to_categories_id; ?><br>
+                <?php echo zen_draw_label(TEXT_SELECT_OPTION_VALUES_TO_CATEGORIES_ID, 'copy_to_categories_id_add', 'class="control-label"') . zen_draw_input_field('copy_to_categories_id', '', 'size="4" class="form-control" id="copy_to_categories_id_add"'); ?><br>
                 <?php echo TEXT_COPY_ATTRIBUTES_CONDITIONS; ?><br>
                 <div class="radio">
                   <label>
@@ -1005,13 +1046,17 @@ if (!empty($action)) {
               <td class="dataTableHeadingContent text-center">
                 <button type="submit" class="btn btn-primary"><?php echo IMAGE_INSERT; ?></button>
               </td>
+                    </tr>
+                </table>
               <?php echo '</form>'; ?>
+            </td>
             </tr>
             <!-- eof: copy all option values to another Option Name -->
           <?php } ?>
         </table>
       </div>
       <!-- option value eof //-->
+      </div>
       <!-- body_text_eof //-->
       <!-- footer //-->
       <?php require DIR_WS_INCLUDES . 'footer.php'; ?>

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -1340,7 +1340,6 @@ if (!empty($action) && $order_exists === true) {
                 <td class="dataTableContent text-left">
 <?php echo $orders->fields['delivery_state'] . '<br>' . $orders->fields['delivery_country']; ?>
                 </td>
-                </td>
 <?php } ?> 
                 <td class="dataTableContent text-right" title="<?php echo zen_output_string($product_details, ['"' => '&quot;', "'" => '&#39;', '<br />' => '', '<hr>' => "----\n"]); ?>">
                   <?php echo strip_tags($currencies->format($orders->fields['order_total'], true, $orders->fields['currency'], $orders->fields['currency_value'])); ?>
@@ -1490,7 +1489,7 @@ if (!empty($action) && $order_exists === true) {
                                               LIMIT 1");
                     if ($gv_check->RecordCount() > 0) {
                       $goto_gv = '<a href="' . zen_href_link(FILENAME_GV_QUEUE, 'order=' . $oInfo->orders_id) . '" class="btn btn-primary" role="button">' . IMAGE_GIFT_QUEUE . '</a>';
-                      $contents[] = ['text' => '<br>' . zen_image(DIR_WS_IMAGES . 'pixel_black.gif', '', '', '3', 'style="width:100%"')];
+                      $contents[] = ['text' => '<br>' . zen_image(DIR_WS_IMAGES . 'pixel_black.gif', '', '100%', '3', '')];
                       $contents[] = ['align' => 'text-center', 'text' => $goto_gv];
                     }
 
@@ -1515,7 +1514,7 @@ if (!empty($action) && $order_exists === true) {
                       $contents[] = ['text' => nl2br(zen_output_string($orders_history_query->fields['comments'], false, $protected))];
                     }
 
-                    $contents[] = ['text' => '<br>' . zen_image(DIR_WS_IMAGES . 'pixel_black.gif', '', '', '3', 'style="width:100%"')];
+                    $contents[] = ['text' => '<br>' . zen_image(DIR_WS_IMAGES . 'pixel_black.gif', '', '100%', '3', '')];
                     $order = new order($oInfo->orders_id);
                     $contents[] = ['text' => TABLE_HEADING_PRODUCTS . ': ' . count($order->products)];
                     for ($i = 0, $n=count($order->products); $i <$n; $i++) {

--- a/admin/orders_status.php
+++ b/admin/orders_status.php
@@ -116,7 +116,7 @@ if (!empty($action)) {
       <div class="row">
         <!-- body_text //-->
         <div class="col-xs-12 col-sm-12 col-md-9 col-lg-9 configurationColumnLeft">
-          <table class="table table-hover">
+          <table class="table table-hover" role="listbox">
             <thead>
               <tr class="dataTableHeadingRow">
                 <th class="dataTableHeadingContent"><?php echo TABLE_HEADING_ORDERS_STATUS_ID; ?></th>
@@ -139,9 +139,9 @@ if (!empty($action)) {
                   }
 
                   if (isset($oInfo) && is_object($oInfo) && ($status['orders_status_id'] == $oInfo->orders_status_id)) {
-                    echo '                  <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href=\'' . zen_href_link(FILENAME_ORDERS_STATUS, 'page=' . $_GET['page'] . '&oID=' . $oInfo->orders_status_id . '&action=edit') . '\'" role="button">' . "\n";
+                    echo '                  <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href=\'' . zen_href_link(FILENAME_ORDERS_STATUS, 'page=' . $_GET['page'] . '&oID=' . $oInfo->orders_status_id . '&action=edit') . '\'" role="option" aria-selected="true">' . "\n";
                   } else {
-                    echo '                  <tr class="dataTableRow" onclick="document.location.href=\'' . zen_href_link(FILENAME_ORDERS_STATUS, 'page=' . $_GET['page'] . '&oID=' . $status['orders_status_id']) . '\'" role="button">' . "\n";
+                    echo '                  <tr class="dataTableRow" onclick="document.location.href=\'' . zen_href_link(FILENAME_ORDERS_STATUS, 'page=' . $_GET['page'] . '&oID=' . $status['orders_status_id']) . '\'" role="option" aria-selected="true">' . "\n";
                   }
                   echo '                    <td class="dataTableContent">' . $status['orders_status_id'] . '</td>';
 

--- a/admin/packingslip.php
+++ b/admin/packingslip.php
@@ -60,7 +60,7 @@ if ($order->billing['street_address'] != $order->delivery['street_address']) {
       <table class="table">
         <tr>
           <td class="pageHeading"><?php echo nl2br(STORE_NAME_ADDRESS); ?></td>
-          <td class="pageHeading" align="right"><?php echo zen_image(DIR_WS_IMAGES . HEADER_LOGO_IMAGE, HEADER_ALT_TEXT); ?></td>
+          <td class="pageHeading text-right"><?php echo zen_image(DIR_WS_IMAGES . HEADER_LOGO_IMAGE, HEADER_ALT_TEXT); ?></td>
         </tr>
       </table>
       <div><?php echo zen_draw_separator(); ?></div>

--- a/admin/popup_image.php
+++ b/admin/popup_image.php
@@ -42,16 +42,13 @@
     }
   }
 ?>
-<!doctype html public "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!doctype html>
 <html <?php echo HTML_PARAMS; ?>>
 <head>
 <title><?php echo $page_title; ?></title>
 <script>
-var i=0;
-
 function resize() {
-  if (navigator.appName == 'Netscape') i = 40;
-  window.resizeTo(document.images[0].width + 30, document.images[0].height + 60 - i);
+    window.resizeTo(document.images[0].width + 30, document.images[0].height + 60 );
 }
 </script>
 </head>

--- a/admin/product_types.php
+++ b/admin/product_types.php
@@ -139,7 +139,7 @@ if (!empty($action)) {
         <div class="row">
           <div class="col-xs-12 col-sm-12 col-md-9 col-lg-9 configurationColumnLeft">
             <!-- body_text //-->
-            <table class="table table-hover">
+            <table class="table table-hover" role="listbox">
               <thead>
                 <tr class="dataTableHeadingRow">
                   <th class="dataTableHeadingContent"><?php echo TABLE_HEADING_CONFIGURATION_TITLE; ?></th>
@@ -179,9 +179,9 @@ if (!empty($action)) {
                   }
 
                   if ((isset($cInfo) && is_object($cInfo)) && ($item['configuration_id'] == $cInfo->configuration_id)) {
-                    echo '                  <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href=\'' . zen_href_link(FILENAME_PRODUCT_TYPES, 'ptID=' . $_GET['ptID'] . '&cID=' . $cInfo->configuration_id . '&action=layout_edit') . '\'" role="button">' . "\n";
+                    echo '                  <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href=\'' . zen_href_link(FILENAME_PRODUCT_TYPES, 'ptID=' . $_GET['ptID'] . '&cID=' . $cInfo->configuration_id . '&action=layout_edit') . '\'" role="option" aria-selected="true">' . "\n";
                   } else {
-                    echo '                  <tr class="dataTableRow" onclick="document.location.href=\'' . zen_href_link(FILENAME_PRODUCT_TYPES, 'ptID=' . $_GET['ptID'] . '&cID=' . $item['configuration_id'] . '&action=layout_edit') . '\'" role="button">' . "\n";
+                    echo '                  <tr class="dataTableRow" onclick="document.location.href=\'' . zen_href_link(FILENAME_PRODUCT_TYPES, 'ptID=' . $_GET['ptID'] . '&cID=' . $item['configuration_id'] . '&action=layout_edit') . '\'" role="option" aria-selected="false">' . "\n";
                   }
                   ?>
                 <td class="dataTableContent"><?php echo $item['configuration_title']; ?></td>
@@ -190,7 +190,7 @@ if (!empty($action)) {
                   if ((isset($cInfo) && is_object($cInfo)) && ($item['configuration_id'] == $cInfo->configuration_id)) {
                     echo zen_image(DIR_WS_IMAGES . 'icon_arrow_right.gif', '');
                   } else {
-                    echo '<a href="' . zen_href_link(FILENAME_PRODUCT_TYPES, 'ptID=' . $_GET['ptID'] . '&cID=' . $item['configuration_id'] . '&action=layout') . '">' . zen_image(DIR_WS_IMAGES . 'icon_info.gif', IMAGE_ICON_INFO) . '</a>';
+                    echo zen_image(DIR_WS_IMAGES . 'icon_info.gif', IMAGE_ICON_INFO);
                   }
                   ?>&nbsp;</td>
                 </tr>
@@ -256,7 +256,7 @@ if (!empty($action)) {
           <div class="col-xs-12 col-sm-12 col-md-9 col-lg-9 configurationColumnLeft">
             <!-- body_text //-->
 
-            <table class="table table-hover">
+            <table class="table table-hover" role="listbox">
               <thead>
                 <tr class="dataTableHeadingRow">
                   <th class="dataTableHeadingContent"><?php echo TABLE_HEADING_PRODUCT_TYPES; ?></th>
@@ -281,18 +281,18 @@ if (!empty($action)) {
                   }
 
                   if (isset($ptInfo) && is_object($ptInfo) && ($product_type['type_id'] == $ptInfo->type_id)) {
-                    echo '              <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href=\'' . zen_href_link(FILENAME_PRODUCT_TYPES, 'page=' . $_GET['page'] . '&ptID=' . $product_type['type_id'] . '&action=layout') . '\'" role="button">' . "\n";
+                    echo '              <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href=\'' . zen_href_link(FILENAME_PRODUCT_TYPES, 'page=' . $_GET['page'] . '&ptID=' . $product_type['type_id'] . '&action=layout') . '\'" role="option" aria-selected="true">' . "\n";
                   } else {
-                    echo '              <tr class="dataTableRow" onclick="document.location.href=\'' . zen_href_link(FILENAME_PRODUCT_TYPES, 'page=' . $_GET['page'] . '&ptID=' . $product_type['type_id']) . '\'" role="button">' . "\n";
+                    echo '              <tr class="dataTableRow" onclick="document.location.href=\'' . zen_href_link(FILENAME_PRODUCT_TYPES, 'page=' . $_GET['page'] . '&ptID=' . $product_type['type_id']) . '\'" role="option" aria-selected="false">' . "\n";
                   }
                   ?>
                 <td class="dataTableContent"><?php echo $product_type['type_name']; ?></td>
-                <td class="dataTableContent" align="center"><?php echo $product_type['allow_add_to_cart']; ?></td>
-                <td class="dataTableContent" align="right"><?php
+                <td class="dataTableContent text-center"><?php echo $product_type['allow_add_to_cart']; ?></td>
+                <td class="dataTableContent text-right"><?php
                   if ((isset($ptInfo) && is_object($ptInfo)) && ($product_type['type_id'] == $ptInfo->type_id)) {
                     echo zen_image(DIR_WS_IMAGES . 'icon_arrow_right.gif', '');
                   } else {
-                    echo '<a href="' . zen_href_link(FILENAME_PRODUCT_TYPES, 'ptID=' . $product_type['type_id']) . '">' . zen_image(DIR_WS_IMAGES . 'icon_info.gif', IMAGE_ICON_INFO) . '</a>';
+                    echo zen_image(DIR_WS_IMAGES . 'icon_info.gif', IMAGE_ICON_INFO);
                   }
                   ?>&nbsp;</td>
                 </tr>

--- a/admin/products_to_categories.php
+++ b/admin/products_to_categories.php
@@ -690,7 +690,7 @@ if ($target_subcategory_count > $max_input_vars) { //warning when in excess of P
                         }
                         // Add a class to the checkbox so that it can be identified as a target category checkbox, for the purposes of selecting all/none at once
                         $zc_categories_checkbox = zen_draw_checkbox_field('categories_add[]',
-                            $categories_list->fields['categories_id'], $selected, '', 'class="TargetCategoryCheckbox"');
+                        $categories_list->fields['categories_id'], $selected, '', 'class="TargetCategoryCheckbox" id="categories_add[' . (int)$categories_list->fields['categories_id'] . '"');
 
                         if ($cnt_columns === 1) {
                             ?>

--- a/admin/profiles.php
+++ b/admin/profiles.php
@@ -202,7 +202,7 @@ switch ($action) {
               <input class="btn btn-info checkButton" type="button" value="<?php echo TEXT_UNCHECK_ALL; ?>" onclick="checkAll(this.form, '<?php echo $menuKey ?>', false);">
             </dt>
             <?php foreach ($pageList as $pageKey => $page) { ?>
-              <dd><label><?php echo zen_draw_checkbox_field('p[]', htmlspecialchars($pageKey, ENT_COMPAT, CHARSET, TRUE), in_array($pageKey, $permittedPages), '', ' class="' . $menuKey . ' admin-profile"'); ?><?php echo zen_output_string($page['name'], false, true); ?></label></dd>
+              <dd><label><?php echo zen_draw_checkbox_field('p[]', htmlspecialchars($pageKey, ENT_COMPAT, CHARSET, TRUE), in_array($pageKey, $permittedPages), '', ' class="' . $menuKey . ' admin-profile" id="' . zen_make_id('p[' . $pageKey . ']"')); ?><?php echo zen_output_string($page['name'], false, true); ?></label></dd>
             <?php } ?>
           </dl>
         <?php } ?>
@@ -234,7 +234,7 @@ switch ($action) {
               <input class="btn btn-info checkButton" type="button" value="<?php echo TEXT_UNCHECK_ALL; ?>" onclick="checkAll(this.form, '<?php echo $menuKey ?>', false);">
             </dt>
             <?php foreach ($pageList as $pageKey => $page) { ?>
-              <dd><label><?php echo zen_draw_checkbox_field('p[]', htmlspecialchars($pageKey, ENT_COMPAT, CHARSET, TRUE), isset($_POST['p']) && in_array($pageKey, $_POST['p']), '', ' class="' . $menuKey . '"'); ?><?php echo zen_output_string($page['name'], false, true); ?></label></dd>
+              <dd><label><?php echo zen_draw_checkbox_field('p[]', htmlspecialchars($pageKey, ENT_COMPAT, CHARSET, TRUE), isset($_POST['p']) && in_array($pageKey, $_POST['p']), '', ' class="' . $menuKey . '" id="' . zen_make_id('p[' . $pageKey . ']"')); ?><?php echo zen_output_string($page['name'], false, true); ?></label></dd>
             <?php } ?>
           </dl>
         <?php } ?>

--- a/admin/record_artists.php
+++ b/admin/record_artists.php
@@ -205,7 +205,7 @@ if (!empty($action)) {
                   $manufacturer_inputs_string .= '<br><div class="input-group"><span class="input-group-addon">' . zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '</span>' . zen_draw_input_field('artists_url[' . $languages[$i]['id'] . ']', '', zen_set_field_length(TABLE_RECORD_ARTISTS_INFO, 'artists_url') . ' class="form-control"') . '</div>';
                 }
 
-                $contents[] = array('text' => zen_draw_label(TEXT_RECORD_ARTIST_URL, 'artists_url', 'class="control-label"') . $manufacturer_inputs_string);
+                $contents[] = array('text' => zen_draw_label(TEXT_RECORD_ARTIST_URL, 'artists_url[' . $languages[0]['id'] . ']', 'class="control-label"') . $manufacturer_inputs_string);
                 $contents[] = array('align' => 'center', 'text' => '<button type="submit" class="btn btn-primary">' . IMAGE_SAVE . '</button> <a href="' . zen_href_link(FILENAME_RECORD_ARTISTS, 'page=' . $_GET['page'] . '&mID=' . $_GET['mID']) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>');
                 break;
               case 'edit':
@@ -227,7 +227,7 @@ if (!empty($action)) {
                   $manufacturer_inputs_string .= '<br><div class="input-group"><span class="input-group-addon">' . zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '</span>' . zen_draw_input_field('artists_url[' . $languages[$i]['id'] . ']', zen_get_artists_url($aInfo->artists_id, $languages[$i]['id']), zen_set_field_length(TABLE_RECORD_ARTISTS_INFO, 'artists_url') . ' class="form-control"') . '</div>';
                 }
 
-                $contents[] = array('text' => zen_draw_label(TEXT_RECORD_ARTIST_URL, 'artists_url', 'class="control-label"') . $manufacturer_inputs_string);
+                $contents[] = array('text' => zen_draw_label(TEXT_RECORD_ARTIST_URL, 'artists_url[' . $languages[0]['id'] . ']', 'class="control-label"') . $manufacturer_inputs_string);
                 $contents[] = array('align' => 'center', 'text' => '<button type="submit" class="btn btn-primary">' . IMAGE_SAVE . '</button> <a href="' . zen_href_link(FILENAME_RECORD_ARTISTS, 'page=' . $_GET['page'] . '&mID=' . $aInfo->artists_id) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>');
                 break;
               case 'delete':

--- a/admin/record_company.php
+++ b/admin/record_company.php
@@ -206,7 +206,7 @@ if (!empty($action)) {
                   $record_company_inputs_string .= '<br><div class="input-group"><span class="input-group-addon">' . zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '</span>' . zen_draw_input_field('record_company_url[' . $languages[$i]['id'] . ']', '', zen_set_field_length(TABLE_RECORD_COMPANY_INFO, 'record_company_url') . ' class="form-control"') . '</div>';
                 }
 
-                $contents[] = array('text' => zen_draw_label(TEXT_RECORD_COMPANY_URL, 'record_company_url', 'class="control-label"') . $record_company_inputs_string);
+                $contents[] = array('text' => zen_draw_label(TEXT_RECORD_COMPANY_URL, 'record_company_url[' . $languages[0]['id'] . ']', 'class="control-label"') . $record_company_inputs_string);
                 $contents[] = array('align' => 'center', 'text' => '<button type="submit" class="btn btn-primary">' . IMAGE_SAVE . '</button> <a href="' . zen_href_link(FILENAME_RECORD_COMPANY, 'page=' . $_GET['page'] . '&mID=' . $_GET['mID']) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>');
                 break;
               case 'edit':
@@ -228,7 +228,7 @@ if (!empty($action)) {
                   $record_company_inputs_string .= '<br><div class="input-group"><span class="input-group-addon">' . zen_image(DIR_WS_CATALOG_LANGUAGES . $languages[$i]['directory'] . '/images/' . $languages[$i]['image'], $languages[$i]['name']) . '</span>' . zen_draw_input_field('record_company_url[' . $languages[$i]['id'] . ']', zen_get_record_company_url($aInfo->record_company_id, $languages[$i]['id']), zen_set_field_length(TABLE_RECORD_COMPANY_INFO, 'record_company_url') . ' class="form-control"') . '</div>';
                 }
 
-                $contents[] = array('text' => zen_draw_label(TEXT_RECORD_COMPANY_URL, 'record_company_url', 'class="control-label"') . $record_company_inputs_string);
+                $contents[] = array('text' => zen_draw_label(TEXT_RECORD_COMPANY_URL, 'record_company_url[' . $languages[0]['id'] . ']', 'class="control-label"') . $record_company_inputs_string);
                 $contents[] = array('align' => 'center', 'text' => '<button type="submit" class="btn btn-primary">' . IMAGE_SAVE . '</button> <a href="' . zen_href_link(FILENAME_RECORD_COMPANY, 'page=' . $_GET['page'] . '&mID=' . $aInfo->record_company_id) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>');
                 break;
               case 'delete':

--- a/admin/salemaker.php
+++ b/admin/salemaker.php
@@ -75,8 +75,8 @@ if (!empty($action)) {
         'sale_specials_condition' => zen_db_prepare_input($_POST['condition']),
         'sale_categories_selected' => $categories_selected_string,
         'sale_categories_all' => $categories_all_string,
-        'sale_date_start' => ((zen_db_prepare_input($_POST['start']) == '') ? '0001-01-01' : zen_date_raw($_POST['start'])),
-        'sale_date_end' => ((zen_db_prepare_input($_POST['end']) == '') ? '0001-01-01' : zen_date_raw($_POST['end'])));
+          'sale_date_start' => ((zen_db_prepare_input($_POST['start']) == '') ? '0001-01-01' : zen_db_prepare_input($_POST['start'])),
+          'sale_date_end' => ((zen_db_prepare_input($_POST['end']) == '') ? '0001-01-01' : zen_db_prepare_input($_POST['end'])));
 
       if ($action == 'insert') {
         $salemaker_sales_data_array['sale_status'] = 1;
@@ -157,8 +157,6 @@ if (!empty($action)) {
     <?php
     if (($action == 'new') || ($action == 'edit')) {
       ?>
-      <link rel="stylesheet" href="includes/javascript/spiffyCal/spiffyCal_v2_1.css">
-      <script src="includes/javascript/spiffyCal/spiffyCal_v2_1.js"></script>
       <script>
         function session_win() {
             window.open("<?php echo zen_href_link(FILENAME_SALEMAKER_INFO); ?>", "salemaker_info", "height=460,width=600,scrollbars=yes,resizable=yes").focus();
@@ -237,12 +235,7 @@ if (!empty($action)) {
       </script>
     </head>
 <?php } ?>
-<?php if ($action == 'new' || $action == 'edit') { ?>
-       <body onload="SetCategories();">
-       <div id="spiffycalendar" class="text"></div>
-<?php } else { ?>
        <body>
-<?php } ?>
   <!-- header //-->
   <?php require(DIR_WS_INCLUDES . 'header.php'); ?>
   <!-- header_eof //-->
@@ -268,13 +261,11 @@ if (!empty($action)) {
       } else {
         $sInfo = new objectInfo(array());
       }
+      echo zen_draw_form("sale_form", FILENAME_SALEMAKER, zen_get_all_get_params(array('action', 'info', 'sID')) . 'action=' . $form_action, 'post', 'onsubmit="return check_dates(start,StartDate.required, end, EndDate.required);" class="form-horizontal"'); 
+      if ($form_action == 'update') {
+          echo zen_draw_hidden_field('sID', $_GET['sID']); 
+      }
       ?>
-      <script>
-        var StartDate = new ctlSpiffyCalendarBox("StartDate", "sale_form", "start", "btnDate1", "<?php echo (($sInfo->sale_date_start == '0001-01-01') ? '' : zen_date_short($sInfo->sale_date_start)); ?>", scBTNMODE_CUSTOMBLUE);
-        var EndDate = new ctlSpiffyCalendarBox("EndDate", "sale_form", "end", "btnDate2", "<?php echo (($sInfo->sale_date_end == '0001-01-01') ? '' : zen_date_short($sInfo->sale_date_end)); ?>", scBTNMODE_CUSTOMBLUE);
-      </script>
-      <?php echo zen_draw_form("sale_form", FILENAME_SALEMAKER, zen_get_all_get_params(array('action', 'info', 'sID')) . 'action=' . $form_action, 'post', 'onsubmit="return check_dates(start,StartDate.required, end, EndDate.required);" class="form-horizontal"'); ?>
-      <?php if ($form_action == 'update') echo zen_draw_hidden_field('sID', $_GET['sID']); ?>
       <div class="row">
         <div class="col-sm-6"><?php echo TEXT_SALEMAKER_POPUP; ?></div>
         <div class="col-sm-6 text-right">
@@ -311,19 +302,13 @@ if (!empty($action)) {
       <div class="form-group">
           <?php echo zen_draw_label(TEXT_SALEMAKER_DATE_START, 'start', 'class="col-sm-3 control-label"'); ?>
         <div class="col-sm-9 col-md-6">
-          <script>
-            StartDate.writeControl();
-            StartDate.dateFormat = "<?php echo DATE_FORMAT_SPIFFYCAL; ?>";
-          </script>
+            <input type="date" id="start" name="start" class="form-control" value="<?php echo (($sInfo->sale_date_start == '0001-01-01') ? '' : $sInfo->sale_date_start);?>">
         </div>
       </div>
       <div class="form-group">
           <?php echo zen_draw_label(TEXT_SALEMAKER_DATE_END, 'end', 'class="col-sm-3 control-label"'); ?>
         <div class="col-sm-9 col-md-6">
-          <script>
-            EndDate.writeControl();
-            EndDate.dateFormat = "<?php echo DATE_FORMAT_SPIFFYCAL; ?>";
-          </script>
+            <input type="date" id="end" name="end" class="form-control" value="<?php echo (($sInfo->sale_date_end == '0001-01-01') ? '' : $sInfo->sale_date_end);?>">
         </div>
       </div>
       <?php
@@ -406,7 +391,7 @@ if (!empty($action)) {
           <div class="col-sm-offset-3 col-xs-5 col-sm-4 col-md-4" onClick="RowClick('<?php echo $category['path'];
           ?>')">
             <div class="checkbox">
-              <label><?php echo zen_draw_checkbox_field('categories[]', $category['path'], $selected); ?><?php echo $category['text']; ?></label>
+              <label><?php echo zen_draw_checkbox_field('categories[]', $category['path'], $selected, '', 'id="categories[' . $category['categories_id'] .']"'); ?><?php echo $category['text']; ?></label>
               <?php
               if (isset($prev_categories_array[$category['categories_id']]) && $prev_categories_array[$category['categories_id']]) {
                 echo sprintf(TEXT_WARNING_SALEMAKER_PREVIOUS_CATEGORIES, $prev_categories_array[$category['categories_id']]);
@@ -461,31 +446,31 @@ if (!empty($action)) {
                     <?php } else { ?>
                   <tr class="dataTableRow" onclick="document.location.href = '<?php echo zen_href_link(FILENAME_SALEMAKER, 'page=' . $_GET['page'] . '&sID=' . $salemaker_sale['sale_id']); ?>'">
                     <?php } ?>
-                  <td  class="dataTableContent" align="left"><?php echo $salemaker_sale['sale_name']; ?></td>
-                  <td  class="dataTableContent" align="right"><?php echo $salemaker_sale['sale_deduction_value']; ?></td>
-                  <td  class="dataTableContent" align="left"><?php echo $deduction_type_array[$salemaker_sale['sale_deduction_type']]['text']; ?></td>
-                  <td  class="dataTableContent" align="center"><?php echo (($salemaker_sale['sale_date_start'] == '0001-01-01') ? TEXT_SALEMAKER_IMMEDIATELY : zen_date_short($salemaker_sale['sale_date_start'])); ?></td>
-                  <td  class="dataTableContent" align="center"><?php echo (($salemaker_sale['sale_date_end'] == '0001-01-01') ? TEXT_SALEMAKER_NEVER : zen_date_short($salemaker_sale['sale_date_end'])); ?></td>
-                  <td  class="dataTableContent" align="center">
+                  <td  class="dataTableContent text-left"><?php echo $salemaker_sale['sale_name']; ?></td>
+                  <td  class="dataTableContent text-right"><?php echo $salemaker_sale['sale_deduction_value']; ?></td>
+                  <td  class="dataTableContent text-left"><?php echo $deduction_type_array[$salemaker_sale['sale_deduction_type']]['text']; ?></td>
+                  <td  class="dataTableContent text-center"><?php echo (($salemaker_sale['sale_date_start'] == '0001-01-01') ? TEXT_SALEMAKER_IMMEDIATELY : zen_date_short($salemaker_sale['sale_date_start'])); ?></td>
+                  <td  class="dataTableContent text-center"><?php echo (($salemaker_sale['sale_date_end'] == '0001-01-01') ? TEXT_SALEMAKER_NEVER : zen_date_short($salemaker_sale['sale_date_end'])); ?></td>
+                  <td  class="dataTableContent text-center">
                       <?php
                       if ($salemaker_sale['sale_status'] == '1') {
                         echo zen_draw_form('setflag_products', FILENAME_SALEMAKER, 'action=setflag&sID=' . $salemaker_sale['sale_id'] . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : ''));
                         ?>
-                      <input type="image" src="<?php echo DIR_WS_IMAGES ?>icon_green_on.gif" title="<?php echo IMAGE_ICON_STATUS_ON; ?>">
+                      <input type="image" src="<?php echo DIR_WS_IMAGES ?>icon_green_on.gif" alt="<?php echo IMAGE_ICON_STATUS_ON; ?>" title="<?php echo IMAGE_ICON_STATUS_ON; ?>">
                       <input type="hidden" name="flag" value="0">
                       <?php echo '</form>'; ?>
                       <?php
                     } else {
                       echo zen_draw_form('setflag_products', FILENAME_SALEMAKER, 'action=setflag&sID=' . $salemaker_sale['sale_id'] . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : ''));
                       ?>
-                      <input type="image" src="<?php echo DIR_WS_IMAGES ?>icon_red_on.gif" title="<?php echo IMAGE_ICON_STATUS_OFF; ?>">
+                      <input type="image" src="<?php echo DIR_WS_IMAGES ?>icon_red_on.gif" alt="<?php echo IMAGE_ICON_STATUS_ON; ?>" title="<?php echo IMAGE_ICON_STATUS_OFF; ?>">
                       <input type="hidden" name="flag" value="1">
                       <?php echo '</form>'; ?>
                       <?php
                     }
                     ?>
                   </td>
-                  <td class="dataTableContent" align="right"><?php
+                  <td class="dataTableContent text-right"><?php
                       if (!empty($sInfo) && (is_object($sInfo)) && !empty($salemaker_sale) && isset($salemaker_sale['sale_id']) && ($salemaker_sale['sale_id'] == $sInfo->sale_id)) {
                         echo zen_image(DIR_WS_IMAGES . 'icon_arrow_right.gif', '');
                       } else {
@@ -532,7 +517,7 @@ if (!empty($action)) {
 
                   $contents[] = array('text' => '<br>' . TEXT_INFO_DEDUCTION . ' ' . $sInfo->sale_deduction_value . ' ' . $deduction_type_array[$sInfo->sale_deduction_type]['text']);
                   $contents[] = array('text' => '' . TEXT_INFO_PRICERANGE_FROM . ' ' . $currencies->format($sInfo->sale_pricerange_from) . TEXT_INFO_PRICERANGE_TO . $currencies->format($sInfo->sale_pricerange_to));
-                  $contents[] = array('text' => '<table class="dataTableContent" border="0" width="100%" cellspacing="0" cellpadding="0"><tr><td valign="top">' . TEXT_INFO_SPECIALS_CONDITION . '&nbsp;</td><td>' . $specials_condition_array[$sInfo->sale_specials_condition]['text'] . '</td></tr></table>');
+                  $contents[] = array('text' => '<table class="table dataTableContent"><tr><td>' . TEXT_INFO_SPECIALS_CONDITION . '&nbsp;</td><td>' . $specials_condition_array[$sInfo->sale_specials_condition]['text'] . '</td></tr></table>');
 
                   $contents[] = array('text' => '<br>' . TEXT_INFO_DATE_START . ' ' . (($sInfo->sale_date_start == '0001-01-01') ? TEXT_SALEMAKER_IMMEDIATELY : zen_date_short($sInfo->sale_date_start)));
                   $contents[] = array('text' => '' . TEXT_INFO_DATE_END . ' ' . (($sInfo->sale_date_end == '0001-01-01') ? TEXT_SALEMAKER_NEVER : zen_date_short($sInfo->sale_date_end)));

--- a/admin/salemaker_popup.php
+++ b/admin/salemaker_popup.php
@@ -20,7 +20,7 @@ $deduction_type_array = array(
   <head>
     <meta charset="<?php echo CHARSET; ?>">
     <title><?php echo TITLE; ?></title>
-    <link rel="stylesheet"href="includes/stylesheet.css">
+    <link rel="stylesheet" href="includes/stylesheet.css">
   </head>
   <body>
     <h1 class="text-center"><?php echo HEADING_TITLE . ' - ' . $cname; ?></h1>

--- a/admin/server_info.php
+++ b/admin/server_info.php
@@ -13,7 +13,7 @@
 
 // the following is for display later
   $sinfo =  '<div class="sysinfo wrapper">' .
-         '  <div class="center"><a href="https://www.zen-cart.com"><img border="0" src="images/small_zen_logo.gif" alt=" Zen Cart "></a></div>' .
+         '  <div class="center"><a href="https://www.zen-cart.com"><img src="images/small_zen_logo.gif" alt=" Zen Cart "></a></div>' .
          '  <div class="center"><h2> ' . PROJECT_VERSION_NAME . ' ' . PROJECT_VERSION_MAJOR . '.' . PROJECT_VERSION_MINOR . '</h2>' .
                ((PROJECT_VERSION_PATCH1 =='') ? '' : '<h3>Patch: ' . PROJECT_VERSION_PATCH1 . '::' . PROJECT_VERSION_PATCH1_SOURCE . '</h3>') .
                ((PROJECT_VERSION_PATCH2 =='') ? '' : '<h3>Patch: ' . PROJECT_VERSION_PATCH2 . '::' . PROJECT_VERSION_PATCH2_SOURCE . '</h3>') .
@@ -41,7 +41,7 @@
     $sinfo .= '<br><a href="https://docs.zen-cart.com/user/first_steps/server_requirements/" rel="noopener" target="_blank">Zen Cart documentation: Server Requirements</a>';
     $sinfo .= '</div></div>';
 ?>
-<!doctype html public "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!doctype html>
 <html <?php echo HTML_PARAMS; ?>>
 <head>
     <?php require DIR_WS_INCLUDES . 'admin_html_head.php'; ?>
@@ -92,7 +92,10 @@ if (strpos($disabled_functions,"phpinfo") === false) {
     ob_end_clean();
     $regs = '';
     preg_match('/<body>(.*)<\/body>/msi', $phpinfo, $regs);
-    echo $regs[1];
+    // clean up html to html 5
+    // replace font with span, replace name with id in <a> tag, remove border="0" from <img> tag
+    $phpinfo = preg_replace(['/<(\/)?font/','/<a name=/','/<img border="0"/'],['<$1span','<a id=','<img '],$regs[1]);
+    echo $phpinfo;
   } else {
     phpinfo();
   }
@@ -113,7 +116,7 @@ if (strpos($disabled_functions,"phpinfo") === false) {
         ?>
         <tr class="db-row">
             <td class="db-info db-name"><?php echo $variable['Variable_name']; ?></td>
-            <td class="db-info db-value"><?php echo empty($variable['Value']) ? '$nbsp;' : $variable['Value']; ?></td>
+            <td class="db-info db-value"><?php echo empty($variable['Value']) ? '$nbsp;' : htmlspecialchars($variable['Value']); ?></td>
         </tr>
         <?php
     }

--- a/admin/sqlpatch.php
+++ b/admin/sqlpatch.php
@@ -806,20 +806,7 @@ if (!empty($action)) {
   <!doctype html>
   <html <?php echo HTML_PARAMS; ?>>
     <head>
-      <meta charset="<?php echo CHARSET; ?>">
-      <title><?php echo TITLE; ?></title>
-      <link rel="stylesheet" href="includes/stylesheet.css">
-      <link rel="stylesheet" href="includes/cssjsmenuhover.css" media="all" id="hoverJS">
-      <script src="includes/menu.js"></script>
-      <script>
-        function init() {
-            cssjsmenu('navbar');
-            if (document.getElementById) {
-                var kill = document.getElementById('hoverJS');
-                kill.disabled = true;
-            }
-        }
-      </script>
+      <?php require DIR_WS_INCLUDES . 'admin_html_head.php'; ?>
     </head>
     <body onLoad="init()">
       <!-- header //-->

--- a/admin/stats_customers_referrals.php
+++ b/admin/stats_customers_referrals.php
@@ -75,7 +75,7 @@ include DIR_FS_CATALOG . DIR_WS_CLASSES . 'order.php';
             <?php echo zen_draw_input_field('end_date', $_GET['end_date'], 'class="form-control"'); ?>
         </div>
       </div>
-      <div class="col-sm-12 text-right"><button type="submit" class="btn btn-primary"><?php echo IMAGE_DISPLAY; ?></div>
+      <div class="col-sm-12 text-right"><button type="submit" class="btn btn-primary"><?php echo IMAGE_DISPLAY; ?></button></div>
       <?php echo '</form>'; ?>
 
 

--- a/admin/stats_sales_report_graphs.php
+++ b/admin/stats_sales_report_graphs.php
@@ -288,8 +288,8 @@ for ($i = 0; $i < $report->size; $i++) {
         </table>
         <table class="table table-condensed">
           <tr class="dataTableRow">
-            <td class="dataTableContent" width="80%" align="left"><?php echo FILTER_STATUS ?></td>
-            <td class="dataTableContent" align="right"><?php echo FILTER_VALUE ?></td>
+            <td class="dataTableContent col-sm-9 text left"><?php echo FILTER_STATUS ?></td>
+            <td class="dataTableContent text-right"><?php echo FILTER_VALUE ?></td>
           </tr>
           <?php
           if (($sales_report_filter) == 0) {
@@ -300,13 +300,13 @@ for ($i = 0; $i < $report->size; $i++) {
           for ($i = 0; $i < $report->status_available_size; $i++) {
             ?>
             <tr>
-              <td class="dataTableContent" align="left"><?php echo $report->status_available[$i]['value'] ?></a></td>
+              <td class="dataTableContent text-left"><?php echo $report->status_available[$i]['value'] ?></td>
               <?php
               if (substr($sales_report_filter, $i, 1) == "0") {
                 $tmp = substr($sales_report_filter, 0, $i) . "1" . substr($sales_report_filter, $i + 1, $report->status_available_size - ($i + 1));
                 $tmp = zen_href_link(FILENAME_STATS_SALES_REPORT_GRAPHS, $report->filter_link . "&filter=" . $tmp);
                 ?>
-                <td class="dataTableContent" width="100%" align="right">
+                <td class="dataTableContent col-sm-12 text-right">
                   <?php echo zen_image(DIR_WS_IMAGES . 'icon_status_green.gif', IMAGE_ICON_STATUS_GREEN, 10, 10) ?>&nbsp;
                   <a href="<?php echo $tmp; ?>"><?php echo zen_image(DIR_WS_IMAGES . 'icon_status_red_light.gif', IMAGE_ICON_STATUS_RED_LIGHT, 10, 10) ?></a></td>
                 <?php
@@ -314,7 +314,7 @@ for ($i = 0; $i < $report->size; $i++) {
                 $tmp = substr($sales_report_filter, 0, $i) . "0" . substr($sales_report_filter, $i + 1);
                 $tmp = zen_href_link(FILENAME_STATS_SALES_REPORT_GRAPHS, $report->filter_link . "&filter=" . $tmp);
                 ?>
-                <td class="dataTableContent" width="100%" align="right">
+                <td class="dataTableContent col-sm-12 text-right">
                   <a href="<?php echo $tmp; ?>"><?php echo zen_image(DIR_WS_IMAGES . 'icon_status_green_light.gif', IMAGE_ICON_STATUS_GREEN, 10, 10) ?></a>
                   &nbsp;<?php echo zen_image(DIR_WS_IMAGES . 'icon_status_red.gif', IMAGE_ICON_STATUS_RED_LIGHT, 10, 10) ?></td>
                 <?php

--- a/admin/tax_classes.php
+++ b/admin/tax_classes.php
@@ -79,7 +79,7 @@ if (!empty($action)) {
       <h1><?php echo HEADING_TITLE; ?></h1>
       <div class="row">
         <div class="col-xs-12 col-sm-12 col-md-9 col-lg-9 configurationColumnLeft">
-          <table class="table table-hover">
+          <table class="table table-hover" role="listbox">
             <thead>
               <tr class="dataTableHeadingRow">
                 <th class="dataTableHeadingContent"><?php echo TABLE_HEADING_TAX_CLASS_ID; ?></th>
@@ -100,14 +100,14 @@ if (!empty($action)) {
                   }
 
                   if (isset($tcInfo) && is_object($tcInfo) && ($class['tax_class_id'] == $tcInfo->tax_class_id)) {
-                    echo '              <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href=\'' . zen_href_link(FILENAME_TAX_CLASSES, 'page=' . $_GET['page'] . '&tID=' . $tcInfo->tax_class_id . '&action=edit') . '\'" role="button">' . "\n";
+                    echo '              <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href=\'' . zen_href_link(FILENAME_TAX_CLASSES, 'page=' . $_GET['page'] . '&tID=' . $tcInfo->tax_class_id . '&action=edit') . '\'" role="option" aria-selected="true">' . "\n";
                   } else {
-                    echo'              <tr class="dataTableRow" onclick="document.location.href=\'' . zen_href_link(FILENAME_TAX_CLASSES, 'page=' . $_GET['page'] . '&tID=' . $class['tax_class_id']) . '\'" role="button">' . "\n";
+                    echo'              <tr class="dataTableRow" onclick="document.location.href=\'' . zen_href_link(FILENAME_TAX_CLASSES, 'page=' . $_GET['page'] . '&tID=' . $class['tax_class_id']) . '\'" role="option" aria-selected="false">' . "\n";
                   }
                   ?>
               <td class="dataTableContent"><?php echo $class['tax_class_id']; ?></td>
               <td class="dataTableContent"><?php echo $class['tax_class_title']; ?></td>
-              <td class="dataTableContent" align="right"><?php
+              <td class="dataTableContent text-right"><?php
                   if (isset($tcInfo) && is_object($tcInfo) && ($class['tax_class_id'] == $tcInfo->tax_class_id)) {
                     echo zen_image(DIR_WS_IMAGES . 'icon_arrow_right.gif', '');
                   } else {

--- a/admin/tax_rates.php
+++ b/admin/tax_rates.php
@@ -78,7 +78,7 @@ if (!empty($action)) {
       <div class="row">
         <!-- body_text //-->
         <div class="col-xs-12 col-sm-12 col-md-9 col-lg-9 configurationColumnLeft">
-          <table class="table table-hover">
+          <table class="table table-hover" role="listbox">
             <thead>
               <tr class="dataTableHeadingRow">
                 <th class="dataTableHeadingContent"><?php echo TABLE_HEADING_TAX_RATE_PRIORITY; ?></th>
@@ -104,9 +104,9 @@ if (!empty($action)) {
                   }
 
                   if (isset($trInfo) && is_object($trInfo) && ($rate['tax_rates_id'] == $trInfo->tax_rates_id)) {
-                    echo '              <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href=\'' . zen_href_link(FILENAME_TAX_RATES, 'page=' . $_GET['page'] . '&tID=' . $trInfo->tax_rates_id . '&action=edit') . '\'" role="button">' . "\n";
+                    echo '              <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href=\'' . zen_href_link(FILENAME_TAX_RATES, 'page=' . $_GET['page'] . '&tID=' . $trInfo->tax_rates_id . '&action=edit') . '\'" role="option" aria-selected="true">' . "\n";
                   } else {
-                    echo '              <tr class="dataTableRow" onclick="document.location.href=\'' . zen_href_link(FILENAME_TAX_RATES, 'page=' . $_GET['page'] . '&tID=' . $rate['tax_rates_id']) . '\'" role="button">' . "\n";
+                    echo '              <tr class="dataTableRow" onclick="document.location.href=\'' . zen_href_link(FILENAME_TAX_RATES, 'page=' . $_GET['page'] . '&tID=' . $rate['tax_rates_id']) . '\'" role="option" aria-selected="false">' . "\n";
                   }
                   ?>
               <td class="dataTableContent"><?php echo $rate['tax_priority']; ?></td>
@@ -139,8 +139,8 @@ if (!empty($action)) {
 
                 $contents = array('form' => zen_draw_form('rates', FILENAME_TAX_RATES, 'page=' . $_GET['page'] . '&action=insert'));
                 $contents[] = array('text' => TEXT_INFO_INSERT_INTRO);
-                $contents[] = array('text' => '<br>' . zen_draw_label(TEXT_INFO_CLASS_TITLE, 'tax_class_id', 'class="control-label"') . zen_tax_classes_pull_down('name="tax_class_id" class="form-control"'));
-                $contents[] = array('text' => '<br>' . zen_draw_label(TEXT_INFO_ZONE_NAME, 'tax_zone_id', 'class="control-label"') . zen_geo_zones_pull_down('name="tax_zone_id" class="form-control"'));
+                $contents[] = array('text' => '<br>' . zen_draw_label(TEXT_INFO_CLASS_TITLE, 'tax_class_id', 'class="control-label"') . zen_tax_classes_pull_down('name="tax_class_id" id="tax_class_id" class="form-control"'));
+                $contents[] = array('text' => '<br>' . zen_draw_label(TEXT_INFO_ZONE_NAME, 'tax_zone_id', 'class="control-label"') . zen_geo_zones_pull_down('name="tax_zone_id" id="tax_zone_id" class="form-control"'));
                 $contents[] = array('text' => '<br>' . zen_draw_label(TEXT_INFO_TAX_RATE, 'tax_rate', 'class="control-label"') . zen_draw_input_field('tax_rate', '', 'class="form-control"'));
                 $contents[] = array('text' => '<br>' . zen_draw_label(TEXT_INFO_RATE_DESCRIPTION, 'tax_description', 'class="control-label"') . zen_draw_input_field('tax_description', '', 'class="form-control"'));
                 $contents[] = array('text' => '<br>' . zen_draw_label(TEXT_INFO_TAX_RATE_PRIORITY, 'tax_priority', 'class="control-label"') . zen_draw_input_field('tax_priority', '', 'class="form-control"'));
@@ -151,15 +151,15 @@ if (!empty($action)) {
 
                 $contents = array('form' => zen_draw_form('rates', FILENAME_TAX_RATES, 'page=' . $_GET['page'] . '&tID=' . $trInfo->tax_rates_id . '&action=save'));
                 $contents[] = array('text' => TEXT_INFO_EDIT_INTRO);
-                $contents[] = array('text' => '<br>' . zen_draw_label(TEXT_INFO_CLASS_TITLE, 'tax_class_id', 'class="control-label"') . zen_tax_classes_pull_down('name="tax_class_id" class="form-control"', $trInfo->tax_class_id));
-                $contents[] = array('text' => '<br>' . zen_draw_label(TEXT_INFO_ZONE_NAME, 'tax_zone_id', 'class="control-label"') . zen_geo_zones_pull_down('name="tax_zone_id" class="form-control"', $trInfo->geo_zone_id));
+                $contents[] = array('text' => '<br>' . zen_draw_label(TEXT_INFO_CLASS_TITLE, 'tax_class_id', 'class="control-label"') . zen_tax_classes_pull_down('name="tax_class_id" id="tax_class_id" class="form-control"', $trInfo->tax_class_id));
+                $contents[] = array('text' => '<br>' . zen_draw_label(TEXT_INFO_ZONE_NAME, 'tax_zone_id', 'class="control-label"') . zen_geo_zones_pull_down('name="tax_zone_id" id="tax_zone_id" class="form-control"', $trInfo->geo_zone_id));
                 $contents[] = array('text' => '<br>' . zen_draw_label(TEXT_INFO_TAX_RATE, 'tax_rate', 'class="control-label"') . zen_draw_input_field('tax_rate', $trInfo->tax_rate, 'class="form-control"'));
                 $contents[] = array('text' => '<br>' . zen_draw_label(TEXT_INFO_RATE_DESCRIPTION, 'tax_description', 'class="control-label"') . zen_draw_input_field('tax_description', htmlspecialchars($trInfo->tax_description, ENT_COMPAT, CHARSET, TRUE), 'class="form-control"'));
                 $contents[] = array('text' => '<br>' . zen_draw_label(TEXT_INFO_TAX_RATE_PRIORITY, 'tax_priority', 'class="control-label"') . zen_draw_input_field('tax_priority', $trInfo->tax_priority, 'class="form-control"'));
                 $contents[] = array('align' => 'text-center', 'text' => '<br><button type="submit" class="btn btn-primary">' . IMAGE_UPDATE . '</button> <a href="' . zen_href_link(FILENAME_TAX_RATES, 'page=' . $_GET['page'] . '&tID=' . $trInfo->tax_rates_id) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>');
                 break;
               case 'delete':
-                $heading[] = array('text' => 'h4>' . TEXT_INFO_HEADING_DELETE_TAX_RATE . '</h4>');
+                $heading[] = array('text' => '<h4>' . TEXT_INFO_HEADING_DELETE_TAX_RATE . '</h4>');
 
                 $contents = array('form' => zen_draw_form('rates', FILENAME_TAX_RATES, 'page=' . $_GET['page'] . '&action=deleteconfirm') . zen_draw_hidden_field('tID', $trInfo->tax_rates_id));
                 $contents[] = array('text' => TEXT_INFO_DELETE_INTRO);

--- a/admin/whos_online.php
+++ b/admin/whos_online.php
@@ -182,7 +182,7 @@ $listingURL = FILENAME_WHOS_ONLINE . '.php?' . zen_get_all_get_params(['q', 't',
                     // item css classes indicating cart status: 'wo-inactive-empty', 'wo-active-empty', 'wo-inactive-not-empty', 'wo-active-not-empty'
                     ?>
                 <td class="dataTableContentWhois <?php echo $item['icon_class']; ?>"><?php echo $item['icon_image'] . '&nbsp;' . gmdate('H:i:s', $item['time_online']); ?></td>
-                <td class="dataTableContentWhois" align="center">
+                <td class="dataTableContentWhois text-center">
                     <?php
                     if ($item['customer_id'] != 0) {
                       echo '<a href="' . zen_href_link(FILENAME_CUSTOMERS, zen_get_all_get_params(['cID', 'action']) . 'cID=' . $item['customer_id'] . '&action=edit', 'NONSSL') . '"><u>' . $item['customer_id'] . '</u></a>';
@@ -191,7 +191,7 @@ $listingURL = FILENAME_WHOS_ONLINE . '.php?' . zen_get_all_get_params(['q', 't',
                     }
                     ?>
                 </td>
-                <td class="dataTableContentWhois" nowrap="nowrap">
+                <td class="dataTableContentWhois text-nowrap">
                     <?php
                     if ($item['customer_id'] != 0) {
                       echo '<a href="' . zen_href_link(FILENAME_ORDERS, 'cID=' . $item['customer_id'], 'NONSSL') . '">' . '<u>' . $item['full_name'] . '</u></a>';
@@ -200,7 +200,7 @@ $listingURL = FILENAME_WHOS_ONLINE . '.php?' . zen_get_all_get_params(['q', 't',
                     }
                     ?>
                 </td>
-                <td class="dataTableContentWhois dataTableButtonCell" align="left" valign="top">
+                <td class="dataTableContentWhois dataTableButtonCell text-left">
                     <?php
                     $whois_url = 'https://whois.domaintools.com/' . $item['ip_address'];
                     $additional_ipaddress_links = '';
@@ -212,9 +212,9 @@ $listingURL = FILENAME_WHOS_ONLINE . '.php?' . zen_get_all_get_params(['q', 't',
                     <?php echo $additional_ipaddress_links; ?>
                 </td>
                 <td>&nbsp;</td>
-                <td class="dataTableContentWhois" align="center" valign="top"><?php echo date('H:i:s', $item['time_entry']); ?></td>
-                <td class="dataTableContentWhois" align="center" valign="top"><?php echo date('H:i:s', $item['time_last_click']); ?></td>
-                <td class="dataTableContentWhois" colspan="2" valign="top">&nbsp;</td>
+                <td class="dataTableContentWhois text-center"><?php echo date('H:i:s', $item['time_entry']); ?></td>
+                <td class="dataTableContentWhois text-center"><?php echo date('H:i:s', $item['time_last_click']); ?></td>
+                <td class="dataTableContentWhois" >&nbsp;</td>
                 </tr>
                 <?php
                 // show host name
@@ -225,8 +225,8 @@ $listingURL = FILENAME_WHOS_ONLINE . '.php?' . zen_get_all_get_params(['q', 't',
                     echo '              <tr class="' . ($item['is_a_bot'] ? 'dataTableRowBot' : 'dataTableRowWhois') .' whois-listing-row" data-sid="' . $item['session_id'] .'">' . "\n";
                   }
                   ?>
-                  <td class="dataTableContentWhois" colspan=3 valign="top">&nbsp;&nbsp;<?php echo TIME_PASSED_LAST_CLICKED . '<br>&nbsp;&nbsp;&nbsp;&nbsp;' . $item['time_since_last_click']; ?> ago</td>
-                  <td class="dataTableContentWhois dataTableButtonCell" colspan=5 valign="top">
+                  <td class="dataTableContentWhois" colspan=3>&nbsp;&nbsp;<?php echo TIME_PASSED_LAST_CLICKED . '<br>&nbsp;&nbsp;&nbsp;&nbsp;' . $item['time_since_last_click']; ?> ago</td>
+                  <td class="dataTableContentWhois dataTableButtonCell" colspan=5>
                       <?php
                       echo TEXT_SESSION_ID . zen_output_string_protected($item['session_id']) . '<br>' .
                       TEXT_HOST . zen_output_string_protected($item['host_address']) . '<br>' .

--- a/admin/zones.php
+++ b/admin/zones.php
@@ -63,7 +63,7 @@ if (!empty($action)) {
       <div class="row">
         <!-- body_text //-->
         <div class="col-xs-12 col-sm-12 col-md-9 col-lg-9 configurationColumnLeft">
-          <table class="table table-hover">
+          <table class="table table-hover" role="listbox">
             <thead>
               <tr class="dataTableHeadingRow">
                 <th class="dataTableHeadingContent"><?php echo TABLE_HEADING_COUNTRY_NAME; ?></th>
@@ -87,9 +87,9 @@ if (!empty($action)) {
                   }
 
                   if (isset($cInfo) && is_object($cInfo) && ($zone['zone_id'] == $cInfo->zone_id)) {
-                    echo '              <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href=\'' . zen_href_link(FILENAME_ZONES, 'zone_page=' . $_GET['zone_page'] . '&cID=' . $cInfo->zone_id . '&action=edit') . '\'" role="button">' . "\n";
+                    echo '              <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href=\'' . zen_href_link(FILENAME_ZONES, 'zone_page=' . $_GET['zone_page'] . '&cID=' . $cInfo->zone_id . '&action=edit') . '\'" role="option" aria-selected="true">' . "\n";
                   } else {
-                    echo '              <tr class="dataTableRow" onclick="document.location.href=\'' . zen_href_link(FILENAME_ZONES, 'zone_page=' . $_GET['zone_page'] . '&cID=' . $zone['zone_id']) . '\'" role="button">' . "\n";
+                    echo '              <tr class="dataTableRow" onclick="document.location.href=\'' . zen_href_link(FILENAME_ZONES, 'zone_page=' . $_GET['zone_page'] . '&cID=' . $zone['zone_id']) . '\'" role="option" aria-selected="false">' . "\n";
                   }
                   ?>
               <td class="dataTableContent"><?php echo $zone['countries_name']; ?></td>


### PR DESCRIPTION
I have reworked admin to be html5 compliant and fixed a number of errors
in the code. see below for details.

# general changes:
correct labels to point at id
add table role="listbox"
change/add tr onclick role to "option" and add aria_selected
Change name to id in a tag
remove width and replace with css from \<table>, \<tr>, \<th>,\< td>
replace \<tt> tag  with \<span class="tt">
replace align with css "text-..." in table elements
changed doctype
remove valign from table elements and replace with css where necessary
remove \<button> tag from inside <\a> tags and add css as appropriate

#  specific changes
## admin/coupon_admin.php
fix missing closing tags
fix php warning missing array element 'uid'
move hidden form fields out of table element

## admin/coupon_admin_export.php
add parameters to redirect to prevent php undefined variables
removed extra table tr td with no closing elements
remove incorrect colspan

## admin/coupon_restrict.php
Added column headings to prevent html error table column not used.

## admin/customer_groups.php
added missing spaces before class

## admin/developers_tool_kit.php
created function to output page head so always written first
added action to variables to make unique
added htmlspecialchars so output does not contain html tags
added additional css

## admin/featured.php
added missing space before class

## admin/group_pricing.php
added missing space before class

## admin/gv_mail.php
corrected position of \</form>

## admin/gv_sent.php
changed !isset to empty to remove php warning

## admin/includes/functions/general.php
use new zen_make_id function to create valid id. correct issue with
spaces in id.

## admin/includes/functions/html_output.php
Change zen_image width and height to be style
Change zen_black_line to use $width instead of style in $parameter
Change zen_draw_seperator to use new zen_draw_image
Change zen_draw_input_field to add id = to name if no id present in $parameters
Change zen_draw_password_field to replace autocomplete with 'off' if in $parameters and $autocomplete is false
Change zen_draw_checkbox_field to add id = to name if no id present in $parameters
Change zen_draw_textarea_field to use style if $width is not numeric and default to 100%
Change zen_draw_pull_down_menu to add id = to name if no id present in $parameters
Change zen_draw_label to not output 'for' if $for is empty
Change zen_draw_date_selector to add id = to name if no id present in $parameters
Added new function zen_make_id to make a valid id field

## admin/includes/modules/copy_product.php
Change to use new zen_image format

## admin/includes/modules/.../collect_info.php
correct inputtype to inputmode

## admin/includes/modules/.../collect_info_metatags.php
change div to fieldset and labes to legend for html5 compliance
added missing space before class

## admin/includes/modules/product_music/copy_product.php
Change to use new zen_image format

## admin/mail.php
add calling parameters so user details are not forgotten on change of editor
add missing \</form> and \</div>

## admin/media_manager.php
remove mouseover and mouse out as javascript rowOutEffect not loaded (also only worked on ever other row if manually loaded)
rewrote action edit to create valid html for form 
added missing &page to buttons
checked empty $product_array to prevent php missing variable warning

## admin/media_types.php
remove ->fields to correct media_type

## admin/music_genre.php
set $_GET['mID'] when not set to prevent all rows being shown as selected

## admin/option_name.php
change column spacing use css and adjust colspan
add table to hold form info
move \</form> to correct location

## admin/options_values_manager.php
add css column widths
add table to hold form data
always output heading to prevent Html unneeded columns error
remove unnecessary colspan
rework dropdown fields to create individual id's. Note require future
rework to id's can be removed from $parameters

## admin/orders.php
change to use new zen_image instead of style in parameters

## admin/popup_image.php
change doctype and remove Netscape from resize

## admin/salemaker.php
remove spiffyCal and use html input type date
move draw form so sits correctly in divs
add alt to images

## admin/salemaker_popup.php
add missing space

## admin/server_info.php
clean up html from phpinfo (note there is still a missing \<td>)
add htmlspecialchars to output database values

## admin/sqlpatch.php
use admin_html_head.php instead of manual loading

## admin/stats_customers_referrals.php
add missing \</button> tag

# created new css files
admin/includes/css/coupon_admin_export.css
admin/includes/css/media_manager.css