### PR TITLE
no sendto for taxes if cart is all virtual

### DIFF
--- a/includes/functions/functions_taxes.php
+++ b/includes/functions/functions_taxes.php
@@ -385,9 +385,7 @@ function zen_get_tax_locations($store_country = -1, $store_zone = -1)
                                   AND ab.address_book_id = " . (int)$_SESSION['billto'];
             $tax_address_result = $db->Execute($tax_address_query);
 
-            if ($tax_address_result->fields['entry_zone_id'] == STORE_ZONE) {
-
-            } else {
+            if ($tax_address_result->fields['entry_zone_id'] !== STORE_ZONE && (!empty($_SESSION['sendto']))) {
                 $tax_address_query = "SELECT ab.entry_country_id, ab.entry_zone_id
                                       FROM " . TABLE_ADDRESS_BOOK . " ab
                                       LEFT JOIN " . TABLE_ZONES . " z ON (ab.entry_zone_id = z.zone_id)


### PR DESCRIPTION
as discussed [in this thread](https://github.com/lat9/edit_orders/issues/215), this function does not account for a cart which is all virtual and the `$_SESSION['sendto']` gets set to `false`.

if `STORE_PRODUCT_TAX_BASIS` is set to Store, and the cart is all virtual, this method returns:

![image](https://user-images.githubusercontent.com/1095136/183983829-58fa898e-2f5b-4717-8463-f7177ff59109.png)

after this change, the method returns:

![image](https://user-images.githubusercontent.com/1095136/183984099-da533c2e-e451-4f93-a2d9-cc3a91517a1a.png)

(your results may vary based on your test data...)