### PR TITLE
HTML5 Compliance Remove Obsolete Align Attribute

### DIFF
--- a/admin/banner_statistics.php
+++ b/admin/banner_statistics.php
@@ -315,14 +315,14 @@ $opts = array(
     <table caption="<?php echo TABLE_HEADING_SOURCE; ?>">
       <tr class="headingRow dataTableHeadingRow">
         <th class="dataTableHeadingContent"><?php echo TABLE_HEADING_SOURCE; ?></th>
-        <th class="dataTableHeadingContent" align="right"><?php echo TABLE_HEADING_VIEWS; ?></th>
-        <th class="dataTableHeadingContent" align="right"><?php echo TABLE_HEADING_CLICKS; ?></th>
+        <th class="dataTableHeadingContent text-right"><?php echo TABLE_HEADING_VIEWS; ?></th>
+        <th class="dataTableHeadingContent text-right"><?php echo TABLE_HEADING_CLICKS; ?></th>
       </tr>
   <?php for ($i=0, $n=sizeof($stats[2]); $i<$n; $i++) { ?>
         <tr class="dataTableRow">
           <td class="dataTableContent"><?php echo $stats[2][$i][0]; ?></td>
-          <td class="dataTableContent" align="right"><?php echo $stats[2][$i][1]; ?></td>
-          <td class="dataTableContent" align="right"><?php echo $stats[2][$i][2]; ?></td>
+          <td class="dataTableContent text-right"><?php echo $stats[2][$i][1]; ?></td>
+          <td class="dataTableContent text-right"><?php echo $stats[2][$i][2]; ?></td>
         </tr>
   <?php } ?>
     </table>

--- a/admin/coupon_admin_export.php
+++ b/admin/coupon_admin_export.php
@@ -320,7 +320,7 @@ require (DIR_WS_INCLUDES . 'header.php');
         <table border="0" width="100%" cellspacing="0" cellpadding="0">
           <tr>
             <td class="pageHeading"><?php echo HEADING_TITLE; ?></td>
-            <td class="pageHeading" align="right"><?php echo zen_draw_separator('pixel_trans.gif', HEADING_IMAGE_WIDTH, HEADING_IMAGE_HEIGHT); ?></td>
+            <td class="pageHeading text-right"><?php echo zen_draw_separator('pixel_trans.gif', HEADING_IMAGE_WIDTH, HEADING_IMAGE_HEIGHT); ?></td>
           </tr>
         </table>
         </td>
@@ -355,7 +355,7 @@ require (DIR_WS_INCLUDES . 'header.php');
               </td>
           </tr>
           <tr>
-            <td class="main" align="right"><?php echo '<input type="submit" name="submit" value="'. (defined('BUTTON_TEXT_EXPORT') ? BUTTON_TEXT_EXPORT : IMAGE_GO) . '" id="export_btn" class="btn btn-danger">' . '&nbsp;&nbsp;<a href="' . zen_href_link(FILENAME_COUPON_ADMIN, 'cid=' . $_GET['cid'] . (isset($_GET['status']) ? '&status=' . $_GET['status'] : '') . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '')) . '" class="btn btn-warning" role="button">' . IMAGE_CANCEL . '</a>'; ?></td>
+            <td class="main text-right"><?php echo '<input type="submit" name="submit" value="'. (defined('BUTTON_TEXT_EXPORT') ? BUTTON_TEXT_EXPORT : IMAGE_GO) . '" id="export_btn" class="btn btn-danger">' . '&nbsp;&nbsp;<a href="' . zen_href_link(FILENAME_COUPON_ADMIN, 'cid=' . $_GET['cid'] . (isset($_GET['status']) ? '&status=' . $_GET['status'] : '') . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '')) . '" class="btn btn-warning" role="button">' . IMAGE_CANCEL . '</a>'; ?></td>
           </tr>
         </table>
         </td>

--- a/admin/developers_tool_kit.php
+++ b/admin/developers_tool_kit.php
@@ -743,7 +743,7 @@ if ($found == false) {
         ?>
         <table border="3" cellspacing="4" cellpadding="4">
           <tr class="infoBoxContent">
-            <td colspan="2" class="pageHeading" align="center"><?php echo TABLE_CONFIGURATION_TABLE; ?></td>
+            <td colspan="2" class="pageHeading text-center"><?php echo TABLE_CONFIGURATION_TABLE; ?></td>
           </tr>
           <tr>
             <td class="infoBoxHeading"><?php echo TABLE_TITLE_KEY; ?></td>
@@ -792,7 +792,7 @@ if ($found == false) {
           <?php } ?>
           <tr>
               <td>&nbsp;</td>
-            <td class="main" align="center">
+            <td class="main text-center">
                 <?php
                 if ($show_products_type_layout == false and ( $check_configure->fields['configuration_id'] != 0 and $check_configure_group->fields['visible'] != 0)) {
                   echo '<a href="' . zen_href_link(FILENAME_CONFIGURATION, 'gID=' . $check_configure_group->fields['configuration_group_id'] . '&cID=' . $check_configure->fields['configuration_id']) . '" class="btn btn-primary" role="button">' . IMAGE_EDIT . '</a>';
@@ -820,7 +820,7 @@ if ($found == false) {
             </td>
           </tr>
           <tr class="infoBoxContent">
-            <td colspan="2" class="pageHeading" align="center">
+            <td colspan="2" class="pageHeading text-center">
                 <?php
                 $links = '<br><strong><span class="alert">' . TEXT_SEARCH_ALL_FILES . '</span></strong> ' . '<a href="' . zen_href_link(FILENAME_DEVELOPERS_TOOL_KIT, 'action=' . 'locate_all_files' . '&configuration_key_lookup=' . zen_output_string_protected($configuration_key_lookup) . '&zv_files=1') . '">' . zen_output_string_protected($configuration_key_lookup) . '</a><br>';
                 echo $links;
@@ -840,8 +840,8 @@ if ($found == false) {
           <!-- bof: update all products price sorter -->
           <table border="0" cellspacing="0" cellpadding="2">
             <tr>
-              <td class="main" align="left" valign="top"><?php echo TEXT_INFO_PRODUCTS_PRICE_SORTER_UPDATE; ?></td>
-              <td class="main" align="right" valign="middle"><?php echo '<a href="' . zen_href_link(FILENAME_DEVELOPERS_TOOL_KIT, 'action=update_all_products_price_sorter') . '" class="btn btn-primary" role="button">' . IMAGE_UPDATE . '</a>'; ?></td>
+              <td class="main text-left" valign="top"><?php echo TEXT_INFO_PRODUCTS_PRICE_SORTER_UPDATE; ?></td>
+              <td class="main text-right" valign="middle"><?php echo '<a href="' . zen_href_link(FILENAME_DEVELOPERS_TOOL_KIT, 'action=update_all_products_price_sorter') . '" class="btn btn-primary" role="button">' . IMAGE_UPDATE . '</a>'; ?></td>
             </tr>
           </table>
           <!-- eof: update all products price sorter -->

--- a/admin/downloads_manager.php
+++ b/admin/downloads_manager.php
@@ -271,7 +271,7 @@ if (!empty($action)) {
           <tr>
             <td><?php echo $products_downloads_split->display_count($products_downloads_query_numrows, MAX_DISPLAY_SEARCH_RESULTS_DOWNLOADS_MANAGER, $_GET['page'], TEXT_DISPLAY_NUMBER_OF_PRODUCTS_DOWNLOADS_MANAGER); ?></td>
             <!--
-            <td class="smallText" align="right"><?php echo $products_downloads_split->display_links($products_downloads_query_numrows, MAX_DISPLAY_SEARCH_RESULTS_DOWNLOADS_MANAGER, MAX_DISPLAY_PAGE_LINKS, $_GET['page'], zen_get_all_get_params(array('page', 'info', 'x', 'y', 'cID'))); ?></td>
+            <td class="smallText text-right"><?php echo $products_downloads_split->display_links($products_downloads_query_numrows, MAX_DISPLAY_SEARCH_RESULTS_DOWNLOADS_MANAGER, MAX_DISPLAY_PAGE_LINKS, $_GET['page'], zen_get_all_get_params(array('page', 'info', 'x', 'y', 'cID'))); ?></td>
             -->
             <td class="text-right"><?php echo $products_downloads_split->display_links($products_downloads_query_numrows, MAX_DISPLAY_SEARCH_RESULTS_DOWNLOADS_MANAGER, MAX_DISPLAY_PAGE_LINKS, $_GET['page']); ?></td>
           </tr>

--- a/admin/includes/attributes_preview.php
+++ b/admin/includes/attributes_preview.php
@@ -247,10 +247,10 @@ if (!defined('IS_ADMIN_FLAG')) {
                   }
 
                 if ($products_options->fields['attributes_image'] != '') {
-                  $tmp_attributes_image .= '<td class="smallText" align="center" valign="top">' . zen_draw_radio_field('id[' . $products_options_names->fields['products_options_id'] . ']',
+                  $tmp_attributes_image .= '<td class="smallText text-center" valign="top">' . zen_draw_radio_field('id[' . $products_options_names->fields['products_options_id'] . ']',
                               $products_options_value_id, $selected_attribute) . zen_image(DIR_WS_CATALOG_IMAGES . $products_options->fields['attributes_image']) . (PRODUCT_IMAGES_ATTRIBUTES_NAMES == '1' ? '<br>' . $products_options->fields['products_options_values_name'] : '') . $products_options_details_noname . '</td>';
                 } else {
-                  $tmp_attributes_image .= '<td class="smallText" align="center" valign="top">' . zen_draw_radio_field('id[' . $products_options_names->fields['products_options_id'] . ']',
+                  $tmp_attributes_image .= '<td class="smallText text-center" valign="top">' . zen_draw_radio_field('id[' . $products_options_names->fields['products_options_id'] . ']',
                               $products_options_value_id, $selected_attribute) . '<br>' . $products_options->fields['products_options_values_name'] . $products_options_details_noname . '</td>';
                 }
               break;
@@ -265,10 +265,10 @@ if (!defined('IS_ADMIN_FLAG')) {
                   }
 
                 if ($products_options->fields['attributes_image'] != '') {
-                  $tmp_attributes_image .= '<td class="smallText" align="center" valign="top">' . zen_image(DIR_WS_CATALOG_IMAGES . $products_options->fields['attributes_image']) . (PRODUCT_IMAGES_ATTRIBUTES_NAMES == '1' ? '<br>' . $products_options->fields['products_options_values_name'] : '') . ($products_options_details_noname != '' ? '<br>' . $products_options_details_noname : '') . '<br>' . zen_draw_radio_field('id[' . $products_options_names->fields['products_options_id'] . ']',
+                  $tmp_attributes_image .= '<td class="smallText text-center" valign="top">' . zen_image(DIR_WS_CATALOG_IMAGES . $products_options->fields['attributes_image']) . (PRODUCT_IMAGES_ATTRIBUTES_NAMES == '1' ? '<br>' . $products_options->fields['products_options_values_name'] : '') . ($products_options_details_noname != '' ? '<br>' . $products_options_details_noname : '') . '<br>' . zen_draw_radio_field('id[' . $products_options_names->fields['products_options_id'] . ']',
                                 $products_options_value_id, $selected_attribute) . '</td>';
                 } else {
-                  $tmp_attributes_image .= '<td class="smallText" align="center" valign="top">' . $products_options->fields['products_options_values_name'] . ($products_options_details_noname != '' ? '<br>' . $products_options_details_noname : '') . '<br>' . zen_draw_radio_field('id[' . $products_options_names->fields['products_options_id'] . ']',
+                  $tmp_attributes_image .= '<td class="smallText text-center" valign="top">' . $products_options->fields['products_options_values_name'] . ($products_options_details_noname != '' ? '<br>' . $products_options_details_noname : '') . '<br>' . zen_draw_radio_field('id[' . $products_options_names->fields['products_options_id'] . ']',
                                 $products_options_value_id, $selected_attribute) . '</td>';
                 }
               break;
@@ -283,10 +283,10 @@ if (!defined('IS_ADMIN_FLAG')) {
                   }
 
                 if ($products_options->fields['attributes_image'] != '') {
-                  $tmp_attributes_image .= '<td class="smallText" align="center" valign="top">' . zen_draw_radio_field('id[' . $products_options_names->fields['products_options_id'] . ']',
+                  $tmp_attributes_image .= '<td class="smallText text-center" valign="top">' . zen_draw_radio_field('id[' . $products_options_names->fields['products_options_id'] . ']',
                                $products_options_value_id, $selected_attribute) . '<br>' . zen_image(DIR_WS_CATALOG_IMAGES . $products_options->fields['attributes_image']) . (PRODUCT_IMAGES_ATTRIBUTES_NAMES == '1' ? '<br>' . $products_options->fields['products_options_values_name'] : '') . ($products_options_details_noname != '' ? '<br>' . $products_options_details_noname : '') . '</td>';
                 } else {
-                  $tmp_attributes_image .= '<td class="smallText" align="center" valign="top">' . zen_draw_radio_field('id[' . $products_options_names->fields['products_options_id'] . ']',
+                  $tmp_attributes_image .= '<td class="smallText text-center" valign="top">' . zen_draw_radio_field('id[' . $products_options_names->fields['products_options_id'] . ']',
                                $products_options_value_id, $selected_attribute) . '<br>' . $products_options->fields['products_options_values_name'] . ($products_options_details_noname != '' ? '<br>' . $products_options_details_noname : '') . '</td>';
                 }
               break;
@@ -357,10 +357,10 @@ if (!defined('IS_ADMIN_FLAG')) {
                   }
 
                 if ($products_options->fields['attributes_image'] != '') {
-                  $tmp_attributes_image .= '<td class="smallText" align="center" valign="top">' . zen_draw_checkbox_field('id[' . $products_options_names->fields['products_options_id'] . ']['.$products_options_value_id.']',
+                  $tmp_attributes_image .= '<td class="smallText text-center" valign="top">' . zen_draw_checkbox_field('id[' . $products_options_names->fields['products_options_id'] . ']['.$products_options_value_id.']',
                                 $products_options_value_id, $selected_attribute) . zen_image(DIR_WS_CATALOG_IMAGES . $products_options->fields['attributes_image']) . (PRODUCT_IMAGES_ATTRIBUTES_NAMES == '1' ? '<br>' . $products_options->fields['products_options_values_name'] : '') . $products_options_details_noname . '</td>';
                 } else {
-                  $tmp_attributes_image .= '<td class="smallText" align="center" valign="top">' . zen_draw_checkbox_field('id[' . $products_options_names->fields['products_options_id'] . ']['.$products_options_value_id.']',
+                  $tmp_attributes_image .= '<td class="smallText text-center" valign="top">' . zen_draw_checkbox_field('id[' . $products_options_names->fields['products_options_id'] . ']['.$products_options_value_id.']',
                                 $products_options_value_id, $selected_attribute) . '<br>' . $products_options->fields['products_options_values_name'] . $products_options_details_noname . '</td>';
                 }
               break;
@@ -375,10 +375,10 @@ if (!defined('IS_ADMIN_FLAG')) {
                   }
 
                 if ($products_options->fields['attributes_image'] != '') {
-                  $tmp_attributes_image .= '<td class="smallText" align="center" valign="top">' . zen_image(DIR_WS_CATALOG_IMAGES . $products_options->fields['attributes_image']) . (PRODUCT_IMAGES_ATTRIBUTES_NAMES == '1' ? '<br>' . $products_options->fields['products_options_values_name'] : '') . ($products_options_details_noname != '' ? '<br>' . $products_options_details_noname : '') . '<br>' . zen_draw_checkbox_field('id[' . $products_options_names->fields['products_options_id'] . ']['.$products_options_value_id.']',
+                  $tmp_attributes_image .= '<td class="smallText text-center" valign="top">' . zen_image(DIR_WS_CATALOG_IMAGES . $products_options->fields['attributes_image']) . (PRODUCT_IMAGES_ATTRIBUTES_NAMES == '1' ? '<br>' . $products_options->fields['products_options_values_name'] : '') . ($products_options_details_noname != '' ? '<br>' . $products_options_details_noname : '') . '<br>' . zen_draw_checkbox_field('id[' . $products_options_names->fields['products_options_id'] . ']['.$products_options_value_id.']',
                                 $products_options_value_id, $selected_attribute) . '</td>';
                 } else {
-                  $tmp_attributes_image .= '<td class="smallText" align="center" valign="top">' . $products_options->fields['products_options_values_name'] . ($products_options_details_noname != '' ? '<br>' . $products_options_details_noname : '') . '<br>' . zen_draw_checkbox_field('id[' . $products_options_names->fields['products_options_id'] . ']['.$products_options_value_id.']',
+                  $tmp_attributes_image .= '<td class="smallText text-center" valign="top">' . $products_options->fields['products_options_values_name'] . ($products_options_details_noname != '' ? '<br>' . $products_options_details_noname : '') . '<br>' . zen_draw_checkbox_field('id[' . $products_options_names->fields['products_options_id'] . ']['.$products_options_value_id.']',
                                 $products_options_value_id, $selected_attribute) . '</td>';
                 }
               break;
@@ -393,10 +393,10 @@ if (!defined('IS_ADMIN_FLAG')) {
                   }
 
                 if ($products_options->fields['attributes_image'] != '') {
-                  $tmp_attributes_image .= '<td class="smallText" align="center" valign="top">' . zen_draw_checkbox_field('id[' . $products_options_names->fields['products_options_id'] . ']['.$products_options_value_id.']',
+                  $tmp_attributes_image .= '<td class="smallText text-center" valign="top">' . zen_draw_checkbox_field('id[' . $products_options_names->fields['products_options_id'] . ']['.$products_options_value_id.']',
                                 $products_options_value_id, $selected_attribute) . '<br>' . zen_image(DIR_WS_CATALOG_IMAGES . $products_options->fields['attributes_image']) . (PRODUCT_IMAGES_ATTRIBUTES_NAMES == '1' ? '<br>' . $products_options->fields['products_options_values_name'] : '') . ($products_options_details_noname != '' ? '<br>' . $products_options_details_noname : '') . '</td>';
                 } else {
-                  $tmp_attributes_image .= '<td class="smallText" align="center" valign="top">' . zen_draw_checkbox_field('id[' . $products_options_names->fields['products_options_id'] . ']['.$products_options_value_id.']',
+                  $tmp_attributes_image .= '<td class="smallText text-center" valign="top">' . zen_draw_checkbox_field('id[' . $products_options_names->fields['products_options_id'] . ']['.$products_options_value_id.']',
                                 $products_options_value_id, $selected_attribute) . '<br>' . $products_options->fields['products_options_values_name'] . ($products_options_details_noname != '' ? '<br>' . $products_options_details_noname : '') . '</td>';
                 }
               break;
@@ -478,7 +478,7 @@ if (!defined('IS_ADMIN_FLAG')) {
                 $tmp_attributes_image_row = 1;
               }
 
-              $tmp_attributes_image .= '<td class="smallText" align="center">' . zen_image(DIR_WS_CATALOG_IMAGES . $products_options->fields['attributes_image']) . (PRODUCT_IMAGES_ATTRIBUTES_NAMES == '1' ? '<br>' . $products_options->fields['products_options_values_name'] : '') . '</td>';
+              $tmp_attributes_image .= '<td class="smallText text-center">' . zen_image(DIR_WS_CATALOG_IMAGES . $products_options->fields['attributes_image']) . (PRODUCT_IMAGES_ATTRIBUTES_NAMES == '1' ? '<br>' . $products_options->fields['products_options_values_name'] : '') . '</td>';
             }
           }
 

--- a/admin/includes/javascript/calendarcode.js
+++ b/admin/includes/javascript/calendarcode.js
@@ -1,7 +1,7 @@
 /*
- * Bazillyo's Spiffy DHTML Popup Calendar v. 1.0 © 2000 S. Ousta
+ * Bazillyo's Spiffy DHTML Popup Calendar v. 1.0 ï¿½ 2000 S. Ousta
  *   - freeware with this comment
- *   - for download size, you can strip all spaces & comments except the © notices
+ *   - for download size, you can strip all spaces & comments except the ï¿½ notices
  *   - Thanks to Chris for the domlay() function
  *   - this requires calendarcode.js, calendar.css, and calendarTest.htm
  *   - works in IE4.x, IE5.x, NS4.75 possibly 4.x, NS6 (with slight cosmetic issues)
@@ -220,7 +220,7 @@ function Calendar(whatMonth,whatYear) {
         output += '<table width="185" border="3" class="cal-Table" cellspacing="0" cellpadding="0"><form name="Cal"><tr>';
     }
      
-    output += '<td class="cal-HeadCell" align="center" width="100%"><a href="javascript:clearDay();"><img name="calbtn1" src="./images/cal_del_small.gif" border="0" width="12" height="10"></a>&nbsp;&nbsp;<a href="javascript:scrollMonth(-1);" class="cal-DayLink">&lt;</a>&nbsp;<SELECT class="cal-TextBox" NAME="cboMonth" onChange="changeMonth();">';
+    output += '<td class="cal-HeadCell text-center" width="100%"><a href="javascript:clearDay();"><img name="calbtn1" src="./images/cal_del_small.gif" border="0" width="12" height="10"></a>&nbsp;&nbsp;<a href="javascript:scrollMonth(-1);" class="cal-DayLink">&lt;</a>&nbsp;<SELECT class="cal-TextBox" NAME="cboMonth" onChange="changeMonth();">';
     for (month=0; month<12; month++) {
         if (month == whatMonth) output += '<OPTION VALUE="' + month + '" SELECTED>' + names[month] + '<\/OPTION>';
         else                output += '<OPTION VALUE="' + month + '">'          + names[month] + '<\/OPTION>';
@@ -233,7 +233,7 @@ function Calendar(whatMonth,whatYear) {
         else              output += '<OPTION VALUE="' + year + '">'          + year + '<\/OPTION>';
     }
 
-    output += '<\/SELECT>&nbsp;<a href="javascript:scrollMonth(1);" class="cal-DayLink">&gt;</a>&nbsp;&nbsp;<a href="javascript:hideCalendar();"><img name="calbtn2" src="./images/cal_close_small.gif" border="0" width="12" height="10"></a><\/td><\/tr><tr><td width="100%" align="center">';
+    output += '<\/SELECT>&nbsp;<a href="javascript:scrollMonth(1);" class="cal-DayLink">&gt;</a>&nbsp;&nbsp;<a href="javascript:hideCalendar();"><img name="calbtn2" src="./images/cal_close_small.gif" border="0" width="12" height="10"></a><\/td><\/tr><tr><td width="100%" class="text-center">';
 
     firstDay = new Date(whatYear,whatMonth,1);
     startDay = firstDay.getDay();
@@ -253,7 +253,7 @@ function Calendar(whatMonth,whatYear) {
         {
             datecolwidth="14%"
         }
-        output += '<td class="cal-HeadCell" width="' + datecolwidth + '" align="center" valign="middle">'+ dow[i] +'<\/td>';
+        output += '<td class="cal-HeadCell text-center" width="' + datecolwidth + '" valign="middle">'+ dow[i] +'<\/td>';
     }
     
     output += '<\/tr><tr>';

--- a/admin/includes/javascript/spiffyCal/spiffyCal_v2_1.js
+++ b/admin/includes/javascript/spiffyCal/spiffyCal_v2_1.js
@@ -857,7 +857,7 @@ function ctlSpiffyCalendarBox(strVarName, strFormName, strTextBoxName, strBtnNam
 
             strOutput += '<\/SELECT>&nbsp;<a href="javascript:' + this.varName + '.scrollMonth(1);" class="cal-DayLink">&gt;</a>&nbsp;&nbsp;<a href="javascript:' + this.varName + '.hide();"><i class="fa fa-close fa-lg"></i></a><\/td>';
         } else {
-            strOutput += '<td class="cal-HeadCell" align="center" colspan="7">' + msNames[intWhatMonth] + '-' + intWhatYear + '<\/td><\/tr>';
+            strOutput += '<td class="cal-HeadCell text-center" colspan="7">' + msNames[intWhatMonth] + '-' + intWhatYear + '<\/td><\/tr>';
         }
 
 

--- a/admin/invoice.php
+++ b/admin/invoice.php
@@ -67,7 +67,7 @@ if ($order->billing['street_address'] != $order->delivery['street_address']) {
       <table class="table">
         <tr>
           <td class="pageHeading"><?php echo nl2br(STORE_NAME_ADDRESS); ?></td>
-          <td class="pageHeading" align="right"><?php echo zen_image(DIR_WS_IMAGES . HEADER_LOGO_IMAGE, HEADER_ALT_TEXT); ?></td>
+          <td class="pageHeading text-right"><?php echo zen_image(DIR_WS_IMAGES . HEADER_LOGO_IMAGE, HEADER_ALT_TEXT); ?></td>
         </tr>
       </table>
       <div><?php echo zen_draw_separator(); ?></div>

--- a/admin/media_manager.php
+++ b/admin/media_manager.php
@@ -141,7 +141,7 @@
         <td width="100%"><table border="0" width="100%" cellspacing="0" cellpadding="0">
           <tr>
             <td class="pageHeading"><?php echo HEADING_TITLE_MEDIA_MANAGER; ?></td>
-            <td class="pageHeading" align="right"><?php echo zen_draw_separator('pixel_trans.gif', HEADING_IMAGE_WIDTH, HEADING_IMAGE_HEIGHT); ?></td>
+            <td class="pageHeading text-right"><?php echo zen_draw_separator('pixel_trans.gif', HEADING_IMAGE_WIDTH, HEADING_IMAGE_HEIGHT); ?></td>
           </tr>
         </table></td>
       </tr>
@@ -151,7 +151,7 @@
             <td valign="top"><table border="0" width="100%" cellspacing="0" cellpadding="2">
               <tr class="dataTableHeadingRow">
                 <td class="dataTableHeadingContent"><?php echo TABLE_HEADING_MEDIA; ?></td>
-                <td class="dataTableHeadingContent" align="right"><?php echo TABLE_HEADING_ACTION; ?>&nbsp;</td>
+                <td class="dataTableHeadingContent text-right"><?php echo TABLE_HEADING_ACTION; ?>&nbsp;</td>
               </tr>
 <?php
   $media_query_raw = "SELECT * FROM " . TABLE_MEDIA_MANAGER . " ORDER BY media_name";
@@ -170,7 +170,7 @@
     }
 ?>
                 <td class="dataTableContent"><?php echo $media->fields['media_name']; ?></td>
-                <td class="dataTableContent" align="right">
+                <td class="dataTableContent text-right">
                   <?php echo '<a href="' . zen_href_link(FILENAME_MEDIA_MANAGER, 'page=' . $_GET['page'] . '&mID=' . $media->fields['media_id'] . '&action=edit') . '">' . zen_image(DIR_WS_IMAGES . 'icon_edit.gif', ICON_EDIT) . '</a>'; ?>
                   <?php echo '<a href="' . zen_href_link(FILENAME_MEDIA_MANAGER, 'page=' . $_GET['page'] . '&mID=' . $media->fields['media_id'] . '&action=delete') . '">' . zen_image(DIR_WS_IMAGES . 'icon_delete.gif', ICON_DELETE) . '</a>'; ?>
                   <?php if (isset($mInfo) && is_object($mInfo) && ($media->fields['media_id'] == $mInfo->media_id)) { echo zen_image(DIR_WS_IMAGES . 'icon_arrow_right.gif', ''); } else { echo '<a href="' . zen_href_link(FILENAME_MEDIA_MANAGER, zen_get_all_get_params(array('mID')) . 'mID=' . $media->fields['media_id']) . '">' . zen_image(DIR_WS_IMAGES . 'icon_info.gif', IMAGE_ICON_INFO) . '</a>'; } ?>
@@ -184,7 +184,7 @@
                 <td colspan="2"><table border="0" width="100%" cellspacing="0" cellpadding="2">
                   <tr>
                     <td class="smallText" valign="top"><?php echo $media_split->display_count($media_query_numrows, MAX_DISPLAY_SEARCH_RESULTS, $_GET['page'], TEXT_DISPLAY_NUMBER_OF_MEDIA); ?></td>
-                    <td class="smallText" align="right"><?php echo $media_split->display_links($media_query_numrows, MAX_DISPLAY_SEARCH_RESULTS, MAX_DISPLAY_PAGE_LINKS, $_GET['page']); ?></td>
+                    <td class="smallText text-right"><?php echo $media_split->display_links($media_query_numrows, MAX_DISPLAY_SEARCH_RESULTS, MAX_DISPLAY_PAGE_LINKS, $_GET['page']); ?></td>
                   </tr>
                 </table></td>
               </tr>

--- a/admin/newsletters.php
+++ b/admin/newsletters.php
@@ -370,16 +370,16 @@ if (!empty($action)) {
                     <tr class="dataTableRow" onclick="document.location.href = '<?php echo zen_href_link(FILENAME_NEWSLETTERS, 'page=' . $_GET['page'] . '&nID=' . $newsletter['newsletters_id']); ?>'">
                       <?php } ?>
                     <td class="dataTableContent"><?php echo '<a href="' . zen_href_link(FILENAME_NEWSLETTERS, 'page=' . $_GET['page'] . '&nID=' . $newsletter['newsletters_id'] . '&action=preview') . '">' . zen_image(DIR_WS_ICONS . 'preview.gif', ICON_PREVIEW) . '</a>&nbsp;' . $newsletter['title']; ?></td>
-                    <td class="dataTableContent" align="right"><?php echo number_format($newsletter['content_length'] + $newsletter['content_html_length']) . ' bytes'; ?></td>
-                    <td class="dataTableContent" align="right"><?php echo $newsletter['module']; ?></td>
-                    <td class="dataTableContent" align="center"><?php
+                    <td class="dataTableContent text-right"><?php echo number_format($newsletter['content_length'] + $newsletter['content_html_length']) . ' bytes'; ?></td>
+                    <td class="dataTableContent text-right"><?php echo $newsletter['module']; ?></td>
+                    <td class="dataTableContent text-center"><?php
                         if ($newsletter['status'] == '1') {
                           echo zen_image(DIR_WS_ICONS . 'tick.gif', ICON_TICK);
                         } else {
                           echo zen_image(DIR_WS_ICONS . 'cross.gif', ICON_CROSS);
                         }
                         ?></td>
-                    <td class="dataTableContent" align="right"><?php
+                    <td class="dataTableContent text-right"><?php
                         if (isset($nInfo) && is_object($nInfo) && ($newsletter['newsletters_id'] == $nInfo->newsletters_id)) {
                           echo zen_image(DIR_WS_IMAGES . 'icon_arrow_right.gif', '');
                         } else {

--- a/admin/option_values.php
+++ b/admin/option_values.php
@@ -95,7 +95,7 @@ switch ($_GET['action']) {
           <?php echo zen_draw_form('quick_jump', FILENAME_PRODUCTS_OPTIONS_VALUES, '', 'get', 'class="form-horizontal"'); ?>
           <table class="table table-condensed">
             <tr class="dataTableHeadingRow">
-              <td colspan="2" align="center" class="dataTableHeadingContent"><?php echo TEXT_UPDATE_OPTION_VALUES; ?></td>
+              <td colspan="2" class="dataTableHeadingContent text-center"><?php echo TEXT_UPDATE_OPTION_VALUES; ?></td>
             </tr>
             <tr class="dataTableHeadingRow">
               <td class="dataTableHeadingContent">
@@ -130,7 +130,7 @@ switch ($_GET['action']) {
           <?php echo zen_draw_form('update', FILENAME_PRODUCTS_OPTIONS_VALUES, 'action=update_sort_order&options_id=' . $_GET['options_id'], 'post', 'class="form-horizontal"'); ?>
           <table class="table table-condensed table-striped">
             <tr class="dataTableHeadingRow">
-              <td colspan="3" class="dataTableHeadingContent" align="center">
+              <td colspan="3" class="dataTableHeadingContent text-center">
                 <?php echo TEXT_EDIT_OPTION_NAME; ?> <?php echo zen_options_name($_GET['options_id']); ?></td>
             </tr>
             <tr class="dataTableHeadingRow">

--- a/admin/packingslip.php
+++ b/admin/packingslip.php
@@ -60,7 +60,7 @@ if ($order->billing['street_address'] != $order->delivery['street_address']) {
       <table class="table">
         <tr>
           <td class="pageHeading"><?php echo nl2br(STORE_NAME_ADDRESS); ?></td>
-          <td class="pageHeading" align="right"><?php echo zen_image(DIR_WS_IMAGES . HEADER_LOGO_IMAGE, HEADER_ALT_TEXT); ?></td>
+          <td class="pageHeading text-right"><?php echo zen_image(DIR_WS_IMAGES . HEADER_LOGO_IMAGE, HEADER_ALT_TEXT); ?></td>
         </tr>
       </table>
       <div><?php echo zen_draw_separator(); ?></div>

--- a/admin/product_types.php
+++ b/admin/product_types.php
@@ -287,8 +287,8 @@ if (!empty($action)) {
                   }
                   ?>
                 <td class="dataTableContent"><?php echo $product_type['type_name']; ?></td>
-                <td class="dataTableContent" align="center"><?php echo $product_type['allow_add_to_cart']; ?></td>
-                <td class="dataTableContent" align="right"><?php
+                <td class="dataTableContent text-center"><?php echo $product_type['allow_add_to_cart']; ?></td>
+                <td class="dataTableContent text-right"><?php
                   if ((isset($ptInfo) && is_object($ptInfo)) && ($product_type['type_id'] == $ptInfo->type_id)) {
                     echo zen_image(DIR_WS_IMAGES . 'icon_arrow_right.gif', '');
                   } else {

--- a/admin/salemaker.php
+++ b/admin/salemaker.php
@@ -461,12 +461,12 @@ if (!empty($action)) {
                     <?php } else { ?>
                   <tr class="dataTableRow" onclick="document.location.href = '<?php echo zen_href_link(FILENAME_SALEMAKER, 'page=' . $_GET['page'] . '&sID=' . $salemaker_sale['sale_id']); ?>'">
                     <?php } ?>
-                  <td  class="dataTableContent" align="left"><?php echo $salemaker_sale['sale_name']; ?></td>
-                  <td  class="dataTableContent" align="right"><?php echo $salemaker_sale['sale_deduction_value']; ?></td>
-                  <td  class="dataTableContent" align="left"><?php echo $deduction_type_array[$salemaker_sale['sale_deduction_type']]['text']; ?></td>
-                  <td  class="dataTableContent" align="center"><?php echo (($salemaker_sale['sale_date_start'] == '0001-01-01') ? TEXT_SALEMAKER_IMMEDIATELY : zen_date_short($salemaker_sale['sale_date_start'])); ?></td>
-                  <td  class="dataTableContent" align="center"><?php echo (($salemaker_sale['sale_date_end'] == '0001-01-01') ? TEXT_SALEMAKER_NEVER : zen_date_short($salemaker_sale['sale_date_end'])); ?></td>
-                  <td  class="dataTableContent" align="center">
+                  <td  class="dataTableContent text-left"><?php echo $salemaker_sale['sale_name']; ?></td>
+                  <td  class="dataTableContent text-right"><?php echo $salemaker_sale['sale_deduction_value']; ?></td>
+                  <td  class="dataTableContent text-left"><?php echo $deduction_type_array[$salemaker_sale['sale_deduction_type']]['text']; ?></td>
+                  <td  class="dataTableContent text-center"><?php echo (($salemaker_sale['sale_date_start'] == '0001-01-01') ? TEXT_SALEMAKER_IMMEDIATELY : zen_date_short($salemaker_sale['sale_date_start'])); ?></td>
+                  <td  class="dataTableContent text-center"><?php echo (($salemaker_sale['sale_date_end'] == '0001-01-01') ? TEXT_SALEMAKER_NEVER : zen_date_short($salemaker_sale['sale_date_end'])); ?></td>
+                  <td  class="dataTableContent text-center">
                       <?php
                       if ($salemaker_sale['sale_status'] == '1') {
                         echo zen_draw_form('setflag_products', FILENAME_SALEMAKER, 'action=setflag&sID=' . $salemaker_sale['sale_id'] . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '') . (isset($_GET['search']) ? '&search=' . $_GET['search'] : ''));
@@ -485,7 +485,7 @@ if (!empty($action)) {
                     }
                     ?>
                   </td>
-                  <td class="dataTableContent" align="right"><?php
+                  <td class="dataTableContent text-right"><?php
                       if (!empty($sInfo) && (is_object($sInfo)) && !empty($salemaker_sale) && isset($salemaker_sale['sale_id']) && ($salemaker_sale['sale_id'] == $sInfo->sale_id)) {
                         echo zen_image(DIR_WS_IMAGES . 'icon_arrow_right.gif', '');
                       } else {

--- a/admin/stats_products_purchased.php
+++ b/admin/stats_products_purchased.php
@@ -98,7 +98,7 @@ $products_filter_name_model = (isset($_GET['products_filter_name_model']) ? $_GE
           <tbody>
               <?php if ($chk_orders_products->EOF) { ?>
               <tr class="dataTableRowSelectedBot">
-                <td colspan="7" class="dataTableContent" align="center"><?php echo NONE; ?></td>
+                <td colspan="7" class="dataTableContent text-center"><?php echo NONE; ?></td>
               </tr>
             <?php } ?>
             <?php

--- a/admin/stats_sales_report_graphs.php
+++ b/admin/stats_sales_report_graphs.php
@@ -288,8 +288,8 @@ for ($i = 0; $i < $report->size; $i++) {
         </table>
         <table class="table table-condensed">
           <tr class="dataTableRow">
-            <td class="dataTableContent" width="80%" align="left"><?php echo FILTER_STATUS ?></td>
-            <td class="dataTableContent" align="right"><?php echo FILTER_VALUE ?></td>
+            <td class="dataTableContent text-left" width="80%"><?php echo FILTER_STATUS ?></td>
+            <td class="dataTableContent text-right"><?php echo FILTER_VALUE ?></td>
           </tr>
           <?php
           if (($sales_report_filter) == 0) {
@@ -300,13 +300,13 @@ for ($i = 0; $i < $report->size; $i++) {
           for ($i = 0; $i < $report->status_available_size; $i++) {
             ?>
             <tr>
-              <td class="dataTableContent" align="left"><?php echo $report->status_available[$i]['value'] ?></a></td>
+              <td class="dataTableContent text-left"><?php echo $report->status_available[$i]['value'] ?></a></td>
               <?php
               if (substr($sales_report_filter, $i, 1) == "0") {
                 $tmp = substr($sales_report_filter, 0, $i) . "1" . substr($sales_report_filter, $i + 1, $report->status_available_size - ($i + 1));
                 $tmp = zen_href_link(FILENAME_STATS_SALES_REPORT_GRAPHS, $report->filter_link . "&filter=" . $tmp);
                 ?>
-                <td class="dataTableContent" width="100%" align="right">
+                <td class="dataTableContent text-right" width="100%">
                   <?php echo zen_image(DIR_WS_IMAGES . 'icon_status_green.gif', IMAGE_ICON_STATUS_GREEN, 10, 10) ?>&nbsp;
                   <a href="<?php echo $tmp; ?>"><?php echo zen_image(DIR_WS_IMAGES . 'icon_status_red_light.gif', IMAGE_ICON_STATUS_RED_LIGHT, 10, 10) ?></a></td>
                 <?php
@@ -314,7 +314,7 @@ for ($i = 0; $i < $report->size; $i++) {
                 $tmp = substr($sales_report_filter, 0, $i) . "0" . substr($sales_report_filter, $i + 1);
                 $tmp = zen_href_link(FILENAME_STATS_SALES_REPORT_GRAPHS, $report->filter_link . "&filter=" . $tmp);
                 ?>
-                <td class="dataTableContent" width="100%" align="right">
+                <td class="dataTableContent text-right" width="100%">
                   <a href="<?php echo $tmp; ?>"><?php echo zen_image(DIR_WS_IMAGES . 'icon_status_green_light.gif', IMAGE_ICON_STATUS_GREEN, 10, 10) ?></a>
                   &nbsp;<?php echo zen_image(DIR_WS_IMAGES . 'icon_status_red.gif', IMAGE_ICON_STATUS_RED_LIGHT, 10, 10) ?></td>
                 <?php

--- a/admin/store_manager.php
+++ b/admin/store_manager.php
@@ -256,8 +256,8 @@ if ($processing_message != '') {
       <tr>
         <td colspan="2"><br><table border="0" cellspacing="0" cellpadding="2">
           <tr>
-            <td class="main" align="left" valign="top"><?php echo TEXT_INFO_PRODUCTS_VIEWED_UPDATE; ?></td>
-            <td class="main" align="right" valign="middle"><?php echo zen_draw_form('update_all_products_viewed', FILENAME_STORE_MANAGER, 'action=update_all_products_viewed')?><input class="btn btn-default btn-sm" type="submit" value="<?php echo IMAGE_RESET; ?>"></form></td>
+            <td class="main text-left" valign="top"><?php echo TEXT_INFO_PRODUCTS_VIEWED_UPDATE; ?></td>
+            <td class="main text-right" valign="middle"><?php echo zen_draw_form('update_all_products_viewed', FILENAME_STORE_MANAGER, 'action=update_all_products_viewed')?><input class="btn btn-default btn-sm" type="submit" value="<?php echo IMAGE_RESET; ?>"></form></td>
           </tr>
         </table></td>
       </tr>

--- a/admin/tax_classes.php
+++ b/admin/tax_classes.php
@@ -107,7 +107,7 @@ if (!empty($action)) {
                   ?>
               <td class="dataTableContent"><?php echo $class['tax_class_id']; ?></td>
               <td class="dataTableContent"><?php echo $class['tax_class_title']; ?></td>
-              <td class="dataTableContent" align="right"><?php
+              <td class="dataTableContent text-right"><?php
                   if (isset($tcInfo) && is_object($tcInfo) && ($class['tax_class_id'] == $tcInfo->tax_class_id)) {
                     echo zen_image(DIR_WS_IMAGES . 'icon_arrow_right.gif', '');
                   } else {

--- a/admin/whos_online.php
+++ b/admin/whos_online.php
@@ -182,7 +182,7 @@ $listingURL = FILENAME_WHOS_ONLINE . '.php?' . zen_get_all_get_params(['q', 't',
                     // item css classes indicating cart status: 'wo-inactive-empty', 'wo-active-empty', 'wo-inactive-not-empty', 'wo-active-not-empty'
                     ?>
                 <td class="dataTableContentWhois <?php echo $item['icon_class']; ?>"><?php echo $item['icon_image'] . '&nbsp;' . gmdate('H:i:s', $item['time_online']); ?></td>
-                <td class="dataTableContentWhois" align="center">
+                <td class="dataTableContentWhois text-center">
                     <?php
                     if ($item['customer_id'] != 0) {
                       echo '<a href="' . zen_href_link(FILENAME_CUSTOMERS, zen_get_all_get_params(['cID', 'action']) . 'cID=' . $item['customer_id'] . '&action=edit', 'NONSSL') . '"><u>' . $item['customer_id'] . '</u></a>';
@@ -200,7 +200,7 @@ $listingURL = FILENAME_WHOS_ONLINE . '.php?' . zen_get_all_get_params(['q', 't',
                     }
                     ?>
                 </td>
-                <td class="dataTableContentWhois dataTableButtonCell" align="left" valign="top">
+                <td class="dataTableContentWhois dataTableButtonCell text-left" valign="top">
                     <?php
                     $whois_url = 'https://whois.domaintools.com/' . $item['ip_address'];
                     $additional_ipaddress_links = '';
@@ -212,8 +212,8 @@ $listingURL = FILENAME_WHOS_ONLINE . '.php?' . zen_get_all_get_params(['q', 't',
                     <?php echo $additional_ipaddress_links; ?>
                 </td>
                 <td>&nbsp;</td>
-                <td class="dataTableContentWhois" align="center" valign="top"><?php echo date('H:i:s', $item['time_entry']); ?></td>
-                <td class="dataTableContentWhois" align="center" valign="top"><?php echo date('H:i:s', $item['time_last_click']); ?></td>
+                <td class="dataTableContentWhois text-center" valign="top"><?php echo date('H:i:s', $item['time_entry']); ?></td>
+                <td class="dataTableContentWhois text-center" valign="top"><?php echo date('H:i:s', $item['time_last_click']); ?></td>
                 <td class="dataTableContentWhois" colspan="2" valign="top">&nbsp;</td>
                 </tr>
                 <?php


### PR DESCRIPTION
Fixes HTML5 Validation error 'The align attribute on the ... element is obsolete. Use CSS instead.' in the admin section of zencart.

fixes #5119