### PR TITLE
ZC158: admin, category-product listing - fix strict comparison

### DIFF
--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -1,10 +1,12 @@
-<?php declare(strict_types=1);
+<?php
+
 /**
  * @copyright Copyright 2003-2022 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: torvista 2022 Jul 10 Modified in v1.5.8-alpha $
  */
+
 require 'includes/application_top.php';
 $languages = zen_get_languages();
 require DIR_WS_CLASSES . 'currencies.php';
@@ -62,7 +64,7 @@ if (!empty($action)) {
       if (isset($_POST['categories_id'])) {
         $categories_id = zen_db_prepare_input($_POST['categories_id']);
 
-        $categories = zen_get_category_tree($categories_id, '', '0', '', true);
+        $categories = zen_get_category_tree((string)$categories_id, '', '0', '', true);
 
         // change the status of categories and products
         zen_set_time_limit(600);
@@ -79,7 +81,7 @@ if (!empty($action)) {
         for ($i = 0, $n = count($categories); $i < $n; $i++) {
 
           //set categories_status
-          if ($categories[$i]['id'] === $categories_id) {//always update THIS category
+          if ($categories[$i]['id'] === (string)$categories_id) {//always update THIS category
               zen_set_category_status($categories[$i]['id'], $category_status);
           } elseif ($subcategories_status !== '') {//optionally update subcategories if a change was selected
               zen_set_category_status($categories[$i]['id'], $subcategories_status);


### PR DESCRIPTION
As per https://github.com/zencart/zencart/pull/5098#discussion_r944373615

Although this PR fixes a mistake, perhaps there is a further discussion to be had...

In this file, $categories_id is ini-cast to integer.
$categories array is generated from zen_get_category_tree/comes from a query and so the 'id' used in the comparison is a string....except in this instance the first element is the passed parameter $categories_id and so is an integer.

Here I have cast the passed parameter integer to string so the returned array is all strings, and made the subsequent strict  comparison as string.

However, regarding the function zen_get_category_tree:
https://github.com/zencart/zencart/blob/22d7eb768062fdf23ab4a2ace5bea2a101d54aeb/includes/functions/functions_categories.php#L648-L657
the first parameter is documented as being an integer, but default is TOPMOST_CATEGORY_PARENT_ID, which is a string.
As this is used in a query, it is cast to integer in the function. 

So not very elegant. 
(I don't find any other uses of this function that may pass an integer.)
