### PR TITLE
HTML5 and Firefox resize

### DIFF
--- a/admin/denied.php
+++ b/admin/denied.php
@@ -9,7 +9,7 @@
 require('includes/application_top.php');
 
 ?>
-<!doctype html public "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!doctype html">
 <html <?php echo HTML_PARAMS; ?>>
 <head>
     <?php require DIR_WS_INCLUDES . 'admin_html_head.php'; ?>

--- a/admin/popup_image.php
+++ b/admin/popup_image.php
@@ -42,16 +42,13 @@
     }
   }
 ?>
-<!doctype html public "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!doctype html>
 <html <?php echo HTML_PARAMS; ?>>
 <head>
 <title><?php echo $page_title; ?></title>
 <script>
-var i=0;
-
 function resize() {
-  if (navigator.appName == 'Netscape') i = 40;
-  window.resizeTo(document.images[0].width + 30, document.images[0].height + 60 - i);
+  window.resizeTo(document.images[0].width + 30, document.images[0].height + 60);
 }
 </script>
 </head>


### PR DESCRIPTION
Change doc type to HTML and remove Netscape coding from java script as
causing resize to be too small when using Firefox.
fixes #5128 5128