### PR TITLE
Coupon_restrict HTML5 Validation

### DIFF
--- a/admin/coupon_restrict.php
+++ b/admin/coupon_restrict.php
@@ -307,15 +307,6 @@ $cr_list = $db->Execute($cr_query_raw);
     <div class="row">
         <h4><?php echo HEADING_TITLE_CATEGORY; ?></h4>
         <table class="table table-hover">
-<?php
-if ($cr_list->EOF) {
-?>
-            <tr class="dataTableHeadingRow">
-                <td colspan="4" class="dataTableHeadingContent text-center"><?php echo TEXT_NO_CATEGORY_RESTRICTIONS; ?></td>
-            </tr>
-<?php
-} else {
-?>
             <tr class="dataTableHeadingRow">
                 <td class="dataTableHeadingContent text-center"><?php echo TABLE_HEADING_CATEGORY_ID; ?></td>
                 <td class="dataTableHeadingContent text-center"><?php echo TABLE_HEADING_CATEGORY_NAME; ?></td>
@@ -323,6 +314,13 @@ if ($cr_list->EOF) {
                 <td class="dataTableHeadingContent text-center"><?php echo TABLE_HEADING_RESTRICT_REMOVE; ?></td>
             </tr>
 <?php
+if ($cr_list->EOF) {
+?>
+            <tr class="dataTableRow">
+                <td colspan="4" class="dataTableContent text-center"><strong><?php echo TEXT_NO_CATEGORY_RESTRICTIONS; ?></strong></td>
+            </tr>
+<?php
+} else {
     while (!$cr_list->EOF) {
         if ($cr_list->fields['category_id'] == -1) {
             $category_name = TEXT_ALL_CATEGORIES;
@@ -371,15 +369,6 @@ $pr_list = $db->Execute($pr_query_raw);
     <div class="row">
         <h4><?php echo HEADING_TITLE_PRODUCT; ?></h4>
         <table class="table table-hover">
-<?php
-if ($pr_list->EOF) {
-?>
-            <tr class="dataTableHeadingRow">
-                <td colspan="6" class="dataTableHeadingContent text-center"><?php echo TEXT_NO_PRODUCT_RESTRICTIONS; ?></td>
-            </tr>
-<?php
-} else {
-?>
             <tr class="dataTableHeadingRow">
                 <td class="dataTableHeadingContent text-center"><?php echo TABLE_HEADING_PRODUCT_ID; ?></td>
                 <td class="dataTableHeadingContent text-center"><?php echo TABLE_HEADING_STATUS; ?></td>
@@ -388,7 +377,14 @@ if ($pr_list->EOF) {
                 <td class="dataTableHeadingContent text-center"><?php echo TABLE_HEADING_RESTRICT; ?></td>
                 <td class="dataTableHeadingContent text-center"><?php echo TABLE_HEADING_RESTRICT_REMOVE; ?></td>
             </tr>
+            <?php
+if ($pr_list->EOF) {
+?>
+            <tr class="dataTableRow">
+                <td colspan="6" class="dataTableContent text-center"><strong><?php echo TEXT_NO_PRODUCT_RESTRICTIONS; ?></strong></td>
+            </tr>
 <?php
+} else {
     $products_status_disabled = zen_image(DIR_WS_IMAGES . 'icon_red_on.gif', IMAGE_ICON_STATUS_OFF);
     $products_status_enabled = zen_image(DIR_WS_IMAGES . 'icon_green_on.gif', IMAGE_ICON_STATUS_ON);
     while (!$pr_list->EOF) {


### PR DESCRIPTION
fix #5141

Always display the table heading rows to remove the HTML5 validation errors.
- Table column 3 established by element td has no cells beginning in it.
- Table columns in range 5…6 established by element td have no cells beginning in them.

I have done this for both tables to be consistent, even though it was only necessary for the second table.

Before
![before](https://user-images.githubusercontent.com/63110817/185576848-cb3933fa-147b-4e62-8601-74e5550e2bb3.png)

After
![After](https://user-images.githubusercontent.com/63110817/185576957-a4ac4483-6574-4c96-8e0c-bd140d9f0450.png)

**Note:** the movement of the two lower buttons means that they are now more consistently placed on the screen when restrictions are present. If you want the screen to be totally consistent, would have to add bootstrap column widths.

![After2](https://user-images.githubusercontent.com/63110817/185577382-e5355ba4-15b1-4871-b600-f56edf1e656d.png)

