### PR TITLE
Use Default copy_product

### DIFF
--- a/admin/includes/modules/product_music/copy_product.php
+++ b/admin/includes/modules/product_music/copy_product.php
@@ -5,3 +5,7 @@
  * See /admin/includes/classes/observers/auto.ProductMusicObserver.php for
  * the updated handling.
  */
+// -----
+// Use the default type's handling.
+//
+require DIR_WS_MODULES . 'copy_product.php';


### PR DESCRIPTION
Fix #5147
Add link to default handler

Either merge this change of delete copy_product.php from admin/includes/modules/product_music