### PR TITLE
Missing Music links

### DIFF
--- a/admin/includes/modules/product_music/copy_product.php
+++ b/admin/includes/modules/product_music/copy_product.php
@@ -5,3 +5,7 @@
  * See /admin/includes/classes/observers/auto.ProductMusicObserver.php for
  * the updated handling.
  */
+// -----
+// Use the default type's handling.
+//
+require DIR_WS_MODULES . 'copy_product.php';

--- a/admin/includes/modules/product_music/copy_product_confirm.php
+++ b/admin/includes/modules/product_music/copy_product_confirm.php
@@ -5,3 +5,7 @@
  * See /admin/includes/classes/observers/auto.ProductMusicObserver.php for
  * the updated handling.
  */
+// -----
+// Use the default type's handling.
+//
+require DIR_WS_MODULES . 'copy_product_confirm.php';

--- a/admin/includes/modules/product_music/delete_product_confirm.php
+++ b/admin/includes/modules/product_music/delete_product_confirm.php
@@ -5,3 +5,7 @@
  * See /admin/includes/classes/observers/auto.ProductMusicObserver.php for
  * the updated handling.
  */
+// -----
+// Use the default type's handling.
+//
+require DIR_WS_MODULES . 'delete_product_confirm.php';

--- a/admin/includes/modules/product_music/update_product.php
+++ b/admin/includes/modules/product_music/update_product.php
@@ -5,3 +5,7 @@
  * See /admin/includes/classes/observers/auto.ProductMusicObserver.php for
  * the updated handling.
  */
+// -----
+// Use the default type's handling.
+//
+require DIR_WS_MODULES . 'update_product.php';


### PR DESCRIPTION
Fix #5147 
Fix #5151
Add link to default handler

Either merge this change of delete:
- copy_product.php
-  copy_product_confirm.php
-  update_product.php 
- delete_product_confirm.php 

from admin/includes/modules/product_music