### PR TITLE
PHP 8.2 Define Parameters table_block

### DIFF
--- a/admin/includes/classes/box.php
+++ b/admin/includes/classes/box.php
@@ -24,7 +24,10 @@ if (!defined('IS_ADMIN_FLAG')) {
 */
 
   class box extends boxTableBlock {
-
+      private
+          $heading,
+          $contents;
+      
     function __construct() {
       $this->heading = array();
       $this->contents = array();

--- a/admin/includes/classes/table_block.php
+++ b/admin/includes/classes/table_block.php
@@ -7,8 +7,11 @@
  * @version $Id: DrByte 2020 Jul 10 Modified in v1.5.8-alpha $
  */
 class boxTableBlock {
-
-  function tableBlock($contents) {
+    protected 
+        $table_row_parameters,
+        $table_data_parameters;
+     
+function tableBlock($contents) {
     $tableBox_string = '';
 
     $form_set = false;


### PR DESCRIPTION
Define parameters for table_block and its sub classes

## boxTableBlock
$table_row_parameters, $table_data_parameters are only used in the class and subclass so I have set to protected.
## box
$heading, $contents are only used in this class so I have set them to private.
## messageStack
no changes required.

Do you agree with my logic? While I come from a process background, I have read up on OO and will happily take input if I have not got it right.

Part of #5103