### PR TITLE
fix for handling filename with no extension

### DIFF
--- a/includes/modules/main_product_image.php
+++ b/includes/modules/main_product_image.php
@@ -16,7 +16,7 @@ if (!defined('IS_ADMIN_FLAG')) {
 //
 $GLOBALS['zco_notifier']->notify('NOTIFY_MODULES_MAIN_PRODUCT_IMAGE_START');
 
-$products_image_extension = substr($products_image, strrpos($products_image, '.'));
+$products_image_extension = '.' . pathinfo($products_image, PATHINFO_EXTENSION);
 $products_image_base = str_replace($products_image_extension, '', $products_image);
 $products_image_medium = $products_image_base . IMAGE_SUFFIX_MEDIUM . $products_image_extension;
 $products_image_large = $products_image_base . IMAGE_SUFFIX_LARGE . $products_image_extension;


### PR DESCRIPTION
If the filename in the database has no extension, strrpos returns false and this is not handled. If in strict mode, page dies.
This cropped up while testing a csv import of multiple products, and some idiot initially forgot to add the extension to the imported filenames.
