### PR TITLE
PHP8.2 Define Parameters AdminRequestSanitizer

### DIFF
--- a/admin/includes/classes/AdminRequestSanitizer.php
+++ b/admin/includes/classes/AdminRequestSanitizer.php
@@ -52,6 +52,10 @@ class AdminRequestSanitizer extends base
      * @var string
      */
     private $charset;
+    /**
+     * @var string
+     */
+    private $arrayName;
 
     /**
      * @return AdminRequestSanitizer


### PR DESCRIPTION
$arrayName set to private. Used to hold current rule being sanitized.

Part of #5103