### PR TITLE
PHP8.2 Define Parameters queryFactory

### DIFF
--- a/includes/classes/db/mysql/query_factory.php
+++ b/includes/classes/db/mysql/query_factory.php
@@ -19,12 +19,14 @@ if (!defined('IS_ADMIN_FLAG')) {
  */
 class queryFactory extends base
 {
-    var $link; // mysqli object
-    var $count_queries = 0;
-    var $total_query_time;
-    var $dieOnErrors = false;
-    var $error_number = 0;
-    var $error_text = '';
+    private $link; // mysqli object
+    private $count_queries = 0;
+    private $total_query_time;
+    public $dieOnErrors = false;
+    public $error_number = 0;
+    public $error_text = '';
+    
+    private $pConnect;
     /**
      * @var bool
      */


### PR DESCRIPTION
Changed to Private
- $link
- $count_queries
- $total_query_time

Changed to public
- $dieOnErrors
- $error_number
- $error_text

Set to private
- $pConnect   

**N.B. $pConnect  could be completely removed as it is not used anywhere**

Part of #5103