### PR TITLE
Coupon description should correctly display HTML

### DIFF
--- a/includes/modules/pages/discount_coupon/header_php.php
+++ b/includes/modules/pages/discount_coupon/header_php.php
@@ -29,7 +29,9 @@
         $coupon_desc = $db->Execute("select * from " . TABLE_COUPONS_DESCRIPTION . " where coupon_id = '" . (int)$lookup_coupon_id . "' and language_id = '" . (int)$_SESSION['languages_id'] . "'");
         $text_coupon_help = TEXT_COUPON_HELP_HEADER;
         $text_coupon_help .= sprintf(TEXT_COUPON_HELP_NAME, $coupon_desc->fields['coupon_name']);
-        if (!empty($coupon_desc->fields['coupon_description'])) $text_coupon_help .= sprintf(TEXT_COUPON_HELP_DESC, zen_output_string_protected($coupon_desc->fields['coupon_description']));
+        if (!empty($coupon_desc->fields['coupon_description'])) {
+           $text_coupon_help .= sprintf(TEXT_COUPON_HELP_DESC, $coupon_desc->fields['coupon_description']);
+        }
         $coupon_amount = $coupon->fields['coupon_amount'];
         switch ($coupon->fields['coupon_type']) {
           case 'F': // amount Off


### PR DESCRIPTION
The field coupon_description (unlike `$_POST['lookup_discount_coupon']`) is not user input and should not be displayed using `zen_output_string_protected`.  It is entered by the store admin and may contain HTML. 