### PR TITLE
Head off a ton of PHP 8.1 deprecations

### DIFF
--- a/includes/functions/database.php
+++ b/includes/functions/database.php
@@ -25,7 +25,7 @@ function zen_db_insert_id()
 function zen_db_input($string)
 {
     global $db;
-    return $db->prepare_input($string);
+    return (empty($string) ? $string : $db->prepare_input($string));
 }
 
 /**


### PR DESCRIPTION
Ensure passed argument to `zen_db_input` is not empty. 
Fixes #5167 