### PR TITLE
PHP8.2 Define Parameters InitSystem

### DIFF
--- a/includes/classes/InitSystem.php
+++ b/includes/classes/InitSystem.php
@@ -11,10 +11,16 @@ namespace Zencart\InitSystem;
 class InitSystem
 {
 
-    protected $context;
-    protected $loaderPrefix;
-    protected $fileSystem;
-    protected $pluginManager;
+    private 
+        $installedPlugins,
+        $debug,
+        $debugList,
+        $actionList;
+        
+    private $context;
+    private $loaderPrefix;
+    private $fileSystem;
+    private $pluginManager;
 
     public function __construct($context, $loaderPrefix, $fileSystem, $pluginManager, $installedPlugins)
     {


### PR DESCRIPTION
Private not used outside class
- $installedPlugins
- $debug
- $debugList
- $actionList

Changed from protected to private as not used outside of class
- $context;
- $loaderPrefix;
- $fileSystem;
- $pluginManager;

Part of #5103