### PR TITLE
PHP8.2 Define Parameters sniffer

### DIFF
--- a/includes/classes/sniffer.php
+++ b/includes/classes/sniffer.php
@@ -17,6 +17,12 @@ if (!defined('IS_ADMIN_FLAG')) {
  */
 class sniffer extends base {
 
+    private
+        $browser,
+        $database,
+        $php,
+        $server;
+
   function __construct() {
     $this->browser = Array();
     $this->php = Array();


### PR DESCRIPTION
Private not used outside class
- $browser,
- $database,
- $php,
- $server;

None of these appear to be set or used anywhere in the system

Part of #5103