### PR TITLE
PHP8.2 Define Parameters zcObserverLog

### DIFF
--- a/admin/includes/classes/class.admin.zcObserverLogEventListener.php
+++ b/admin/includes/classes/class.admin.zcObserverLogEventListener.php
@@ -17,6 +17,8 @@
 
 class zcObserverLogEventListener extends base {
 
+    private $notifier;
+    
   /**
    * using integer values implemented by monolog API
    */

--- a/admin/includes/classes/class.admin.zcObserverLogWriterDatabase.php
+++ b/admin/includes/classes/class.admin.zcObserverLogWriterDatabase.php
@@ -11,6 +11,8 @@
 
 class zcObserverLogWriterDatabase extends base {
 
+    private $notifier;
+    
   public function __construct(notifier $zco_notifier = null) {
     if (!$zco_notifier) $zco_notifier = new notifier;
     $this->notifier = $zco_notifier;

--- a/admin/includes/classes/class.admin.zcObserverLogWriterTextfile.php
+++ b/admin/includes/classes/class.admin.zcObserverLogWriterTextfile.php
@@ -12,6 +12,7 @@
 class zcObserverLogWriterTextfile extends base {
 
   private $destinationLogFilename = '';
+  private $notifier;
 
   public function __construct(notifier $zco_notifier = null) {
     if (!$zco_notifier) $zco_notifier = new notifier;


### PR DESCRIPTION
Private not used outside class
- $notifier

I have bundeled these three together as basically same change.

Part of #5103