### PR TITLE
PHP8.2 Define Parameters queryFactory

### DIFF
--- a/includes/classes/db/mysql/query_factory.php
+++ b/includes/classes/db/mysql/query_factory.php
@@ -441,7 +441,7 @@ class queryFactory extends base
      */
     public function queryTime(): int
     {
-        return $this->total_query_time;
+        return (int)$this->total_query_time;
     }
 
     /**
@@ -959,6 +959,9 @@ class queryFactoryResult implements Countable, Iterator
 
 class queryFactoryMeta extends base
 {
+    public $type;
+    public $max_length;
+    
     function __construct($field)
     {
         $type = $field['Type'];


### PR DESCRIPTION
## queryFactory
Necessary to cast queryTime to int to avoid warning.

## queryFactoryResult
No changes

## queryFactoryMeta
public $type; used by zen_field_type in includes\functions\functions_general_shared.php
public $max_length; used by zen_field_length in includes\functions\functions_general_shared.php