### PR TITLE
PHP8.2 Define Parameters zcDate

### DIFF
--- a/includes/classes/zcDate.php
+++ b/includes/classes/zcDate.php
@@ -12,7 +12,8 @@ class zcDate extends base
         $locale,                //- Only used when $this->useIntlDate is true
         $strftime2date,         //- Only used when $this->useStrftime is false
         $strftime2intl,         //- Only used when $this->useStrftime is false
-        $debug = false;
+        $debug = false,
+        $dateObject;
 
     // -----
     // Initial construction; initializes the conversion arrays and determines which PHP


### PR DESCRIPTION
$dateObject set to protected. 
All other parameters are protected. This will allow for other classes to extend zcDate if needed.