### PR TITLE
PHP8.2 Define Parameters AdminNotifiers

### DIFF
--- a/admin/includes/classes/AdminNotifications.php
+++ b/admin/includes/classes/AdminNotifications.php
@@ -9,6 +9,7 @@
 class AdminNotifications
 {
     protected $enabled = true;
+    private $projectNotificationServer;
 
     public function __construct()
     {
@@ -50,6 +51,9 @@ class AdminNotifications
 
     protected function getNotificationInfo()
     {
+        if (empty($this->projectNotificationServer)){
+            return [];
+        }
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $this->projectNotificationServer);
         curl_setopt($ch, CURLOPT_VERBOSE, 0);


### PR DESCRIPTION
$projectNotificationServer set to private and not used outside of class

Also added check to see if set and return empty array if not set.
**Alternative**, if desired, remove both checks and fail if PROJECT_NOTIFICATIONSERVER_URL is not defined. 
Currently defined in include/version.php as "https://ping.zen-cart.com/api/notifications" and
in zc_install/includes/version.php as "https://versionserver.zen-cart.com/api/notifications".