### PR TITLE
 PHP8.2 Define Parameters statsSalesReportGraph

### DIFF
--- a/admin/includes/classes/stats_sales_report_graph.php
+++ b/admin/includes/classes/stats_sales_report_graph.php
@@ -29,8 +29,12 @@ class statsSalesReportGraph
         $previous = '',
         $next = '',
         $filter = '',
+        $filter_link,
+        $filter_sql = '',
+        $status_available = [],
+        $status_available_size = 0,
         $size = 0;
-
+       
     /**
      * statsSalesReportGraph constructor.
      *


### PR DESCRIPTION
All set to public as used outside class $filter_link, $filter_sql = '', $status_available = [], $status_available_size = 0.
I did not set $filter_link as only defined in the class.