### PR TITLE
PHP8.2 Define Parameters pulldown

### DIFF
--- a/includes/classes/categoryPulldown.php
+++ b/includes/classes/categoryPulldown.php
@@ -10,6 +10,10 @@
 
     class categoryPulldown extends pulldown
     {
+
+        private $show_full_path;
+        private $show_parent;
+
         /**
          *
          */

--- a/includes/classes/productPulldown.php
+++ b/includes/classes/productPulldown.php
@@ -21,7 +21,12 @@
             'products_price' => 'p',
             'products_sort_order' => 'p',
         ];
-
+        
+        private $categories_join;
+        private $output_string;
+        private $show_model;
+        private $show_price;
+        
         /**
          *
          */

--- a/includes/classes/pulldown.php
+++ b/includes/classes/pulldown.php
@@ -10,39 +10,42 @@
 
     abstract class pulldown extends base
     {
-        /**
-         * @var
-         */
-        public $pulldown;
+
         /**
          * @var string
          */
-        public $attributes_join;
+        protected $attributes_join;
         /**
          * @var false
          */
-        public $show_id;
+        protected $show_id;
         /**
          * @var int
          */
-        public $set_selected;
+        protected $set_selected;
         /**
          * @var string
          */
-        public $parameters;
+        protected $parameters;
         /**
          * @var string
          */
-        public $condition;
+        protected $condition;
         /**
          * @var array
          */
-        public $exclude;
+        protected $exclude = [];
         /**
          * @var int
          */
-        public $count = 0;
-
+        protected $count = 0;
+        
+        protected $keywords;
+        protected $keyword_search_fields; 
+        protected $results;    
+        protected $sort;
+        protected $sql;
+        protected $values = [];
 
         /**
          *


### PR DESCRIPTION
## pulldown

$pulldown; is not used anywhere, so removed

Changed to protected as not used outside subclasses
- $attributes_join
- $show_id
- $set_selected
- $parameters
- $condition
- $exclude = []
- $count

Set as protected as used in sub classes not previously defined
- $keywords
- $keyword_search_fields
- $sort
- $sql
- $results
- $values = []

## categoryPulldown extends pulldown
Set a private not used outside of class not previously defined
- $show_parent
- $show_full_path

## productOptionsPulldown extends pulldown
No changes necessary

## productPulldown extends pulldown
Set as private as not used outside of class not previously defined
- $categories_join
- $output_string
- $show_model
- $show_price

part of #5103 