### PR TITLE
PHP8.2 Define Parameters storefront messageStack

### DIFF
--- a/includes/classes/message_stack.php
+++ b/includes/classes/message_stack.php
@@ -19,6 +19,8 @@ class messageStack extends base
 {
     /** to override these, call setMessageFormatting() and pass it an array of the desired formats, similar to what getDefaultFormats() returns */
     private $formats = [];
+    /** array of messages to be displayed */
+    private $messages = [];
 
     function __construct()
     {


### PR DESCRIPTION
$messages defined as private, not used outside of class, output method available to retrieve and add method to set.
