### PR TITLE
PHP8.2 Define Parameters shipping

### DIFF
--- a/includes/classes/shipping.php
+++ b/includes/classes/shipping.php
@@ -17,7 +17,21 @@ if (!defined('IS_ADMIN_FLAG')) {
  */
 class shipping extends base
 {
+    /**
+     * $enabled allows notifier to turn off shipping method
+     * @var boolean
+     */
+    public $enabled;
+    /**
+     * $modules is an array of installed shipping module names can be altered by notifier
+     * @var array
+     */
     public $modules;
+    /**
+     * $abort_legacy_calculations allows a notifier to enable the calculate_boxes_weight_and_tare method
+     * @var boolean
+     */
+    public $abort_legacy_calculations;
 
     public function __construct($module = null)
     {

--- a/includes/modules/shipping/flat.php
+++ b/includes/modules/shipping/flat.php
@@ -7,8 +7,59 @@
  */
 
   class flat {
-    var $code, $title, $description, $icon, $enabled;
-
+    
+    /**
+     * $_check is used to check the configuration key set up
+     * @var int
+     */
+    protected $_check;
+    /**
+     * $code determines the internal 'code' name used to designate "this" shipping module
+     *
+     * @var string
+     */
+    public $code;
+    /**
+     * $description is a soft name for this shipping method
+     * @var string 
+     */
+    public $description;
+    /**
+     * $enabled determines whether this module shows or not... during checkout.
+     * @var boolean
+     */
+    public $enabled;
+    /**
+     * $icon is the file name containing the Shipping method icon
+     * @var string
+     */
+    public $icon;
+    /** 
+     * $quotes is an array containing all the quote information for this shipping module
+     * @var array
+     */
+    public $quotes;
+    /**
+     * $sort_order is the order priority of this shipping module when displayed
+     * @var int
+     */
+    public $sort_order;
+    /**
+     * $tax_basis is used to indicate if tax is based on shipping, billing or store address.
+     * @var string
+     */
+    public $tax_basis;
+    /**
+     * $tax_class is the  Tax class to be applied to the shipping cost
+     * @var string
+     */
+    public $tax_class;
+    /**
+     * $title is the displayed name for this shipping method
+     * @var string
+     */
+    public $title;
+    
     function __construct() {
       $this->code = 'flat';
       $this->title = MODULE_SHIPPING_FLAT_TEXT_TITLE;

--- a/includes/modules/shipping/freeoptions.php
+++ b/includes/modules/shipping/freeoptions.php
@@ -7,14 +7,64 @@
  */
 class freeoptions extends base
  {
-    public
-        $code,
-        $title,
-        $description,
-        $icon,
-        $enabled,
-        $debug = [];
-
+    
+    /**
+     * $_check is used to check the configuration key set up
+     * @var int
+     */
+    protected $_check;
+    /**
+     * $code determines the internal 'code' name used to designate "this" shipping module
+     *
+     * @var string
+     */
+    public $code;
+    /**
+     * $description is a soft name for this shipping method
+     * @var string 
+     */
+    public $description;
+    /**
+     * $enabled determines whether this module shows or not... during checkout.
+     * @var boolean
+     */
+    public $enabled;
+    /**
+     * $debug is an array containing debug information
+     * @var array
+     */
+    public $debug = [];
+    /**
+     * $icon is the file name containing the Shipping method icon
+     * @var string
+     */
+    public $icon;
+    /** 
+     * $quotes is an array containing all the quote information for this shipping module
+     * @var array
+     */
+    public $quotes;
+    /**
+     * $sort_order is the order priority of this shipping module when displayed
+     * @var int
+     */
+    public $sort_order;
+    /**
+     * $tax_basis is used to indicate if tax is based on shipping, billing or store address.
+     * @var string
+     */
+    public $tax_basis;
+    /**
+     * $tax_class is the  Tax class to be applied to the shipping cost
+     * @var string
+     */
+    public $tax_class;
+    /**
+     * $title is the displayed name for this shipping method
+     * @var string
+     */
+    public $title;
+  
     public function __construct()
     {
         $this->code = 'freeoptions';

--- a/includes/modules/shipping/freeshipper.php
+++ b/includes/modules/shipping/freeshipper.php
@@ -7,8 +7,59 @@
  */
 //
   class freeshipper {
-    var $code, $title, $description, $icon, $enabled;
-
+      
+    /**
+     * $_check is used to check the configuration key set up
+     * @var int
+     */
+    protected $_check;
+    /**
+     * $code determines the internal 'code' name used to designate "this" shipping module
+     *
+     * @var string
+     */
+    public $code;
+    /**
+     * $description is a soft name for this shipping method
+     * @var string 
+     */
+    public $description;
+    /**
+     * $enabled determines whether this module shows or not... during checkout.
+     * @var boolean
+     */
+    public $enabled;
+    /**
+     * $icon is the file name containing the Shipping method icon
+     * @var string
+     */
+    public $icon;
+    /** 
+     * $quotes is an array containing all the quote information for this shipping module
+     * @var array
+     */
+    public $quotes;
+    /**
+     * $sort_order is the order priority of this shipping module when displayed
+     * @var int
+     */
+    public $sort_order;
+    /**
+     * $tax_basis is used to indicate if tax is based on shipping, billing or store address.
+     * @var string
+     */
+    public $tax_basis;
+    /**
+     * $tax_class is the  Tax class to be applied to the shipping cost
+     * @var string
+     */
+    public $tax_class;
+    /**
+     * $title is the displayed name for this shipping method
+     * @var string
+     */
+    public $title;
+  
     function __construct() {
       $this->code = 'freeshipper';
       $this->title = MODULE_SHIPPING_FREESHIPPER_TEXT_TITLE;

--- a/includes/modules/shipping/item.php
+++ b/includes/modules/shipping/item.php
@@ -8,8 +8,59 @@
 
 
   class item {
-    var $code, $title, $description, $icon, $enabled;
-
+      
+    /**
+     * $_check is used to check the configuration key set up
+     * @var int
+     */
+    protected $_check;
+    /**
+     * $code determines the internal 'code' name used to designate "this" shipping module
+     *
+     * @var string
+     */
+    public $code;
+    /**
+     * $description is a soft name for this shipping method
+     * @var string 
+     */
+    public $description;
+    /**
+     * $enabled determines whether this module shows or not... during checkout.
+     * @var boolean
+     */
+    public $enabled;
+    /**
+     * $icon is the file name containing the Shipping method icon
+     * @var string
+     */
+    public $icon;
+    /** 
+     * $quotes is an array containing all the quote information for this shipping module
+     * @var array
+     */
+    public $quotes;
+    /**
+     * $sort_order is the order priority of this shipping module when displayed
+     * @var int
+     */
+    public $sort_order;
+    /**
+     * $tax_basis is used to indicate if tax is based on shipping, billing or store address.
+     * @var string
+     */
+    public $tax_basis;
+    /**
+     * $tax_class is the  Tax class to be applied to the shipping cost
+     * @var string
+     */
+    public $tax_class;
+    /**
+     * $title is the displayed name for this shipping method
+     * @var string
+     */
+    public $title;
+  
     function __construct() {
       $this->code = 'item';
       $this->title = MODULE_SHIPPING_ITEM_TEXT_TITLE;

--- a/includes/modules/shipping/perweightunit.php
+++ b/includes/modules/shipping/perweightunit.php
@@ -10,36 +10,59 @@
  *
  */
 class perweightunit extends base {
-  /**
-   * $code determines the internal 'code' name used to designate "this" payment module
-   *
-   * @var string
-   */
-  var $code;
-  /**
-   * $title is the displayed name for this payment method
-   *
-   * @var string
-   */
-  var $title;
-  /**
-   * $description is a soft name for this payment method
-   *
-   * @var string
-   */
-  var $description;
-  /**
-   * module's icon
-   *
-   * @var string
-   */
-  var $icon;
-  /**
-   * $enabled determines whether this module shows or not... during checkout.
-   *
-   * @var boolean
-   */
-  var $enabled;
+
+    /**
+     * $_check is used to check the configuration key set up
+     * @var int
+     */
+    protected $_check;
+    /**
+     * $code determines the internal 'code' name used to designate "this" shipping module
+     *
+     * @var string
+     */
+    public $code;
+    /**
+     * $description is a soft name for this shipping method
+     * @var string 
+     */
+    public $description;
+    /**
+     * $enabled determines whether this module shows or not... during checkout.
+     * @var boolean
+     */
+    public $enabled;
+    /**
+     * $icon is the file name containing the Shipping method icon
+     * @var string
+     */
+    public $icon;
+    /** 
+     * $quotes is an array containing all the quote information for this shipping module
+     * @var array
+     */
+    public $quotes;
+    /**
+     * $sort_order is the order priority of this shipping module when displayed
+     * @var int
+     */
+    public $sort_order;
+    /**
+     * $tax_basis is used to indicate if tax is based on shipping, billing or store address.
+     * @var string
+     */
+    public $tax_basis;
+    /**
+     * $tax_class is the  Tax class to be applied to the shipping cost
+     * @var string
+     */
+    public $tax_class;
+    /**
+     * $title is the displayed name for this shipping method
+     * @var string
+     */
+    public $title;
+    
   /**
      * Constructor
    *

--- a/includes/modules/shipping/storepickup.php
+++ b/includes/modules/shipping/storepickup.php
@@ -10,36 +10,69 @@
  * with multiple location choices as radio-buttons
  */
 class storepickup extends base {
-  /**
-   * $code determines the internal 'code' name used to designate "this" shipping module
-   *
-   * @var string
-   */
-  var $code;
-  /**
-   * $title is the displayed name for this shipping method
-   *
-   * @var string
-   */
-  var $title;
-  /**
-   * $description is a soft name for this shipping method
-   *
-   * @var string
-   */
-  var $description;
-  /**
-   * module's icon
-   *
-   * @var string
-   */
-  var $icon;
-  /**
-   * $enabled determines whether this module shows or not... during checkout.
-   *
-   * @var boolean
-   */
-  var $enabled;
+
+    /**
+     * $_check is used to check the configuration key set up
+     * @var int
+     */
+    protected $_check;
+    /**
+     * $code determines the internal 'code' name used to designate "this" shipping module
+     *
+     * @var string
+     */
+    public $code;
+    /**
+     * $description is a soft name for this shipping method
+     * @var string 
+     */
+    public $description;
+    /**
+     * $enabled determines whether this module shows or not... during checkout.
+     * @var boolean
+     */
+    public $enabled;
+    /**
+     * $icon is the file name containing the Shipping method icon
+     * @var string
+     */
+    public $icon;
+    /**
+     * $locations is an array of locations for the customer to pickup order
+     * @var array
+     */
+    protected $locations = [];
+    /**
+     * $methodsList is an array of translations for the $locations
+     * @var array
+     */
+    protected $methodsList = [];
+    /** 
+     * $quotes is an array containing all the quote information for this shipping module
+     * @var array
+     */
+    public $quotes;
+    /**
+     * $sort_order is the order priority of this shipping module when displayed
+     * @var int
+     */
+    public $sort_order;
+    /**
+     * $tax_basis is used to indicate if tax is based on shipping, billing or store address.
+     * @var string
+     */
+    public $tax_basis;
+    /**
+     * $tax_class is the  Tax class to be applied to the shipping cost
+     * @var string
+     */
+    public $tax_class;
+    /**
+     * $title is the displayed name for this shipping method
+     * @var string
+     */
+    public $title;
+    
   /**
    * constructor
    *

--- a/includes/modules/shipping/table.php
+++ b/includes/modules/shipping/table.php
@@ -10,38 +10,61 @@
  *
  */
 class table extends base {
+
+    /**
+     * $_check is used to check the configuration key set up
+     * @var int
+     */
+    protected $_check;
+    /**
+     * $code determines the internal 'code' name used to designate "this" shipping module
+     *
+     * @var string
+     */
+    public $code;
+    /**
+     * $description is a soft name for this shipping method
+     * @var string 
+     */
+    public $description;
+    /**
+     * $enabled determines whether this module shows or not... during checkout.
+     * @var boolean
+     */
+    public $enabled;
+    /**
+     * $icon is the file name containing the Shipping method icon
+     * @var string
+     */
+    public $icon;
+    /** 
+     * $quotes is an array containing all the quote information for this shipping module
+     * @var array
+     */
+    public $quotes;
+    /**
+     * $sort_order is the order priority of this shipping module when displayed
+     * @var int
+     */
+    public $sort_order;
+    /**
+     * $tax_basis is used to indicate if tax is based on shipping, billing or store address.
+     * @var string
+     */
+    public $tax_basis;
+    /**
+     * $tax_class is the  Tax class to be applied to the shipping cost
+     * @var string
+     */
+    public $tax_class;
+    /**
+     * $title is the displayed name for this shipping method
+     * @var string
+     */
+    public $title;
+    
   /**
-   * Enter description here...
-   *
-   * @var string
-   */
-  var $code;
-  /**
-   * Enter description here...
-   *
-   * @var string
-   */
-  var $title;
-  /**
-   * Enter description here...
-   *
-   * @var string
-   */
-  var $description;
-  /**
-   * Enter description here...
-   *
-   * @var string
-   */
-  var $icon;
-  /**
-   * Enter description here...
-   *
-   * @var boolean
-   */
-  var $enabled;
-  /**
-   * Enter description here...
+   * constructor
    *
    * @return table
    */
@@ -104,9 +127,9 @@ class table extends base {
     }
   }
   /**
-   * Enter description here...
+   *  Obtain quote from shipping system/calculations
    *
-   * @param unknown_type $method
+   * @param string $method
    * @return unknown
    */
   function quote($method = '') {
@@ -174,7 +197,7 @@ class table extends base {
     return $this->quotes;
   }
   /**
-   * Enter description here...
+   * Check to see whether module is installed
    *
    * @return unknown
    */
@@ -187,7 +210,7 @@ class table extends base {
     return $this->_check;
   }
   /**
-   * Enter description here...
+   * Install the shipping module and its configuration settings
    *
    */
   function install() {
@@ -205,7 +228,7 @@ class table extends base {
     $db->Execute("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Sort Order', 'MODULE_SHIPPING_TABLE_SORT_ORDER', '0', 'Sort order of display.', '6', '0', now())");
   }
   /**
-   * Enter description here...
+   * Remove the module and all its settings
    *
    */
     function remove() {
@@ -214,8 +237,8 @@ class table extends base {
     }
 
   /**
-   * Enter description here...
-   *
+   * Internal list of configuration keys used for configuration of the module
+   * 
    * @return unknown
    */
   function keys() {

--- a/includes/modules/shipping/zones.php
+++ b/includes/modules/shipping/zones.php
@@ -92,7 +92,62 @@
 */
 
   class zones {
-    var $code, $title, $description, $enabled, $num_zones;
+    /**
+     * $_check is used to check the configuration key set up
+     * @var int
+     */
+    protected $_check;
+    /**
+     * $code determines the internal 'code' name used to designate "this" shipping module
+     *
+     * @var string
+     */
+    public $code;
+    /**
+     * $description is a soft name for this shipping method
+     * @var string 
+     */
+    public $description;
+    /**
+     * $enabled determines whether this module shows or not... during checkout.
+     * @var boolean
+     */
+    public $enabled;
+    /**
+     * $icon is the file name containing the Shipping method icon
+     * @var string
+     */
+    public $icon;
+    /**
+     * $num_zones is the number of zones to process
+     * @var integer
+     */
+    protected $num_zones;
+    /** 
+     * $quotes is an array containing all the quote information for this shipping module
+     * @var array
+     */
+    public $quotes;
+    /**
+     * $sort_order is the order priority of this shipping module when displayed
+     * @var int
+     */
+    public $sort_order;
+    /**
+     * $tax_basis is used to indicate if tax is based on shipping, billing or store address.
+     * @var string
+     */
+    public $tax_basis;
+    /**
+     * $tax_class is the  Tax class to be applied to the shipping cost
+     * @var string
+     */
+    public $tax_class;
+    /**
+     * $title is the displayed name for this shipping method
+     * @var string
+     */
+    public $title;
 
     function __construct() {
       $this->code = 'zones';


### PR DESCRIPTION
## shipping
Set to public as notifiers may modify values
- $modules
- $enabled
- $abort_legacy_calculations

## All shipping modules
Set to protected not required outside class
- $_check;

Set to public used outside class
- $code;
- $description;
- $enabled;
- $icon;
- $quotes;
- $sort_order;
- $tax_basis;
- $tax_class;
- $title;

## Individual shipping module addition changes
### freeoptions
Set to public
- $debug = [];

### freeshipper
Did not have $tax_basis have still included definition

### storepickup
Set protected as not required outside module
- $locations = [];
- $methodsList = [];

### zones
Set to protected only required by class
- $num_zones;
