### PR TITLE
PHP8.2 Define Parameters order totals

### DIFF
--- a/includes/classes/order_total.php
+++ b/includes/classes/order_total.php
@@ -17,7 +17,11 @@ if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
 }
 class order_total extends base {
-  var $modules = array();
+  /**
+     * $modules is an array of installed order totals module names 
+     * @var array
+     */
+    public $modules;
 
   // class constructor
   function __construct() {

--- a/includes/modules/order_total/ot_cod_fee.php
+++ b/includes/modules/order_total/ot_cod_fee.php
@@ -14,7 +14,42 @@
  */
 
   class ot_cod_fee {
-    var $title, $output;
+      
+   /**
+     * $_check is used to check the configuration key set up
+     * @var int
+     */
+    protected $_check;
+    /**
+     * $code determines the internal 'code' name used to designate "this" order module
+     * @var string
+     */
+    public $code;
+    /**
+     * $description is a soft name for this order total method
+     * @var string 
+     */
+    public $description;
+    /**
+     * $enabled determines whether this module shows or not... during checkout.
+     * @var boolean
+     */
+    public $enabled;
+    /**
+     * $sort_order is the order priority of this order total module when displayed
+     * @var int
+     */
+    public $sort_order;
+    /**
+     * $title is the displayed name for this order total method
+     * @var string
+     */
+    public $title;
+    /**
+     * $output is an array of the display elements used on checkout pages
+     * @var array
+     */
+    public $output = [];
 
     function __construct() {
       $this->code = 'ot_cod_fee';

--- a/includes/modules/order_total/ot_coupon.php
+++ b/includes/modules/order_total/ot_coupon.php
@@ -17,30 +17,85 @@
  */
 class ot_coupon extends base
 {
+
     /**
-     * module title
+     * $_check is used to check the configuration key set up
+     * @var int
+     */
+    protected $_check;
+    /**
+     * $calculate_tax determines how tax should be applied to coupon Standard, Credit Note, None
+     * @var string
+     */
+    public $calculate_tax;
+    /**
+     * $code determines the internal 'code' name used to designate "this" order total module
+     * @var string
+     */
+    public $code;
+    /**
+     * $coupon_code is the coupon_code under consideration while being applied to an order
+     * @var string
+     */
+    protected $coupon_code;
+    /**
+     * $credit_class flag to indicate order totals method is a credit class
+     * @var boolean
+     */
+    public $credit_class;
+    /**
+     * $deduction amount of deduction calculated/afforded while being applied to an order
+     * @var float|null
+     */
+    protected $deduction;
+    /**
+     * $description is a soft name for this order total method
+     * @var string 
+     */
+    public $description;
+    /**
+     * $header the module box header 
+     * @var string
+     */
+    public $header;
+    /**
+     * $include_shipping allow shipping costs to be discounted by coupon if 'true'
+     * @var string
+     */
+    public $include_shipping;
+    /**
+     * $include_tax allow tax to be discounted by coupon if 'true'
+     * @var string
+     */
+    public $include_tax;
+    /**
+     * $sort_order is the order priority of this order total module when displayed
+     * @var int
+     */
+    public $sort_order;
+    /**
+     * $tax_class is the Tax class to be applied to the coupon cost
+     * @var
+     */
+    public $tax_class;
+    /**
+     * $title is the displayed name for this order total method
      * @var string
      */
     public $title;
     /**
-     * display elements used on checkout pages
+     * $output is an array of the display elements used on checkout pages
      * @var array
      */
     public $output = [];
-
     /**
-     * while being applied to an order, this is the coupon_code under consideration
+     * $user_prompt not used = ''
      * @var string
      */
-    var $coupon_code;
+    public $user_prompt;
     /**
-     * amount of deduction calculated/afforded while being applied to an order
-     * @var float|null
-     */
-    var $deduction;
-
-    /**
-     * error messages from coupon validation
+     * $validation_errors is an array of error messages from coupon validation
+     * @var array
      */
     protected $validation_errors = [];
 
@@ -637,12 +692,12 @@ class ot_coupon extends base
     function check()
     {
         global $db;
-        if (!isset($this->check)) {
+        if (!isset($this->_check)) {
             $check_query = $db->Execute("SELECT configuration_value FROM " . TABLE_CONFIGURATION . " WHERE configuration_key = 'MODULE_ORDER_TOTAL_COUPON_STATUS'");
-            $this->check = $check_query->RecordCount();
+            $this->_check = $check_query->RecordCount();
         }
 
-        return $this->check;
+        return $this->_check;
     }
 
     /**

--- a/includes/modules/order_total/ot_group_pricing.php
+++ b/includes/modules/order_total/ot_group_pricing.php
@@ -9,7 +9,67 @@
  */
 
 class ot_group_pricing {
-  var $title, $output;
+
+    /**
+     * $_check is used to check the configuration key set up
+     * @var int
+     */
+    protected $_check;
+    /**
+     * $code determines the internal 'code' name used to designate "this" order total module
+     * @var string
+     */
+    public $code;
+    /**
+     * $calculate_tax determines how tax should be applied to coupon Standard, Credit Note, None
+     * @var string
+     */
+    public $calculate_tax;
+    /**
+     * $credit_class flag to indicate order totals method is a credit class
+     * @var boolean
+     */
+    public $credit_class;
+    /**
+     * $deduction amount of deduction calculated/afforded while being applied to an order
+     * @var float|null
+     */
+    protected $deduction;
+    /**
+     * $description is a soft name for this order total method
+     * @var string 
+     */
+    public $description;
+    /**
+     * $include_shipping allow shipping costs to be discounted by coupon if 'true'
+     * @var string
+     */
+    public $include_shipping;
+    /**
+     * $include_tax allow tax to be discounted by coupon if 'true'
+     * @var string
+     */
+    public $include_tax;
+    /**
+     * $sort_order is the order priority of this order total module when displayed
+     * @var int
+     */
+    public $sort_order;
+    /**
+     * $tax_class is the Tax class to be applied to the coupon cost
+     * @var
+     */
+    public $tax_class;
+    /**
+     * $title is the displayed name for this order total method
+     * @var string
+     */
+    public $title;
+    /**
+     * $output is an array of the display elements used on checkout pages
+     * @var array
+     */
+    public $output = [];
 
   function __construct() {
     $this->code = 'ot_group_pricing';

--- a/includes/modules/order_total/ot_gv.php
+++ b/includes/modules/order_total/ot_gv.php
@@ -12,20 +12,95 @@
  *
  */
 class ot_gv {
+
+    /**
+     * $_check is used to check the configuration key set up
+     * @var int
+     */
+    protected $_check;
+    /**
+     * $calculate_tax determines how tax should be applied to coupon Standard, Credit Note, None
+     * @var string
+     */
+    public $calculate_tax;
+    /**
+     * $checkbox is the output to request the amount of gift vouchers the user wants to redeem
+     * @var string
+     */
+    public $checkbox;
+    /**
+     * $code determines the internal 'code' name used to designate "this" order total module
+     * @var string
+     */
+    public $code;
+    /**
+     * $credit_class flag to indicate order totals method is a credit class
+     * @var boolean
+     */
+    public $credit_class;
+    /**
+     * $credit_tax if 'true' tax is to be calculated on purchased GVs
+     * @var string
+     */
+    public $credit_tax;
+    /**
+     * $deduction amount of deduction calculated/afforded while being applied to an order
+     * @var float|null
+     */
+    protected $deduction;
+    /**
+     * $description is a soft name for this order total method
+     * @var string 
+     */
+    public $description;
+    /**
+     * $header the module box header 
+     * @var string
+     */
+    public $header;
+    /**
+     * $include_shipping allow shipping costs to be discounted by coupon if 'true'
+     * @var string
+     */
+    public $include_shipping;
+    /**
+     * $include_tax allow tax to be discounted by coupon if 'true'
+     * @var string
+     */
+    public $include_tax;
+    /**
+     * $sort_order is the order priority of this order total module when displayed
+     * @var int
+     */
+    public $sort_order;
+    /**
+     * $tax_class is the Tax class to be applied to the coupon cost
+     * @var
+     */
+    public $tax_class;
+    /**
+     * $title is the displayed name for this order total method
+     * @var string
+     */
+    public $title;
+    /**
+     * $output is an array of the display elements used on checkout pages
+     * @var array
+     */
+    public $output = [];
+    /**
+     * $user_prompt string to request redemption of gift vouchers
+     * @var string
+     */
+    public $user_prompt;
+    /**
+     * $validation_errors is an array of error messages from coupon validation
+     * @var array
+     */
+    protected $validation_errors = [];
+  
   /**
-   * Enter description here...
-   *
-   * @var unknown_type
-   */
-  var $title;
-  /**
-   * Enter description here...
-   *
-   * @var unknown_type
-   */
-  var $output;
-  /**
-   * Enter description here...
+   * process gift vouchers
    *
    * @return ot_gv
    */
@@ -393,12 +468,12 @@ class ot_gv {
    */
   function check() {
     global $db;
-    if (!isset($this->check)) {
+    if (!isset($this->_check)) {
       $check_query = $db->Execute("SELECT configuration_value FROM " . TABLE_CONFIGURATION . " WHERE configuration_key = 'MODULE_ORDER_TOTAL_GV_STATUS'");
-      $this->check = $check_query->RecordCount();
+      $this->_check = $check_query->RecordCount();
     }
 
-    if ($this->check) {
+    if ($this->_check) {
       // move switch for admin-display of queue in header from lang file to module settings
       if (!defined('MODULE_ORDER_TOTAL_GV_SHOW_QUEUE_IN_ADMIN')) {
           $db->Execute("INSERT INTO " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) VALUES ('Show Queue in Admin header?', 'MODULE_ORDER_TOTAL_GV_SHOW_QUEUE_IN_ADMIN', 'true', 'Show Queue button on all pages of Admin?<br>(Will auto-hide if nothing in queue, and will auto-display on \'Orders\' screen, regardless of this setting)', '6', '3','zen_cfg_select_option(array(\'true\', \'false\'), ', now())");
@@ -409,7 +484,7 @@ class ot_gv {
 
     }
 
-    return $this->check;
+    return $this->_check;
   }
   /**
    * Enter description here...

--- a/includes/modules/order_total/ot_loworderfee.php
+++ b/includes/modules/order_total/ot_loworderfee.php
@@ -8,7 +8,37 @@
  * @version $Id: DrByte 2020 Dec 25 Modified in v1.5.8-alpha $
  */
   class ot_loworderfee {
-    var $title, $output;
+
+    /**
+     * $_check is used to check the configuration key set up
+     * @var int
+     */
+    protected $_check;
+    /**
+     * $code determines the internal 'code' name used to designate "this" order total module
+     * @var string
+     */
+    public $code;
+    /**
+     * $description is a soft name for this order total method
+     * @var string 
+     */
+    public $description;
+    /**
+     * $sort_order is the order priority of this order total module when displayed
+     * @var int
+     */
+    public $sort_order;
+    /**
+     * $title is the displayed name for this order total method
+     * @var string
+     */
+    public $title;
+    /**
+     * $output is an array of the display elements used on checkout pages
+     * @var array
+     */
+    public $output = [];
 
     function __construct() {
       $this->code = 'ot_loworderfee';

--- a/includes/modules/order_total/ot_shipping.php
+++ b/includes/modules/order_total/ot_shipping.php
@@ -9,12 +9,36 @@
  */
 class ot_shipping extends base
 {
-    public    $code,
-              $title,
-              $description,
-              $sort_order,
-              $output;
+    /**
+     * $_check is used to check the configuration key set up
+     * @var int
+     */
     protected $_check;
+    /**
+     * $code determines the internal 'code' name used to designate "this" order total module
+     * @var string
+     */
+    public $code;
+    /**
+     * $description is a soft name for this order total method
+     * @var string 
+     */
+    public $description;
+    /**
+     * $sort_order is the order priority of this order total module when displayed
+     * @var int
+     */
+    public $sort_order;
+    /**
+     * $title is the displayed name for this order total method
+     * @var string
+     */
+    public $title;
+    /**
+     * $output is an array of the display elements used on checkout pages
+     * @var array
+     */
+    public $output = [];
 
     public function __construct() 
     {

--- a/includes/modules/order_total/ot_subtotal.php
+++ b/includes/modules/order_total/ot_subtotal.php
@@ -8,7 +8,37 @@
  * @version $Id: DrByte 2020 Jul 10 Modified in v1.5.8-alpha $
  */
   class ot_subtotal {
-    var $title, $output;
+
+    /**
+     * $_check is used to check the configuration key set up
+     * @var int
+     */
+    protected $_check;
+    /**
+     * $code determines the internal 'code' name used to designate "this" order total module
+     * @var string
+     */
+    public $code;
+    /**
+     * $description is a soft name for this order total method
+     * @var string 
+     */
+    public $description;
+    /**
+     * $sort_order is the order priority of this order total module when displayed
+     * @var int
+     */
+    public $sort_order;
+    /**
+     * $title is the displayed name for this order total method
+     * @var string
+     */
+    public $title;
+    /**
+     * $output is an array of the display elements used on checkout pages
+     * @var array
+     */
+    public $output = [];
 
     function __construct() {
       $this->code = 'ot_subtotal';

--- a/includes/modules/order_total/ot_tax.php
+++ b/includes/modules/order_total/ot_tax.php
@@ -12,8 +12,36 @@
 
     class ot_tax
     {
-        public $title;
-        public $output;
+     /**
+     * $_check is used to check the configuration key set up
+     * @var int
+     */
+    protected $_check;
+    /**
+     * $code determines the internal 'code' name used to designate "this" order total module
+     * @var string
+     */
+    public $code;
+    /**
+     * $description is a soft name for this order total method
+     * @var string 
+     */
+    public $description;
+    /**
+     * $sort_order is the order priority of this order total module when displayed
+     * @var int
+     */
+    public $sort_order;
+    /**
+     * $title is the displayed name for this order total method
+     * @var string
+     */
+    public $title;
+    /**
+     * $output is an array of the display elements used on checkout pages
+     * @var array
+     */
+    public $output = [];
 
         public function __construct()
         {

--- a/includes/modules/order_total/ot_total.php
+++ b/includes/modules/order_total/ot_total.php
@@ -8,7 +8,37 @@
  * @version $Id: DrByte 2020 Jul 10 Modified in v1.5.8-alpha $
  */
   class ot_total {
-    var $title, $output;
+
+    /**
+     * $_check is used to check the configuration key set up
+     * @var int
+     */
+    protected $_check;
+    /**
+     * $code determines the internal 'code' name used to designate "this" order total module
+     * @var string
+     */
+    public $code;
+    /**
+     * $description is a soft name for this order total method
+     * @var string 
+     */
+    public $description;
+    /**
+     * $sort_order is the order priority of this order total module when displayed
+     * @var int
+     */
+    public $sort_order;
+    /**
+     * $title is the displayed name for this order total method
+     * @var string
+     */
+    public $title;
+    /**
+     * $output is an array of the display elements used on checkout pages
+     * @var array
+     */
+    public $output = [];
 
     function __construct() {
       $this->code = 'ot_total';


### PR DESCRIPTION
## order_total

Set to public used/required outside module
- $modules;

## All order total modules

Set to protected as not required outside module
- $_check;

Set to public used/required outside module
- $code;
- $description;
- $sort_order;
- $title;
- $output = [];

## Additional requirements by module

### ot_cod_fee

Set to public used/required outside module
- $enabled;

### ot_coupon

$check changed to $_check for consistency.

Set to protected as not required outside module
- $coupon_code;
- $deduction;
- $validation_errors = [];

Set to public used/required outside module
- $calculate_tax;
- $credit_class;
- $header;
- $include_shipping;
- $include_tax;
- $tax_class;
- $user_prompt;

### ot_group_pricing

Set to protected as not required outside module
- $deduction;

Set to public used/required outside module
- $calculate_tax;
- $credit_class;
- $include_shipping;
- $include_tax;
- $tax_class;

### ot_gv

$check changed to $_check for consistency.

Set to protected as not required outside module
- $deduction;
- $validation_errors = [];

Set to public used/required outside module
- $calculate_tax;
- $checkbox;
- $credit_class;
- $credit_tax;
- $header;
- $include_shipping;
- $include_tax;
- $tax_class;
- $user_prompt;