### PR TITLE
HTML5 Width

### DIFF
--- a/admin/countries.php
+++ b/admin/countries.php
@@ -98,7 +98,7 @@ if (!empty($action)) {
           <table class="table table-hover">
             <thead>
               <tr class="dataTableHeadingRow">
-                <th class="dataTableHeadingContent" width="50%"><?php echo TABLE_HEADING_COUNTRY_NAME; ?></th>
+                <th class="dataTableHeadingContent col-sm-6"><?php echo TABLE_HEADING_COUNTRY_NAME; ?></th>
                 <th class="dataTableHeadingContent text-center" colspan="2"><?php echo TABLE_HEADING_COUNTRY_CODES; ?></th>
                 <th class="dataTableHeadingContent text-center"><?php echo TABLE_HEADING_COUNTRY_STATUS; ?></th>
                 <th class="dataTableHeadingContent text-right"><?php echo TABLE_HEADING_ACTION; ?></th>
@@ -122,7 +122,7 @@ if (!empty($action)) {
                   <?php } else { ?>
                   <tr class="dataTableRow country-listing-row" onclick="document.location.href = '<?php echo zen_href_link(FILENAME_COUNTRIES, zen_get_all_get_params(array('cID', 'action')) . 'cID=' . $country['countries_id']); ?>'" data-cid="<?php echo $country['countries_id']; ?>">
                   <?php } ?>
-                  <td class="dataTableContent" width="50%"><?php echo zen_output_string_protected($country['countries_name']); ?></td>
+                  <td class="dataTableContent col-sm-6"><?php echo zen_output_string_protected($country['countries_name']); ?></td>
                   <td class="dataTableContent text-center"><?php echo $country['countries_iso_code_2']; ?></td>
                   <td class="dataTableContent text-center"><?php echo $country['countries_iso_code_3']; ?></td>
                   <td class="dataTableContent text-center dataTableButtonCell">

--- a/admin/coupon_admin.php
+++ b/admin/coupon_admin.php
@@ -701,7 +701,7 @@ switch ($_GET['action']) {
             ?>
             <table class="table">
               <tr>
-                <td width="25%" class="text-right"><b><?php echo TEXT_CUSTOMER; ?></b></td>
+                <td class="text-right col-sm-3"><b><?php echo TEXT_CUSTOMER; ?></b></td>
                 <td><?php echo $mail_sent_to; ?></td>
               </tr>
               <tr>
@@ -803,7 +803,7 @@ switch ($_GET['action']) {
             ?>
             <table class="table">
               <tr>
-                <td width="25%" class="main"><?php echo COUPON_ZONE_RESTRICTION; ?></td>
+                <td class="main col-sm-3"><?php echo COUPON_ZONE_RESTRICTION; ?></td>
                 <td class="main"><?php echo zen_get_geo_zone_name($_POST['coupon_zone_restriction']); ?>
               </tr>
               <tr>

--- a/admin/coupon_admin_export.php
+++ b/admin/coupon_admin_export.php
@@ -310,14 +310,14 @@ require (DIR_WS_INCLUDES . 'header.php');
 <!-- header_eof //-->
 
 <!-- body //-->
-<table border="0" width="100%" cellspacing="2" cellpadding="2">
+<table class="col-sm-12" border="0" cellspacing="2" cellpadding="2">
   <tr>
     <!-- body_text //-->
-    <td class="align-top" width="100%">
-    <table border="0" width="100%" cellspacing="0" cellpadding="0">
+    <td class="align-top col-sm-12">
+    <table class="col-sm-12" border="0" cellspacing="0" cellpadding="0">
       <tr>
-        <td width="100%">
-        <table border="0" width="100%" cellspacing="0" cellpadding="0">
+        <td class="col-sm-12">
+        <table class="col-sm-12" border="0" cellspacing="0" cellpadding="0">
           <tr>
             <td class="pageHeading"><?php echo HEADING_TITLE; ?></td>
             <td class="pageHeading text-right"><?php echo zen_draw_separator('pixel_trans.gif', HEADING_IMAGE_WIDTH, HEADING_IMAGE_HEIGHT); ?></td>

--- a/admin/gv_mail.php
+++ b/admin/gv_mail.php
@@ -204,7 +204,7 @@ if (!empty($_GET['mail_sent_to']) && $_GET['mail_sent_to']) {
           <?php echo zen_draw_form('mail', FILENAME_GV_MAIL, 'action=send_email_to_user'); ?>
           <table class="table">
             <tr>
-              <td width="25%" class="text-right"><b><?php echo TEXT_FROM; ?></b></td>
+              <td class="text-right col-sm-3"><b><?php echo TEXT_FROM; ?></b></td>
               <td><?php echo htmlspecialchars(stripslashes($_POST['from']), ENT_COMPAT, CHARSET, true); ?></td>
             </tr>
             <tr>

--- a/admin/includes/javascript/calendarcode.js
+++ b/admin/includes/javascript/calendarcode.js
@@ -220,7 +220,7 @@ function Calendar(whatMonth,whatYear) {
         output += '<table width="185" border="3" class="cal-Table" cellspacing="0" cellpadding="0"><form name="Cal"><tr>';
     }
      
-    output += '<td class="cal-HeadCell text-center" width="100%"><a href="javascript:clearDay();"><img name="calbtn1" src="./images/cal_del_small.gif" border="0" width="12" height="10"></a>&nbsp;&nbsp;<a href="javascript:scrollMonth(-1);" class="cal-DayLink">&lt;</a>&nbsp;<SELECT class="cal-TextBox" NAME="cboMonth" onChange="changeMonth();">';
+    output += '<td class="cal-HeadCell text-center col-sm-12"><a href="javascript:clearDay();"><img name="calbtn1" src="./images/cal_del_small.gif" border="0" width="12" height="10"></a>&nbsp;&nbsp;<a href="javascript:scrollMonth(-1);" class="cal-DayLink">&lt;</a>&nbsp;<SELECT class="cal-TextBox" NAME="cboMonth" onChange="changeMonth();">';
     for (month=0; month<12; month++) {
         if (month == whatMonth) output += '<OPTION VALUE="' + month + '" SELECTED>' + names[month] + '<\/OPTION>';
         else                output += '<OPTION VALUE="' + month + '">'          + names[month] + '<\/OPTION>';
@@ -233,7 +233,7 @@ function Calendar(whatMonth,whatYear) {
         else              output += '<OPTION VALUE="' + year + '">'          + year + '<\/OPTION>';
     }
 
-    output += '<\/SELECT>&nbsp;<a href="javascript:scrollMonth(1);" class="cal-DayLink">&gt;</a>&nbsp;&nbsp;<a href="javascript:hideCalendar();"><img name="calbtn2" src="./images/cal_close_small.gif" border="0" width="12" height="10"></a><\/td><\/tr><tr><td width="100%" class="text-center">';
+    output += '<\/SELECT>&nbsp;<a href="javascript:scrollMonth(1);" class="cal-DayLink">&gt;</a>&nbsp;&nbsp;<a href="javascript:hideCalendar();"><img name="calbtn2" src="./images/cal_close_small.gif" border="0" width="12" height="10"></a><\/td><\/tr><tr><td class="text-center col-sm-12">';
 
     firstDay = new Date(whatYear,whatMonth,1);
     startDay = firstDay.getDay();

--- a/admin/media_manager.php
+++ b/admin/media_manager.php
@@ -133,12 +133,12 @@
 <!-- header_eof //-->
 
 <!-- body //-->
-<table border="0" width="100%" cellspacing="2" cellpadding="2">
+<table class="col-sm-12" border="0" cellspacing="2" cellpadding="2">
   <tr>
 <!-- body_text //-->
-    <td class="align-top" width="100%"><table border="0" width="100%" cellspacing="0" cellpadding="2">
+    <td class="align-top col-sm-12" ><table class="col-sm-12" border="0" cellspacing="0" cellpadding="2">
       <tr>
-        <td width="100%"><table border="0" width="100%" cellspacing="0" cellpadding="0">
+        <td class="col-sm-12"><table class="col-sm-12" border="0" cellspacing="0" cellpadding="0">
           <tr>
             <td class="pageHeading"><?php echo HEADING_TITLE_MEDIA_MANAGER; ?></td>
             <td class="pageHeading text-right"><?php echo zen_draw_separator('pixel_trans.gif', HEADING_IMAGE_WIDTH, HEADING_IMAGE_HEIGHT); ?></td>
@@ -146,9 +146,9 @@
         </table></td>
       </tr>
       <tr>
-        <td><table border="0" width="100%" cellspacing="0" cellpadding="0">
+        <td><table class="col-sm-12" border="0" cellspacing="0" cellpadding="0">
           <tr>
-            <td class="align-top"><table border="0" width="100%" cellspacing="0" cellpadding="2">
+            <td class="align-top"><table class="col-sm-12" border="0" cellspacing="0" cellpadding="2">
               <tr class="dataTableHeadingRow">
                 <td class="dataTableHeadingContent"><?php echo TABLE_HEADING_MEDIA; ?></td>
                 <td class="dataTableHeadingContent text-right"><?php echo TABLE_HEADING_ACTION; ?>&nbsp;</td>
@@ -181,7 +181,7 @@
   }
 ?>
               <tr>
-                <td colspan="2"><table border="0" width="100%" cellspacing="0" cellpadding="2">
+                <td colspan="2"><table class="col-sm-12" border="0" cellspacing="0" cellpadding="2">
                   <tr>
                     <td class="smallText align-top"><?php echo $media_split->display_count($media_query_numrows, MAX_DISPLAY_SEARCH_RESULTS, $_GET['page'], TEXT_DISPLAY_NUMBER_OF_MEDIA); ?></td>
                     <td class="smallText text-right"><?php echo $media_split->display_links($media_query_numrows, MAX_DISPLAY_SEARCH_RESULTS, MAX_DISPLAY_PAGE_LINKS, $_GET['page']); ?></td>
@@ -319,7 +319,7 @@
   }
 
   if (!empty($heading) && !empty($contents)) {
-    echo '            <td class="align-top" width="25%">' . "\n";
+    echo '            <td class="align-top col-sm-3">' . "\n";
 
     $box = new box;
     echo $box->infoBox($heading, $contents);

--- a/admin/salemaker.php
+++ b/admin/salemaker.php
@@ -532,7 +532,7 @@ if (!empty($action)) {
 
                   $contents[] = array('text' => '<br>' . TEXT_INFO_DEDUCTION . ' ' . $sInfo->sale_deduction_value . ' ' . $deduction_type_array[$sInfo->sale_deduction_type]['text']);
                   $contents[] = array('text' => '' . TEXT_INFO_PRICERANGE_FROM . ' ' . $currencies->format($sInfo->sale_pricerange_from) . TEXT_INFO_PRICERANGE_TO . $currencies->format($sInfo->sale_pricerange_to));
-                  $contents[] = array('text' => '<table class="dataTableContent" border="0" width="100%" cellspacing="0" cellpadding="0"><tr><td valign="top">' . TEXT_INFO_SPECIALS_CONDITION . '&nbsp;</td><td>' . $specials_condition_array[$sInfo->sale_specials_condition]['text'] . '</td></tr></table>');
+                  $contents[] = array('text' => '<table class="dataTableContent col-sm-12" border="0" cellspacing="0" cellpadding="0"><tr><td valign="top">' . TEXT_INFO_SPECIALS_CONDITION . '&nbsp;</td><td>' . $specials_condition_array[$sInfo->sale_specials_condition]['text'] . '</td></tr></table>');
 
                   $contents[] = array('text' => '<br>' . TEXT_INFO_DATE_START . ' ' . (($sInfo->sale_date_start == '0001-01-01') ? TEXT_SALEMAKER_IMMEDIATELY : zen_date_short($sInfo->sale_date_start)));
                   $contents[] = array('text' => '' . TEXT_INFO_DATE_END . ' ' . (($sInfo->sale_date_end == '0001-01-01') ? TEXT_SALEMAKER_NEVER : zen_date_short($sInfo->sale_date_end)));

--- a/admin/stats_sales_report_graphs.php
+++ b/admin/stats_sales_report_graphs.php
@@ -288,7 +288,7 @@ for ($i = 0; $i < $report->size; $i++) {
         </table>
         <table class="table table-condensed">
           <tr class="dataTableRow">
-            <td class="dataTableContent text-left" width="80%"><?php echo FILTER_STATUS ?></td>
+            <td class="dataTableContent text-left col-sm-10"><?php echo FILTER_STATUS ?></td>
             <td class="dataTableContent text-right"><?php echo FILTER_VALUE ?></td>
           </tr>
           <?php
@@ -306,7 +306,7 @@ for ($i = 0; $i < $report->size; $i++) {
                 $tmp = substr($sales_report_filter, 0, $i) . "1" . substr($sales_report_filter, $i + 1, $report->status_available_size - ($i + 1));
                 $tmp = zen_href_link(FILENAME_STATS_SALES_REPORT_GRAPHS, $report->filter_link . "&filter=" . $tmp);
                 ?>
-                <td class="dataTableContent text-right" width="100%">
+                <td class="dataTableContent text-right col-sm-12">
                   <?php echo zen_image(DIR_WS_IMAGES . 'icon_status_green.gif', IMAGE_ICON_STATUS_GREEN, 10, 10) ?>&nbsp;
                   <a href="<?php echo $tmp; ?>"><?php echo zen_image(DIR_WS_IMAGES . 'icon_status_red_light.gif', IMAGE_ICON_STATUS_RED_LIGHT, 10, 10) ?></a></td>
                 <?php
@@ -314,7 +314,7 @@ for ($i = 0; $i < $report->size; $i++) {
                 $tmp = substr($sales_report_filter, 0, $i) . "0" . substr($sales_report_filter, $i + 1);
                 $tmp = zen_href_link(FILENAME_STATS_SALES_REPORT_GRAPHS, $report->filter_link . "&filter=" . $tmp);
                 ?>
-                <td class="dataTableContent text-right" width="100%">
+                <td class="dataTableContent text-right col-sm-12">
                   <a href="<?php echo $tmp; ?>"><?php echo zen_image(DIR_WS_IMAGES . 'icon_status_green_light.gif', IMAGE_ICON_STATUS_GREEN, 10, 10) ?></a>
                   &nbsp;<?php echo zen_image(DIR_WS_IMAGES . 'icon_status_red.gif', IMAGE_ICON_STATUS_RED_LIGHT, 10, 10) ?></td>
                 <?php


### PR DESCRIPTION
Replace width with css in \<table> and \<td> elements

Fix html5 validation error
Error The width attribute on the \<> element is obsolete. Use CSS instead.

fix #5220 