### PR TITLE
Fix PHP_OS check to look at first 3 chars only

### DIFF
--- a/includes/functions/functions_dates.php
+++ b/includes/functions/functions_dates.php
@@ -52,7 +52,9 @@ function zen_date_long($raw_date)
 
     global $zcDate;
     $retVal = $zcDate->output(DATE_FORMAT_LONG, mktime($hour, $minute, $second, $month, $day, $year));
-    if (stristr(PHP_OS, 'win')) return utf8_encode($retVal);
+    if (stristr(PHP_OS, 'win') === 0) {
+       return utf8_encode($retVal);
+    }
     return $retVal;
 }
 


### PR DESCRIPTION
Checking for "win" anywhere in the string returns true for "Darwin" (MacOS). 
This is the only check in the core that doesn't look only at the first three characters. 