### PR TITLE
Remove utf8 conversion for Windows

### DIFF
--- a/includes/functions/functions_dates.php
+++ b/includes/functions/functions_dates.php
@@ -52,9 +52,6 @@ function zen_date_long($raw_date)
 
     global $zcDate;
     $retVal = $zcDate->output(DATE_FORMAT_LONG, mktime($hour, $minute, $second, $month, $day, $year));
-    if (stristr(PHP_OS, 'win') === 0) {
-       return utf8_encode($retVal);
-    }
     return $retVal;
 }
 


### PR DESCRIPTION
Per #5224 testing by @torvista the call to `utf8_encode` should not be required anymore for PHP 8.0 and 8.1.

Rather than add code to deal with the edge case of {PHP7.4, ZC 1.5.8}, I'd rather remove this conversion since `utf8_encode` has been deprecated in PHP 8.2 