### PR TITLE
Refactor SqlPatchInstaller

### DIFF
--- a/admin/includes/languages/english/lang.plugin_manager.php
+++ b/admin/includes/languages/english/lang.plugin_manager.php
@@ -44,6 +44,9 @@ $define = [
     'TEXT_INFO_UPGRADE_WARNING' => '',
     'TEXT_INFO_CONFIRM_CLEAN' => 'Confirm version directories to clean/remove',
     'TEXT_LABEL_STATUS' => 'Status: ',
+    'ERROR_NOT_FOUND_IN_SQL_FUNCTIONS_MAP' => 'Check your sql statement. A sql function map cannot be found for : ',
+    'ERROR_INVALID_SYNTAX' => 'The table cannot be identified as syntax is invalid in: ',
+    'ERROR_SQL_PATCH' => 'Error while processing SQL install. ',
 ];
 
 return $define;

--- a/includes/classes/PluginSupport/SqlPatchInstaller.php
+++ b/includes/classes/PluginSupport/SqlPatchInstaller.php
@@ -9,23 +9,36 @@ namespace Zencart\PluginSupport;
 
 class SqlPatchInstaller
 {
+
+    /**
+     * $dbConn is a database object 
+     * @var object
+     */
     protected $dbConn;
-    protected $errors = [];
+    /**
+     * $errorContainer is a PluginErrorContainer object
+     * @var object
+     */
+    protected $errorContainer;
+    /**
+     * $sqlFunctionMap is a list of acceptable SQL 
+     * @var array
+     */
     protected $sqlFunctionMap = [
-        ['find' => 'DROP TABLE IF EXISTS ', 'length' => 21, 'method' => 'basic', 'tableParamsOffset' => 1],
-        ['find' => 'DROP TABLE ', 'length' => 11, 'method' => 'basic', 'tableParamsOffset' => 1],
+        ['find' => 'DROP TABLE IF EXISTS ', 'length' => 21, 'method' => 'basic', 'tableParamsOffset' => 4],
+        ['find' => 'DROP TABLE ', 'length' => 11, 'method' => 'basic', 'tableParamsOffset' => 2],
         ['find' => 'CREATE TABLE IF NOT EXISTS ', 'length' => 27, 'method' => 'basic', 'tableParamsOffset' => 5],
         ['find' => 'CREATE TABLE ', 'length' => 13, 'method' => 'basic', 'tableParamsOffset' => 2],
         ['find' => 'TRUNCATE TABLE ', 'length' => 15, 'method' => 'basic', 'tableParamsOffset' => 2],
-        ['find' => 'REPLACE INTO ', 'length' => 13, 'method' => 'replaceinto', 'tableParamsOffset' => 1],
+        ['find' => 'REPLACE INTO ', 'length' => 13, 'method' => 'basic', 'tableParamsOffset' => 2],
         ['find' => 'INSERT INTO ', 'length' => 12, 'method' => 'basic', 'tableParamsOffset' => 2],
         ['find' => 'INSERT IGNORE INTO ', 'length' => 19, 'method' => 'basic', 'tableParamsOffset' => 3],
-        ['find' => 'ALTER TABLE ', 'length' => 12, 'method' => 'basic', 'tableParamsOffset' => 1],
-        ['find' => 'RENAME TABLE ', 'length' => 13, 'method' => 'renameTable', 'tableParamsOffset' => 1],
+        ['find' => 'ALTER TABLE ', 'length' => 12, 'method' => 'basic', 'tableParamsOffset' => 2],
+        ['find' => 'RENAME TABLE ', 'length' => 13, 'method' => 'renameTable', 'tableParamsOffset' => 2],
         ['find' => 'UPDATE ', 'length' => 7, 'method' => 'basic', 'tableParamsOffset' => 1],
         ['find' => 'DELETE FROM ', 'length' => 12, 'method' => 'basic', 'tableParamsOffset' => 2],
-        ['find' => 'DROP INDEX ', 'length' => 11, 'method' => 'dropIndex', 'tableParamsOffset' => 1],
-        ['find' => 'CREATE INDEX ', 'length' => 13, 'method' => 'createIndex', 'tableParamsOffset' => 1],
+        ['find' => 'DROP INDEX ', 'length' => 11, 'method' => 'index', 'tableParamsOffset' => 2],
+        ['find' => 'CREATE INDEX ', 'length' => 13, 'method' => 'index', 'tableParamsOffset' => 2],
         ['find' => 'SELECT ', 'length' => 7, 'method' => 'select', 'tableParamsOffset' => 1],
     ];
 
@@ -42,9 +55,6 @@ class SqlPatchInstaller
         $paramLines = [];
         foreach ($builtLines as $line) {
             $paramLines[] = $this->processLine($line);
-            if ($this->errorContainer->hasErrors()) {
-                break;
-            }
         }
         return $paramLines;
     }
@@ -56,7 +66,7 @@ class SqlPatchInstaller
             $sql = implode(' ', $line) . ';';
             $this->dbConn->execute($sql);
             if ($this->dbConn->error_number !== 0) {
-                $this->errorContainer->addError(0, $this->dbConn->error_text);
+                $this->errorContainer->addError(0, ERROR_SQL_PATCH . $this->dbConn->error_text . '<br>' . $sql, true);
                 break;
             }
         }
@@ -84,11 +94,17 @@ class SqlPatchInstaller
         $type = $this->findSqlLineType(strtoupper($line));
 
         if (count($type) === 0) {
-            $this->errors[] = 'NOT FOUND ' . $line;
+             $this->errorContainer->addError(0, ERROR_NOT_FOUND_IN_SQL_FUNCTIONS_MAP. $line, true);
             return [];
         }
         $method = 'processLine' . ucfirst($type['method']);
         $newParams = $this->$method($params, $type);
+        /*
+         * if empty the line could not be correctly parsed
+         */
+        if (empty($newParams)) {
+             $this->errorContainer->addError(0, ERROR_INVALID_SYNTAX . $line, true);            
+        }
         return $newParams;
     }
 
@@ -114,10 +130,33 @@ class SqlPatchInstaller
     protected function processLineSelect($params, $typeEntry)
     {
         $fromKey = array_search('FROM', $params);
-        $params[$fromKey + 1] = DB_PREFIX . $params[$fromKey + 1];
-        if ($fromKey = array_search('JOIN', $params)) {
-            $params[$fromKey + 1] = DB_PREFIX . $params[$fromKey + 1];
+        if ($fromKey === false) {
+            return [];
         }
+        $params[$fromKey + 1] = DB_PREFIX . $params[$fromKey + 1];
+        $joinKeys = array_keys($params, 'JOIN');
+        if (!empty($joinKeys)) {
+            foreach ($joinKeys as $fromKey) {
+                $params[$fromKey + 1] = DB_PREFIX . $params[$fromKey + 1];
+            }
+        }
+        return $params;
+    }
+    
+    protected function processLineIndex($params, $typeEntry)
+    {
+        $fromKey = array_search('ON', $params);
+        if ($fromKey === false) {
+            return [];
+        }
+        $params[$fromKey + 1] = DB_PREFIX . $params[$fromKey + 1];
+        return $params;
+    }
+    
+    protected function processLineRenameTable($params, $typeEntry)
+    {
+        $params[$typeEntry['tableParamsOffset']] = DB_PREFIX . $params[$typeEntry['tableParamsOffset']];
+        $params[$typeEntry['tableParamsOffset'] + 2] = DB_PREFIX . $params[$typeEntry['tableParamsOffset'] + 2];
         return $params;
     }
 }


### PR DESCRIPTION
- Define parameters
- Correct tableParamsOffset
- Remove break from function parse, so all errors are reported, not just first.
- Remove hard coding of error message in function processLine
- Add error for invalid syntax in function processLine
- Add check for missing FROM in processLineSelect
- Recode Join to find and process all joins in processLineSelect
- Add missing function processLineIndex to process create and drop index
- Add missing function processLineRenameTable to process rename table index
- Make sql error a friendly error, so an error is displayed if there is a failure installing install.sql

fix #5228 

Note more could be done to improve this. Currently, if you double-space anything, it will fail. Not an easy fix. Will add to documentation.