### PR TITLE
Prevent log on product creation

### DIFF
--- a/admin/includes/modules/update_product.php
+++ b/admin/includes/modules/update_product.php
@@ -26,7 +26,9 @@ if (isset($_POST['edit']) && $_POST['edit'] == 'edit') {
   }
   $products_date_available = (date('Y-m-d') < $products_date_available) ? $products_date_available : 'null';
 
-  $zco_notifier->notify('NOTIFY_MODULES_UPDATE_PRODUCT_START', ['action' => $action, 'products_id' => $products_id]);
+  if (!empty($products_id)) { 
+    $zco_notifier->notify('NOTIFY_MODULES_UPDATE_PRODUCT_START', ['action' => $action, 'products_id' => $products_id]);
+  }
 
   // Data-cleaning to prevent data-type mismatch errors:
   $sql_data_array = array(


### PR DESCRIPTION
```
[18-Sep-2022 14:03:18 UTC] Request URI: /gh_demo_158/admin/index.php?cmd=product&cPath=18&action=insert_product, IP address: ::1
#0 /Users/scott/sites/gh_demo_158/admin/includes/modules/update_product.php(29): zen_debug_error_handler()
#1 /Users/scott/sites/gh_demo_158/admin/product.php(33): require('/Users/scott/si...')
#2 /Users/scott/sites/gh_demo_158/admin/index.php(11): require('/Users/scott/si...')
--> PHP Warning: Undefined variable $products_id in /Users/scott/sites/gh_demo_158/admin/includes/modules/update_product.php on line 29.
```
