### PR TITLE
Fix product edit Preview->Back to have product id

### DIFF
--- a/admin/includes/modules/product/collect_info.php
+++ b/admin/includes/modules/product/collect_info.php
@@ -56,7 +56,7 @@ if (isset($_GET['pID']) && empty($_POST)) {
   $pInfo->updateObjectInfo($product->fields);
 } elseif (!empty($_POST)) {
   $pInfo->updateObjectInfo($_POST);
-  if (isset($_GET['pID'])) { 
+  if (isset($_GET['pID'])) {
      $pInfo->products_id = (int)$_GET['pID']; 
   }
   $products_name = isset($_POST['products_name']) ? $_POST['products_name'] : '';

--- a/admin/includes/modules/product/collect_info.php
+++ b/admin/includes/modules/product/collect_info.php
@@ -56,6 +56,9 @@ if (isset($_GET['pID']) && empty($_POST)) {
   $pInfo->updateObjectInfo($product->fields);
 } elseif (!empty($_POST)) {
   $pInfo->updateObjectInfo($_POST);
+  if (isset($_GET['pID'])) { 
+     $pInfo->products_id = (int)$_GET['pID']; 
+  }
   $products_name = isset($_POST['products_name']) ? $_POST['products_name'] : '';
   $products_description = isset($_POST['products_description']) ? $_POST['products_description'] : '';
   $products_url = isset($_POST['products_url']) ? $_POST['products_url'] : '';


### PR DESCRIPTION
Corrected from #5239 

After a product edit, then preview, then back, the $pInfo->products_id field is not set. This means that notifiers get called without this value, and fail.

This should be done for other product types too but I wanted to get this one in first.