### PR TITLE
PHP8.2 Define Parameters php82PaymentMethod Authorize

### DIFF
--- a/includes/modules/payment/authorizenet.php
+++ b/includes/modules/payment/authorizenet.php
@@ -17,45 +17,45 @@ class authorizenet extends base {
    *
    * @var string
    */
-  var $code = 'authorizenet'; // SIM
+  public $code = 'authorizenet'; // SIM
   /**
    * Internal module version string
    * @var string
    */
-  var $version = '2019-02-26';
+  protected $version = '2019-02-26';
   /**
    * $title is the displayed name for this payment method
    *
    * @var string
    */
-  var $title;
+  public $title;
   /**
    * $description is a soft name for this payment method
    *
    * @var string
    */
-  var $description;
+  public $description;
   /**
    * $enabled determines whether this module shows or not... in catalog.
    *
    * @var boolean
    */
-  var $enabled = false;
+  public $enabled = false;
   /**
    * log file folder
    *
    * @var string
    */
-  var $_logDir = '';
+  private $_logDir = '';
   /**
    * vars
    */
-  var $gateway_mode;
-  var $reportable_submit_data;
-  var $authorize;
-  var $auth_code;
-  var $transaction_id;
-  var $order_status;
+  protected $gateway_mode;
+  protected $reportable_submit_data;
+  protected $authorize;
+  public $auth_code;
+  public $transaction_id;
+  public $order_status;
   /**
    * @var string the currency enabled in this gateway's merchant account
    */
@@ -64,8 +64,15 @@ class authorizenet extends base {
    * What order this module displays in relation to other enabled modules
    * @var int $sort_order
    */
-  var $sort_order = 0;
+  public $sort_order = 0;
 
+    private $_check;
+    protected $cc_card_number;
+    protected $cc_card_type;
+    protected $cc_expiry_month;
+    protected $cc_expiry_year;
+    public $form_action_url;
+    public $submit_extras;
 
   /**
    * Constructor

--- a/includes/modules/payment/authorizenet_aim.php
+++ b/includes/modules/payment/authorizenet_aim.php
@@ -17,25 +17,25 @@ class authorizenet_aim extends base {
    *
    * @var string
    */
-  var $code;
+  public $code;
   /**
    * $title is the displayed name for this payment method
    *
    * @var string
    */
-  var $title;
+  public $title;
   /**
    * $description is a soft name for this payment method
    *
    * @var string
    */
-  var $description;
+  public $description;
   /**
    * $enabled determines whether this module shows or not... in catalog.
    *
    * @var boolean
    */
-  var $enabled;
+  public $enabled;
   /**
    * Do we display specific info about CVV and/or Expiry Date errors?
    * The default is no, as Authorize.net also defaults to no.
@@ -60,22 +60,22 @@ class authorizenet_aim extends base {
    *
    * @var string
    */
-  var $_logDir = '';
+  private $_logDir = '';
   /**
    * communication vars
    */
-  var $authorize = '';
-  var $commErrNo = 0;
-  var $commError = '';
-  var $transaction_id = null;
+  protected $authorize = '';
+  protected $commErrNo = 0;
+  protected $commError = '';
+  public $transaction_id = null;
   /**
    * this module collects card-info onsite
    */
-  var $collectsCardDataOnsite = TRUE;
+  public $collectsCardDataOnsite = TRUE;
   /**
    * debug content var
    */
-  var $reportable_submit_data = array();
+  protected $reportable_submit_data = array();
   /**
    * Given that this module can be used to interact with other gateways (authnet emulators),
    * this var is used to declare which gateway to work with
@@ -85,6 +85,22 @@ class authorizenet_aim extends base {
    * @var string the currency enabled in this gateway's merchant account
    */
   private $gateway_currency;
+  
+    private $_check;
+    public $auth_code;
+    protected $avs_response;
+    protected $cc_card_number;
+    protected $cc_card_type;
+    protected $cc_expiry_month;
+    protected $cc_expiry_year;
+    protected $ccv_response;
+    protected $commInfo;
+    public $form_action_url;
+    protected $include_x_type;
+    public $order_status;
+    protected $proxy_tunnel_flag;
+    public $sort_order;
+    public $submit_extras;
 
   /**
    * Constructor


### PR DESCRIPTION
**Note: I have done these base on the code as I don't have Authorize set up to test.**

 ## authorizenet

 - var change to public
    - $code
    - $title 
    - $description 
    - $enabled 
    - $auth_code 
    - $transaction_id 
    - $order_status 
    - $sort_order

 - var changed to protected 
    - $version 
    - $gateway_mode 
    - $reportable_submit_data 
    - $authorize

 - var changed to private
    - $_logDir

 - new set to public 
    - $form_action_url 
    - $submit_extras

 - new set to protected
    - $cc_card_number
    - $cc_card_type 
    - $cc_expiry_month 
    - $cc_expiry_year

 - new set to private
    - $_check

 ## authorizenet_aim

 - var change to public
    - $code
    - $title 
    - $description 
    - $transaction_id 
    - $collectsCardDataOnsite

 - var changed to protected 
    - $authorize 
    - $commErrNo 
    - $commError 
    - $reportable_submit_data

 - var changed to private
    - $_logDir

 - new set to public
   - $auth_code
   - $form_action_url
   - $order_status
   - $sort_order
   - $submit_extras

 - new set to protected
   - $avs_response
   - $cc_card_number
   - $cc_card_type
   - $cc_expiry_month
   - $cc_expiry_year
   - $ccv_respons;
   - $commInfo
   - $include_x_type
   - $proxy_tunnel_flag

 - new set to private
    - $_check


Part of #5103