### PR TITLE
Fix company field definitions

### DIFF
--- a/admin/includes/modules/product/collect_info.php
+++ b/admin/includes/modules/product/collect_info.php
@@ -56,7 +56,9 @@ if (isset($_GET['pID']) && empty($_POST)) {
   $pInfo->updateObjectInfo($product->fields);
 } elseif (!empty($_POST)) {
   $pInfo->updateObjectInfo($_POST);
-  $pInfo->products_id = $pInfo->id;
+  if (isset($_GET['pID'])) { 
+     $pInfo->products_id = (int)$_GET['pID']; 
+  }
   $products_name = isset($_POST['products_name']) ? $_POST['products_name'] : '';
   $products_description = isset($_POST['products_description']) ? $_POST['products_description'] : '';
   $products_url = isset($_POST['products_url']) ? $_POST['products_url'] : '';

--- a/zc_install/sql/updates/mysql_upgrade_zencart_158.sql
+++ b/zc_install/sql/updates/mysql_upgrade_zencart_158.sql
@@ -224,6 +224,13 @@ UPDATE configuration SET val_function = '{"error":"TEXT_EMAIL_ADDRESS_VALIDATE",
 ### Added v158 bring banners_titles up to date
 UPDATE banners SET banners_title = 'Zen Cart Certified Services' WHERE banners_html_text LIKE '%<script>%';
 
+### Add missing updates from 137->138 
+ALTER TABLE address_book MODIFY COLUMN entry_company varchar(64) default NULL; 
+ALTER TABLE orders MODIFY COLUMN customers_company varchar(64) default NULL; 
+ALTER TABLE orders MODIFY COLUMN delivery_company varchar(64) default NULL; 
+ALTER TABLE orders MODIFY COLUMN billing_company varchar(64) default NULL; 
+
+
 #############
 ### Added to correct storepickup tax basis description
 UPDATE configuration set configuration_description = 'On what basis is Shipping Tax calculated. Options are<br>Shipping - Based on Store Pickup Address <br>Billing - Based on customers Billing address' WHERE  configuration_key= 'MODULE_SHIPPING_STOREPICKUP_TAX_BASIS';


### PR DESCRIPTION
In 1.3.8, the lengths of the _company fields were increased but there was no conversion done for people who had older databases.  All customers who have been using Zen Cart since 1.3.7 or prior have this issue. 