### PR TITLE
Check Logged in when setting tax locations

### DIFF
--- a/includes/functions/functions_taxes.php
+++ b/includes/functions/functions_taxes.php
@@ -357,7 +357,14 @@ function zen_get_tax_locations($store_country = -1, $store_zone = -1)
     }
 
     $tax_address = [];
-
+    // PapPal express processing
+    // If we're just starting the checkout process via the PPEC button, there's
+    // no customer or shipping-address currently defined.  Use the store values for tax calculation.
+    if (!zen_is_logged_in())  {
+        $tax_address['zone_id'] = (int)STORE_COUNTRY;
+        $tax_address['country_id'] = (int)STORE_ZONE;
+        return $tax_address;
+    }
     switch (STORE_PRODUCT_TAX_BASIS) {
 
         case 'Shipping':


### PR DESCRIPTION
In line with other parts of this set of tax functions. Set the tax_address to the store values if customer is not logged in. This is used by ot_loworderfee.
As raised in #5060 
fix #5296