### PR TITLE
PHP8.2 Define Parameters papyal_curl

### DIFF
--- a/includes/modules/payment/paypal/paypal_curl.php
+++ b/includes/modules/payment/paypal/paypal_curl.php
@@ -23,7 +23,7 @@ class paypal_curl extends base {
    *
    * @var integer $_logLevel
    */
-  var $_logLevel = 3;
+  public $_logLevel = 3;
 
   /**
    * If we're logging, what directory should we create log files in?
@@ -35,22 +35,27 @@ class paypal_curl extends base {
    *
    * @var string $_logFile
    */
-  var $_logDir = DIR_FS_LOGS;
+  public $_logDir = DIR_FS_LOGS;
+  /**
+   * log output destination
+   * @var string
+   */
+  protected $outputDestination;
 
   /**
    * Debug or production?
    */
-  var $_server = 'sandbox';
+  protected $_server = 'sandbox';
 
   /**
    * URL endpoints -- defaults here are for three-token NVP implementation
    */
-  var $_endpoints = array('live'    => 'https://api-3t.paypal.com/nvp',
+  public $_endpoints = array('live'    => 'https://api-3t.paypal.com/nvp',
                           'sandbox' => 'https://api-3t.sandbox.paypal.com/nvp');
   /**
    * Options for cURL. Defaults to preferred (constant) options.
    */
-  var $_curlOptions = array(CURLOPT_HEADER => 0,
+  protected $_curlOptions = array(CURLOPT_HEADER => 0,
                             CURLOPT_RETURNTRANSFER => TRUE,
                             CURLOPT_TIMEOUT => 45,
                             CURLOPT_CONNECTTIMEOUT => 10,
@@ -66,17 +71,17 @@ class paypal_curl extends base {
    * Parameters that are always required and that don't change
    * request to request.
    */
-  var $_partner;
-  var $_vendor;
-  var $_user;
-  var $_pwd;
-  var $_version;
-  var $_signature;
+  protected $_partner;
+  protected $_vendor;
+  protected $_user;
+  protected $_pwd;
+  protected $_version;
+  protected $_signature;
 
   /**
    * nvp or payflow?
    */
-  var $_mode = 'nvp';
+  public $_mode = 'nvp';
 
   /**
    * Sales or authorizations? For the U.K. this will always be 'S'
@@ -84,21 +89,21 @@ class paypal_curl extends base {
    * authorizations. The other option is 'A' for Authorization.
    * NOTE: 'A' is not supported for pre-signup-EC-boarding.
    */
-  var $_trxtype = 'S';
+  public $_trxtype = 'S';
 
   /**
    * Store the last-generated name/value list for debugging.
    */
-  var $lastParamList = null;
+  public $lastParamList = null;
 
   /**
    * Store the last-generated headers for debugging.
    */
-  var $lastHeaders = null;
+  protected $lastHeaders = null;
   /**
    * submission values
    */
-  var $values = array();
+  protected $values = array();
   /**
    * Constructor. Sets up communication infrastructure.
    */


### PR DESCRIPTION
Set to public
-  $_endpoints
-  $_logDir
-  $_logLevel
-  $_mode
-  $_trxtype
-  $lastParamList

Set to protected
-  $_curlOptions
-  $_partner
-  $_pwd
-  $_server
-  $_signature
-  $_user
-  $_vendor
-  $_version
-  $lastHeaders
-  $values

Defined as protected
-  $outputDestination;

**NB.** This class has a function setParam($name, $value) which is not used that will cause undefined warnings if it is use for any parameters not in list above