### PR TITLE
PHP8.2 Define Parameters install

### DIFF
--- a/zc_install/includes/classes/LanguageManager.php
+++ b/zc_install/includes/classes/LanguageManager.php
@@ -7,6 +7,17 @@
 
 class LanguageManager
 {
+    /**
+     * $langPath is the directory path to languages files
+     * @var type string
+     */
+    protected $langPath;
+    /**
+     * $languagesInstalled is an array of the languages installed
+     * @var array
+     */
+    protected $languagesInstalled = [];
+          
     public function __construct($langPath = 'includes/languages/')
     {
         $this->langPath = $langPath;

--- a/zc_install/includes/classes/class.systemChecker.php
+++ b/zc_install/includes/classes/class.systemChecker.php
@@ -11,6 +11,13 @@
  */
 class systemChecker
 {
+    protected $adminDirectoryList = [];
+    protected $errorList = [];
+    protected $extraRunLevels = [];
+    protected $localErrors;
+    protected $selectedAdminDir;
+    protected $serverConfig;
+    protected $systemChecks;
     public function __construct($selectedAdminDir = 'UNSPECIFIED')
     {
         $this->adminDirectoryList = self::getAdminDirectoryList();

--- a/zc_install/includes/classes/class.zcConfigureFileWriter.php
+++ b/zc_install/includes/classes/class.zcConfigureFileWriter.php
@@ -10,7 +10,9 @@
  */
 class zcConfigureFileWriter
 {
-  public $errors = array();
+  public $errors = [];
+  protected $inputs = [];
+  protected $replaceVars;
 
   public function __construct($inputs)
   {

--- a/zc_install/includes/classes/class.zcDatabaseInstaller.php
+++ b/zc_install/includes/classes/class.zcDatabaseInstaller.php
@@ -8,8 +8,31 @@
 
 class zcDatabaseInstaller
 {
-    public $ignoreLine;
-    var $jsonProgressLoggingCount = 0;
+    protected $ignoreLine;
+    protected $jsonProgressLoggingCount = 0;
+    protected $basicParseStrings = [];
+    protected $collateSuffix;
+    protected $completeLine;
+    protected $db;
+    protected $dbCharset;
+    protected $dbHost;
+    protected $dbName;
+    protected $dbPassword;
+    protected $dbPrefix;
+    protected $dbType;
+    protected $dbUser;
+    protected $dieOnErrors;
+    protected $errors = [];
+    protected $extendedOptions;
+    protected $fileName;
+    protected $func;
+    protected $jsonProgressLoggingTotal;
+    protected $keepTogetherCount;
+    protected $keepTogetherLines;
+    protected $line;
+    protected $lineSplit = [];
+    protected $newLine;
+    protected $upgradeExceptions;
 
     public function __construct($options)
     {


### PR DESCRIPTION
# systemChecker
## Set to protected
- $adminDirectoryList = [];
- $errorList = [];
- $extraRunLevels = [];
- $localErrors;
- $selectedAdminDir;
- $serverConfig;
- $systemChecks;

# zcConfigureFileWriter
## Set to protected
- $inputs = [];
- $replaceVars;

# zcDatabaseInstaller
## Changed to protected
- $ignoreLine;
- $jsonProgressLoggingCount = 0; 

## Set to protected
- $basicParseStrings = [];
- $collateSuffix;
- $completeLine;
- $db;
- $dbCharset;
- $dbHost;
- $dbName;
- $dbPassword;
- $dbPrefix;
- $dbType;
- $dbUser;
- $dieOnErrors;
- $errors = [];
- $extendedOptions;
- $fileName;
- $func;
- $jsonProgressLoggingTotal;
- $keepTogetherCount;
- $keepTogetherLines;
- $line;
- $lineSplit = [];
- $newLine;
- $upgradeExceptions; # LanguageManager

## Set to protected
- $langPath;
- $$languagesInstalled = [];



part of #5103