### PR TITLE
Fix PayPal require USD

### DIFF
--- a/includes/modules/pages/login/header_php.php
+++ b/includes/modules/pages/login/header_php.php
@@ -145,8 +145,8 @@ $breadcrumb->add(NAVBAR_TITLE);
 // Check for PayPal express checkout button suitability:
 $paypalec_enabled = (defined('MODULE_PAYMENT_PAYPALWPP_STATUS') && MODULE_PAYMENT_PAYPALWPP_STATUS == 'True' && defined('MODULE_PAYMENT_PAYPALWPP_ECS_BUTTON') && MODULE_PAYMENT_PAYPALWPP_ECS_BUTTON == 'On');
 // Check for express checkout button suitability (must have cart contents, value > 0, and value < 10000USD):
-$ec_button_enabled = ($paypalec_enabled && $_SESSION['cart']->count_contents() > 0 && $_SESSION['cart']->total > 0 && $currencies->value($_SESSION['cart']->total, true, 'USD') <= 10000);
-
+require_once DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/paypal_currency_check.php';
+$ec_button_enabled = ($paypalec_enabled && $_SESSION['cart']->count_contents() > 0 && $_SESSION['cart']->total > 0 && paypalUSDCheck($_SESSION['cart']->total) === true);
 
 // This should be last line of the script:
 $zco_notifier->notify('NOTIFY_HEADER_END_LOGIN');

--- a/includes/modules/payment/paypal/paypal_currency_check.php
+++ b/includes/modules/payment/paypal/paypal_currency_check.php
@@ -1,0 +1,41 @@
+<?php
+/* 
+ * function to check if below 10000 usd limit
+ * Returns true $amount if below the limit or the exchange rate cannot be found
+ * 
+ * @copyright Copyright 2003-2022 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: brittainmark 2022 Oct 16 Modified in v1.5.8 $
+ */
+function paypalUSDCheck ($amount) : bool
+{
+    global $currencies;
+    
+    // Check if USD is defined as a currency
+
+    if ($currencies->is_set('USD')) {
+        $amount = $currencies->value($amount, true, 'USD');
+    } else {
+        $rate = 0;
+        
+        // Get the exchange rate functions to calculate USD exchange rate
+        require_once DIR_FS_CATALOG . DIR_WS_FUNCTIONS . 'functions_exchange_rates.php';
+        $quote_function = 'quote_' . CURRENCY_SERVER_PRIMARY . '_currency';
+        if (function_exists($quote_function)) {
+            $rate = $quote_function('USD');
+        }
+        if (empty($rate) && !empty(CURRENCY_SERVER_BACKUP)) {
+            $quote_function = 'quote_' . CURRENCY_SERVER_BACKUP . '_currency';
+            if (function_exists($quote_function)) {
+                $rate = $quote_function('USD');
+            }
+        }
+        
+        // Use the system CURRENCY_UPLIFT_RATIO to adjust the rate
+        $multiplier = (defined('CURRENCY_UPLIFT_RATIO') && (int) CURRENCY_UPLIFT_RATIO != 0) ? CURRENCY_UPLIFT_RATIO : 1;
+        
+        // Calculate the value in USD
+        $amount = ($amount * $rate * $multiplier);
+    }
+    return $amount < 10000;
+}

--- a/includes/modules/payment/paypal/tpl_ec_button.php
+++ b/includes/modules/payment/paypal/tpl_ec_button.php
@@ -7,7 +7,9 @@
  * @version $Id: Scott C Wilson 2022 Feb 02 Modified in v1.5.8-alpha $
  */
 
-$paypalec_enabled = (defined('MODULE_PAYMENT_PAYPALWPP_STATUS') && MODULE_PAYMENT_PAYPALWPP_STATUS == 'True');
+// PayPal module cannot be used for purchase > $10,000 USD equiv
+require_once DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/paypal_currency_check.php';
+$paypalec_enabled = (defined('MODULE_PAYMENT_PAYPALWPP_STATUS') && MODULE_PAYMENT_PAYPALWPP_STATUS == 'True'  && paypalUSDCheck($_SESSION['cart']->total) === true);
 $ecs_off = (defined('MODULE_PAYMENT_PAYPALWPP_ECS_BUTTON') && MODULE_PAYMENT_PAYPALWPP_ECS_BUTTON == 'Off');
 if ($ecs_off) $paypalec_enabled = FALSE;
 
@@ -42,10 +44,6 @@ if ($paypalec_enabled) {
     $paypalec_enabled = false;
   }
 
-  // PayPal module cannot be used for purchase > $10,000 USD equiv
-  if ($currencies->value($_SESSION['cart']->total, true, 'USD') > 10000) {
-    $paypalec_enabled = false;
-  }
 }
 // if all is okay, display the button
 if ($paypalec_enabled) {

--- a/includes/modules/payment/paypaldp.php
+++ b/includes/modules/payment/paypaldp.php
@@ -369,8 +369,8 @@ class paypaldp extends base {
     // Purchase amount
     if ($this->enabled && isset($order) && isset($order->info)) {
       // module cannot be used for purchase > $10,000 USD equiv
-      $order_amount = $this->calc_order_amount($order->info['total'], 'USD', false);
-      if ($order_amount > 10000) {
+      require_once DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/paypal_currency_check.php';
+      if (paypalUSDCheck($order->info['total']) === false) {
         $this->enabled = false;
         $this->zcLog('update_status', 'Module disabled because purchase price (' . $order_amount . ') exceeds PayPal-imposed maximum limit of 10,000 USD.');
       }

--- a/includes/modules/payment/paypalwpp.php
+++ b/includes/modules/payment/paypalwpp.php
@@ -280,8 +280,8 @@ class paypalwpp extends base {
       $this->zcLog('update_status', 'Module disabled because purchase price (' . $order->info['total'] . ') exceeds PayPal-imposed maximum limit of 1000000 JPY.');
     }
     // module cannot be used for purchase > $10,000 USD equiv
-    $order_amount = $this->calc_order_amount($order->info['total'], 'USD', false);
-    if ($order_amount > 10000) {
+    require_once DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/paypal_currency_check.php';
+    if (paypalUSDCheck($order->info['total']) === false) {
       $this->enabled = false;
       $this->zcLog('update_status', 'Module disabled because purchase price (' . $order_amount . ') exceeds PayPal-imposed maximum limit of 10,000 USD or equivalent.');
     }


### PR DESCRIPTION
This would be better written as a function. Having said that, where do I put it so that it can be called by all these routines.

I have checked to see is 'USD' is a valid currency and if not then fetched the conversion value using the functions_exchange_rates. If that fails to find a rate it will create a warning file with $rate not found similar to now. It will still process the transaction as it does now.

I am expecting feedback to please review.

Will fix #4749 