### PR TITLE
Fix headers for two patched files

### DIFF
--- a/zc_install/sql/install/mysql_zencart.sql
+++ b/zc_install/sql/install/mysql_zencart.sql
@@ -4,7 +4,7 @@
 # * @copyright Copyright 2003-2022 Zen Cart Development Team
 # * @copyright Portions Copyright 2003 osCommerce
 # * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
-# * @version $Id: torvista 2022 Oct 12 Modified in v1.5.8 $
+# * @version $Id: mc12345678 2022 Oct 17 Modified in v1.5.8 $
 #
 
 ############ IMPORTANT INSTRUCTIONS ###############

--- a/zc_install/sql/updates/mysql_upgrade_zencart_158.sql
+++ b/zc_install/sql/updates/mysql_upgrade_zencart_158.sql
@@ -5,7 +5,7 @@
 # * @copyright Copyright 2003-2022 Zen Cart Development Team
 # * @copyright Portions Copyright 2003 osCommerce
 # * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
-# * @version $Id: torvista 2022 Oct 12 Modified in v1.5.8 $
+# * @version $Id: mc12345678 2022 Oct 17 Modified in v1.5.8 $
 #
 
 ############ IMPORTANT INSTRUCTIONS ###############


### PR DESCRIPTION
Kudos to @mc12345678 for identifying that the zc_install version files were missed in the update.  The pre-release checklist has been updated.