### PR TITLE
Correct HTML5 form Element Position

### DIFF
--- a/admin/includes/css/options_values_manager.css
+++ b/admin/includes/css/options_values_manager.css
@@ -1,0 +1,7 @@
+/*
+ * @copyright Copyright 2003-2022 Zen Cart Development Team
+ * @copyright Portions Copyright 2003 osCommerce
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: Brittainmark 2022 Oct 21 Modified in v1.5.8 $
+ */
+.form-horizontal .form-group {margin-right:0;margin-left:0}

--- a/admin/option_name.php
+++ b/admin/option_name.php
@@ -72,11 +72,11 @@ if ($_GET['action'] == "update_sort_order") {
         <table class="table table-condensed table-striped">
           <thead>
             <tr class="dataTableHeadingRow">
-              <th colspan="<?php echo ($_GET['lng_id'] == $_SESSION['languages_id'] ? '5' : '8'); ?>" class="dataTableHeadingContent text-center"><?php echo TEXT_EDIT_ALL; ?></th>
+              <th class="dataTableHeadingContent text-center"><?php echo TEXT_EDIT_ALL; ?></th>
             </tr>
             <tr class="dataTableHeadingRow">
-              <th colspan="3" class="dataTableHeadingContent text-center"><?php echo ($_GET['lng_id'] != $_SESSION['languages_id'] ? 'Current Language' : '&nbsp;'); ?></th>
-              <th colspan="<?php echo ($_GET['lng_id'] == $_SESSION['languages_id'] ? '2' : '5'); ?>" class="dataTableHeadingContent" class="text-center">
+              <th  class="dataTableHeadingContent text-center col-sm-5"><?php echo ($_GET['lng_id'] != $_SESSION['languages_id'] ? 'Current Language' : '&nbsp;'); ?></th>
+              <th  class="dataTableHeadingContent text-center">
                   <?php echo zen_draw_form('lng', FILENAME_PRODUCTS_OPTIONS_NAME, '', 'get'); ?>
                   <?php echo zen_hide_session_id(); ?>
                 <?php echo zen_draw_label(TEXT_SELECTED_LANGUAGE . zen_get_language_icon($_GET['lng_id']), 'lng_id', 'class="control-label"'); ?>&nbsp;&nbsp;&nbsp;
@@ -84,8 +84,13 @@ if ($_GET['action'] == "update_sort_order") {
                 <?php echo '</form>'; ?>
               </th>
             </tr>
+          </thead>
+          <tr>
+              <td colspan="2">
             <?php echo zen_draw_form('update', FILENAME_PRODUCTS_OPTIONS_NAME, 'action=update_sort_order&lng_id=' . $_GET['lng_id']); ?>
-            <tr class="dataTableHeadingRow">
+                <table class="table table-condensed table-striped">
+                    <thead>
+          <tr class="dataTableHeadingRow">
                 <?php
                 if ($_GET['lng_id'] != $_SESSION['languages_id']) {
                   ?>
@@ -101,7 +106,7 @@ if ($_GET['action'] == "update_sort_order") {
             </tr>
           </thead>
           <tbody>
-            <tr>
+            
                 <?php
                 $options_types = $db->Execute("SELECT * FROM " . TABLE_PRODUCTS_OPTIONS_TYPES);
                 $options_types_names = array();
@@ -116,7 +121,9 @@ if ($_GET['action'] == "update_sort_order") {
                 foreach ($rows as $row) {
                   $option_type = $row['products_options_type'];
                   $the_attributes_type = (isset($options_types_names[$option_type])) ? $options_types_names[$option_type] : " (UNKNOWN: $option_type)";
-
+                ?>
+              <tr>
+                <?php  
                   if ($_GET['lng_id'] != $_SESSION['languages_id']) {
                     ?>
                   <td class="dataTableContent text-center"><?php echo zen_get_language_icon($_SESSION['languages_id']); ?></td>
@@ -140,8 +147,11 @@ if ($_GET['action'] == "update_sort_order") {
                 <button type="submit" class="btn btn-primary"><?php echo TEXT_UPDATE_SUBMIT; ?></button>
               </td>
             </tr>
-            <?php echo '</form>'; ?>
           </tbody>
+        </table>
+            <?php echo '</form>'; ?>
+                </td>
+            </tr>
         </table>
         <!-- body_text_eof //-->
         <!-- body_eof //-->

--- a/admin/options_values_manager.php
+++ b/admin/options_values_manager.php
@@ -706,7 +706,24 @@ if (!empty($action)) {
                   <?php
 // edit option values
                   if (($action == 'update_option_value') && ($_GET['value_id'] == $values_value['products_options_values_id'])) {
+                  ?>
+                    <td colspan=5>
+                     <?php 
                     echo zen_draw_form('values', FILENAME_OPTIONS_VALUES_MANAGER, 'action=update_value' . ($currentPage !== 0 && $currentPage !== 1 ? '&page=' . $currentPage: '') . ($filter !== 0 ? '&set_filter=' . $filter : '') . ($max_search_results != 0 ? '&max_search_results=' . $max_search_results : ''), 'post', 'class="form-horizontal"');
+                     ?>
+                        <table class="table">
+                            <thead>
+                                <tr class="dataTableHeadingRow">
+                                    <th class="dataTableHeadingContent text-right col-md-1"><?php echo TABLE_HEADING_ID; ?></th>
+                                    <th class="dataTableHeadingContent col-md-3"><?php echo TABLE_HEADING_OPTION_NAME; ?></th>
+                                    <th class="dataTableHeadingContent col-md-4"><?php echo TABLE_HEADING_OPTION_VALUE; ?></th>
+                                    <th class="dataTableHeadingContent text-right col-md-1"><?php echo TABLE_HEADING_OPTION_VALUE_SORT_ORDER; ?></th>
+                                    <th class="dataTableHeadingContent text-right col-md-3"><?php echo TABLE_HEADING_ACTION; ?></th>
+                                </tr>
+                            </thead>
+                            <tbody> 
+                                <tr>
+                  <?php 
                     $inputs = '';
                     for ($i = 0, $n = sizeof($languages); $i < $n; $i++) {
                       $value_name = $db->Execute("SELECT products_options_values_name
@@ -754,8 +771,13 @@ if (!empty($action)) {
                       <button type="submit" class="btn btn-primary"><?php echo IMAGE_UPDATE; ?></button>
                       <a href="<?php echo zen_href_link(FILENAME_OPTIONS_VALUES_MANAGER, ($currentPage !== 0 ? 'page=' . $currentPage . '&' : '') . ($filter !== 0 ? 'set_filter=' . $filter . '&' : '') . ($max_search_results != 0 ? 'max_search_results=' . $max_search_results : '')); ?>" class="btn btn-default" role="button"><?php echo IMAGE_CANCEL ?></a>
                     </td>
+                            </tbody>
+                        </table>
                     <?php
                     echo '</form>';
+                    ?>
+                    </td>
+                    <?php 
                   } else {
                     ?>
                     <td class="text-right"><?php echo $values_value["products_options_values_id"]; ?></td>
@@ -781,8 +803,10 @@ if (!empty($action)) {
               </tr>
               <?php if ($action != 'update_option_value') { ?>
                 <tr>
+                <td colspan="5">
+                
                   <?php echo zen_draw_form('values', FILENAME_OPTIONS_VALUES_MANAGER, 'action=add_product_option_values' . ($currentPage !== 0 && $currentPage !== 1 ? '&page=' . $currentPage : '') . ($filter !== 0 ? '&set_filter=' . $filter : '') . ($max_search_results != 0 ? '&max_search_results=' . $max_search_results : ''), 'post', 'class="form-horizontal"'); ?>
-                  <td colspan="4">
+                  
                     <?php
                     $options_values = $db->Execute("SELECT products_options_id, products_options_name, products_options_type
                                                     FROM " . TABLE_PRODUCTS_OPTIONS . "
@@ -819,14 +843,15 @@ if (!empty($action)) {
                         <?php echo zen_draw_input_field('products_options_values_sort_order', '', 'size="4" class="form-control"'); ?>
                       </div>
                     </div>
-                  </td>
-                  <td class="text-right">
+                  <div class="col-md-3 text-right">
                     <?php echo zen_draw_hidden_field('value_id', $next_id); ?>
+                    <br>
                     <button type="submit" class="btn btn-primary"><?php echo IMAGE_INSERT; ?></button>
-                  </td>
+                  </div>
                   <?php
                   echo '</form>';
                   ?>
+                  </td>
                 </tr>
                 <tr>
                   <td colspan="5"><?php echo zen_black_line(); ?></td>
@@ -907,13 +932,16 @@ if (!empty($action)) {
         <div class="table-responsive" style="border: 2px solid #999;">
           <table class="table">
             <tr>
-              <td colspan="4"><?php echo TEXT_OPTION_VALUE_COPY_ALL; ?></td>
+              <td ><?php echo TEXT_OPTION_VALUE_COPY_ALL; ?></td>
             </tr>
             <tr>
-              <td colspan="4"><?php echo TEXT_INFO_OPTION_VALUE_COPY_ALL; ?></td>
+              <td ><?php echo TEXT_INFO_OPTION_VALUE_COPY_ALL; ?></td>
             </tr>
             <tr class="dataTableHeadingRow">
+            <td>
               <?php echo zen_draw_form('quick_jump', FILENAME_OPTIONS_VALUES_MANAGER, 'action=copy_options_values_one_to_another', 'post', 'class="form-horizontal"'); ?>
+              <table class="table">
+                  <tr class="dataTableHeadingRow">
               <td class="dataTableHeadingContent">
                 <?php echo zen_draw_label(TEXT_SELECT_OPTION_FROM, 'options_id_from', 'class="control-label"') . zen_draw_pull_down_menu('options_id_from', $option_from_dropdown, '', 'class="form-control"'); ?><br>
                 <?php echo zen_draw_label(TEXT_SELECT_OPTION_VALUES_FROM, 'options_values_values_id_from', 'class="control-label"') . zen_draw_pull_down_menu('options_values_values_id_from', $option_values_from_dropdown, '', 'class="form-control"'); ?>
@@ -926,7 +954,10 @@ if (!empty($action)) {
               <td class="dataTableHeadingContent text-center">
                 <button type="submit" class="btn btn-warning"><?php echo IMAGE_INSERT; ?></button>
               </td>
+                  </tr>
+              </table>
               <?php echo '</form>'; ?>
+              </td>
             </tr>
           </table>
         </div>
@@ -942,13 +973,16 @@ if (!empty($action)) {
         <div class="table-responsive" style="border: 2px solid #999;">
           <table class="table">
             <tr>
-              <td colspan="3"><?php echo TEXT_OPTION_VALUE_DELETE_ALL; ?></td>
+              <td><?php echo TEXT_OPTION_VALUE_DELETE_ALL; ?></td>
             </tr>
             <tr>
-              <td colspan="3"><?php echo TEXT_INFO_OPTION_VALUE_DELETE_ALL; ?></td>
+              <td><?php echo TEXT_INFO_OPTION_VALUE_DELETE_ALL; ?></td>
             </tr>
             <tr class="dataTableHeadingRow">
+            <td>
               <?php echo zen_draw_form('quick_jump', FILENAME_OPTIONS_VALUES_MANAGER, 'action=delete_options_values_of_option_name', 'post', 'class="form-horizontal"'); ?>
+                <table>
+                    <tr  class="dataTableHeadingRow">
               <td class="dataTableHeadingContent">
                 <?php echo zen_draw_label(TEXT_SELECT_DELETE_OPTION_FROM, 'options_id_from', 'class="control-label"') . zen_draw_pull_down_menu('options_id_from', $option_from_dropdown, '', 'class="form-control"'); ?><br>
                 <?php echo zen_draw_label(TEXT_SELECT_DELETE_OPTION_VALUES_FROM, 'options_values_values_id_from', 'class="control-label"') . zen_draw_pull_down_menu('options_values_values_id_from', $option_values_from_dropdown, '', 'class="form-control"'); ?>
@@ -957,7 +991,10 @@ if (!empty($action)) {
               <td class="dataTableHeadingContent text-center">
                 <button type="submit" class="btn btn-danger"><i class="fa fa-trash"></i> <?php echo IMAGE_DELETE; ?></button>
               </td>
+                  </tr>
+              </table>
               <?php echo '</form>'; ?>
+              </td>
             </tr>
           </table>
         </div>
@@ -973,13 +1010,16 @@ if (!empty($action)) {
         <div class="table-responsive" style="border: 2px solid #999;">
           <table class="table">
             <tr>
-              <td colspan="4"><?php echo TEXT_OPTION_VALUE_COPY_OPTIONS_TO; ?></td>
+              <td><?php echo TEXT_OPTION_VALUE_COPY_OPTIONS_TO; ?></td>
             </tr>
             <tr>
-              <td colspan="4"><?php echo TEXT_INFO_OPTION_VALUE_COPY_OPTIONS_TO; ?></td>
+              <td><?php echo TEXT_INFO_OPTION_VALUE_COPY_OPTIONS_TO; ?></td>
             </tr>
             <tr class="dataTableHeadingRow">
+            <td>
               <?php echo zen_draw_form('quick_jump', FILENAME_OPTIONS_VALUES_MANAGER, 'action=copy_options_values_one_to_another_options_id', 'post', 'class="form-horizontal"'); ?>
+                <table class="table">
+                    <tr  class="dataTableHeadingRow">
               <td class="dataTableHeadingContent">
                 <?php echo zen_draw_label(TEXT_SELECT_OPTION_FROM_ADD, 'options_id_from', 'class="control-label"') . zen_draw_pull_down_menu('options_id_from', $option_from_dropdown, '', 'class="form-control"'); ?><br>
                 <?php echo zen_draw_label(TEXT_SELECT_OPTION_VALUES_FROM_ADD, 'options_values_values_id_from', 'class="control-label"') . zen_draw_pull_down_menu('options_values_values_id_from', $option_values_from_dropdown, '', 'class="form-control"'); ?><br>
@@ -1005,13 +1045,17 @@ if (!empty($action)) {
               <td class="dataTableHeadingContent text-center">
                 <button type="submit" class="btn btn-primary"><?php echo IMAGE_INSERT; ?></button>
               </td>
+                    </tr>
+                </table>
               <?php echo '</form>'; ?>
+            </td>
             </tr>
             <!-- eof: copy all option values to another Option Name -->
           <?php } ?>
         </table>
       </div>
       <!-- option value eof //-->
+      </div>
       <!-- body_text_eof //-->
       <!-- footer //-->
       <?php require DIR_WS_INCLUDES . 'footer.php'; ?>


### PR DESCRIPTION
- Move \<form> element to with in \<td> or \<th> and adjust \<table> elements to remove HTML5 errors.
- Add additional formatting to options_values_manager to retain current look and feel.
- Correct `colspan` for revised form position.
- Remove additional `class` attribute from option_name

fix #5337