### PR TITLE
Handle ALTER TABLE DROP/ADD commands on db with prefix

### DIFF
--- a/zc_install/includes/classes/class.zcDatabaseInstaller.php
+++ b/zc_install/includes/classes/class.zcDatabaseInstaller.php
@@ -479,7 +479,7 @@ class zcDatabaseInstaller
     {
         if (!defined('DB_DATABASE')) define('DB_DATABASE', $this->dbName);
         $check = $this->db->Execute(
-            'SHOW COLUMNS FROM `' . DB_DATABASE . '`.`' . $this->db->prepare_input($table) . '` ' .
+            'SHOW COLUMNS FROM `' . DB_DATABASE . '`.`' . $this->dbPrefix . $this->db->prepare_input($table) . '` ' .
             'WHERE `Field` = \'' . $this->db->prepare_input($column) . '\''
         );
         return !$check->EOF;
@@ -489,7 +489,7 @@ class zcDatabaseInstaller
     {
         if (!defined('DB_DATABASE')) define('DB_DATABASE', $this->dbName);
         $check = $this->db->Execute(
-            'SHOW INDEX FROM `' . DB_DATABASE . '`.`' . $this->db->prepare_input($table) . '` ' .
+            'SHOW INDEX FROM `' . DB_DATABASE . '`.`' . $this->dbPrefix . $this->db->prepare_input($table) . '` ' .
             'WHERE `Key_name` = \'' . $this->db->prepare_input($index) . '\''
         );
         return !$check->EOF;


### PR DESCRIPTION
Fixes #5343. 

Databases with prefixes have not yet gotten the fixes from the 157 upgrade file that perform these operations:
ALTER TABLE customers_basket DROP final_price;
ALTER TABLE ezpages DROP languages_id;
ALTER TABLE ezpages DROP pages_title;
ALTER TABLE ezpages DROP pages_html_text;
