### PR TITLE
zc_install was still comparing against 158-dev

### DIFF
--- a/zc_install/includes/systemChecks.yml
+++ b/zc_install/includes/systemChecks.yml
@@ -285,8 +285,8 @@ systemChecks:
   checkDBVersion158:
     runLevel: dbVersion
     errorLevel: WARN
-    version: '1.5.8-dev'
-    mainErrorText: <?php echo sprintf(TEXT_DB_VERSION_NOT_FOUND, 'v1.5.8-dev') . PHP_EOL; ?>
+    version: '1.5.8'
+    mainErrorText: <?php echo sprintf(TEXT_DB_VERSION_NOT_FOUND, 'v1.5.8') . PHP_EOL; ?>
     methods:
       dbVersionChecker:
         parameters:


### PR DESCRIPTION
This is not a bug in the 158 build, it's just an update for documentation. 