### PR TITLE
Fix log when manufs list empty

### DIFF
--- a/admin/manufacturers.php
+++ b/admin/manufacturers.php
@@ -326,7 +326,7 @@ if (!empty($action)) {
         </div>
         <!-- body_text_eof //-->
       </div>
-      <?php if (empty($action)) { ?>
+      <?php if (empty($action) && !empty($mInfo)) { ?>
         <div class="col-sm-12 text-right">
           <a href="<?php echo zen_href_link(FILENAME_MANUFACTURERS, ($currentPage != 0 ? 'page=' . $currentPage . '&' : '') . 'mID=' . $mInfo->manufacturers_id . '&action=new'); ?>" class="btn btn-primary" role="button"><?php echo IMAGE_INSERT; ?></a>
         </div>


### PR DESCRIPTION
Logs: 

```
[25-Oct-2022 15:32:55 UTC] Request URI: /client/admin/index.php?cmd=manufacturers, IP address: ::1
#0 /Users/scott/sites/client/admin/manufacturers.php(331): zen_debug_error_handler()
#1 /Users/scott/sites/client/admin/index.php(11): require('/Users/scott/si...')
--> PHP Warning: Undefined variable $mInfo in /Users/scott/sites/client/admin/manufacturers.php on line 331.

[25-Oct-2022 15:32:55 UTC] Request URI: /client/admin/index.php?cmd=manufacturers, IP address: ::1
#0 /Users/scott/sites/client/admin/manufacturers.php(331): zen_debug_error_handler()
#1 /Users/scott/sites/client/admin/index.php(11): require('/Users/scott/si...')
--> PHP Warning: Attempt to read property "manufacturers_id" on null in /Users/scott/sites/client/admin/manufacturers.php on line 331.

```