### PR TITLE
v158: Correcting `zen_get_products_description`

### DIFF
--- a/includes/functions/functions_products.php
+++ b/includes/functions/functions_products.php
@@ -669,14 +669,15 @@ function zen_get_products_description($product_id, $language_id = 0)
 {
     global $db;
 
-    if (empty($language_id)) $language = $_SESSION['languages_id'];
+    if (empty($language_id)) {
+        $language_id = $_SESSION['languages_id'];
+    }
 
     $product = $db->Execute("SELECT products_description
                              FROM " . TABLE_PRODUCTS_DESCRIPTION . "
                              WHERE products_id = " . (int)$product_id . "
                              AND language_id = " . (int)$language_id, 1);
-    if ($product->EOF) return '';
-    return $product->fields['products_description'];
+    return ($product->EOF) ? '' : $product->fields['products_description'];
 }
 
 /**


### PR DESCRIPTION
As identified in [this](https://www.zen-cart.com/showthread.php?229078-Product-Description-Does-not-Show-up-in-All-Products-and-other-Pages) Zen Cart forum posting, the description returned by the subject function is always an empty string.  That's because the fall-back (when no language is supplied on the call) was setting a variable named `$language` instead of `$language_id`, so the $language_id used for the query was always 0.