### PR TITLE
Add language id to log for multilanguage sites

### DIFF
--- a/includes/extra_configures/enable_error_logging.php
+++ b/includes/extra_configures/enable_error_logging.php
@@ -81,7 +81,8 @@ function zen_debug_error_handler($errno, $errstr, $errfile, $errline)
     if (!empty($backtrace)) {
         $backtrace = PHP_EOL . rtrim($backtrace);
     }
-    $message = date('[d-M-Y H:i:s e]') . ' Request URI: ' . $_SERVER['REQUEST_URI'] . ', IP address: ' . (isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : 'not set')  . $backtrace;
+    $language_info = ', Language id ' . $_SESSION['languages_id']; 
+    $message = date('[d-M-Y H:i:s e]') . ' Request URI: ' . $_SERVER['REQUEST_URI'] . ', IP address: ' . (isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : 'not set')  . $language_info . $backtrace;
 
     $message .= PHP_EOL . "--> PHP $error_type: $errstr in $errfile on line $errline.";
     


### PR DESCRIPTION
Rationale: newer stricter PHP versions are going to produce a lot more language file logs, and fixing them can be tricky in multilanguage carts if you're not sure which language was being used when the log was created. 