### PR TITLE
Improve Efficency  in products_listing

### DIFF
--- a/includes/modules/product_listing.php
+++ b/includes/modules/product_listing.php
@@ -204,16 +204,12 @@ if ($num_products_count > 0) {
         if (!empty($_GET['cPath'])) $linkCpath = $_GET['cPath'];
         if (!empty($_GET['manufacturers_id']) && !empty($_GET['filter_id'])) $linkCpath = $_GET['filter_id'];
 
-        for ($col = 0, $n = count($column_list); $col < $n; $col++) {
-            $lc_align = '';
-            $lc_text = '';
 
             $href = zen_href_link(zen_get_info_page($record['products_id']), 'cPath=' . zen_get_generated_category_path_rev($linkCpath) . '&products_id=' . $record['products_id']);
             $listing_product_name = (isset($record['products_name'])) ? $record['products_name'] : '';
             $listing_description = '';
             if ((int)PRODUCT_LIST_DESCRIPTION > 0) {
                 $listing_description = zen_trunc_string(zen_clean_html(stripslashes(zen_get_products_description($record['products_id'], $_SESSION['languages_id']))), PRODUCT_LIST_DESCRIPTION);
-                $lc_text .= '<div class="listingDescription">' . $listing_description . '</div>';
             }
             $listing_model = (isset($record['products_model'])) ? $record['products_model'] : '';
             $listing_mfg_name = (isset($record['manufacturers_name'])) ? $record['manufacturers_name'] : '';
@@ -273,7 +269,12 @@ if ($num_products_count > 0) {
             }
             $zco_notifier->notify('NOTIFY_MODULES_PRODUCT_LISTING_PRODUCTS_BUTTON', [], $record, $lc_button);
 
-
+        for ($col = 0, $n = count($column_list); $col < $n; $col++) {
+            $lc_align = '';
+            $lc_text = '';
+            if ((int)PRODUCT_LIST_DESCRIPTION > 0) {
+                $lc_text .= '<div class="listingDescription">' . $listing_description . '</div>';
+            }
             switch ($column_list[$col]) {
                 case 'PRODUCT_LIST_MODEL':
                     $lc_align = 'center';


### PR DESCRIPTION
There are a large number of variables that are calculated repeatedly to the same value in the loop that started on line 207. Moving the loop stare and the initialised variables to line 273 removes the repeated calculation of these variables.

I have not changed the indentation, so it is easier to see the change.

And move the $listing_description processing to stay in the loop.