### PR TITLE
Place update category links button under cat table

### DIFF
--- a/admin/includes/css/products_to_categories.css
+++ b/admin/includes/css/products_to_categories.css
@@ -21,7 +21,7 @@ label, input[type="checkbox"] {
   -webkit-box-shadow: 0 0 6px 0 rgba(0, 0, 0, 0.8);
   -moz-box-shadow: 0 0 6px 0 rgba(0, 0, 0, 0.8);
   box-shadow: 0 0 6px 0 rgba(0, 0, 0, 0.8);
-  bottom: 200px;
+  bottom: 10px;
 }
 
 /*product name and model in Update Categories button*/


### PR DESCRIPTION
Go to the multiple categories link manager page on product 2 in the demo data set:

/admin/index.php?cmd=products_to_categories&products_filter=2&current_category_id=4

As a floating button, the update category links button can occlude other parts of the page.
<img width="200" alt="float" src="https://user-images.githubusercontent.com/4391638/198998602-f2826c33-6eb5-4591-91f1-b7b018b860a2.png">

It's better to just put it under the table it operates on.

<img width="600" alt="nofloat" src="https://user-images.githubusercontent.com/4391638/198998653-60128070-1b89-4bcb-a156-ca6be06df79c.png">
