### PR TITLE
v158: Correct debug-log issued when editing a manufacturer with no im…

### DIFF
--- a/admin/manufacturers.php
+++ b/admin/manufacturers.php
@@ -270,7 +270,7 @@ if (!empty($action)) {
               $contents[] = ['text' => '<label class="checkbox-inline">' . zen_draw_checkbox_field('featured', '1', $mInfo->featured) . TEXT_MANUFACTURER_FEATURED_LABEL . '</label>'];
               $contents[] = ['text' => zen_draw_label(TEXT_MANUFACTURERS_IMAGE, 'manufacturers_image', 'class="control-label"') . zen_draw_file_field('manufacturers_image', '', ' class="form-control" id="manufacturers_image"') . '<br>' . $mInfo->manufacturers_image];
               $dir_info = zen_build_subdirectories_array(DIR_FS_CATALOG_IMAGES);
-              $default_directory = substr($mInfo->manufacturers_image, 0, strpos($mInfo->manufacturers_image ?? '', '/') + 1);
+              $default_directory = ($mInfo->manufacturers_image === null) ? '/' : substr($mInfo->manufacturers_image, 0, strpos($mInfo->manufacturers_image, '/') + 1);
 
               $contents[] = ['text' => zen_draw_label(TEXT_UPLOAD_DIR, 'img_dir', 'class="control-label"') . zen_draw_pull_down_menu('img_dir', $dir_info, $default_directory, 'class="form-control" id="img_dir"')];
 


### PR DESCRIPTION
…age defined

Seeing logs similar to the following if a manufacturer is created without an associated image (the database default is `null`):
```
[31-Oct-2022 07:14:17 America/New_York] Request URI: /zc158/hoisT-PYL-teAch/index.php?cmd=manufacturers&mID=10&action=edit, IP address: 127.0.0.1
#0 [internal function]: zen_debug_error_handler()
#1 C:\xampp\htdocs\zc158\hoisT-PYL-teAch\manufacturers.php(273): substr()
#2 C:\xampp\htdocs\zc158\hoisT-PYL-teAch\index.php(11): require('C:\\xampp\\htdocs...')
--> PHP Deprecated: substr(): Passing null to parameter #1 ($string) of type string is deprecated in C:\xampp\htdocs\zc158\hoisT-PYL-teAch\manufacturers.php on line 273.
```