### PR TITLE
admin: category-product listing, add DISTINCT to search query

### DIFF
--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -792,7 +792,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
             $extra_select = $extra_from = $extra_joins = $extra_ands = '';
             $zco_notifier->notify('NOTIFY_ADMIN_PROD_LISTING_PRODUCTS_QUERY', '', $extra_select, $extra_from, $extra_joins, $extra_ands, $order_by);
 
-            $products_query_raw = "SELECT p.products_type, p.products_id, pd.products_name, p.products_quantity,
+            $products_query_raw = "SELECT DISTINCT p.products_type, p.products_id, pd.products_name, p.products_quantity,
                                           p.products_price, p.products_status, p.products_model, p.products_sort_order,
                                           p.master_categories_id";
             $products_query_raw .= $extra_select;


### PR DESCRIPTION
Makes no difference to core functionality, but when the query is expanded by an observer to include other tables, multiple results may be returned.