### PR TITLE
space as opposed to null to output function

### DIFF
--- a/includes/modules/payment/square_support/square_admin_notification.php
+++ b/includes/modules/payment/square_support/square_admin_notification.php
@@ -40,7 +40,7 @@ if (!empty($transaction) && $transaction->getId()) {
     $outputSquare .= '<tr><td class="main">' . "\n";
     $outputSquare .= 'Reference: ' . "\n";
     $outputSquare .= '</td><td class="main">' . "\n";
-    $outputSquare .= zen_output_string_protected($transaction->getReferenceId()) . "\n";
+    $outputSquare .= zen_output_string_protected($transaction->getReferenceId() ?? ' ') . "\n";
     $outputSquare .= '</td></tr>' . "\n";
 
     $outputSquare .= '<tr><td class="main">' . "\n";


### PR DESCRIPTION
in the original square module, the reference id was set to a session id:
https://github.com/zencart/zencart/blob/9910e3d1aa80466f9d59afb53ae494849a2bda8c/includes/modules/payment/square.php#L332
this was done as the order had not been created.  and in the new module, it is still not.

square_webPay makes use of this `square_admin_notification` script; but i am NOT setting a reference id of the session.  in fact, i am not setting a reference id at all.  and there has been no problem with tying requests from square back to zc.

as such, `getReferenceId()` returns null and causes the following deprecated error in php8.1:

```
[04-Nov-2022 17:10:31 America/Los_Angeles] Request URI: /zcdev/admin/index.php?cmd=orders&page=1&oID=133&action=edit, IP address: 192.168.14.74
#0 [internal function]: zen_debug_error_handler()
#1 /var/www/zcdev/includes/functions/functions_strings.php(20): htmlspecialchars()
#2 /var/www/zcdev/includes/functions/functions_strings.php(41): zen_output_string()
#3 /var/www/zcdev/includes/modules/payment/square_support/square_admin_notification.php(43): zen_output_string_protected()
#4 /var/www/zcdev/includes/modules/payment/square_webPay.php(535): require('...')
#5 /var/www/zcdev/admin/orders.php(741): square_webPay->admin_notification()
#6 /var/www/zcdev/admin/index.php(11): require('...')
--> PHP Deprecated: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/zcdev/includes/functions/functions_strings.php on line 20.
```
passing a single space addresses this error and also provides for the future possibility of setting a reference id.

