### PR TITLE
Add test for null

### DIFF
--- a/includes/functions/functions_strings.php
+++ b/includes/functions/functions_strings.php
@@ -15,6 +15,10 @@
  */
 function zen_output_string($string, $translate = false, $protected = false): string
 {
+    if (is_null($string) === true) {
+        return '';
+    }
+
     if ($protected === true) {
         $double_encode = (IS_ADMIN_FLAG ? FALSE : TRUE);
         return htmlspecialchars($string, ENT_COMPAT, CHARSET, $double_encode);
@@ -82,6 +86,9 @@ function zen_not_null($value)
  */
 function zen_break_string($string, $len, $break_char = '-')
 {
+    if (is_null($string) === true) {
+        return '';
+    }
     $l = 0;
     $output = '';
     for ($i = 0, $n = strlen($string); $i < $n; $i++) {
@@ -111,6 +118,9 @@ function zen_break_string($string, $len, $break_char = '-')
  */
 function zen_trunc_string($str = "", $len = 150, $more = 'true')
 {
+    if (is_null($str) === true) {
+        return '';
+    }
     if ($str == "") return $str;
     if (is_array($str)) return $str;
     $str = trim($str);


### PR DESCRIPTION
Have added tests for null value in a few places to avoid depreciation errors in php8.2. An alternative is to place (string) before the parameter. e.g.
`strlen((string)$string)`

This also removes the depreciation warning. If you think this is a better approach, let me know and I'll redo.

As requested #5373