### PR TITLE
Correct log for table-based shipping when the mode is not by weight

### DIFF
--- a/includes/modules/shipping/table.php
+++ b/includes/modules/shipping/table.php
@@ -163,6 +163,7 @@ class table extends base {
       }
     }
 
+    $show_box_weight = ''; 
     if (MODULE_SHIPPING_TABLE_MODE == 'weight') {
       $shipping = $shipping * $shipping_num_boxes;
       // show boxes if weight


### PR DESCRIPTION
--> PHP Warning: Undefined variable $show_box_weight in /home/thatsoftwareguy4/public_html/SITE/includes/modules/shipping/table.php on line 186.