### PR TITLE
Fix logs created by cron running PHP job

### DIFF
--- a/includes/extra_configures/enable_error_logging.php
+++ b/includes/extra_configures/enable_error_logging.php
@@ -81,8 +81,8 @@ function zen_debug_error_handler($errno, $errstr, $errfile, $errline)
     if (!empty($backtrace)) {
         $backtrace = PHP_EOL . rtrim($backtrace);
     }
-    $language_info = ', Language id ' . $_SESSION['languages_id']; 
-    $message = date('[d-M-Y H:i:s e]') . ' Request URI: ' . $_SERVER['REQUEST_URI'] . ', IP address: ' . (isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : 'not set')  . $language_info . $backtrace;
+    $language_info = ', Language id ' . $_SESSION['languages_id'];
+    $message = date('[d-M-Y H:i:s e]') . ' Request URI: ' . ($_SERVER['REQUEST_URI'] ?? 'not set') . ', IP address: ' . ($_SERVER['REMOTE_ADDR'] ?? 'not set')  . $language_info . $backtrace;
 
     $message .= PHP_EOL . "--> PHP $error_type: $errstr in $errfile on line $errline.";
     
@@ -96,7 +96,7 @@ function zen_fatal_error_handler()
     $last_error = error_get_last();
 
     if (!empty($last_error) && in_array($last_error['type'], [E_ERROR, E_USER_ERROR, E_PARSE])) {
-        $message = date('[d-M-Y H:i:s e]') . ' Request URI: ' . $_SERVER['REQUEST_URI'] . ', IP address: ' . (isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : 'not set') . PHP_EOL;
+        $message = date('[d-M-Y H:i:s e]') . ' Request URI: ' . ($_SERVER['REQUEST_URI'] ?? 'not set') . ', IP address: ' . ($_SERVER['REMOTE_ADDR'] ?? 'not set') . PHP_EOL;
         $message_type = ($last_error['type'] == E_PARSE) ? 'Parse' : (($last_error['type'] == E_RECOVERABLE_ERROR) ? 'Catchable Fatal' : 'Fatal');
         $message .= "--> PHP $message_type error: {$last_error['message']} in {$last_error['file']} on line {$last_error['line']}.";
         error_log(PHP_EOL . $message . PHP_EOL, 3, $GLOBALS['debug_logfile_path']);

--- a/includes/functions/functions_traffic.php
+++ b/includes/functions/functions_traffic.php
@@ -29,7 +29,7 @@ function zen_get_ip_address() {
             $ip = $_SERVER['HTTP_FORWARDED_FOR'];
         } elseif (isset($_SERVER['HTTP_FORWARDED'])) {
             $ip = $_SERVER['HTTP_FORWARDED'];
-        } else {
+        } elseif (isset($_SERVER['REMOTE_ADDR'])) {
             $ip = $_SERVER['REMOTE_ADDR'];
         }
     }


### PR DESCRIPTION
These happened because a cron job was using `php <path>` to run a script, so things that would normally be set in browser invocation were not set. 


```
[20-Nov-2022 08:08:07 America/Chicago] PHP Warning:  Undefined array key "REQUEST_URI" in /home/client/public_html/siteurl/_livesite/includes/extra_configures/enable_error_logging.php on line 84
```

```
--> PHP Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in /home/client/public_html/siteurl/_livesite/includes/functions/functions_traffic.php on line 36.
```