### PR TITLE
Fix cc validation log

### DIFF
--- a/includes/classes/cc_validation.php
+++ b/includes/classes/cc_validation.php
@@ -19,7 +19,7 @@ class cc_validation extends base {
   public $cc_type, $cc_number, $cc_expiry_month, $cc_expiry_year;
 
   function validate($number, $expiry_m, $expiry_y, $start_m = null, $start_y = null) {
-    $this->cc_number = preg_replace('/[^0-9]/', '', $number);
+    $this->cc_number = preg_replace('/[^0-9]/', '', ($number ?? ''));
     // NOTE: We check Solo before Maestro, and Maestro/Switch *before* we check Visa/Mastercard, so we don't have to rule-out numerous types from V/MC matching rules.
     if (preg_match('/^(6334[5-9][0-9]|6767[0-9]{2})[0-9]{10}([0-9]{2,3}?)?$/', $this->cc_number) && CC_ENABLED_SOLO=='1') {
       $this->cc_type = "Solo"; // is also a Maestro product


### PR DESCRIPTION
Seeing on Authorize sites.

```
PHP Deprecated: preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in [19-Nov-2022 17:27:20 UTC] Request URI: /index.php?main_page=checkout_confirmation, IP address: 70.162.73.147
#0 [internal function]: zen_debug_error_handler()
#1 /home/client/public_html/siteurl/_livesite/includes/classes/cc_validation.php(22): preg_replace()
#2 /home/client/public_html/siteurl/_livesite/includes/modules/payment/authorizenet_aim.php(263): cc_validation->validate()
#3 /home/client/public_html/siteurl/_livesite/includes/classes/payment.php(248): authorizenet_aim->pre_confirmation_check()
#4 /home/client/public_html/siteurl/_livesite/includes/modules/pages/checkout_confirmation/header_php.php(89): payment->pre_confirmation_check()
#5 /home/client/public_html/siteurl/_livesite/index.php(35): require('/home/client...')
--> PHP Deprecated: preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /home/client/public_html/siteurl/_livesite/includes/classes/cc_validation.php on line 22.

```