### PR TITLE
Optionally Bypass loading substring-matching language files

### DIFF
--- a/includes/classes/ResourceLoaders/CatalogFilesLanguageLoader.php
+++ b/includes/classes/ResourceLoaders/CatalogFilesLanguageLoader.php
@@ -36,13 +36,18 @@ class CatalogFilesLanguageLoader extends FilesLanguageLoader
         }
 
         $directory = DIR_WS_LANGUAGES . $_SESSION['language'] . '/' . $this->templateDir;
-        $files = $this->fileSystem->listFilesFromDirectoryAlphaSorted($directory, '~^' . $this->currentPage  . '(.*)\.php$~i');
+        if (defined('NO_LANGUAGE_SUBSTRING_MATCH') && in_array($this->currentPage, NO_LANGUAGE_SUBSTRING_MATCH)) {
+            $files_to_match = $this->currentPage;
+        } else {
+            $files_to_match = $this->currentPage . '(.*)';
+        }
+        $files = $this->fileSystem->listFilesFromDirectoryAlphaSorted($directory, '~^' . $files_to_match  . '\.php$~i');
         foreach ($files as $file) {
             $this->loadFileDefineFile($directory . '/' . $file);
         }
 
         $directory = DIR_WS_LANGUAGES . $_SESSION['language'];
-        $files = $this->fileSystem->listFilesFromDirectoryAlphaSorted($directory, '~^' . $this->currentPage . '(.*)\.php$~i');
+        $files = $this->fileSystem->listFilesFromDirectoryAlphaSorted($directory, '~^' . $files_to_match  . '\.php$~i');
         foreach ($files as $file) {
             $this->loadFileDefineFile($directory . '/' . $file);
         }

--- a/includes/extra_datafiles/dist-site_specific_overrides.php
+++ b/includes/extra_datafiles/dist-site_specific_overrides.php
@@ -14,7 +14,7 @@
  * @version $Id: lat9 2022 May 06 New in v1.5.8-alpha $
  */
 // -----
-// Idenfify whether the link to the 'about_us' page is included in the "Information" sidebox.
+// Identify whether the link to the 'about_us' page is included in the "Information" sidebox.
 //
 // true .... Show in the sidebox (default)
 // false ... Don't show in the sidebox
@@ -38,3 +38,8 @@
 // false ..... The zcDate debug is disabled (the default).
 //
 //$zen_date_debug = false;
+
+// Identify if some pages should not load matching language file substrings
+// In this example, loading page "video" will not load "video_info" files
+// define('NO_LANGUAGE_SUBSTRING_MATCH', ['video']);
+


### PR DESCRIPTION
This worked before PHP 8 because additional duplicate defines were simply dropped.  Now they create log files, so we have to provide a mechanism to disallow (at least for legacy language files) if it will be harmful. 

I don't think the same change is required for includes/classes/ResourceLoaders/CatalogArraysLanguageLoader.php because there, the first setting wins and there's no PHP warning.