### PR TITLE
authorizenet_aim: Ensure variables are set prior to use

### DIFF
--- a/includes/modules/payment/authorizenet_aim.php
+++ b/includes/modules/payment/authorizenet_aim.php
@@ -260,7 +260,7 @@ class authorizenet_aim extends base {
     include(DIR_WS_CLASSES . 'cc_validation.php');
 
     $cc_validation = new cc_validation();
-    $result = $cc_validation->validate($_POST['authorizenet_aim_cc_number'], $_POST['authorizenet_aim_cc_expires_month'], $_POST['authorizenet_aim_cc_expires_year'], $_POST['authorizenet_aim_cc_cvv']);
+    $result = $cc_validation->validate(($_POST['authorizenet_aim_cc_number'] ?? ''), ($_POST['authorizenet_aim_cc_expires_month'] ?? ''), ($_POST['authorizenet_aim_cc_expires_year'] ?? ''), ($_POST['authorizenet_aim_cc_cvv'] ?? ''));
     $error = '';
     switch ($result) {
       case -1:


### PR DESCRIPTION
```
[21-Nov-2022 03:44:18 UTC] Request URI: /index.php?main_page=checkout_confirmation, IP address: 174.... 
#0 /home/client/public_html/site/_livesite/includes/modules/payment/authorizenet_aim.php(263): zen_debug_error_handler()
#1 /home/client/public_html/site/_livesite/includes/classes/payment.php(248): authorizenet_aim->pre_confirmation_check()
#2 /home/client/public_html/site/_livesite/includes/modules/pages/checkout_confirmation/header_php.php(89): payment->pre_confirmation_check()
#3 /home/client/public_html/site/_livesite/index.php(35): require('/home/client...')
--> PHP Warning: Undefined array key "authorizenet_aim_cc_number" in /home/client/public_html/site/_livesite/includes/modules/payment/authorizenet_aim.php on line 263.
```

And three more for authorizenet_aim_cc_expires_month, authorizenet_aim_cc_expires_year, authorizenet_aim_cc_cvv