### PR TITLE
Admin: Don't load admin menu names if the associate constant isn't defined

### DIFF
--- a/admin/includes/functions/admin_access.php
+++ b/admin/includes/functions/admin_access.php
@@ -835,7 +835,9 @@ function zen_get_menu_titles()
     $sql = "SELECT menu_key, language_key FROM " . TABLE_ADMIN_MENUS . " ORDER BY sort_order";
     $result = $db->Execute($sql);
     foreach ($result as $row) {
-        $retVal[$row['menu_key']] = constant($row['language_key']);
+       if (defined($row['language_key'])) {
+          $retVal[$row['menu_key']] = constant($row['language_key']);
+       }
     }
     $retVal['_productTypes'] = BOX_HEADING_PRODUCT_TYPES;
     return $retVal;


### PR DESCRIPTION
Plugins that extend the menuing system may not be defined if they are being removed or haven't yet been added.

```
[24-Nov-2022 14:30:58 UTC] PHP Fatal error:  Uncaught Error: Undefined constant "BOX_HEADING_M1_EXPORT_ALL" in /Users/scott/sites/client/admin/includes/functions/admin_access.php:838
```