### PR TITLE
Misleading warning message in Salemaker

### DIFF
--- a/admin/salemaker.php
+++ b/admin/salemaker.php
@@ -358,7 +358,7 @@ if (!empty($action)) {
       }
 
       $prev_sales = $db->Execute("SELECT sale_categories_all
-                                  FROM " . TABLE_SALEMAKER_SALES);
+                                  FROM " . TABLE_SALEMAKER_SALES . " WHERE sale_status = 1 AND sale_id != " . (int)$_GET['sID']);
       foreach ($prev_sales as $prev_sale) {
         $prev_categories = explode(',', $prev_sale['sale_categories_all']);
         foreach ($prev_categories as $key => $value) {


### PR DESCRIPTION
Setup: use the demo data, go to Admin > Catalog > Salemaker and turn off all sales except the first one ($5.00 off). 
Edit this sale.  You'll see the message 

Warning: 1 sale(s) already include this category

which is created because it's not filtering out the sale you are editing. 