### PR TITLE
Observe the name change for Türkiye

### DIFF
--- a/zc_install/sql/install/mysql_utf8.sql
+++ b/zc_install/sql/install/mysql_utf8.sql
@@ -228,7 +228,7 @@ INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, count
 INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (212,'Tonga','TO','TON','8');
 INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (213,'Trinidad and Tobago','TT','TTO','2');
 INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (214,'Tunisia','TN','TUN','9');
-INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (215,'Turkey','TR','TUR','9');
+INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (215,'Türkiye','TR','TUR','9');
 INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (216,'Turkmenistan','TM','TKM','5');
 INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (217,'Turks and Caicos Islands','TC','TCA','6');
 INSERT INTO countries (countries_id, countries_name, countries_iso_code_2, countries_iso_code_3, address_format_id) VALUES (218,'Tuvalu','TV','TUV','6');

--- a/zc_install/sql/updates/mysql_upgrade_zencart_158.sql
+++ b/zc_install/sql/updates/mysql_upgrade_zencart_158.sql
@@ -191,6 +191,11 @@ UPDATE countries SET address_format_id = '19' WHERE countries_iso_code_2 = 'HU' 
 UPDATE countries SET address_format_id = '20' WHERE countries_iso_code_2 = 'ES' AND address_format_id = '3';
 ################
 
+#############
+#### Updated country information that has changed.
+UPDATE countries SET countries_name = 'Türkiye' WHERE countries_iso_code_3 = 'TUR';
+#############
+
 #### Added in case was missed on upgrades.  also modified to allow for IgnoreDups in case someone had earlier version installed.
 INSERT IGNORE INTO configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added, use_function, set_function) VALUES ('Report All Errors (Admin)?', 'REPORT_ALL_ERRORS_ADMIN', 'No', 'Do you want create debug-log files for <b>all</b> PHP errors, even warnings, that occur during your Zen Cart admin\'s processing?  If you want to log all PHP errors <b>except</b> duplicate-language definitions, choose <em>IgnoreDups</em>.', 10, 40, now(), NULL, 'zen_cfg_select_option(array(\'Yes\', \'No\', \'IgnoreDups\'),');
 INSERT IGNORE INTO configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added, use_function, set_function) VALUES ('Report All Errors (Store)?', 'REPORT_ALL_ERRORS_STORE', 'No', 'Do you want create debug-log files for <b>all</b> PHP errors, even warnings, that occur during your Zen Cart store\'s processing?  If you want to log all PHP errors <b>except</b> duplicate-language definitions, choose <em>IgnoreDups</em>.<br /><br /><strong>Note:</strong> Choosing \'Yes\' is not suggested for a <em>live</em> store, since it will reduce performance significantly!', 10, 41, now(), NULL, 'zen_cfg_select_option(array(\'Yes\', \'No\', \'IgnoreDups\'),');


### PR DESCRIPTION
United Nations as of 2 June 2022 recognizes the name change and it should therefore be adopted here.

Keeping in line with the way that countries are now handled in Zen Cart, a new install will have Türkiye at country 215, while an upgrade will update the country name if it's countries_iso_code_3 is present. This is in line with the explanation/direction provided in issue #3664.

If the country has been deleted, then reinsertion would need to be by some other path.