### PR TITLE
function for loading not-loaded language file

### DIFF
--- a/includes/functions/functions_general_shared.php
+++ b/includes/functions/functions_general_shared.php
@@ -412,3 +412,16 @@ function zen_get_admin_name($id = null)
     $result = $db->Execute($sql);
     return $result->RecordCount() ? $result->fields['admin_name'] : null;
 }
+
+function zen_load_extra_language_file()
+{
+    global $define;
+    if (empty($define) || (!is_array($define))) {
+        return;
+    }
+    foreach ($define as $key => $value) {
+        if (!defined($key)) {
+            define($key, $value);
+        }
+    }
+}


### PR DESCRIPTION
as documented in [this forum post](https://tinyurl.com/2h35lgcs), i think there is a need for plugin developers to load language files that are NOT normally loaded on a page based on the ZC language loader.

in the past, one could just include that file and all of those constants would then be defined.  

now with the new language files, ie the ones that return a `$define` array, there needs to be a method to load those new constants.  similar to what is suggested in [this post. ](https://tinyurl.com/2e4mjgut)

using this function, one can easily write the following code to get all of those new defines loaded:

```
require('admin/' . DIR_WS_LANGUAGES . $_SESSION['language'] . '/' . 'lang.' . FILENAME_MAIL . '.php');
zen_load_extra_language_file();
```

i think a simple function like this will be beneficial.

note, i am not opposed to eliminating the use of the global var `$define` and passing it to the method as a parm, providing we explicitly type it as an array.