### PR TITLE
Admin, Option Values Sort: fix sort per language, formatting, expand messagestack

### DIFF
--- a/admin/includes/languages/english/lang.option_values.php
+++ b/admin/includes/languages/english/lang.option_values.php
@@ -8,15 +8,19 @@
 
 $define = [
     'HEADING_TITLE' => 'Option Values Default Sort Order',
+    'TABLE_HEADING_OPTION_VALUE_ID' => 'Option Value ID',
+    'TABLE_HEADING_OPTION_VALUE_NAME' => 'Option Value Name',
     'TEXT_UPDATE_OPTION_VALUES' => 'Update Option Values Sort Order',
     'TEXT_SELECT_OPTION' => 'Select an Option Name:',
     'TEXT_EDIT_OPTION_NAME' => 'Editing Option Name: ',
-    'TEXT_NO_OPTION_VALUE' => 'No Option Values Defined for<br>Option Name: ',
+    'TEXT_NO_OPTION_VALUE' => 'There are no Option Values defined for Option Name: ',
     'TEXT_UPDATE_SUBMIT' => 'Update Sort Order',
+    'TEXT_UPDATE_SORT_LANGUAGE_CURRENT' => 'Update for current admin language <b>only</b>',
+    'TEXT_UPDATE_SORT_LANGUAGE_ALL' => 'Update for <b>all</b> languages',
     'TEXT_UPDATE_SORT_ORDERS_OPTIONS_PRODUCTS' => '<strong>For a Product:</strong> ',
     'TEXT_UPDATE_SORT_ORDERS_OPTIONS_CATEGORIES' => '<strong>For a Category:</strong> ',
     'SUCCESS_PRODUCT_UPDATE_SORT_ALL' => 'Successful Attribute Sort Order Update for ALL Products ',
-    'SUCCESS_OPTION_VALUES_SORT_ORDER' => 'Successful Update of Option Values Sort Order: ',
+    'SUCCESS_OPTION_VALUES_SORT_ORDER_NAME' => 'Option Name "%1$s" (#%2$u): Option Value "%3$s" (#%4$u), sort order updated to %5$u',
     'SUCCESS_CATEGORIES_UPDATE_SORT' => 'Successful Attribute Sort Order Update for Categories ID# ',
 ];
 


### PR DESCRIPTION
Impetus was a bug that sorting was updated for one language only
https://github.com/zencart/zencart/issues/5355

I worked on the first sort option only, and the formatting. There are other issues with the other sorting options, not fixed here.

Too much work to try and separate these changes, so...

Before:

![aasasa2-11-26 22_59_23-Admin Option Values — Mozilla Firefox](https://user-images.githubusercontent.com/4391026/204112229-29458e26-a669-4a70-8484-def3d166847a.gif)

Dropdown is a pointless size, unrelated to content.
![2022-11-26 23_00_19-Admin Option Values — Mozilla Firefox](https://user-images.githubusercontent.com/4391026/204112244-541b63c2-4267-4d1c-8495-eae78b4d4b0b.gif)

Edit, similar, occupying the whole page.
![2022-11-27 00_10_41-Admin Option Values — Mozilla Firefox](https://user-images.githubusercontent.com/4391026/204112261-609e07b2-daaf-4942-8507-d7e45879d70f.gif)

Masessage after a successful sort
![2022-11-27 00_11_06-Admin Option Values — Mozilla Firefox](https://user-images.githubusercontent.com/4391026/204112284-d07cf4ca-acc4-4047-ab46-c73f9e0a77b7.gif)
as
After PR:
Main Page (other sort options are for another PR)
![2022-11-27 00_07_10-Admin Option Values — Mozilla Firefox](https://user-images.githubusercontent.com/4391026/204112308-6f8db33e-1327-43d1-8320-50646d265427.gif)

Dropdown fits content:
![2022-11-27 00_07_27-Admin Option Values — Mozilla Firefox](https://user-images.githubusercontent.com/4391026/204112318-5eb5ac2e-f852-4644-92dd-a908fce32195.gif)

Edit page: 
![2022-11-27 00_11_33-Admin Option Values — Mozilla Firefox](https://user-images.githubusercontent.com/4391026/204112411-d71ede0c-81b3-4cd5-9b52-e5ce0836ad07.gif)

language options are only shown when more than one language installed
![2022-11-27 00_13_33-Admin Option Values — Mozilla Firefox](https://user-images.githubusercontent.com/4391026/204112350-8866a8b5-66a9-4208-832f-b9707af44033.gif)

Expanded message:
![2022-11-27 00_11_51-Admin Option Values — Mozilla Firefox](https://user-images.githubusercontent.com/4391026/204112373-c845cba5-cc29-46a8-9e81-a7c24b0e3e9b.gif)


