### PR TITLE
Add old signatures for backwards compatibility

### DIFF
--- a/includes/functions/functions_general_shared.php
+++ b/includes/functions/functions_general_shared.php
@@ -412,3 +412,28 @@ function zen_get_admin_name($id = null)
     $result = $db->Execute($sql);
     return $result->RecordCount() ? $result->fields['admin_name'] : null;
 }
+
+// Compatibility 
+
+function zen_draw_products_pull_down($field_name, $parameters = '', $exclude = [], $show_id = false, $set_selected = 0, $show_model = false, $show_current_category = false, $order_by = '', $filter_by_option_name = null)
+{
+   trigger_error('Call to deprecated function; please use new names', E_USER_DEPRECATED);
+   return zen_draw_pulldown_products($field_name, $parameters, $exclude, $show_id, $set_selected, $show_model, $show_current_category, $order_by, $filter_by_option_name); 
+}
+
+function zen_draw_products_pull_down_attributes($field_name, $parameters = '', $exclude = [], $order_by = 'name', $filter_by_option_name = null)
+{
+   trigger_error('Call to deprecated function; please use new names', E_USER_DEPRECATED);
+   return zen_draw_pulldown_products_having_attributes($field_name, $parameters, $exclude, $order_by, $filter_by_option_name); 
+}
+ 
+function zen_draw_products_pull_down_categories($field_name, $parameters = '', $exclude = [], $show_id = false, $show_parent = false) {
+   trigger_error('Call to deprecated function; please use new names', E_USER_DEPRECATED);
+   return zen_draw_pulldown_categories_having_products($field_name, $parameters, $exclude, $show_id, $show_parent); 
+}
+
+function zen_draw_products_pull_down_categories_attributes($field_name, $parameters = '', $exclude = [], $show_full_path = false, $filter_by_option_name = null){
+   trigger_error('Call to deprecated function; please use new names', E_USER_DEPRECATED);
+   return zen_draw_pulldown_categories_having_products_with_attributes($field_name, $parameters, $exclude, $show_full_path, $filter_by_option_name);
+}
+


### PR DESCRIPTION
These function signatures were changed in 1.5.8 in #4083; let's add back the old signatures so that plugins won't break.  We can add a deprecated log in the future.

Fixes issue described in https://www.zen-cart.com/showthread.php?229167-Functions-removed-from-1-5-8-discussion
