### PR TITLE
Don't show search box during special add by ID

### DIFF
--- a/admin/featured.php
+++ b/admin/featured.php
@@ -212,7 +212,7 @@ if (!empty($action)) {
 //          }
         }
 
-          if ($action === 'new') {
+          if ($action === 'new' && !isset($_GET['preID'])) {
               $form = addSearchKeywordForm(FILENAME_FEATURED, $action);
               echo $form;
           }

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -283,7 +283,7 @@ if (!empty($action)) {
 //            $specials_array[] = $item['products_id'];
 //          }
         }
-          if ($action === 'new') {
+          if ($action === 'new' && !isset($_GET['preID'])) {
               $form = addSearchKeywordForm(FILENAME_SPECIALS, $action);
               echo $form;
           }


### PR DESCRIPTION
Repro steps: 
- Using demo dataset, go to Admin > Catalog > Specials 
- click "Add Special by Product ID" and enter id 15. 
- Observe that add screen shows a search field.  It should not. 