### PR TITLE
Attributes Controller, Copy Attributes to Another Product: match current_category_id to product

### DIFF
--- a/admin/attributes_controller.php
+++ b/admin/attributes_controller.php
@@ -556,6 +556,7 @@ if (!empty($action)) {
       zen_copy_products_attributes($_POST['products_filter'], $_POST['products_update_id']);
       $_GET['action'] = '';
       $products_filter = $_POST['products_update_id'];
+      $_POST['current_category_id'] = zen_products_lookup($products_filter, 'master_categories_id');
       zen_redirect(zen_href_link(FILENAME_ATTRIBUTES_CONTROLLER, 'products_filter=' . $products_filter . '&current_category_id=' . $_POST['current_category_id']));
       break;
 


### PR DESCRIPTION
After copying (for example graphics card to mouse), the category is maintained for the graphics card but the product shown is the mouse:
![image](https://user-images.githubusercontent.com/4391026/206433190-3a7b6501-3c3c-42c1-8cdf-000638f7bd15.png)

This PR corrects that.