### PR TITLE
Fixes for logs created when sale has no categories

### DIFF
--- a/admin/salemaker.php
+++ b/admin/salemaker.php
@@ -43,7 +43,7 @@ if (!empty($action)) {
     case 'update':
 // insert a new sale or update an existing sale
 // Create a string of all affected (sub-)categories
-      if (zen_not_null($_POST['categories'])) {
+      if (!empty($_POST['categories'])) {
         $categories_selected = array();
         $categories_all = array();
         foreach (zen_db_prepare_input($_POST['categories']) as $category_path) {
@@ -350,8 +350,8 @@ if (!empty($action)) {
         }
         $categories_array[$i]['path'] = $categories_array[$i]['path'] . '_';
       }
-      $categories_selected = explode(',', $sInfo->sale_categories_selected);
       if (zen_not_null($sInfo->sale_categories_selected)) {
+        $categories_selected = explode(',', $sInfo->sale_categories_selected);
         $selected = in_array(TOPMOST_CATEGORY_PARENT_ID, $categories_selected);
       } else {
         $selected = false;

--- a/includes/functions/functions_prices.php
+++ b/includes/functions/functions_prices.php
@@ -1061,6 +1061,9 @@ function zen_get_products_sale_discount_type($product_id = false, $categories_id
     $sql = "SELECT * FROM " . TABLE_SALEMAKER_SALES . " WHERE sale_status=1";
     $results = $db->Execute($sql);
     foreach ($results as $result) {
+       if (empty($result['sale_categories_all'])) {
+          continue; 
+       }
         $categories = explode(',', $result['sale_categories_all']);
         foreach ($categories as $key => $value) {
             if ($value == $check_category) {
@@ -1536,6 +1539,9 @@ function zen_update_products_price_sorter($product_id)
  */
 function zen_parse_salemaker_categories($categories_csv)
 {
+    if (empty($categories_csv)) {
+       return []; 
+    }
     $clist_array = explode(',', $categories_csv);
     return array_unique($clist_array);
 }


### PR DESCRIPTION
Lots of logs are created when working on a sale with no categories selected. 

--> PHP Deprecated: explode(): Passing null to parameter #2 ($string) of type string is deprecated in /Users/scott/sites/gh_demo_158/includes/functions/functions_prices.php on line 1064.

--> PHP Deprecated: explode(): Passing null to parameter #2 ($string) of type string is deprecated in /Users/scott/sites/gh_demo_158/includes/functions/functions_prices.php on line 1542.

--> PHP Deprecated: explode(): Passing null to parameter #2 ($string) of type string is deprecated in /Users/scott/sites/gh_demo_158/admin/salemaker.php on line 353.

--> PHP Deprecated: explode(): Passing null to parameter #2 ($string) of type string is deprecated in /Users/scott/sites/gh_demo_158/admin/salemaker.php on line 353.
