### PR TITLE
mt_srand requires integer parameter

### DIFF
--- a/zc_install/includes/functions/general.php
+++ b/zc_install/includes/functions/general.php
@@ -35,7 +35,7 @@ function zen_get_select_options($optionList, $setDefault)
     static $seeded;
 
     if (!isset($seeded)) {
-      mt_srand((double)microtime()*1000000);
+      mt_srand((int)(microtime(true)*1000000));
       $seeded = true;
     }
 


### PR DESCRIPTION
a float parameter was being fed to mt_srand. As of PHP 8.1, this conversion had been deprecated but zc_install was not evaluated for having the same issue as found elsewhere in the code.

Fixes #5476