### PR TITLE
Notify when <head> tag's been rendered ...

### DIFF
--- a/includes/templates/responsive_classic/common/html_header.php
+++ b/includes/templates/responsive_classic/common/html_header.php
@@ -45,6 +45,13 @@ if (!class_exists('Mobile_Detect')) {
 <!DOCTYPE html>
 <html <?php echo HTML_PARAMS; ?>>
   <head>
+<?php
+// -----
+// Provide a notification that the <head> tag has been rendered for the current page; some scripts need to be
+// inserted just after that tag's rendered.
+//
+$zco_notifier->notify('NOTIFY_HTML_HEAD_TAG_START', $current_page_base);
+?>
   <meta charset="<?php echo CHARSET; ?>">
   <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">
   <link rel="dns-prefetch" href="https://code.jquery.com">

--- a/includes/templates/template_default/common/html_header.php
+++ b/includes/templates/template_default/common/html_header.php
@@ -30,6 +30,13 @@ require(DIR_WS_MODULES . zen_get_module_directory('meta_tags.php'));
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" <?php echo HTML_PARAMS; ?>>
 <head>
+<?php
+// -----
+// Provide a notification that the <head> tag has been rendered for the current page; some scripts need to be
+// inserted just after that tag's rendered.
+//
+$zco_notifier->notify('NOTIFY_HTML_HEAD_TAG_START', $current_page_base);
+?>
 <meta charset="<?php echo CHARSET; ?>"/>
 <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">
 <link rel="dns-prefetch" href="https://code.jquery.com">


### PR DESCRIPTION
... some external observers need to insert their scripts just after that tag's rendering.

Note that this is a template-related change.