### PR TITLE
Restore access to the mysqli object

### DIFF
--- a/includes/classes/db/mysql/query_factory.php
+++ b/includes/classes/db/mysql/query_factory.php
@@ -19,7 +19,7 @@ if (!defined('IS_ADMIN_FLAG')) {
  */
 class queryFactory extends base
 {
-    private $link; // mysqli object
+    public $link; // mysqli object
     private $count_queries = 0;
     private $total_query_time;
     public $dieOnErrors = false;


### PR DESCRIPTION
Allows access to the mysqli object of the database class. This permits the following mysqli_xxx functions to be usable:

mysqli_affected_rows
mysqli_autocommit
mysqli_begin_transaction
mysqli_change_user
mysqli_character_set_name
mysqli_close
mysqli_commit
mysqli_dump_debug_info
mysqli_errno
mysqli_error_list
mysqli_error
mysqli_execute_query
mysqli_field_count
mysqli_get_charset
mysqli_get_connection_stats
mysqli_get_host_info
mysqli_get_proto_info
mysqli_get_server_info
mysqli_get_server_version
mysqli_get_warnings
mysqli_info
mysqli_insert_id
mysqli_kill
mysqli_more_results
mysqli_multi_query
mysqli_next_result
mysqli_options
mysqli_ping
mysqli_prepare
mysqli_query
mysqli_real_connect
mysqli_real_escape_string
mysqli_real_query
mysqli_reap_async_query
mysqli_refresh
mysqli_release_savepoint
mysqli_rollback
mysqli_savepoint
mysqli_select_db
mysqli_set_charset
mysqli_sqlstate
mysqli_ssl_set
mysqli_stat
mysqli_stmt_init
mysqli_store_result
mysqli_thread_id
mysqli_use_result
mysqli_warning_count

An alternative to this would be to create an accessor function. Doing so would still break other code just like the member currently being private.

Fixes #5484