### PR TITLE
Split Invoice And Packing Image Decision

### DIFF
--- a/admin/includes/extra_datafiles/dist-site_specific_admin_overrides.php
+++ b/admin/includes/extra_datafiles/dist-site_specific_admin_overrides.php
@@ -17,9 +17,13 @@
 // admin/invoice.php and admin/packingslip.php 
 // to determine whether attribute images should be displayed. 
 //
-// true ...... attribute images are shown on invoice and packingslip (the default) 
-// false ..... attribute images are not shown on invoice and packingslip 
+// $show_attrib_images   $show_attrib_images_pack
+// true or unset         true or unset            ...... attribute images are shown on invoice and packingslip (the default) 
+// false                 false or unset           ...... attribute images are NOT shown on invoice or packingslip 
+// false                 true                     ...... attribute images are NOT shown on invoice but are shown packingslip 
+// true or unset         false                    ...... attribute images are shown on invoice but are NOT shown packingslip
 // $show_attrib_images = false;
+// $show_attrib_images_pack = false;
 
 // Set the width of the attribute image used in packingslip and invoice.
 // the default is 25. if $show_attrinb_images = false is set above then setting this value will have no effect
@@ -29,10 +33,14 @@
 // The flag show_product_images is used by the files 
 // admin/invoice.php and admin/packingslip.php 
 // to determine whether product images should be displayed. 
-//
-// true ...... product images are shown on invoice and packingslip (the default) 
-// false ..... product images are not shown on invoice and packingslip 
+// 
+// $show_product_images  $show_product_images_pack
+// true or unset         true or unset            ...... product images are shown on invoice and packingslip (the default) 
+// false                 false or unset           ...... product images are NOT shown on invoice or packingslip 
+// false                 true                     ...... product images are NOT shown on invoice  but are shown packingslip 
+// true or unset         false                    ...... product images are shown on invoice and but are NOT shown packingslip
 // $show_product_images = false;
+// $show_product_images_pack = false;
 
 // The flag show_product_tax is used by the file 
 // admin/invoice.php 

--- a/admin/packingslip.php
+++ b/admin/packingslip.php
@@ -9,12 +9,11 @@ require('includes/application_top.php');
 
 // To override the $show_* values or $attr_img_width, see 
 // https://docs.zen-cart.com/user/admin/site_specific_overrides/
-if (!isset($show_product_images)) {
-    $show_product_images = true;
-}
-if (!isset($show_attrib_images)) {
-    $show_attrib_images = true;
-}
+
+$show_product_images_pack = $show_product_images_pack ?? $show_product_images ?? true;
+ 
+$show_attrib_images_pack = $show_attrib_images_pack ?? $show_attrib_images ?? true;
+
 $img_width = defined('IMAGE_ON_INVOICE_IMAGE_WIDTH') ? (int)IMAGE_ON_INVOICE_IMAGE_WIDTH : '100';
 if (!isset($attr_img_width)) {
     $attr_img_width = '25';
@@ -138,7 +137,7 @@ if ($order->billing['street_address'] != $order->delivery['street_address']) {
       <table class="table table-striped">
         <thead>
           <tr class="dataTableHeadingRow">
-            <?php if ($show_product_images) { ?>
+            <?php if ($show_product_images_pack) { ?>
             <th class="dataTableHeadingContent" style="width: <?php echo (int)$img_width . 'px'; ?>">&nbsp;</th>
             <?php } ?>
             <th class="dataTableHeadingContent">&nbsp;</th>
@@ -194,7 +193,7 @@ if ($order->billing['street_address'] != $order->delivery['street_address']) {
             $product_name = $order->products[$i]['name'];
             ?>
             <tr class="dataTableRow">
-                <?php if ($show_product_images) { ?>
+                <?php if ($show_product_images_pack) { ?>
                 <td class="dataTableContent">
                     <?php echo zen_image(DIR_WS_CATALOG . DIR_WS_IMAGES . zen_get_products_image($order->products[$i]['id']), zen_output_string($product_name), (int)$img_width); ?>
                 </td>
@@ -217,7 +216,7 @@ if ($order->billing['street_address'] != $order->delivery['street_address']) {
                       <li>
                         <?php
 
-                                    if ($show_attrib_images && !empty($attribute_image)) {
+                                    if ($show_attrib_images_pack && !empty($attribute_image)) {
                                         echo zen_image(DIR_WS_CATALOG.DIR_WS_IMAGES . $attribute_image, zen_output_string($attribute_name), (int)$attr_img_width);
                         }
                         ?>


### PR DESCRIPTION
Allow the packing Slip and the invoice to have different options for displaying images.
This allows images to be displayed on the invoice but not the packing slip ang vice versa.