### PR TITLE
Fix paypaldp fatal error on initial installation

### DIFF
--- a/includes/modules/payment/paypaldp.php
+++ b/includes/modules/payment/paypaldp.php
@@ -1179,7 +1179,7 @@ class paypaldp extends base {
    */
   function check() {
     global $db;
-    if (!defined('MODULE_PAYMENT_PAYPALDP_MERCHANT_COUNTRY')) {
+    if (defined('MODULE_PAYMENT_PAYPALDP_STATUS') && !defined('MODULE_PAYMENT_PAYPALDP_MERCHANT_COUNTRY')) {
        $db->Execute("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Merchant Country', 'MODULE_PAYMENT_PAYPALDP_MERCHANT_COUNTRY', 'USA', 'Which country is your PayPal Account registered to? <br><u>Choices:</u><br><font color=green>You will need to supply <strong>API Settings</strong> in the Express Checkout module.</font><br><strong>USA and Canada merchants</strong> need PayPal API credentials and a PayPal Payments Pro account.<br><strong>UK merchants</strong> need to supply <strong>PAYFLOW settings</strong> (and have a Payflow account)<br><strong>Australia merchants</strong> choose Canada<br><em>(This setting is really about the internal PayPal API specification, and not so much about country: US=1.5, UK=2.0, Canada/Australia=3.0)</em>', '6', '25',  'zen_cfg_select_option(array(\'USA\', \'UK\', \'Canada\'), ', now())");
     }
     if (!isset($this->_check)) {


### PR DESCRIPTION
Fixes https://www.zen-cart.com/showthread.php?229094-New-install-1-5-8-Paypal-Pro-PHP-Fatal-error-1062

Log produced was
```
[30-Oct-2022 02:38:15 UTC] Request URI: /MyAdmin/index.php?cmd=modules&set=payment&action=install, IP address: **.***.***.***
#0 [internal function]: zen_debug_error_handler()
#1 /home/gtbullet/public_html/includes/classes/db/mysql/query_factory.php(667): trigger_error()
#2 /home/gtbullet/public_html/includes/classes/db/mysql/query_factory.php(634): queryFactory->show_error()
#3 /home/gtbullet/public_html/includes/classes/db/mysql/query_factory.php(275): queryFactory->set_error()
#4 /home/gtbullet/public_html/includes/modules/payment/paypaldp.php(1218): queryFactory->Execute()
#5 /home/gtbullet/public_html/MyAdmin/modules.php(109): paypaldp->install()
#6 /home/gtbullet/public_html/MyAdmin/index.php(11): require('/home/gtbullet/...')
--> PHP Fatal error: 1062:Duplicate entry 'MODULE_PAYMENT_PAYPALDP_MERCHANT_COUNTRY' for key 'unq_config_key_zen' :: INSERT INTO configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) VALUES ('Merchant Country', 'MODULE_PAYMENT_PAYPALDP_MERCHANT_COUNTRY', 'USA', 'Which country is your PayPal Account registered to? <br /><u>Choices:</u><br /><font color=green>You will need to supply <strong>API Settings</strong> in the Express Checkout module.</font><br /><strong>USA and Canada merchants</strong> need PayPal API credentials and a PayPal Payments Pro account.<br /><strong>UK merchants</strong> need to supply <strong>PAYFLOW settings</strong> (and have a Payflow account)<br><strong>Australia merchants</strong> choose Canada<br><em>(This setting is really about the internal PayPal API specification, and not so much about country: US=1.5, UK=2.0, Canada/Australia=3.0)</em>', '6', '25',  'zen_cfg_select_option(array(\'USA\', \'UK\', \'Canada\'), ', now()) ==> (as called by) /home/gtbullet/public_html/includes/modules/payment/paypaldp.php on line 1218 <== in /home/gtbullet/public_html/includes/classes/db/mysql/query_factory.php on line 667.
```