### PR TITLE
Retain disabled product status after upgrade

### DIFF
--- a/includes/functions/functions_products.php
+++ b/includes/functions/functions_products.php
@@ -129,7 +129,7 @@ function zen_enable_disabled_upcoming($datetime = null)
             FROM " . TABLE_PRODUCTS . "
             WHERE products_status = 0
             AND products_date_available <= " . $zc_disabled_upcoming_date . "
-            AND products_date_available >= '0001-01-01'
+            AND products_date_available != '0001-01-01'
             AND products_date_available IS NOT NULL
             ";
 


### PR DESCRIPTION
Prevents activating disabled product that have a historical `products_date_available` that is equal to `'0001-01-01'`. Initial testing of this (nearly two years ago) had indicated that the same result is obtained if the actual date/time is `'0001-01-01 00:00:00'`.

Fixes #5502