### PR TITLE
Check for null company value

### DIFF
--- a/admin/customers.php
+++ b/admin/customers.php
@@ -720,7 +720,7 @@ if (!empty($action)) {
                             <?php
                             echo zen_draw_input_field(
                                 'entry_company',
-                                htmlspecialchars($cInfo->company, ENT_COMPAT, CHARSET, true),
+                                htmlspecialchars(($cInfo->company ?? ''), ENT_COMPAT, CHARSET, true),
                                 zen_set_field_length(
                                     TABLE_ADDRESS_BOOK,
                                     'entry_company',


### PR DESCRIPTION
`address_book.entry_company` can be null, and we need to check for it or we'll get this log:

```
#0 [internal function]: zen_debug_error_handler()
#1 /Users/scott/sites/gh_demo_158/admin/customers.php(723): htmlspecialchars()
#2 /Users/scott/sites/gh_demo_158/admin/index.php(11): require('/Users/scott/si...')
--> PHP Deprecated: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in /Users/scott/sites/gh_demo_158/admin/customers.php on line 723.
```