### PR TITLE
Add inverse selection feature for DisplayLogs plugin

### DIFF
--- a/zc_plugins/DisplayLogs/v3.0.2/Installer/ScriptedInstaller.php
+++ b/zc_plugins/DisplayLogs/v3.0.2/Installer/ScriptedInstaller.php
@@ -1,0 +1,38 @@
+<?php
+
+use Zencart\PluginSupport\ScriptedInstaller as ScriptedInstallBase;
+
+class ScriptedInstaller extends ScriptedInstallBase
+{
+    protected function executeInstall()
+    {
+        zen_deregister_admin_pages(['toolsDisplayLogs']);
+        zen_register_admin_page(
+            'toolsDisplayLogs', 'BOX_TOOLS_DISPLAY_LOGS', 'FILENAME_DISPLAY_LOGS', '', 'tools', 'Y', 20);
+        $sql =
+            "INSERT IGNORE INTO " . TABLE_CONFIGURATION . " 
+            ( configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added, use_function, set_function ) 
+         VALUES 
+            
+            ('Display Logs: Display Maximum', 'DISPLAY_LOGS_MAX_DISPLAY', '20', 'Identify the maximum number of logs to display.  (Default: <b>20</b>)', 10, 100, now(), NULL, NULL),
+            
+            ('Display Logs: Maximum File Size', 'DISPLAY_LOGS_MAX_FILE_SIZE', '80000', 'Identify the maximum size of any file to display.  (Default: <b>80000</b>)', 10, 101, now(), NULL, NULL),
+            
+            ('Display Logs: Included File Prefixes', 'DISPLAY_LOGS_INCLUDED_FILES', 'myDEBUG-|AIM_Debug_|SIM_Debug_|FirstData_Debug_|Paypal|paypal|ipn_|zcInstall|notifier|usps|SHIP_usps', 'Identify the log-file <em>prefixes</em> to include in the display, separated by the pipe character (|).  Any intervening spaces are removed by the processing code.', 10, 102, now(), NULL, NULL),
+            
+            ('Display Logs: Excluded File Prefixes', 'DISPLAY_LOGS_EXCLUDED_FILES', '', 'Identify the log-file prefixes to <em>exclude</em> from the display, separated by the pipe character (|). Any intervening spaces are removed by the processing code.', 10, 103, now(), NULL, NULL)";
+
+        $this->executeInstallerSql($sql);
+    }
+
+    protected function executeUninstall()
+    {
+        zen_deregister_admin_pages(['toolsDisplayLogs']);
+
+        $deleteMap = "'DISPLAY_LOGS_MAX_DISPLAY', 'DISPLAY_LOGS_MAX_FILE_SIZE', 'DISPLAY_LOGS_INCLUDED_FILES', 'DISPLAY_LOGS_EXCLUDED_FILES'";
+
+        $sql = "DELETE FROM " . TABLE_CONFIGURATION . " WHERE configuration_key IN (" . $deleteMap . ")";
+
+        $this->executeInstallerSql($sql);
+    }
+}

--- a/zc_plugins/DisplayLogs/v3.0.2/admin/display_logs.php
+++ b/zc_plugins/DisplayLogs/v3.0.2/admin/display_logs.php
@@ -1,0 +1,338 @@
+<?php
+// -----
+// Part of the "Display Logs" plugin for Zen Cart v1.5.7 or later
+//
+// Copyright (c) 2012-2020, Vinos de Frutas Tropicales (lat9)
+//
+
+// -----
+// Functions that gather the log-related files and provide the ascending/descending sort thereof.
+//
+function sortLogDateAsc($a, $b)
+{
+    if ($a['mtime'] == $b['mtime']) return 0;
+    return ($a['mtime'] < $b['mtime']) ? -1 : 1;
+}
+function sortLogDateDesc($a, $b)
+{
+    if ($a['mtime'] == $b['mtime']) return 0;
+    return ($a['mtime'] > $b['mtime']) ? -1 : 1;
+}
+function sortLogSizeAsc($a, $b)
+{
+    if ($a['filesize'] == $b['filesize']) return 0;
+    return ($a['filesize'] < $b['filesize']) ? -1 : 1;
+}
+function sortLogSizeDesc($a, $b)
+{
+    if ($a['filesize'] == $b['filesize']) return 0;
+    return ($a['filesize'] > $b['filesize']) ? -1 : 1;
+}
+
+// -----
+// Start main processing ...
+//
+require 'includes/application_top.php';
+
+// -----
+// If debug-logs-only has been selected, display only those files.  If multiple file prefixes are
+// to be either included or excluded, wrap that value with parenthese to make preg_match "happy".
+//
+if (isset($_GET['debug_only'])) {
+    $files_to_match = 'myDEBUG-(adm-)?[0-9]+-[0-9]+-[0-9]+((-deprecated)|(-warning)|(-error))?';
+    $files_to_exclude = '';
+} else {
+    $files_to_match = str_replace(' ', '', DISPLAY_LOGS_INCLUDED_FILES);
+    if (strpos($files_to_match, '|') !== false) {
+        $files_to_match = "($files_to_match)";
+    }
+    $files_to_match .= '.*';
+
+    $files_to_exclude = str_replace(' ', '', DISPLAY_LOGS_EXCLUDED_FILES);
+    if (strpos($files_to_exclude, '|') !== false) {
+        $files_to_exclude = "($files_to_exclude)";
+    }
+    if ($files_to_exclude != '') {
+        $files_to_exclude .= '.*';
+    }
+}
+
+// -----
+// Determine (and properly default) the number of log files to be displayed.
+//
+$max_logs_to_display = (int)DISPLAY_LOGS_MAX_DISPLAY;
+if ($max_logs_to_display < 1) {
+    $max_logs_to_display = 20;
+}
+
+// -----
+// Gather the current log files.
+//
+$logFiles = array();
+foreach (array (DIR_FS_LOGS, DIR_FS_SQL_CACHE, DIR_FS_CATALOG . '/includes/modules/payment/paypal/logs') as $logFolder) {
+    $logFolder = rtrim($logFolder, '/');
+    $dir = @dir($logFolder);
+    if ($dir != NULL) {
+        while ($file = $dir->read()) {
+            if ( ($file != '.') && ($file != '..') && substr($file, 0, 1) != '.') {
+                if (preg_match('/^' . $files_to_match . '\.log$/', $file)) {
+                    if ($files_to_exclude == '' || !preg_match('/^' . $files_to_exclude . '\.log$/', $file)) {
+                        $hash = sha1($logFolder . '/' . $file);
+                        $logFiles[$hash] = array (
+                            'name'  => $logFolder . '/' . $file,
+                            'mtime' => filemtime($logFolder . '/' . $file),
+                            'filesize' => filesize($logFolder . '/' . $file)
+                        );
+                    }
+                }
+            }
+        }
+        $dir->close();
+        unset($dir);
+    }
+}
+
+// -----
+// Determine the current sort-method chosen by the admin user, sorting the list of matching
+// files based on that choice.
+//
+$sort = 'date_d';
+$sort_description = TEXT_MOST_RECENT;
+$sort_function = 'sortLogDateDesc';
+if (isset($_GET['sort'])) {
+    $sort = $_GET['sort'];
+    switch ($sort) {
+        case 'date_a':
+            $sort_description = TEXT_OLDEST;
+            $sort_function = 'sortLogDateAsc';
+            break;
+        case 'size_a':
+            $sort_description = TEXT_SMALLEST;
+            $sort_function = 'sortLogSizeAsc';
+            break;
+        case 'size_d':
+            $sort_description = TEXT_LARGEST;
+            $sort_function = 'sortLogSizeDesc';
+            break;
+        default:
+            $sort = 'date_a';
+            break;
+    }
+}
+uasort($logFiles, $sort_function);
+reset($logFiles);
+
+// -----
+// If more files were found than will be displayed, free up the memory associated with
+// those files' entries by popping them off the end of the array.
+//
+$numLogFiles = count($logFiles);
+if ($numLogFiles > $max_logs_to_display) {
+    for ($i = 0, $n = $numLogFiles - $max_logs_to_display; $i < $n; $i++) {
+        array_pop ($logFiles);
+    }
+}
+
+// -----
+// If any file delete requests have been made, process them first.
+//
+$action = (isset($_GET['action'])) ? $_GET['action'] : '';
+if ($action == 'delete') {
+    if (isset($_POST['dList']) && count($_POST['dList']) != 0) {
+        $numFiles = count($_POST['dList']);
+        $filesDeleted = 0;
+        foreach ($_POST['dList'] as $currentHash => $value) {
+            if (array_key_exists($currentHash, $logFiles)) {
+                if (is_writeable($logFiles[$currentHash]['name'])) {
+                    zen_remove($logFiles[$currentHash]['name']);
+                    $filesDeleted++;
+                }
+            }
+        }
+        if ($filesDeleted == $numFiles) {
+            $messageStack->add_session(sprintf(SUCCESS_FILES_DELETED, $numFiles), 'success');
+        } else {
+            $messageStack->add_session(sprintf(WARNING_SOME_FILES_DELETED, $filesDeleted, $numFiles), 'warning');
+        }
+    } else {
+        $messageStack->add_session(WARNING_NO_FILES_SELECTED, 'warning');
+    }
+    zen_redirect (zen_href_link(FILENAME_DISPLAY_LOGS, zen_get_all_get_params(array('action'))));
+}
+
+if (isset($_GET['fID'])) {
+    if (array_key_exists($_GET['fID'], $logFiles)) {
+        $getFile = $_GET['fID'];
+    } else {
+        unset($_GET['fID']);
+        $getFile = key($logFiles);
+    }
+} elseif (count($logFiles) != 0) {
+    $getFile = key($logFiles);
+} else {
+    $getFile = '';
+}
+
+// -----
+// "Sanitize" the maximum file-size to be fully read, defaulting if the configured value is not a positive integer.
+//
+$max_log_file_size = (int)DISPLAY_LOGS_MAX_FILE_SIZE;
+if ($max_log_file_size < 1) {
+    $max_log_file_size = 80000;
+}
+?>
+    <!doctype html >
+    <html <?php echo HTML_PARAMS; ?>>
+    <head>
+        <?php require DIR_WS_INCLUDES . 'admin_html_head.php'; ?>
+        <script>
+            function buttonCheck(whichButton) {
+                var submitOK = false;
+                var elements = document.getElementsByClassName('cBox');
+                var n = elements.length;
+                if (whichButton == 'all') {
+                    submitOK = confirm('<?php echo JS_MESSAGE_DELETE_ALL_CONFIRM; ?>');
+                    if (submitOK) {
+                        for (var i = 0; i < n; i++) {
+                            elements[i].checked = true;
+                        }
+                    }
+                } else if (whichButton == 'inverse') {
+                    for (var i = 0; i < n; i++) {
+                        elements[i].checked = !elements[i].checked;
+                    }
+                } else {
+                    var selected = 0;
+                    for (var i = 0; i < n; i++) {
+                        if (elements[i].checked) selected++;
+                    }
+                    if (selected > 0) {
+                        submitOK = confirm('<?php echo JS_MESSAGE_DELETE_SELECTED_CONFIRM; ?>');
+                    } else {
+                        alert('<?php echo WARNING_NO_FILES_SELECTED; ?>');
+                    }
+                }
+                return submitOK;
+            }
+        </script>
+    </head>
+    <body>
+    <!-- header //-->
+    <?php require(DIR_WS_INCLUDES . 'header.php'); ?>
+    <!-- header_eof //-->
+
+    <!-- body //-->
+    <table>
+        <tr>
+            <!-- body_text //-->
+            <td ><table>
+                    <tr>
+                        <td><table>
+                                <tr>
+                                    <td class="pageHeading"><?php echo HEADING_TITLE; ?></td>
+                                    <td class="pageHeading text-right"><?php echo zen_draw_separator('pixel_trans.gif', HEADING_IMAGE_WIDTH, HEADING_IMAGE_HEIGHT); ?></td>
+                                </tr>
+
+                                <tr>
+                                    <td class="main"><?php echo ((substr(HTTP_SERVER, 0, 5) != 'https') ? WARNING_NOT_SECURE : '') . sprintf(TEXT_INSTRUCTIONS, $max_log_file_size, $sort_description, (($numLogFiles > $max_logs_to_display) ? $max_logs_to_display : $numLogFiles), $numLogFiles, $files_to_match, $files_to_exclude, zen_image (DIR_WS_IMAGES . 'icon_info.gif', ICON_INFO_VIEW)); ?></td>
+                                    <td class="main text-right"><?php echo zen_draw_separator('pixel_trans.gif', HEADING_IMAGE_WIDTH, HEADING_IMAGE_HEIGHT); ?></td>
+                                </tr>
+
+                                <tr>
+                                    <td  colspan="2"><?php echo zen_draw_form('logs_form', FILENAME_DISPLAY_LOGS, '', 'get') . '<b>' . DISPLAY_DEBUG_LOGS_ONLY . '</b>&nbsp;&nbsp;' . zen_draw_checkbox_field('debug_only', 'on', (isset($_GET['debug_only'])) ? true : false, '', 'onclick="this.form.submit();"') . zen_draw_hidden_field('sort', $sort) . '</form>'; ?></td>
+                                </tr>
+
+                            </table></td>
+                    </tr>
+                </table></td>
+        </tr>
+
+        <tr>
+            <td>
+                <form id="dlFormID" name="dlForm" action="<?php echo zen_href_link(FILENAME_DISPLAY_LOGS, zen_get_all_get_params (array('action')) . 'action=delete', 'NONSSL'); ?>" method="post"><?php echo zen_draw_hidden_field('securityToken', $_SESSION['securityToken']) . "\n"; ?>
+                    <table>
+
+                        <tr>
+                            <td><table>
+                                    <tr>
+                                        <td id="logFileDetails"><table >
+                                                <tr class="dataTableHeadingRow">
+                                                    <td class="dataTableHeadingContent text-left"><?php echo TABLE_HEADING_FILENAME; ?></td>
+                                                    <td class="dataTableHeadingContent text-center"><?php echo TABLE_HEADING_MODIFIED; ?><br><a href="<?php echo zen_href_link(FILENAME_DISPLAY_LOGS, zen_get_all_get_params(array('sort')) . 'sort=date_a', 'NONSSL'); ?>"><?php echo TEXT_ASC; ?></a>&nbsp;&nbsp;<a href="<?php echo zen_href_link(FILENAME_DISPLAY_LOGS, zen_get_all_get_params(array('sort')) . 'sort=date_d', 'NONSSL'); ?>"><?php echo TEXT_DESC; ?></a></td>
+                                                    <td class="dataTableHeadingContent text-center"><?php echo TABLE_HEADING_FILESIZE; ?><br><a href="<?php echo zen_href_link (FILENAME_DISPLAY_LOGS, zen_get_all_get_params(array('sort')) . 'sort=size_a', 'NONSSL'); ?>"><?php echo TEXT_ASC; ?></a>&nbsp;&nbsp;<a href="<?php echo zen_href_link(FILENAME_DISPLAY_LOGS, zen_get_all_get_params(array('sort')) . 'sort=size_d', 'NONSSL'); ?>"><?php echo TEXT_DESC; ?></a></td>
+                                                    <td class="dataTableHeadingContent text-center"><?php echo TABLE_HEADING_DELETE; ?></td>
+                                                    <td class="dataTableHeadingContent text-right"><?php echo TABLE_HEADING_ACTION; ?>&nbsp;</td>
+                                                </tr>
+                                                <?php
+                                                reset($logFiles);
+                                                $fileData = '';
+                                                $heading = array();
+                                                $contents = array();
+                                                foreach ($logFiles as $curHash => $curFile) {
+                                                    ?>
+                                                    <tr>
+                                                        <td class="dataTableContent text-left"><?php echo str_replace(DIR_FS_CATALOG, '/', $curFile['name']); ?></td>
+                                                        <td class="dataTableContent text-center"><?php echo date(DATE_FORMAT . ' H:i:s', $curFile['mtime']); ?></td>
+                                                        <td class="dataTableContent<?php echo ($curFile['filesize'] > $max_log_file_size) ? ' bigfile' : ''; ?> text-center"><?php echo $curFile['filesize']; ?></td>
+                                                        <td class="dataTableContent text-center"><?php echo zen_draw_checkbox_field('dList[' . $curHash . ']', false, false, '', 'class="cBox"'); ?></td>
+                                                        <td class="dataTableContent text-right"><?php if ($getFile == $curHash) { echo zen_image(DIR_WS_IMAGES . 'icon_arrow_right.gif', ''); } else { echo '<a href="' . zen_href_link(FILENAME_DISPLAY_LOGS, 'fID=' . $curHash . '&amp;' . zen_get_all_get_params(array('fID'))) . '">' . zen_image(DIR_WS_IMAGES . 'icon_info.gif', ICON_INFO_VIEW) . '</a>'; } ?>&nbsp;</td>
+                                                    </tr>
+                                                    <?php
+                                                    if ($getFile == $curHash) {
+                                                        $heading[] = array(
+                                                            'text' => '<strong>' . TEXT_HEADING_INFO . '( ' . $curFile['name'] . ')</strong>'
+                                                        );
+                                                        $fileContent = str_replace(DIR_FS_CATALOG, '/', nl2br(htmlentities(trim(file_get_contents($curFile['name'], false, NULL, 0, $max_log_file_size)), ENT_COMPAT+ENT_IGNORE, CHARSET, false)));
+                                                        $contents[] = array(
+                                                            'align' => 'left',
+                                                            'text' => '<div id="fContents">' . $fileContent . '</div>'
+                                                        );
+                                                        unset($fileContent);
+                                                    }
+                                                }
+                                                ?>
+                                            </table></td>
+                                        <?php
+                                        if (!empty($heading) && !empty($contents)) {
+                                            ?>
+                                            <td id="contentsOuter" >
+                                                <?php
+                                                $box = new box;
+                                                echo $box->infoBox($heading, $contents);
+                                                ?>
+                                            </td>
+                                            <?php
+                                        }
+                                        ?>
+                                    </tr>
+                                </table></td>
+                        </tr>
+                        <?php
+                        if ($numLogFiles > 0) {
+                            ?>
+                            <tr>
+                                <td id="theButtons">
+                                    <div id="dButtons">
+                                        <div id="dInv"><button class="btn btn-primary" type="submit" onclick="return buttonCheck('inverse');"><?php echo BUTTON_INVERT_SELECTED; ?></button></div>
+                                        <div id="dSel"><button class="btn btn-primary" type="submit" onclick="return buttonCheck('delete');"><?php echo BUTTON_DELETE_SELECTED; ?></button></div>
+                                        <div id="dAll"><button class="btn btn-primary" type="submit" onclick="return buttonCheck('all');"><?php echo BUTTON_DELETE_ALL; ?></button></div>
+                                    </div>
+                                    <div id="dSpace">&nbsp;</div>
+                                </td>
+                            </tr>
+                            <?php
+                        }
+                        ?>
+                    </table></form></td>
+            <!-- body_text_eof //-->
+        </tr>
+    </table>
+    <!-- body_eof //-->
+
+    <!-- footer //-->
+    <?php require(DIR_WS_INCLUDES . 'footer.php'); ?>
+    <!-- footer_eof //-->
+    <br>
+    </body>
+    </html>
+<?php require(DIR_WS_INCLUDES . 'application_bottom.php'); ?>

--- a/zc_plugins/DisplayLogs/v3.0.2/admin/includes/auto_loaders/config.display_logs.php
+++ b/zc_plugins/DisplayLogs/v3.0.2/admin/includes/auto_loaders/config.display_logs.php
@@ -1,0 +1,13 @@
+<?php
+// -----
+// Part of the "Display Logs" plugin for Zen Cart v1.5.0 and later.
+//
+// Copyright (c) 2016, Vinos de Frutas Tropicales (lat9)
+//
+if (!defined('IS_ADMIN_FLAG')) {
+    die('Illegal Access');
+}
+
+$autoLoadConfig[200][] = array(
+    'autoType'  => 'init_script',
+    'loadFile'  => 'init_display_logs.php');

--- a/zc_plugins/DisplayLogs/v3.0.2/admin/includes/css/display_logs.css
+++ b/zc_plugins/DisplayLogs/v3.0.2/admin/includes/css/display_logs.css
@@ -1,0 +1,13 @@
+/*
+ * css for display logs
+ */
+table { width:100%}
+.bigfile { font-weight: bold; color: red; }
+#theButtons { padding-top: 10px; margin-top: 10px; border-top: 1px solid black; }
+#dButtons, #dSpace { width: 50%; }
+#dAll { float: right; padding-right: 20px; }
+#dSel { float: right; }
+#dInv { float: right; padding-left: 20px; }
+#fContents { overflow: auto; max-height: <?php echo 23 * $max_logs_to_display; ?>px; }
+#contentsOuter, #logFileDetails { vertical-align: top; width: 50%;}
+

--- a/zc_plugins/DisplayLogs/v3.0.2/admin/includes/extra_datafiles/display_log_filenames.php
+++ b/zc_plugins/DisplayLogs/v3.0.2/admin/includes/extra_datafiles/display_log_filenames.php
@@ -1,0 +1,22 @@
+<?php
+//
+// +----------------------------------------------------------------------+
+// |zen-cart Open Source E-commerce                                       |
+// +----------------------------------------------------------------------+
+// | Copyright (c) 2004 The zen-cart developers                           |
+// |                                                                      |
+// | http://www.zen-cart.com/index.php                                    |
+// |                                                                      |
+// | Portions Copyright (c) 2003 osCommerce                               |
+// +----------------------------------------------------------------------+
+// | This source file is subject to version 2.0 of the GPL license,       |
+// | that is bundled with this package in the file LICENSE, and is        |
+// | available through the world-wide-web at the following url:           |
+// | http://www.zen-cart.com/license/2_0.txt.                             |
+// | If you did not receive a copy of the zen-cart license and are unable |
+// | to obtain it through the world-wide-web, please send a note to       |
+// | license@zen-cart.com so we can mail you a copy immediately.          |
+// +----------------------------------------------------------------------+
+// $Id: display_logs_filenames.php,v1.0 2012-12-20 lat9 $
+//
+define('FILENAME_DISPLAY_LOGS', 'display_logs');

--- a/zc_plugins/DisplayLogs/v3.0.2/admin/includes/init_includes/init_display_logs.php
+++ b/zc_plugins/DisplayLogs/v3.0.2/admin/includes/init_includes/init_display_logs.php
@@ -1,0 +1,23 @@
+<?php
+// -----
+// Part of the "Display Logs" plugin for Zen Cart v1.5.0 or later
+//
+// Copyright (c) 2012-2020, Vinos de Frutas Tropicales (lat9)
+//
+if (!defined('IS_ADMIN_FLAG')) {
+    die('Illegal Access');
+}
+
+// -----
+// Check to see if there are any debug-logs present and, if so, notify the current admin via header message ... unless the admin is already on the display logs page.
+//
+if ($current_page != FILENAME_DISPLAY_LOGS . '.php') {
+    $path = (defined('DIR_FS_LOGS')) ? DIR_FS_LOGS : DIR_FS_SQL_CACHE;
+    $log_files = glob($path . '/myDEBUG-*.log');
+    $num_log_files = ($log_files === false) ? 0 : count ($log_files);
+    unset ($log_files);
+    if ($num_log_files > 0) {
+        $messageStack->add(sprintf(DISPLAY_LOGS_MESSAGE_LOGS_PRESENT, $num_log_files, zen_href_link(FILENAME_DISPLAY_LOGS)), 'caution');
+    }
+}
+

--- a/zc_plugins/DisplayLogs/v3.0.2/admin/includes/languages/english/extra_definitions/lang.display_logs_name.php
+++ b/zc_plugins/DisplayLogs/v3.0.2/admin/includes/languages/english/extra_definitions/lang.display_logs_name.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @copyright Copyright 2003-2022 Zen Cart Development Team
+ * @copyright Portions Copyright 2003 osCommerce
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: Zcwilt 2020 Jun 02 New in v1.5.8-alpha $
+*/
+
+$define = [
+      'BOX_TOOLS_DISPLAY_LOGS' => 'Display Log Files',
+      'DISPLAY_LOGS_MESSAGE_LOGS_PRESENT' => '%1$u debug-log files exist, click <a href="%2$s">here</a> to view.',
+];
+
+return $define;

--- a/zc_plugins/DisplayLogs/v3.0.2/admin/includes/languages/english/lang.display_logs.php
+++ b/zc_plugins/DisplayLogs/v3.0.2/admin/includes/languages/english/lang.display_logs.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @copyright Copyright 2003-2022 Zen Cart Development Team
+ * @copyright Portions Copyright 2003 osCommerce
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: Steve 2021 Apr 02 New in v1.5.8-alpha $
+*/
+
+
+$define = [
+    'HEADING_TITLE' => 'Display Debug Log Files',
+    'TABLE_HEADING_FILENAME' => 'File Name',
+    'TABLE_HEADING_MODIFIED' => 'Date Modified',
+    'TABLE_HEADING_FILESIZE' => 'File Size (bytes)',
+    'TABLE_HEADING_DELETE' => 'Delete?',
+    'TABLE_HEADING_ACTION' => 'Action',
+    'BUTTON_INVERT_SELECTED' => 'Inverse Selection(s)',
+    'BUTTON_DELETE_SELECTED' => 'Delete Selected',
+    'DELETE_SELECTED_ALT' => 'Delete all selected files',
+    'BUTTON_DELETE_ALL' => 'Delete All',
+    'DELETE_ALL_ALT' => 'Delete all files in the current view',
+    'ICON_INFO_VIEW' => 'View the contents of this file',
+    'DISPLAY_DEBUG_LOGS_ONLY' => 'Display debug-logs only?',
+    'TEXT_HEADING_INFO' => 'File Contents',
+    'TEXT_MOST_RECENT' => 'most recent',
+    'TEXT_OLDEST' => 'oldest',
+    'TEXT_SMALLEST' => 'smallest',
+    'TEXT_LARGEST' => 'largest',
+    'TEXT_INSTRUCTIONS' => '<br><br>The files can be sorted in either ascending or descending order (based on either the last-modified date or the file-size) by clicking on one of the <em>Asc</em> or <em>Desc</em> links. Click on an %7$s icon to view the contents of the associated file.  Only the first %1$u bytes of the selected file will be read; if a file is &quot;over-sized&quot;, its <em>File Size</em> will be highlighted like <span class="bigfile">this</span>.<br><br>Clicking the <strong>delete all</strong> button will delete all files currently being viewed; clicking <strong>delete selected</strong> will delete only those files with checked checkboxes, clicking <strong>inverse selection(s)</strong> will swap checked for unchecked and unchecked for checked.<br><br>Currently viewing the %2$s %3$u of %4$u log files with these <code>%5$s</code> prefixes and <b>not</b> matching these <code>%6$s</code>.<br>',
+    'JS_MESSAGE_DELETE_ALL_CONFIRM' => 'Are you sure you want to delete these \'+n+\' files?',
+    'JS_MESSAGE_DELETE_SELECTED_CONFIRM' => 'Are you sure you want to delete the \'+selected+\' selected file(s)?',
+    'WARNING_NOT_SECURE' => '<span class="errorText">NOTE: You do not have SSL enabled. File contents you view from this page will not be encrypted and could present a security risk.</span>',
+    'WARNING_NO_FILES_SELECTED' => 'No files were selected for deletion!',
+    'WARNING_SOME_FILES_DELETED' => 'Warning: Only %u of %u log files were deleted; check permissions.',
+    'SUCCESS_FILES_DELETED' => '%u log files were deleted.',
+];
+
+return $define;

--- a/zc_plugins/DisplayLogs/v3.0.2/manifest.php
+++ b/zc_plugins/DisplayLogs/v3.0.2/manifest.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+    'pluginVersion' => 'v3.0.2',
+    'pluginName' => 'Display logs',
+    'pluginDescription' => 'Display and manage Zen Cart log files.',
+    'pluginAuthor' => 'Vinos de Frutas Tropicales (lat9)',
+    'pluginId' => 1583, // ID from Zen Cart forum
+    'zcVersions' => ['v158'],
+    'changelog' => '', // online URL (eg github release tag page, or changelog file there) or local filename only, ie: changelog.txt (in same dir as this manifest file)
+    'github_repo' => '', // url
+    'pluginGroups' => [],
+];


### PR DESCRIPTION
There are times when there are just a few files to keep, but many others to be removed. Selecting a few to then inverse the selection and then choose to delete all selected improves efficiency.

Added a button to inverse the selection(s). Also updated the script within the main file to not be encapsulated around HTML comment blocks.

Updated as version 3.0.2. Tested the upgrade process which successfully completed.

Fixes #5515