### PR TITLE
fixes product sorts on pulldown

### DIFF
--- a/includes/classes/productPulldown.php
+++ b/includes/classes/productPulldown.php
@@ -19,14 +19,15 @@
             'products_model' => 'p',
             'products_id' => 'p',
             'products_price' => 'p',
+            'products_price_sorter' => 'p',
             'products_sort_order' => 'p',
         ];
-        
+
         private $categories_join;
         private $output_string;
         private $show_model;
         private $show_price;
-        
+
         /**
          *
          */
@@ -64,7 +65,7 @@
             $this->sort = '';
             foreach ($fieldnameArray as $fieldname) {
                 if (array_key_exists($fieldname, $this->keyed_allowed_sort_array)) {
-                    $this->sort = ($first ? ' ORDER BY ' : ', ') . $this->keyed_allowed_sort_array[$fieldname] . '.' . $fieldname;
+                    $this->sort .= ($first ? ' ORDER BY ' : ', ') . $this->keyed_allowed_sort_array[$fieldname] . '.' . $fieldname;
                     $first = false;
                 }
             }
@@ -128,7 +129,7 @@
             $this->sql = "SELECT DISTINCT pd.products_id, p.products_sort_order, p.products_price, p.products_model, pd.products_name
                 FROM " . TABLE_PRODUCTS . " p"
                 . $this->categories_join . "
-                INNER JOIN " . TABLE_PRODUCTS_DESCRIPTION . " pd ON (p.products_id = pd.products_id) 
+                INNER JOIN " . TABLE_PRODUCTS_DESCRIPTION . " pd ON (p.products_id = pd.products_id)
 				" . $this->attributes_join . "
 				WHERE pd.language_id = " . (int)$_SESSION['languages_id'];
         }

--- a/includes/functions/functions_categories.php
+++ b/includes/functions/functions_categories.php
@@ -336,10 +336,33 @@ function zen_draw_pulldown_products($field_name, $parameters = '', $exclude = []
     }
 
     if (empty($order_by)) {
-        $order_by = $prev_next_order;
+        switch(PRODUCT_INFO_PREVIOUS_NEXT_SORT) {
+            case 0:
+                $order_by = 'products_id';
+                break;
+            case 2:
+                $order_by = 'products_model';
+                break;
+            case 3:
+                $order_by = 'products_price_sorter, products_name';
+                break;
+            case 4:
+                $order_by = 'products_price_sorter, products_model';
+                break;
+            case 5:
+                $order_by = 'products_name, products_model';
+                break;
+            case 6:
+                $order_by = 'products_sort_order, products_name';
+                break;
+            case 1:
+            default:
+                $order_by = 'products_name';
+                break;
+        }
     }
 
-    $sort_array = array_filter(explode(',', str_ireplace('order by ', '', trim($order_by))));
+    $sort_array = array_map('trim', array_filter(explode(',', str_ireplace('order by ', '', $order_by))));
 
     $pulldown = new productPulldown();
 


### PR DESCRIPTION
fixes the bug as documented in [this forum post.](https://www.zen-cart.com/showthread.php?229219-Am-curious-how-to-alphabetize-this)

the  only question now is if we want to add to the description of this config value that it is also used for product pulldowns:

https://github.com/zencart/zencart/blob/d4398a6ccc9e1c8f30007a0720d9e6024c123109/zc_install/sql/install/mysql_zencart.sql#L2881