### PR TITLE
Eliminate debug generation

### DIFF
--- a/includes/functions/functions_lookups.php
+++ b/includes/functions/functions_lookups.php
@@ -95,6 +95,9 @@ function zen_get_configuration_key_value_layout($lookup, $type = 1)
 {
     global $db;
     $configuration_query = $db->Execute("select configuration_value from " . TABLE_PRODUCT_TYPE_LAYOUT . " where configuration_key='" . zen_db_input($lookup) . "' and product_type_id='" . (int)$type . "'");
+    if ($configuration_query->EOF) {
+      return '<span class="lookupAttention">' . $lookup . '</span>';
+    }
     $lookup_value = $configuration_query->fields['configuration_value'];
     if (!($lookup_value)) {
         $lookup_value = '<span class="lookupAttention">' . $lookup . '</span>';


### PR DESCRIPTION
Passing a lookup value for `configuration_key` that does not exist in the database generates a warning debug log in PHP 8.2.
````php
#0 /catalog/includes/functions/functions_lookups.php(98): zen_debug_error_handler()
#1 /admin/plugin.php(): zen_get_configuration_key_value_layout()
#2 /admin/index.php(11): require('admin...')
--> PHP Warning: Undefined array key "configuration_value" in catalog/includes/functions/functions_lookups.php on line 98.
````

Fixes #5547