### PR TITLE
add cat_id to product category search

### DIFF
--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -540,6 +540,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
               $keyword_search_fields = [
                 'cd.categories_name',
                 'cd.categories_description',
+                'cd.categories_id',
               ];
               $sql .= zen_build_keyword_where_clause($keyword_search_fields, trim($keywords), true);
           } else {


### PR DESCRIPTION
use case:

working with a client who has 5726 categories short of 4 gazillion, i have found the ability to input a category_id number into the search field very beneficial.