### PR TITLE
add notifier to build_keyword function

### DIFF
--- a/includes/functions/functions_search.php
+++ b/includes/functions/functions_search.php
@@ -159,7 +159,9 @@ function zen_parse_search_string($search_str = '', &$objects = array()) {
 
     function zen_build_keyword_where_clause($fields, $string, $startWithWhere = false)
     {
-        global $db;
+        global $db, $zco_notifier;
+
+        $zco_notifier->notify('NOTIFY_BUILD_KEYWORD_SEARCH', '', $fields, $string);
         if (zen_parse_search_string(stripslashes($string), $search_keywords)) {
             $where_str = " AND (";
             if ($startWithWhere) {


### PR DESCRIPTION
use case:
scott wilson wants to limit searches on a particular page to only `products_id`.  adding this notifier will allow him to do that.  it will also allow for adding of additional fields as well.

i see plenty of times when this will come in handy.