### PR TITLE
add notifier to search box

### DIFF
--- a/admin/includes/modules/search_box.php
+++ b/admin/includes/modules/search_box.php
@@ -34,5 +34,10 @@ if (isset($_GET['search']) && zen_not_null($_GET['search'])) {
       </div>
     </div>
   </div>
-<?php } ?>
+    <?php
+}
+$extra_form_group = '';
+$zco_notifier->notify('NOTIFY_ADMIN_SEARCH_BOX_FORM_GROUP', '', $extra_form_group);
+echo $extra_form_group;
+?>
 <?php echo '</form>'; ?>


### PR DESCRIPTION
given that the search box is drawing a form using the http request of get; providing the ability to add other items in the form group is crucial to being able to make use of them.

use case and example:
category products listings now searches the description; by utilizing a checkbox (added using this notifier), one can add a checkbox for search in description.  if the box is unchecked, one can then use the `NOTIFY_BUILD_KEYWORD_SEARCH` notifier to remove the `products_description` and `category_description` from the `$fields` array in the `zen_build_keyword_where_clause` method.

it has always been my intention to allow that flexibility when using the `zen_build_keyword_where_clause` method.  with all/most of the search boxes, now sharing a common bit of code (thank you @Zen4All!); users can now add additional modifiers based on what page they are on, and add or subtract search fields in the aforementioned method, based on any new selection criteria added using this notifier.