### PR TITLE
fix build search

### DIFF
--- a/includes/functions/functions_search.php
+++ b/includes/functions/functions_search.php
@@ -162,6 +162,7 @@ function zen_parse_search_string($search_str = '', &$objects = array()) {
         global $db, $zco_notifier;
 
         $zco_notifier->notify('NOTIFY_BUILD_KEYWORD_SEARCH', '', $fields, $string);
+        $first_field = true;
         if (zen_parse_search_string(stripslashes($string), $search_keywords)) {
             $where_str = " AND (";
             if ($startWithWhere) {
@@ -178,7 +179,6 @@ function zen_parse_search_string($search_str = '', &$objects = array()) {
                         break;
                     default:
                         $sql_add = " (";
-                        $first_field = true;
                         $sql_or = ' ';
                         foreach ($fields as $field_name) {
                             if (!$first_field) {
@@ -207,6 +207,9 @@ function zen_parse_search_string($search_str = '', &$objects = array()) {
                 }
             }
             $where_str .= " )";
+        }
+        if ($first_field) {
+            return ' ';
         }
         return $where_str ?? ' ';
     }


### PR DESCRIPTION
use case:

```
$where = zen_build_keyword_where_clause(['products_id',], 'anythingThatIsNotInteger', true);
```
in this situation, `$where` evaluates to `WHERE ( ()  )`.

this PR addresses that situation.