### PR TITLE
allow override on search inputs

### DIFF
--- a/includes/modules/pages/search_result/header_php.php
+++ b/includes/modules/pages/search_result/header_php.php
@@ -128,7 +128,7 @@ if ($search_additional_clause === false &&
     }
 }
 
-if (empty($dfrom) && empty($dto) && empty($pfrom) && empty($pto) && empty($keywords)) {
+if (empty($dfrom) && empty($dto) && empty($pfrom) && empty($pto) && empty($keywords) && $search_additional_clause === false) {
     $error = true;
     // redundant should be able to remove this
     if (!$missing_one_input) {


### PR DESCRIPTION
i am not sure why this conditional is in here.  line 133 even states it (although it should be above line 132).

this code seems to mimic the code at the top of the file.  but it does not allow for the overriding by the notifier.

i'm not sure why we need these redundant checks, i was tempted to remove them; rather than that i just allowed the override done with the notifier on line 34, to override these checks as well.  code at the top:

https://github.com/zencart/zencart/blob/29399901200641ca2c94415877e9eea1ac8a2bef/includes/modules/pages/search_result/header_php.php#L33-L41