### PR TITLE
Add manufacturers_id to query

### DIFF
--- a/includes/modules/pages/products_all/header_php.php
+++ b/includes/modules/pages/products_all/header_php.php
@@ -19,7 +19,7 @@
 
   $products_all_array = array();
 
-  $products_all_query_raw = "SELECT p.products_type, p.products_id, pd.products_name, p.products_image, p.products_price, p.products_tax_class_id,
+  $products_all_query_raw = "SELECT p.products_type, p.products_id, pd.products_name, p.products_image, p.products_price, p.products_tax_class_id, p.manufacturers_id, 
                                     p.products_date_added, m.manufacturers_name, p.products_model, p.products_quantity, p.products_weight, p.product_is_call,
                                     p.product_is_always_free_shipping, p.products_qty_box_status,
                                     p.master_categories_id


### PR DESCRIPTION
Prevents log: 
[09-Feb-2023 11:44:41 America/Los_Angeles] Request URI: /client/index.php?main_page=products_all, IP address: ::1
#0 /Users/scott/sites/client/includes/modules/westminster_new/product_listing.php(416): zen_debug_error_handler()
#1 /Users/scott/sites/client/includes/templates/westminster_new/templates/tpl_modules_product_listing.php(14): include('/Users/scott/si...')
#2 /Users/scott/sites/client/includes/templates/westminster_new/templates/tpl_products_all_default.php(18): require('/Users/scott/si...')
#3 /Users/scott/sites/client/includes/templates/westminster_new/common/tpl_main_page.php(253): require('/Users/scott/si...')
#4 /Users/scott/sites/client/index.php(94): require('/Users/scott/si...')
--> PHP Warning: Undefined array key "manufacturers_id" in /Users/scott/sites/client/includes/modules/westminster_new/product_listing.php on line 416.

This is includes/modules/product_listing.php line 398 in an unmodified copy of Zen Cart 1.5.8. 