### PR TITLE
Correct PHP Warnings during download

### DIFF
--- a/includes/classes/observers/auto.downloads_via_url.php
+++ b/includes/classes/observers/auto.downloads_via_url.php
@@ -154,7 +154,6 @@ class zcObserverDownloadsViaUrl extends base {
 
     $file_parts = explode(':', $filename);
     if (preg_match('~^(https?://)(?!=.*)~', $filename, $matches)) {
-//       $file_parts[1] = ltrim($file_parts[1], '/');
       return $file_parts;
     }
 

--- a/includes/classes/observers/auto.downloads_via_url.php
+++ b/includes/classes/observers/auto.downloads_via_url.php
@@ -90,6 +90,9 @@ class zcObserverDownloadsViaUrl extends base {
   protected function updateNotifyCheckDownloadHandler(&$class, $eventID, $var, &$fields, &$origin_filename, &$browser_filename, &$source_directory, &$file_exists, &$service)
   {
     $file_parts = $this->parseFileParts($origin_filename);
+    if ($file_parts === false) {
+        return;
+    }
     if ($file_parts[0] == 'http' || $file_parts[0] == 'https') {
       $origin_filename  = $file_parts[1];
       $browser_filename = substr($origin_filename, strrpos($origin_filename, '/') + 1);
@@ -119,7 +122,9 @@ class zcObserverDownloadsViaUrl extends base {
     // verify that the passed "file" is an http/https URL
     if ($source_directory != 'http' && $source_directory != 'https') {
       $file_parts = $this->parseFileParts($origin_filename);
-      if ($file_parts[0] != 'http' && $file_parts[0] != 'https') return;
+      if ($file_parts === false || ($file_parts[0] != 'http' && $file_parts[0] != 'https')) {
+          return;
+      }
       $origin_filename  = $file_parts[1];
       $browser_filename = substr($origin_filename, strrpos($origin_filename, '/') + 1);
       $source_directory = $file_parts[0];


### PR DESCRIPTION
Seeing logs similar to
```
[15-Feb-2023 14:53:06 America/New_York] Request URI: /zc158/index.php?main_page=download&order=40&id=3, IP address: 127.0.0.1, Language id 1
#1  zcObserverDownloadsViaUrl->updateNotifyCheckDownloadHandler() called at [C:\xampp\htdocs\zc158\includes\classes\traits\NotifierManager.php:87]
#2  base->notify() called at [C:\xampp\htdocs\zc158\includes\modules\pages\download\header_php.php:89]
#3  require(C:\xampp\htdocs\zc158\includes\modules\pages\download\header_php.php) called at [C:\xampp\htdocs\zc158\index.php:35]
--> PHP Notice: Trying to access array offset on value of type bool in C:\xampp\htdocs\zc158\includes\classes\observers\auto.downloads_via_url.php on line 93.

[15-Feb-2023 14:53:06 America/New_York] Request URI: /zc158/index.php?main_page=download&order=40&id=3, IP address: 127.0.0.1, Language id 1
#1  zcObserverDownloadsViaUrl->updateNotifyCheckDownloadHandler() called at [C:\xampp\htdocs\zc158\includes\classes\traits\NotifierManager.php:87]
#2  base->notify() called at [C:\xampp\htdocs\zc158\includes\modules\pages\download\header_php.php:89]
#3  require(C:\xampp\htdocs\zc158\includes\modules\pages\download\header_php.php) called at [C:\xampp\htdocs\zc158\index.php:35]
--> PHP Notice: Trying to access array offset on value of type bool in C:\xampp\htdocs\zc158\includes\classes\observers\auto.downloads_via_url.php on line 93.

[15-Feb-2023 14:53:06 America/New_York] Request URI: /zc158/index.php?main_page=download&order=40&id=3, IP address: 127.0.0.1, Language id 1
#1  zcObserverDownloadsViaUrl->updateNotifyDownloadReadyToStart() called at [C:\xampp\htdocs\zc158\includes\classes\traits\NotifierManager.php:87]
#2  base->notify() called at [C:\xampp\htdocs\zc158\includes\modules\pages\download\header_php.php:148]
#3  require(C:\xampp\htdocs\zc158\includes\modules\pages\download\header_php.php) called at [C:\xampp\htdocs\zc158\index.php:35]
--> PHP Notice: Trying to access array offset on value of type bool in C:\xampp\htdocs\zc158\includes\classes\observers\auto.downloads_via_url.php on line 122.

[15-Feb-2023 14:53:06 America/New_York] Request URI: /zc158/index.php?main_page=download&order=40&id=3, IP address: 127.0.0.1, Language id 1
#1  zcObserverDownloadsViaUrl->updateNotifyDownloadReadyToStart() called at [C:\xampp\htdocs\zc158\includes\classes\traits\NotifierManager.php:87]
#2  base->notify() called at [C:\xampp\htdocs\zc158\includes\modules\pages\download\header_php.php:148]
#3  require(C:\xampp\htdocs\zc158\includes\modules\pages\download\header_php.php) called at [C:\xampp\htdocs\zc158\index.php:35]
--> PHP Notice: Trying to access array offset on value of type bool in C:\xampp\htdocs\zc158\includes\classes\observers\auto.downloads_via_url.php on line 122.
```

As reported on the Zen Cart forums [here](https://www.zen-cart.com/showthread.php?229298-1-5-8-Digital-Downloads-PHP-Warning-Trying-to-access-array-offset-on-value-of-type&p=1393137#post1393137).