### PR TITLE
`zen_draw_form`, correct hidden 'cmd' variable contents

### DIFF
--- a/admin/includes/functions/html_output.php
+++ b/admin/includes/functions/html_output.php
@@ -230,24 +230,27 @@ function zen_image_submit($image, $alt = '', $parameters = '')
 
 ////
 // Output a form
-  function zen_draw_form($name, $action, $parameters = '', $method = 'post', $params = '', $usessl = 'false') {
+function zen_draw_form($name, $action, $parameters = '', $method = 'post', $params = '', $usessl = 'false')
+{
     $form = '<form name="' . zen_output_string($name) . '" action="';
     if (!empty($parameters)) {
-      $form .= zen_href_link($action, $parameters, 'NONSSL');
+        $form .= zen_href_link($action, $parameters, 'NONSSL');
     } else {
-      $form .= zen_href_link($action, '', 'NONSSL');
+        $form .= zen_href_link($action, '', 'NONSSL');
     }
     $form .= '" method="' . zen_output_string($method) . '"';
     if (!empty($params)) {
-      $form .= ' ' . $params;
+        $form .= ' ' . $params;
     }
     $form .= '>';
-    if (strtolower($method) == 'post') $form .= '<input type="hidden" name="securityToken" value="' . $_SESSION['securityToken'] . '">';
-    if (strtolower($method) == 'get') {
-      $form .= '<input type="hidden" name="cmd" value="' . $action . '">';
+    if (strtolower($method) === 'post') {
+        $form .= '<input type="hidden" name="securityToken" value="' . $_SESSION['securityToken'] . '">';
+    }
+    if (strtolower($method) === 'get') {
+        $form .= '<input type="hidden" name="cmd" value="' . str_replace('.php', '', $action) . '">';
     }
     return $form;
-  }
+}
 
   /**
  *


### PR DESCRIPTION
The issue here was that, for 'get' type forms, the hidden field added by `zen_draw_form` neglected to remove the `.php` from the submitted `$action`, which identified the associated 'cmd=' variable's value.

Fixes #5607