### PR TITLE
Correct `ot_coupon` determination of max-uses-per-coupon

### DIFF
--- a/includes/modules/order_total/ot_coupon.php
+++ b/includes/modules/order_total/ot_coupon.php
@@ -17,7 +17,6 @@
  */
 class ot_coupon extends base
 {
-
     /**
      * $_check is used to check the configuration key set up
      * @var int
@@ -391,7 +390,6 @@ class ot_coupon extends base
             $this->validation_errors[] = sprintf(TEXT_INVALID_FINISHDATE_COUPON, (empty($this->validation_errors) ? $dc_link : $coupon_code), zen_date_short($coupon_details['coupon_expire_date']));
             // return;
         }
-
 
         $validNotExceededNumberOfUses = $this->validateCouponMaximumUses($coupon_details);
         if (!$validNotExceededNumberOfUses) {
@@ -939,7 +937,7 @@ class ot_coupon extends base
 
         $result = $db->Execute($sql);
 
-        return ($result->RecordCount() < $coupon_details['uses_per_coupon']);
+        return ($result->fields['total_uses_of_coupon'] < $coupon_details['uses_per_coupon']);
     }
 
     /**


### PR DESCRIPTION
Fixes #5619.

The root-cause of the issue was the `validateCouponMaximumUses` method's checking of the _number of records_ returned as opposed to the _count of uses_ returned.  The issue surfaces whenever a coupon's maximum uses is configured as a value other than empty (i.e. unlimited).

The number of records returned is *always* 1 (since the query's a `COUNT`), so the coupon check would always fail if the coupon's max-usage was configured as `1` and would _always pass_ for a max-usage > 1.