### PR TITLE
Remove unwanted spaces from popup_coupon_help language file

### DIFF
--- a/includes/languages/english/lang.popup_coupon_help.php
+++ b/includes/languages/english/lang.popup_coupon_help.php
@@ -1,9 +1,9 @@
 <?php
 $define = [
-    'TEXT_COUPON_HELP_NAME' => '<br><br>Coupon Name : %s',
+    'TEXT_COUPON_HELP_NAME' => '<br><br>Coupon Name: %s',
     'TEXT_COUPON_HELP_FIXED' => '<br><br>The coupon is worth %s discount against your order',
     'TEXT_COUPON_HELP_FREESHIP' => '<br><br>This coupon gives you free shipping on your order',
-    'TEXT_COUPON_HELP_DESC' => '<br><br>Coupon Description : %s',
+    'TEXT_COUPON_HELP_DESC' => '<br><br>Coupon Description: %s',
     'TEXT_COUPON_HELP_RESTRICT' => '<br><br>Product/Category Restrictions',
     'TEXT_COUPON_HELP_CATEGORIES' => 'Category',
     'TEXT_COUPON_HELP_PRODUCTS' => 'Product',


### PR DESCRIPTION
Otherwise the coupon-help displays `Coupon Name :` instead of `Coupon Name:`; ditto for "Coupon Description"