### PR TITLE
Brands page and sidebox restrictions

### DIFF
--- a/includes/modules/pages/brands/header_php.php
+++ b/includes/modules/pages/brands/header_php.php
@@ -16,10 +16,20 @@ $breadcrumb->add(BREADCRUMB_BRANDS, zen_href_link(FILENAME_BRANDS));
 $category_depth = 'brands';
 $typefilter = $_GET['typefilter'] = 'brands';
 
-$listing_sql =
-    "SELECT manufacturers_name, manufacturers_image, manufacturers_id, featured
-       FROM " . TABLE_MANUFACTURERS . " m
-      ORDER BY featured DESC, manufacturers_name";
+if (PRODUCTS_MANUFACTURERS_STATUS === '1') {
+    $listing_sql =
+        "SELECT DISTINCT m.manufacturers_name, m.manufacturers_image, m.manufacturers_id, m.featured
+           FROM " . TABLE_MANUFACTURERS . " m
+                LEFT JOIN " . TABLE_PRODUCTS . " p
+                    ON m.manufacturers_id = p.manufacturers_id
+          WHERE p.products_status = 1
+          ORDER BY m.featured DESC, m.manufacturers_name";
+} else {
+    $listing_sql =
+        "SELECT m.manufacturers_name, m.manufacturers_image, m.manufacturers_id, m.featured
+           FROM " . TABLE_MANUFACTURERS . " m
+           ORDER BY m.featured DESC, m.manufacturers_name";
+}
 
 $brands = [
     'featured' => [],

--- a/includes/modules/sideboxes/brands.php
+++ b/includes/modules/sideboxes/brands.php
@@ -15,10 +15,22 @@ if ($current_page_base === FILENAME_DEFAULT && !empty($_GET['manufacturers_id'])
     return;
 }
 
-// retrieve with featured items first
-$sql = "SELECT manufacturers_name, manufacturers_image, manufacturers_id, featured, (featured=1) as weighted
-        FROM " . TABLE_MANUFACTURERS . " m
-        ORDER BY weighted DESC, manufacturers_name";
+if (PRODUCTS_MANUFACTURERS_STATUS === '1') {
+    // retrieve with featured manufacturers first
+    $sql =
+        "SELECT DISTINCT m.manufacturers_name, m.manufacturers_image, m.manufacturers_id, m.featured, (m.featured=1) AS weighted
+           FROM " . TABLE_MANUFACTURERS . " m
+                LEFT JOIN " . TABLE_PRODUCTS . " p
+                    ON m.manufacturers_id = p.manufacturers_id
+          WHERE p.products_status = 1
+          ORDER BY weighted DESC, manufacturers_name";
+} else {
+    // retrieve with featured manufacturers first
+    $sql =
+        "SELECT m.manufacturers_name, m.manufacturers_image, m.manufacturers_id, m.featured, (m.featured=1) AS weighted
+           FROM " . TABLE_MANUFACTURERS . " m
+           ORDER BY weighted DESC, manufacturers_name";
+}
 $results = $db->Execute($sql);
 
 if ($results->EOF) {

--- a/includes/modules/sideboxes/brands.php
+++ b/includes/modules/sideboxes/brands.php
@@ -8,10 +8,10 @@
  */
 
 // test if brands sidebox should show
-if ($current_page_base === 'brands') {
+if ($current_page_base === FILENAME_BRANDS) {
     return;
 }
-if ($current_page_base === 'index' && !empty($_GET['manufacturers_id'])) {
+if ($current_page_base === FILENAME_DEFAULT && !empty($_GET['manufacturers_id'])) {
     return;
 }
 
@@ -21,9 +21,11 @@ $sql = "SELECT manufacturers_name, manufacturers_image, manufacturers_id, featur
         ORDER BY weighted DESC, manufacturers_name";
 $results = $db->Execute($sql);
 
-if ($results->RecordCount() == 0) return;
+if ($results->EOF) {
+    return;
+}
 
-$brands_array = array();
+$brands_array = [];
 foreach ($results as $result) {
     $brands_array[] = [
         'id' => $result['manufacturers_id'],
@@ -33,7 +35,7 @@ foreach ($results as $result) {
     ];
 }
 
-require($template->get_template_dir('tpl_brands.php', DIR_WS_TEMPLATE, $current_page_base, 'sideboxes') . '/tpl_brands.php');
+require $template->get_template_dir('tpl_brands.php', DIR_WS_TEMPLATE, $current_page_base, 'sideboxes') . '/tpl_brands.php';
 $title = BOX_HEADING_BRANDS;
 $title_link = FILENAME_BRANDS;
-require($template->get_template_dir($column_box_default, DIR_WS_TEMPLATE, $current_page_base, 'common') . '/' . $column_box_default);
+require $template->get_template_dir($column_box_default, DIR_WS_TEMPLATE, $current_page_base, 'common') . '/' . $column_box_default;


### PR DESCRIPTION
Fixes #5629 

On the "Brands" sidebox and listing-page, don't display manufacturers that have no active products if the site's configuration (`PRODUCTS_MANUFACTURERS_STATUS`) so indicates.