### PR TITLE
Stop duplication of defines if Square Webpay is installed.

### DIFF
--- a/includes/languages/english/modules/payment/lang.square.php
+++ b/includes/languages/english/modules/payment/lang.square.php
@@ -16,40 +16,49 @@ $define = [
     'MODULE_PAYMENT_SQUARE_TEXT_COMM_ERROR' => 'Unable to process payment due to a communications error. You may try again or contact us for assistance.',
     'MODULE_PAYMENT_SQUARE_ERROR_INVALID_CARD_DATA' => 'We could not initiate your transaction because of a problem with the card data you entered. Please correct the card data, or report this error to the Store Owner: SQ-NONCE-FAILURE',
     'MODULE_PAYMENT_SQUARE_ERROR_DECLINED' => 'Sorry, your payment could not be authorized. Please select an alternate method of payment.',
-    'MODULE_PAYMENT_SQUARE_ENTRY_TRANSACTION_SUMMARY' => '<strong>Transaction Summary</strong>',
     'MODULE_PAYMENT_SQUARE_ENTRY_TRANSACTION_ACTIONS' => '<strong>Actions</strong>',
     'MODULE_PAYMENT_SQUARE_TEXT_UPDATE_FAILED' => 'Sorry, the attempted transaction update failed unexpectedly. See logs for details.',
-    'MODULE_PAYMENT_SQUARE_ENTRY_REFUND_TITLE' => '<strong>Refund Transaction</strong>',
-    'MODULE_PAYMENT_SQUARE_ENTRY_REFUND' => 'You may refund money to the customer here:',
-    'MODULE_PAYMENT_SQUARE_TEXT_REFUND_CONFIRM_CHECK' => 'Check this box to confirm your intent: ',
-    'MODULE_PAYMENT_SQUARE_ENTRY_REFUND_AMOUNT_TEXT' => 'Enter the amount you wish to refund',
-    'MODULE_PAYMENT_SQUARE_ENTRY_REFUND_TEXT_COMMENTS' => 'Notes (will show on Order History):',
-    'MODULE_PAYMENT_SQUARE_ENTRY_REFUND_DEFAULT_MESSAGE' => 'Refund Issued',
-    'MODULE_PAYMENT_SQUARE_ENTRY_REFUND_SUFFIX' => 'You may refund an order within 120 days, up to the original amount tendered. You must supply the original transaction ID and tender ID<br>See the Square site for more <a href="https://squareup.com/help/us/en/article/5060" rel="noopener" target="_blank">information on Square refunds</a>.',
-    'MODULE_PAYMENT_SQUARE_ENTRY_REFUND_BUTTON_TEXT' => 'Do Refund',
     'MODULE_PAYMENT_SQUARE_TEXT_REFUND_CONFIRM_ERROR' => 'Error: You requested to do a refund but did not check the Confirmation box.',
     'MODULE_PAYMENT_SQUARE_TEXT_INVALID_REFUND_AMOUNT' => 'Error: You requested a refund but entered an invalid amount.',
     'MODULE_PAYMENT_SQUARE_TEXT_REFUND_INITIATED' => 'Refunded ',
-    'MODULE_PAYMENT_SQUARE_ENTRY_CAPTURE_TITLE' => '<strong>Capture Transaction</strong>',
-    'MODULE_PAYMENT_SQUARE_ENTRY_CAPTURE' => 'You may capture previously-authorized funds here:',
-    'MODULE_PAYMENT_SQUARE_TEXT_CAPTURE_CONFIRM_CHECK' => 'Check this box to confirm your intent: ',
-    'MODULE_PAYMENT_SQUARE_ENTRY_CAPTURE_TEXT_COMMENTS' => 'Notes (will show on Order History):',
-    'MODULE_PAYMENT_SQUARE_ENTRY_CAPTURE_DEFAULT_MESSAGE' => '',
-    'MODULE_PAYMENT_SQUARE_ENTRY_CAPTURE_SUFFIX' => 'Captures must be performed within 6 days of the original authorization. You may only capture an order ONCE.',
     'MODULE_PAYMENT_SQUARE_TEXT_CAPTURE_CONFIRM_ERROR' => 'Error: You requested to do a capture but did not check the Confirmation box.',
-    'MODULE_PAYMENT_SQUARE_ENTRY_CAPTURE_BUTTON_TEXT' => 'Do Capture',
     'MODULE_PAYMENT_SQUARE_TEXT_TRANS_ID_REQUIRED_ERROR' => 'Error: You need to specify a Transaction ID.',
     'MODULE_PAYMENT_SQUARE_TEXT_CAPT_INITIATED' => 'Funds Capture initiated. Transaction ID: %s',
-    'MODULE_PAYMENT_SQUARE_ENTRY_VOID_TITLE' => '<strong>Voiding Transaction</strong>',
-    'MODULE_PAYMENT_SQUARE_ENTRY_VOID' => 'You may void an authorization which has not been captured.',
-    'MODULE_PAYMENT_SQUARE_TEXT_VOID_CONFIRM_CHECK' => 'Check this box to confirm your intent:',
-    'MODULE_PAYMENT_SQUARE_ENTRY_VOID_TEXT_COMMENTS' => 'Notes (will show on Order History):',
-    'MODULE_PAYMENT_SQUARE_ENTRY_VOID_DEFAULT_MESSAGE' => 'Transaction Cancelled',
-    'MODULE_PAYMENT_SQUARE_ENTRY_VOID_SUFFIX' => '',
-    'MODULE_PAYMENT_SQUARE_ENTRY_VOID_BUTTON_TEXT' => 'Do Void',
     'MODULE_PAYMENT_SQUARE_TEXT_VOID_CONFIRM_ERROR' => 'Error: You requested a Void but did not check the Confirmation box.',
     'MODULE_PAYMENT_SQUARE_TEXT_VOID_INITIATED' => 'Void Initiated. Transaction ID: %s',
 ];
+
+// Check current directory to see if SquareWebpay is installed have include lang.square_webPay.php in case it changes before Square is fully removed from zen cart
+// This prevents the duplication message as square_webPay defines all below as constants.
+if (file_exists(dirname(__FILE__) . '/square_webPay.php') === false && file_exists(dirname(__FILE__) . '/lang.square_webPay.php') === false) {
+    $defineExtra = [
+        'MODULE_PAYMENT_SQUARE_ENTRY_TRANSACTION_SUMMARY' => '<strong>Transaction Summary</strong>',
+        'MODULE_PAYMENT_SQUARE_ENTRY_REFUND_TITLE' => '<strong>Refund Transaction</strong>',
+        'MODULE_PAYMENT_SQUARE_ENTRY_REFUND' => 'You may refund money to the customer here:',
+        'MODULE_PAYMENT_SQUARE_TEXT_REFUND_CONFIRM_CHECK' => 'Check this box to confirm your intent: ',
+        'MODULE_PAYMENT_SQUARE_ENTRY_REFUND_AMOUNT_TEXT' => 'Enter the amount you wish to refund',
+        'MODULE_PAYMENT_SQUARE_ENTRY_REFUND_TEXT_COMMENTS' => 'Notes (will show on Order History):',
+        'MODULE_PAYMENT_SQUARE_ENTRY_REFUND_DEFAULT_MESSAGE' => 'Refund Issued',
+        'MODULE_PAYMENT_SQUARE_ENTRY_REFUND_SUFFIX' => 'You may refund an order within 120 days, up to the original amount tendered. You must supply the original transaction ID and tender ID<br>See the Square site for more <a href="https://squareup.com/help/us/en/article/5060" rel="noopener" target="_blank">information on Square refunds</a>.',
+        'MODULE_PAYMENT_SQUARE_ENTRY_REFUND_BUTTON_TEXT' => 'Do Refund',
+        'MODULE_PAYMENT_SQUARE_ENTRY_CAPTURE_TITLE' => '<strong>Capture Transaction</strong>',
+        'MODULE_PAYMENT_SQUARE_ENTRY_CAPTURE' => 'You may capture previously-authorized funds here:',
+        'MODULE_PAYMENT_SQUARE_TEXT_CAPTURE_CONFIRM_CHECK' => 'Check this box to confirm your intent: ',
+        'MODULE_PAYMENT_SQUARE_ENTRY_CAPTURE_TEXT_COMMENTS' => 'Notes (will show on Order History):',
+        'MODULE_PAYMENT_SQUARE_ENTRY_CAPTURE_DEFAULT_MESSAGE' => '',
+        'MODULE_PAYMENT_SQUARE_ENTRY_CAPTURE_SUFFIX' => 'Captures must be performed within 6 days of the original authorization. You may only capture an order ONCE.',
+        'MODULE_PAYMENT_SQUARE_ENTRY_CAPTURE_BUTTON_TEXT' => 'Do Capture',
+        'MODULE_PAYMENT_SQUARE_ENTRY_VOID_TITLE' => '<strong>Voiding Transaction</strong>',
+        'MODULE_PAYMENT_SQUARE_ENTRY_VOID' => 'You may void an authorization which has not been captured.',
+        'MODULE_PAYMENT_SQUARE_TEXT_VOID_CONFIRM_CHECK' => 'Check this box to confirm your intent:',
+        'MODULE_PAYMENT_SQUARE_ENTRY_VOID_TEXT_COMMENTS' => 'Notes (will show on Order History):',
+        'MODULE_PAYMENT_SQUARE_ENTRY_VOID_DEFAULT_MESSAGE' => 'Transaction Cancelled',
+        'MODULE_PAYMENT_SQUARE_ENTRY_VOID_SUFFIX' => '',
+        'MODULE_PAYMENT_SQUARE_ENTRY_VOID_BUTTON_TEXT' => 'Do Void',
+    ];
+    $define = array_merge($define, $defineExtra);       
+}
+
 
 if (IS_ADMIN_FLAG === true) {
     $define['MODULE_PAYMENT_SQUARE_TEXT_NEED_ACCESS_TOKEN'] =


### PR DESCRIPTION
Modified to stop the already defined messages appearing if you have installed Square webPay. It defines a number of variables as constants that are already defined in this language file.

As I assume that square will be removed completely from Zen Cart at some point. So I thought it better to modify this file rather than have code in a new webPay module.