### PR TITLE
Paypaldp.php INVNUM format change to fight duplicated orders

### DIFF
--- a/includes/modules/payment/paypaldp.php
+++ b/includes/modules/payment/paypaldp.php
@@ -930,7 +930,7 @@ class paypaldp extends base {
       $optionsAll['CUSTOM'] = 'DP-' . (int)$_SESSION['customer_id'] . '-' . time();
 
       // send the store name as transaction identifier, to help distinguish payments between multiple stores:
-      $optionsAll['INVNUM'] = (int)$_SESSION['customer_id'] . '-' . time() . '-[' . substr(preg_replace('/[^a-zA-Z0-9_]/', '', STORE_NAME), 0, 30) . ']';  // (cannot send actual invoice number because it's not assigned until after payment is completed)
+      $optionsAll['INVNUM'] = (int)$_SESSION['customer_id'] . '-' . (floor(time()/60)) . '-[' . substr(preg_replace('/[^a-zA-Z0-9_]/', '', STORE_NAME), 0, 30) . ']';  // (cannot send actual invoice number because it's not assigned until after payment is completed)
 
 //       This feature must be enabled in your PayPal account, by contacting PayPal Support:
 //       $optionsAll['SOFTDESCRIPTOR'] = substr(preg_replace('/[^a-zA-Z0-9. ]/', '', STORE_NAME), 0, 23);


### PR DESCRIPTION
As mentioned in the forum:

https://www.zen-cart.com/showthread.php?229318-Advise-needed-to-change-the-format-of-INVNUM-to-fight-duplicated-orders&p=1393626

This PR is a walk around solution to reduce/fight the duplicated orders/submissions. It will reduce the resolution for INVNUM value from 1s to 60s. Paypal will auto denied the duplicated transactions with the same INVNUM number. 