### PR TITLE
Fix authorize aim issue in 1.5.8/PHP 8.1

### DIFF
--- a/includes/classes/ajax/zcAjaxPayment.php
+++ b/includes/classes/ajax/zcAjaxPayment.php
@@ -126,7 +126,7 @@ class zcAjaxPayment extends base
     }
 
     // update customers_referral with $_SESSION['gv_id']
-    if ($_SESSION['cc_id']) {
+    if (!empty($_SESSION['cc_id'])) {
       $discount_coupon_query = "SELECT coupon_code
                             FROM ".TABLE_COUPONS."
                             WHERE coupon_id = :couponID";
@@ -163,7 +163,7 @@ class zcAjaxPayment extends base
 
     // if shipping-edit button should be overridden, do so
     $editShippingButtonLink = zen_href_link (FILENAME_CHECKOUT_SHIPPING, '', 'SSL');
-    if (!empty($_SESSION['payment']) && method_exists (${$_SESSION['payment']}, 'alterShippingEditButton')) {
+    if (!empty($_SESSION['payment']) && !empty(${$_SESSION['payment']}) && is_object(${$_SESSION['payment']}) && method_exists(${$_SESSION['payment']}, 'alterShippingEditButton')) {
       $theLink = ${$_SESSION['payment']}->alterShippingEditButton ();
       if ($theLink)
         $editShippingButtonLink = $theLink;


### PR DESCRIPTION
Fixes issue documented in https://www.zen-cart.com/showthread.php?229178-Authorize-net-AIM-problems-1-5-8

Last one is fatal and kills checkout. 

```
[14-Mar-2023 16:12:47 America/Chicago] Request URI: /ajax.php?act=ajaxPayment&method=prepareConfirmation, IP address: 1.1.1.1
#0 /home/client/public_html/includes/classes/ajax/zcAjaxPayment.php(129): zen_debug_error_handler()
#1 /home/client/public_html/ajax.php(85): zcAjaxPayment->prepareConfirmation()
--> PHP Warning: Undefined array key "cc_id" in /home/client/public_html/includes/classes/ajax/zcAjaxPayment.php on line 129.

[14-Mar-2023 16:12:47 America/Chicago] Request URI: /ajax.php?act=ajaxPayment&method=prepareConfirmation, IP address: 1.1.1.1
#0 /home/client/public_html/includes/classes/ajax/zcAjaxPayment.php(166): zen_debug_error_handler()
#1 /home/client/public_html/ajax.php(85): zcAjaxPayment->prepareConfirmation()
--> PHP Warning: Undefined variable $authorizenet_aim in /home/client/public_html/includes/classes/ajax/zcAjaxPayment.php on line 166.

[14-Mar-2023 16:12:47 America/Chicago] PHP Fatal error:  Uncaught TypeError: method_exists(): Argument #1 ($object_or_class) must be of type object|string, null given in /home/client/public_html/includes/classes/ajax/zcAjaxPayment.php:166
Stack trace:
#0 /home/client/public_html/includes/classes/ajax/zcAjaxPayment.php(166): method_exists(NULL, 'alterShippingEd...')
#1 /home/client/public_html/ajax.php(85): zcAjaxPayment->prepareConfirmation()
#2 {main}
  thrown in /home/client/public_html/includes/classes/ajax/zcAjaxPayment.php on line 166

[14-Mar-2023 16:12:47 America/Chicago] Request URI: /ajax.php?act=ajaxPayment&method=prepareConfirmation, IP address: 1.1.1.1
--> PHP Fatal error: Uncaught TypeError: method_exists(): Argument #1 ($object_or_class) must be of type object|string, null given in /home/client/public_html/includes/classes/ajax/zcAjaxPayment.php:166
Stack trace:
#0 /home/client/public_html/includes/classes/ajax/zcAjaxPayment.php(166): method_exists(NULL, 'alterShippingEd...')
#1 /home/client/public_html/ajax.php(85): zcAjaxPayment->prepareConfirmation()
#2 {main}
  thrown in /home/client/public_html/includes/classes/ajax/zcAjaxPayment.php on line 166.

```