### PR TITLE
Fix log from authorize_aim in admin

### DIFF
--- a/includes/modules/payment/authorizenet_aim.php
+++ b/includes/modules/payment/authorizenet_aim.php
@@ -757,7 +757,7 @@ class authorizenet_aim extends base {
       $sql = $db->bindVars($sql, ':respCode', $response[0], 'integer');
       $sql = $db->bindVars($sql, ':respText', $db_response_text, 'string');
       $sql = $db->bindVars($sql, ':authType', $response[11], 'string');
-      if (trim($this->transaction_id) != '') {
+      if (!empty($this->transaction_id)) {
         $sql = $db->bindVars($sql, ':transID', substr($this->transaction_id, 0, strpos($this->transaction_id, ' ')), 'string');
       } else {
         $sql = $db->bindVars($sql, ':transID', 'NULL', 'passthru');


### PR DESCRIPTION
```
[14-Mar-2023 18:39:39 America/Chicago] Request URI: /admin/index.php?cmd=orders&page=1&oID=17072&action=doVoid, IP address: 1.1.1.1
#0 [internal function]: zen_debug_error_handler()
#1 /home/client/public_html/includes/modules/payment/authorizenet_aim.php(760): trim()
#2 /home/client/public_html/includes/modules/payment/authorizenet_aim.php(944): authorizenet_aim->_debugActions()
#3 /home/client/public_html/admin/orders.php(385): authorizenet_aim->_doVoid()
#4 /home/client/public_html/admin/index.php(11): require('/home/client/...')
--> PHP Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in /home/client/public_html/includes/modules/payment/authorizenet_aim.php on line 760.

```