### PR TITLE
Add a notifier for `SHOW_` . `$info_page` . `_ASK_A_QUESTION`

### DIFF
--- a/includes/modules/pages/ask_a_question/header_php.php
+++ b/includes/modules/pages/ask_a_question/header_php.php
@@ -24,7 +24,9 @@ if ($pid === false) {
 //
 $info_page = zen_get_info_page($pid);
 $show_info_page_ask_a_question = 'SHOW_' . strtoupper($info_page) . '_ASK_A_QUESTION';
-if (!defined($show_info_page_ask_a_question) || constant($show_info_page_ask_a_question) === '0') {
+$bypass_redirect = false;
+$zco_notifier->notify('NOTIFY_ASK_A_QUESTION_ALLOW_BYPASS_REDIRECT', ['products_id' => $pid, ], $bypass_redirect);
+if ($bypass_redirect === false && (!defined($show_info_page_ask_a_question) || constant($show_info_page_ask_a_question) === '0')) {
     zen_redirect(zen_href_link($info_page, 'products_id=' . $_GET['pid']));
 }
 


### PR DESCRIPTION
Adds a notifier to allow being asked a product question as an observer permits.

Defaults to redirect as set in the header file, allowing override. At least one situation where this functionality is desired is in turning off display of ask a question for product type, but including link in email to ask a product question.

Without this change, then code edit required instead of addition of an auto loading observer.