### PR TITLE
Update observer to current format

### DIFF
--- a/admin/includes/classes/observers/auto.search_box.php
+++ b/admin/includes/classes/observers/auto.search_box.php
@@ -13,10 +13,8 @@ class zcObserverSearchBox extends base
         );
     }
 
-    public function update(&$class, $eventID, &$p1, &$p2, &$p3, &$p4)
+    public function notify_build_keyword_search(&$class, $eventID, $unused, &$fields, &$string)
     {
-        switch ($eventID) {
-            case 'NOTIFY_BUILD_KEYWORD_SEARCH':
                 if (!empty($_REQUEST['restrictIDs']) && $_REQUEST['restrictIDs'] === 'on') {
                     $removeElements = [
                         'pd.products_name',
@@ -25,11 +23,7 @@ class zcObserverSearchBox extends base
                         'cd.categories_name',
                         'cd.categories_description',
                     ];
-                    $p2 = array_diff($p2, $removeElements);
-                }
-                break;
-            default:
-                break;
+                    $fields = array_diff($fields, $removeElements);
         }
     }
 }

--- a/admin/includes/classes/observers/auto.search_box.php
+++ b/admin/includes/classes/observers/auto.search_box.php
@@ -15,15 +15,15 @@ class zcObserverSearchBox extends base
 
     public function notify_build_keyword_search(&$class, $eventID, $unused, &$fields, &$string)
     {
-                if (!empty($_REQUEST['restrictIDs']) && $_REQUEST['restrictIDs'] === 'on') {
-                    $removeElements = [
-                        'pd.products_name',
-                        'p.products_model',
-                        'pd.products_description',
-                        'cd.categories_name',
-                        'cd.categories_description',
-                    ];
-                    $fields = array_diff($fields, $removeElements);
+        if (!empty($_REQUEST['restrictIDs']) && $_REQUEST['restrictIDs'] === 'on') {
+            $removeElements = [
+                'pd.products_name',
+                'p.products_model',
+                'pd.products_description',
+                'cd.categories_name',
+                'cd.categories_description',
+            ];
+            $fields = array_diff($fields, $removeElements);
         }
     }
 }


### PR DESCRIPTION
Two commits:
1)
Use the more performant observer snake_cased method name.
Use more descriptive variable names for method parameters.
Receive the first notifier parameter as an unchangeable value in accordance
  with core Zen Cart code. For this notifier, there is only an empty string
  being passed (instead of an empty array). Because nothing is passed, the
  variable `$unused` was chosen.
Removed the non-existent fourth parameter from the method declaration.

2)
Refactor spacing of code: Visual formatting only. No change in operation.