### PR TITLE
Fixes for ROBOTS_PAGES_TO_SKIP

### DIFF
--- a/includes/extra_configures/robots_pages_to_skip.php
+++ b/includes/extra_configures/robots_pages_to_skip.php
@@ -12,6 +12,7 @@ define('ROBOTS_PAGES_TO_SKIP', '
     account_notifications,
     account_password,
     address_book,
+    ask_a_question,
     checkout_confirmation,
     checkout_payment,
     checkout_process,
@@ -32,7 +33,7 @@ define('ROBOTS_PAGES_TO_SKIP', '
     login,
     logoff,
     no_account,
-    order_status
+    order_status,
     password_forgotten,
     popup_image,
     popup_image_additional,


### PR DESCRIPTION
- ask a question should be in the list (since contact us is)
- order_status needs a comma after it.