### PR TITLE
check empty vs using count

### DIFF
--- a/includes/classes/shopping_cart.php
+++ b/includes/classes/shopping_cart.php
@@ -2109,7 +2109,7 @@ class shoppingCart extends base
         if ($this->display_debug_messages) $messageStack->add_session('header', 'FUNCTION ' . __FUNCTION__, 'caution');
 
         $addCount = 0;
-        if (is_array($_POST['products_id']) && count($_POST['products_id']) > 0) {
+        if (!empty($_POST['products_id']) && is_array($_POST['products_id'])) {
             $products_list = $_POST['products_id'];
             foreach ($products_list as $key => $val) {
                 $prodId = preg_replace('/[^0-9a-f:.]/', '', $key);


### PR DESCRIPTION
Prevents log when POST data missing entirely. 

```
--> PHP Warning: Undefined array key "products_id" in /home/client/public_html/includes/classes/shopping_cart.php on line 2112.
```