### PR TITLE
Update not_for_release.php

### DIFF
--- a/includes/extra_configures/not_for_release.php
+++ b/includes/extra_configures/not_for_release.php
@@ -15,9 +15,9 @@ $fsDir = DIR_FS_CATALOG . 'not_for_release/testFramework/extra_scripts/';
 $wsDir = 'not_for_release/testFramework/extra_scripts/';
 
 // Check for new functions in extra_scripts directory
-$directory_array = array();
+$directory_array = [];
 
-if ($dir = @dir($fsDir)) {
+if (is_dir($fsDir) && $dir = dir($fsDir)) {
   while ($file = $dir->read()) {
     if (!is_dir($fsDir . $file)) {
       if (preg_match('~^[^\._].*\.php$~i', $file) > 0) {


### PR DESCRIPTION
Stop using @ and actually check if the directory exists.

Prior to PHP 8.0.0, the error_reporting() called inside the custom error handler always returned 0 if the error was suppressed by the @ operator. As of PHP 8.0.0, it returns the value E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR | E_PARSE.

Hence, errors are being produced.