### PR TITLE
Protect against empty data during save for authorizenet_aim

### DIFF
--- a/includes/modules/payment/authorizenet_aim.php
+++ b/includes/modules/payment/authorizenet_aim.php
@@ -762,7 +762,7 @@ class authorizenet_aim extends base {
       } else {
         $sql = $db->bindVars($sql, ':transID', 'NULL', 'passthru');
       }
-      $sql = $db->bindVars($sql, ':sentData', print_r($this->reportable_submit_data, true), 'string');
+      $sql = $db->bindVars($sql, ':sentData', print_r($this->reportable_submit_data, true), 'stringIgnoreNull');
       $sql = $db->bindVars($sql, ':recvData', print_r($response, true), 'string');
       $sql = $db->bindVars($sql, ':orderTime', $order_time, 'string');
       $sql = $db->bindVars($sql, ':sessID', $sessID, 'string');


### PR DESCRIPTION
Seen a few times in a 1.5.7 cart; issue still exists in 1.5.8.   Happens if Enable Database Storage = true. 

```
[14-Mar-2023 17:11:10 America/Los_Angeles] Request URI: /shop/index.php?main_page=checkout_process, IP address: ********
#1  trigger_error() called at [/var/www/html/client/shop/includes/classes/db/mysql/query_factory.php:170]
#2  queryFactory->show_error() called at [/var/www/html/client/shop/includes/classes/db/mysql/query_factory.php:142]
#3  queryFactory->set_error() called at [/var/www/html/client/shop/includes/classes/db/mysql/query_factory.php:269]
#4  queryFactory->Execute() called at [/var/www/html/client/shop/includes/modules/payment/authorizenet_aim.php:752]
#5  authorizenet_aim->_debugActions() called at [/var/www/html/client/shop/includes/modules/payment/authorizenet_aim.php:456]
#6  authorizenet_aim->before_process() called at [/var/www/html/client/shop/includes/classes/payment.php:252]
#7  payment->before_process() called at [/var/www/html/client/shop/includes/modules/checkout_process.php:91]
#8  require(/var/www/html/client/shop/includes/modules/checkout_process.php) called at [/var/www/html/client/shop/includes/modules/pages/checkout_process/header_php.php:14]
#9  require(/var/www/html/client/shop/includes/modules/pages/checkout_process/header_php.php) called at [/var/www/html/client/shop/index.php:35]
--> PHP Fatal error: 1048:Column 'sent' cannot be null :: INSERT INTO authorizenet  (id, customer_id, order_id, response_code, response_text, authorization_type, transaction_id, sent, received, time, session_id) VALUES (NULL, 9023, 139043, 1, 'This transaction has been approved.', 'auth_capture', '', null, null, 'March 14, 2023, 5:11 pm', '**********************bp9d' ) ==> (as called by) /var/www/html/client/shop/includes/modules/payment/authorizenet_aim.php on line 752 <== in /var/www/html/client/shop/includes/classes/db/mysql/query_factory.php on line 170.

```
