### PR TITLE
Restore T&C Error message in checkout confirmation

### DIFF
--- a/includes/languages/lang.english.php
+++ b/includes/languages/lang.english.php
@@ -174,7 +174,7 @@ $define = [
     'ENTRY_TELEPHONE_NUMBER_TEXT' => '*',
     'ERROR_AT_LEAST_ONE_INPUT' => 'At least one of the fields in the search form must be entered.',
     'ERROR_CART_UPDATE' => '<strong>Please update your order.</strong> ',
-    'ERROR_CONDITIONS_NOT_ACCEPTED' => 'Please confirm you have read and agree to the terms and conditions bound to this order by ticking this box.',
+    'ERROR_CONDITIONS_NOT_ACCEPTED' => 'Please confirm you have read and agree to the terms and conditions bound to this order by ticking the box.',
     'ERROR_CORRECTIONS_HEADING' => 'Please correct the following: <br>',
     'ERROR_CUSTOMERS_ID_INVALID' => 'Customer information cannot be validated!<br>Please login or recreate your account ...',
     'ERROR_DATABASE_MAINTENANCE_NEEDED' => '<a href="https://docs.zen-cart.com/user/troubleshooting/error_71_maintenance_required/" rel="noopener" target="_blank">ERROR 0071 There appears to be a problem with the database. Maintenance is required.</a>',

--- a/includes/modules/pages/checkout_confirmation/header_php.php
+++ b/includes/modules/pages/checkout_confirmation/header_php.php
@@ -52,7 +52,9 @@ $_SESSION['comments'] = !empty($_POST['comments']) ? $_POST['comments'] : '';
 
 
 if (DISPLAY_CONDITIONS_ON_CHECKOUT == 'true') {
-    $_SESSION['conditions'] = $_POST['conditions'] ?? NULL;
+  if (!isset($_POST['conditions']) || ($_POST['conditions'] != '1')) {
+    $messageStack->add_session('checkout_payment', ERROR_CONDITIONS_NOT_ACCEPTED, 'error');
+  }
 }
 //echo $messageStack->size('checkout_payment');
 


### PR DESCRIPTION
Having found, you can bypass ticking the T&C's box in checkout_payment. (Have bootstrap and squareWebpay installed then checkout with a credit card.)

I thought it would be prudent to restore the check in checkout_confirmation.