### PR TITLE
Add lead-in text for products' quantities ...

### DIFF
--- a/includes/modules/product_listing.php
+++ b/includes/modules/product_listing.php
@@ -328,7 +328,7 @@ if ($num_products_count > 0) {
                     if ($product_listing_layout_style === 'table') $lc_align = 'right';
                     $lc_text = '';
                     //if ($product_listing_layout_style === 'columns') $lc_text .= '<label>' . TABLE_HEADING_QUANTITY . '</label>';
-                    $lc_text .= $listing_quantity;
+                    $lc_text .= TEXT_PRODUCTS_QUANTITY . $listing_quantity;
                     break;
 
                 case 'PRODUCT_LIST_WEIGHT':

--- a/includes/modules/responsive_classic/product_listing.php
+++ b/includes/modules/responsive_classic/product_listing.php
@@ -343,7 +343,7 @@ if ($num_products_count > 0) {
                     $lc_text = '';
                     $lc_text .= '<div class="list-quantity">';
                     //if ($product_listing_layout_style === 'columns') $lc_text .= '<label>' . TABLE_HEADING_QUANTITY . '</label>';
-                    $lc_text .= $listing_quantity;
+                    $lc_text .= TEXT_PRODUCTS_QUANTITY . $listing_quantity;
                     $lc_text .= '</div>';
                     break;
 


### PR DESCRIPTION
... on the product-listing pages.  Requires `Configuration :: Product Listing :: Display Product Weight` to be set to a value _other than_ '0' (the default).