### PR TITLE
unset session vars when doing an hmac admin login

### DIFF
--- a/includes/modules/pages/login/header_php.php
+++ b/includes/modules/pages/login/header_php.php
@@ -40,6 +40,8 @@ if (isset($_GET['action']) && $_GET['action'] == 'process') {
         if (!zen_validate_hmac_timestamp() || !$adminId = zen_validate_hmac_admin_id($_POST['aid'])) {
             zen_redirect(zen_href_link(FILENAME_TIME_OUT));
         }
+        unset($_SESSION['billto']);
+        unset($_SESSION['sendto']);
         $loginAuthorized = true;
         $_SESSION['emp_admin_login'] = true;
         $_SESSION['emp_admin_id'] = $adminId;


### PR DESCRIPTION
i have tracked down the following error:
```
PHP Fatal error: unknown address_book_id (225223) for customer_id (5684) in /var/www/myBloodyDomain/includes/classes/OnePageCheckout.php on line 1063.
```
to some session vars not getting unset when an admin places multiple orders in a row.

there might be other session vars that need to get unset; and destroying the session entirely is not really an option.