### PR TITLE
States pull down menu error when creating account

### DIFF
--- a/includes/modules/checkout_new_address.php
+++ b/includes/modules/checkout_new_address.php
@@ -79,7 +79,7 @@ if (isset($_POST['action']) && ($_POST['action'] == 'submit')) {
       $check_query = $db->bindVars($check_query, ':zoneCountryID', $country, 'integer');
       $check = $db->Execute($check_query);
       $entry_state_has_zones = ($check->fields['total'] > 0);
-      if ($entry_state_has_zones == true) {
+      if ($entry_state_has_zones == true && ACCOUNT_STATE_DRAW_INITIAL_DROPDOWN === 'true') {
       $zone_query = "SELECT distinct zone_id, zone_name, zone_code
                        FROM " . TABLE_ZONES . "
                        WHERE zone_country_id = :zoneCountryID

--- a/includes/modules/create_account.php
+++ b/includes/modules/create_account.php
@@ -198,7 +198,7 @@ if (isset($_POST['action']) && ($_POST['action'] == 'process') && !isset($login_
         $check_query = $db->bindVars($check_query, ':zoneCountryID', $country, 'integer');
         $check = $db->Execute($check_query);
         $entry_state_has_zones = ($check->fields['total'] > 0);
-        if ($entry_state_has_zones == true) {
+		if ($entry_state_has_zones == true && ACCOUNT_STATE_DRAW_INITIAL_DROPDOWN === 'true') {
             $zone_query = "SELECT distinct zone_id, zone_name, zone_code
                      FROM " . TABLE_ZONES . "
                      WHERE zone_country_id = :zoneCountryID


### PR DESCRIPTION
Fixes #5707
When submitting create account form, message 'Please select a state from the States pull down menu.' appears although state field (input text) has been properly filled. Only when 'Configuration>Customers Details>State field - Display as pulldown when possible?' is set to false and has zones defined.