### PR TITLE
Fix fatal error if GVs not used

### DIFF
--- a/includes/functions/functions_products.php
+++ b/includes/functions/functions_products.php
@@ -796,7 +796,7 @@ function zen_get_products_allow_add_to_cart($product_id)
 
     // If product is encoded as GV but GV feature is turned off, disallow add-to-cart
     if ($allow_add_to_cart && preg_match('/^GIFT/', addslashes($product_query_results->fields['products_model']))) {
-        if (MODULE_ORDER_TOTAL_GV_STATUS !== 'true') {
+        if (!defined('MODULE_ORDER_TOTAL_GV_STATUS') || MODULE_ORDER_TOTAL_GV_STATUS !== 'true') {
             $allow_add_to_cart = false;
         }
     }


### PR DESCRIPTION
```
[27-Apr-2023 12:46:50 America/New_York] PHP Fatal error:  Uncaught Error: Undefined constant "MODULE_ORDER_TOTAL_GV_STATUS" in /homepages/19/userid/htdocs/estore/includes/functions/functions_products.php:777
Stack trace:
#0 /homepages/19/userid/htdocs/estore/includes/functions/functions_general.php(201): zen_get_products_allow_add_to_cart()
#1 /homepages/19/userid/htdocs/estore/includes/modules/bootstrap/product_listing.php(349): zen_get_buy_now_button()
#2 /homepages/19/userid/htdocs/estore/includes/templates/bootstrap/templates/tpl_modules_product_listing.php(12): require('/homepages/19/d...')
#3 /homepages/19/userid/htdocs/estore/includes/templates/bootstrap/templates/tpl_index_product_list.php(105): require('/homepages/19/d...')
#4 /homepages/19/userid/htdocs/estore/includes/modules/pages/index/main_template_vars.php(231): require('/homepages/19/d...')
#5 /homepages/19/userid/htdocs/estore/includes/templates/bootstrap/common/tpl_main_page.php(213): require('/homepages/19/d...')
#6 /homepages/19/userid/htdocs/estore/index.php(94): require('/homepages/19/d...')
#7 {main}
  thrown in /homepages/19/userid/htdocs/estore/includes/functions/functions_products.php on line 777

```