### PR TITLE
Fix deprecation

### DIFF
--- a/includes/modules/payment/paypaldp.php
+++ b/includes/modules/payment/paypaldp.php
@@ -1029,9 +1029,11 @@ class paypaldp extends base {
     if ($this->requiresLookup($order->info['cc_type']) == true) {
       // CardinalCommerce Liability Protection Status
       // Inserts 'PROTECTED' or 'NOT PROTECTED' status, ECI, CAVV values in the order status history comments
-      $auth_proc_status = $this->determine3DSecureProtection($order->info['cc_type'], $_SESSION['3Dsecure_auth_eci']);
-      $commentString = "3D-Secure: " . $auth_proc_status . "\n" . 'ECI Value = ' . $_SESSION['3Dsecure_auth_eci'] . "\n" . 'CAVV Value = ' . $_SESSION['3Dsecure_auth_cavv'];
-      zen_update_orders_history($insert_id, $commentString, null, $order->info['order_status'], -1);
+      if (!empty($_SESSION['3Dsecure_auth_eci'])) { 
+         $auth_proc_status = $this->determine3DSecureProtection($order->info['cc_type'], $_SESSION['3Dsecure_auth_eci']);
+         $commentString = "3D-Secure: " . $auth_proc_status . "\n" . 'ECI Value = ' . $_SESSION['3Dsecure_auth_eci'] . "\n" . 'CAVV Value = ' . $_SESSION['3Dsecure_auth_cavv'];
+         zen_update_orders_history($insert_id, $commentString, null, $order->info['order_status'], -1);
+      }
     }
 
     // store the PayPal order meta data -- used for later matching and back-end processing activities


### PR DESCRIPTION
[01-May-2023 02:41:58 UTC] Request URI: /index.php?main_page=checkout_process, IP address: 68.110.228.9, Language id 1
#0 [internal function]: zen_debug_error_handler()
#1 /home/client/public_html/site/shop/includes/modules/payment/paypaldp.php(2215): strcasecmp()
#2 /home/client/public_html/site/shop/includes/modules/payment/paypaldp.php(1032): paypaldp->determine3DSecureProtection()
#3 /home/client/public_html/site/shop/includes/classes/payment.php(297): paypaldp->after_process()
#4 /home/client/public_html/site/shop/includes/modules/pages/checkout_process/header_php.php(16): payment->after_process()
#5 /home/client/public_html/site/shop/index.php(35): require('/home/teamrick2...')
--> PHP Deprecated: strcasecmp(): Passing null to parameter #1 ($string1) of type string is deprecated in /home/client/public_html/site/shop/includes/modules/payment/paypaldp.php on line 2215.
