### PR TITLE
Remove 'selected_box' references

### DIFF
--- a/admin/coupon_admin.php
+++ b/admin/coupon_admin.php
@@ -9,11 +9,6 @@ require 'includes/application_top.php';
 require DIR_WS_CLASSES . 'currencies.php';
 $currencies = new currencies();
 $languages = zen_get_languages();
-$status_array = [];
-if (!empty($_GET['selected_box'])) {
-  $_GET['action'] = '';
-  $_GET['old_action'] = '';
-}
 if (!isset($_GET['action'])) {
   $_GET['action'] = '';
 }

--- a/admin/includes/init_includes/init_category_path.php
+++ b/admin/includes/init_includes/init_category_path.php
@@ -26,12 +26,3 @@ if (zen_not_null($cPath)) {
     $cPath_array = [];
     $current_category_id = TOPMOST_CATEGORY_PARENT_ID;
 }
-
-// default open navigation box
-if (!isset($_SESSION['selected_box'])) {
-    $_SESSION['selected_box'] = 'configuration';
-}
-
-if (isset($_GET['selected_box'])) {
-    $_SESSION['selected_box'] = $_GET['selected_box'];
-}

--- a/admin/includes/init_includes/init_sanitize.php
+++ b/admin/includes/init_includes/init_sanitize.php
@@ -143,7 +143,6 @@ $group = [
     'rID',
     's',
     'saction',
-    'selected_box',
     'set',
     'set_display_categories_dropdown',
     'sID',

--- a/admin/includes/modules/dashboard_widgets/OrderStatusDashboardWidget.php
+++ b/admin/includes/modules/dashboard_widgets/OrderStatusDashboardWidget.php
@@ -21,7 +21,7 @@ if (!zen_is_superuser() && !check_page(FILENAME_ORDERS, '')) return;
           $orders_pending = $db->Execute("SELECT count(*) as count FROM " . TABLE_ORDERS . " WHERE orders_status = " . (int)$row['orders_status_id'], false, true, 1800);
           ?>
         <tr>
-          <td><a href="<?php echo zen_href_link(FILENAME_ORDERS, 'selected_box=customers&statusFilterSelect=' . $row['orders_status_id']); ?>"><?php echo $row['orders_status_name']; ?></a>:</td>
+          <td><a href="<?php echo zen_href_link(FILENAME_ORDERS, 'statusFilterSelect=' . $row['orders_status_id']); ?>"><?php echo $row['orders_status_name']; ?></a>:</td>
           <td class="text-right"> <?php echo $orders_pending->fields['count']; ?></td>
         </tr>
         <?php


### PR DESCRIPTION
This seems to obsolete code, that has been there since the beginning of Zen Cart.