### PR TITLE
Restore cart identification in whos online

### DIFF
--- a/admin/includes/classes/WhosOnline.php
+++ b/admin/includes/classes/WhosOnline.php
@@ -30,9 +30,15 @@ class WhosOnline extends base
 
     public function __construct($forceRebuild = false, $skip_gc = false)
     {
-        if (defined('WHOIS_TIMER_REMOVE')) $this->timer_remove_threshold = WHOIS_TIMER_REMOVE;
-        if (defined('WHOIS_TIMER_INACTIVE')) $this->timer_inactive_threshold = WHOIS_TIMER_INACTIVE;
-        if (defined('WHOIS_TIMER_DEAD')) $this->timer_dead_threshold = WHOIS_TIMER_DEAD;
+        if (defined('WHOIS_TIMER_REMOVE')) {
+            $this->timer_remove_threshold = WHOIS_TIMER_REMOVE;
+        }
+        if (defined('WHOIS_TIMER_INACTIVE')) {
+            $this->timer_inactive_threshold = WHOIS_TIMER_INACTIVE;
+        }
+        if (defined('WHOIS_TIMER_DEAD')) {
+            $this->timer_dead_threshold = WHOIS_TIMER_DEAD;
+        }
 
         // normally we get rid of expired data
         if (!$skip_gc) {
@@ -264,13 +270,13 @@ class WhosOnline extends base
         foreach ($this->whos_online as $session) {
             if (empty($session['session_id'])) {
                 $this->spider_array[$session['status_code']]++;
-            } else {
-                if ($session['full_name'] === "&yen;Guest") {
-                    $this->guest_array[$session['status_code']]++;
-                } else {
-                    $this->user_array[$session['status_code']]++;
-                }
+                continue;
             }
+            if ($session['full_name'] === "&yen;Guest") {
+                $this->guest_array[$session['status_code']]++;
+                continue;
+            }
+            $this->user_array[$session['status_code']]++;
         }
     }
 
@@ -299,7 +305,9 @@ class WhosOnline extends base
     protected function inspectSessionCart($session_id = '', $session_data = '')
     {
         // we need at least one of these parameters
-        if (empty($session_id) && empty($session_data)) return null;
+        if (empty($session_id) && empty($session_data)) {
+          return null;
+        }
 
         // or we can pass in the already-queried session data
         if (empty($session_data)) {


### PR DESCRIPTION
Decoding session data with `base64_decode` appears to no longer return all data that was initially encoded. As a result, the search of the decoded session data could likely fail finding one or more product in the list. This takes advantage of the added class method `inspectSessionCart` that temporarily becomes the session to collect the data and return the session information back.

Passing an empty value for the `session_id` because the code already requires the `session_data` to be non-`empty` and the method is written to operate so long as either is non-`empty`.

Added a variable (`$inactive`) to support a single calculation instead of the same evaluation multiple times.

Simplified logic as either there is a return because there are no rows in the cart or the return is because of the activity status.

Fixes:
https://www.zen-cart.com/showthread.php?229530-Who-s-Online-not-showing-active-carts&p=1395104#post1395104

Fixes #5740 