### PR TITLE
SaleMaker: fix issue with sale turning on and immediately turning off.

### DIFF
--- a/includes/functions/salemaker.php
+++ b/includes/functions/salemaker.php
@@ -57,7 +57,7 @@ function zen_start_salemaker()
 {
     global $db;
 
-    $sale_date = date('Ymd', time());
+    $sale_date = date('Y-m-d', time());
 
     $sql = "SELECT sale_id
             FROM " . TABLE_SALEMAKER_SALES . "
@@ -89,7 +89,7 @@ function zen_start_salemaker()
     $sql = "SELECT sale_id
             FROM " . TABLE_SALEMAKER_SALES . "
             WHERE sale_status = 1
-            AND (" . $sale_date . " < sale_date_start AND sale_date_start != '0001-01-01')
+            AND ('" . $sale_date . "' < sale_date_start AND sale_date_start != '0001-01-01')
             ";
 
     $results = $db->Execute($sql);


### PR DESCRIPTION
Additions to the changes @scottcwilson made in #5726.  Issue is that it turns them "on", but because the expires select query was not changed as well, it will immediately turn them "off".  

To Recreate using `Zencart 1.5.8a` with `msql 8.0`:
* Set up a sale to start today and end in a few days.
* Sale turns on https://github.com/zencart/zencart/blob/9ccb250afda600b06c3446b50b992406f6ae661f/includes/functions/salemaker.php#L81
* Sale would immediately turn off
https://github.com/zencart/zencart/blob/9ccb250afda600b06c3446b50b992406f6ae661f/includes/functions/salemaker.php#L95


