### PR TITLE
Fix admin prod/cat search with missing whitespace or empty string - Fixes #5715, #5666

### DIFF
--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -549,7 +549,6 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
           }
 
           $sql .= $order_by;
-          echo "DEBUG: $sql<br><br>";
 
           $categories = $db->Execute($sql);
 

--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -536,7 +536,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
                   LEFT JOIN " . TABLE_CATEGORIES_DESCRIPTION . " cd ON c.categories_id = cd.categories_id
                     AND cd.language_id = " . (int)$_SESSION['languages_id'];
 
-            if (isset($_GET['search'])) {
+          if (isset($_GET['search']) && !empty($_GET['search'])) {
               $keyword_search_fields = [
                 'cd.categories_name',
                 'cd.categories_description',
@@ -549,6 +549,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
           }
 
           $sql .= $order_by;
+          echo "DEBUG: $sql<br><br>";
 
           $categories = $db->Execute($sql);
 

--- a/includes/functions/functions_search.php
+++ b/includes/functions/functions_search.php
@@ -162,9 +162,6 @@ function zen_parse_search_string($search_str = '', &$objects = array()) {
         global $db, $zco_notifier;
 
         $zco_notifier->notify('NOTIFY_BUILD_KEYWORD_SEARCH', '', $fields, $string);
-        if (empty($string)) {
-            return '';
-        }
         $where_str = '';
         if (zen_parse_search_string(stripslashes($string), $search_keywords)) {
             $where_str = " AND (";

--- a/includes/functions/functions_search.php
+++ b/includes/functions/functions_search.php
@@ -11,6 +11,9 @@
 function zen_parse_search_string($search_str = '', &$objects = array()) {
     $search_str = trim(strtolower($search_str));
 
+// Separate any parentheses from adjacent words so splitting works as intended
+    $search_str = preg_replace([ '/(\b)(\()/', '/(\))(\b)/' ], [ '$1 $2', '$1 $2' ], $search_str);
+
 // Break up $search_str on whitespace; quoted string will be reconstructed later
     $pieces = preg_split('/[[:space:]]+/', $search_str);
     $objects = array();
@@ -162,6 +165,7 @@ function zen_parse_search_string($search_str = '', &$objects = array()) {
         global $db, $zco_notifier;
 
         $zco_notifier->notify('NOTIFY_BUILD_KEYWORD_SEARCH', '', $fields, $string);
+        if (empty($string)) { return ''; }
         if (zen_parse_search_string(stripslashes($string), $search_keywords)) {
             $where_str = " AND (";
             if ($startWithWhere) {

--- a/includes/functions/functions_search.php
+++ b/includes/functions/functions_search.php
@@ -162,7 +162,9 @@ function zen_parse_search_string($search_str = '', &$objects = array()) {
         global $db, $zco_notifier;
 
         $zco_notifier->notify('NOTIFY_BUILD_KEYWORD_SEARCH', '', $fields, $string);
-        if (empty($string)) { return ''; }
+        if (empty($string)) {
+            return '';
+        }
         $where_str = '';
         if (zen_parse_search_string(stripslashes($string), $search_keywords)) {
             $where_str = " AND (";

--- a/includes/functions/functions_search.php
+++ b/includes/functions/functions_search.php
@@ -11,9 +11,6 @@
 function zen_parse_search_string($search_str = '', &$objects = array()) {
     $search_str = trim(strtolower($search_str));
 
-// Separate any parentheses from adjacent words so splitting works as intended
-    $search_str = preg_replace([ '/(\b)(\()/', '/(\))(\b)/' ], [ '$1 $2', '$1 $2' ], $search_str);
-
 // Break up $search_str on whitespace; quoted string will be reconstructed later
     $pieces = preg_split('/[[:space:]]+/', $search_str);
     $objects = array();
@@ -21,7 +18,7 @@ function zen_parse_search_string($search_str = '', &$objects = array()) {
     $flag = '';
 
     for ($k=0; $k<count($pieces); $k++) {
-        while (substr($pieces[$k], 0, 1) == '(') {
+        while (substr($pieces[$k], 0, 1) == '(' && strpos($pieces[$k], ')', 1) == false) {
             $objects[] = '(';
             if (strlen($pieces[$k]) > 1) {
                 $pieces[$k] = substr($pieces[$k], 1);
@@ -32,7 +29,7 @@ function zen_parse_search_string($search_str = '', &$objects = array()) {
 
         $post_objects = array();
 
-        while (substr($pieces[$k], -1) == ')')  {
+        while (substr($pieces[$k], -1) == ')' && strpos($pieces[$k], '(') == false)  {
             $post_objects[] = ')';
             if (strlen($pieces[$k]) > 1) {
                 $pieces[$k] = substr($pieces[$k], 0, -1);

--- a/includes/functions/functions_search.php
+++ b/includes/functions/functions_search.php
@@ -163,6 +163,7 @@ function zen_parse_search_string($search_str = '', &$objects = array()) {
 
         $zco_notifier->notify('NOTIFY_BUILD_KEYWORD_SEARCH', '', $fields, $string);
         if (empty($string)) { return ''; }
+        $where_str = '';
         if (zen_parse_search_string(stripslashes($string), $search_keywords)) {
             $where_str = " AND (";
             if ($startWithWhere) {
@@ -212,5 +213,5 @@ function zen_parse_search_string($search_str = '', &$objects = array()) {
         if (substr($where_str, -7) === '( ()  )') {
             return ' ';
         }
-        return $where_str ?? ' ';
+        return $where_str;
     }


### PR DESCRIPTION
Regarding #5715, the search parsing code tries to split around whitespace, and then recognise grouped logical terms, e.g. `foo (wibble and bar)` but fails when there is missing whitespace e.g. `foo(wibble and bar)`.

I've taken a very simple approach of using regex replace to separate words from parentheses before the parsing begins, so the search string is turned from `foo(wibble and bar)` into `foo (wibble and bar)` and the splitting and query building proceeds as normal.

Also return early (after notifier is called in case of required modification) when search string is empty to fix #5666.