### PR TITLE
Update spiffyCal_v2_1.js

### DIFF
--- a/admin/includes/javascript/spiffyCal/spiffyCal_v2_1.js
+++ b/admin/includes/javascript/spiffyCal/spiffyCal_v2_1.js
@@ -873,7 +873,7 @@ function ctlSpiffyCalendarBox(strVarName, strFormName, strTextBoxName, strBtnNam
         strOutput += '<tr>';
         // Header ROW showing days of week here
         for (intLoop = 0; intLoop < 7; intLoop++) {
-            strOutput += '<td class="cal-HeadCell text-center align-middle>' + msDOW[intLoop] + '<\/td>';
+            strOutput += '<td class="cal-HeadCell text-center align-middle">' + msDOW[intLoop] + '<\/td>';
         }
 
         strOutput += '<\/tr><tr>';


### PR DESCRIPTION
Fix #5713
Added missing " on line 876 correcting issue 5713 where display of days of the week header was mixed with date (number) of the day lines in calendar popup.