### PR TITLE
Fix accessibility for all product listing pages with tables

### DIFF
--- a/includes/modules/product_listing.php
+++ b/includes/modules/product_listing.php
@@ -78,8 +78,7 @@ if ($product_listing_layout_style === 'table') {
                 $zc_col_count_description++;
                 break;
             case 'PRODUCT_LIST_IMAGE':
-                $lc_text = '&nbsp;';
-//                $lc_text = TABLE_HEADING_IMAGE;   //-Uncomment this line if you want the "Products Image" header title
+                $lc_text = TABLE_HEADING_IMAGE;
                 $lc_align = 'center';
                 $zc_col_count_description++;
                 break;

--- a/includes/modules/responsive_classic/product_listing.php
+++ b/includes/modules/responsive_classic/product_listing.php
@@ -78,8 +78,7 @@ if ($product_listing_layout_style === 'table') {
                 $zc_col_count_description++;
                 break;
             case 'PRODUCT_LIST_IMAGE':
-                $lc_text = '&nbsp;';
-//                $lc_text = TABLE_HEADING_IMAGE;   //-Uncomment this line if you want the "Products Image" header title
+                $lc_text = TABLE_HEADING_IMAGE;
                 $lc_align = 'center';
                 $zc_col_count_description++;
                 break;


### PR DESCRIPTION
It's an accessibility violation to not specify the TH in a table.

"Data tables include header and data cells arranged in a grid.

Each data cell <td> should be assigned to at least one column or row header cell <th>. When this is done, a screen reader can announce each data cell in context."