### PR TITLE
replace hard-coded warning missing shipping info

### DIFF
--- a/includes/languages/english/lang.account_history_info.php
+++ b/includes/languages/english/lang.account_history_info.php
@@ -5,6 +5,7 @@ $define = [
     'NAVBAR_TITLE_2' => 'History',
     'NAVBAR_TITLE_3' => 'Order #%s',
     'HEADING_TITLE' => 'Order Information',
+    'TEXT_MISSING_SHIPPING_INFO' => 'WARNING: missing shipping details',
 ];
 
 return $define;

--- a/includes/templates/template_default/templates/tpl_account_history_info_default.php
+++ b/includes/templates/template_default/templates/tpl_account_history_info_default.php
@@ -144,8 +144,8 @@ if (!empty($order->statuses)) {
 ?>
 <h4><?php echo HEADING_SHIPPING_METHOD; ?></h4>
 <div><?php echo $order->info['shipping_method']; ?></div>
-<?php } else { // temporary just remove these 4 lines ?>
-<div>WARNING: Missing Shipping Information</div>
+<?php } else { ?>
+<div><?php echo TEXT_MISSING_SHIPPING_INFO; ?></div>
 <?php
     }
 ?>


### PR DESCRIPTION
fixes: https://github.com/zencart/zencart/issues/5553

![2023-06-29 19_13_02-Order Information _ Zen Cart!, The Art of E-commerce — Mozilla Firefox](https://github.com/zencart/zencart/assets/4391026/3a00105c-34ef-44a9-954a-8195ae77f9fe)
