### PR TITLE
v158 ajax closure and refactor

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -38,23 +38,26 @@ if (!function_exists('utf8_encode_recurse')) {
     {
         if (strtolower(CHARSET) == 'utf-8') {
             return $mixed_value;
-        } elseif (!is_array($mixed_value)) {
-            return utf8_encode((string)$mixed_value);
-        } else {
-            $result = array();
-            foreach ($mixed_value as $key => $value) {
-                $result[$key] = utf8_encode($value);
-            }
-            return $result;
         }
+        if (!is_array($mixed_value)) {
+            return utf8_encode((string)$mixed_value);
+        }
+        $result = array();
+        foreach ($mixed_value as $key => $value) {
+            $result[$key] = utf8_encode($value);
+        }
+        return $result;
     }
 }
 
 function ajaxAbort($status = 400, $msg = null)
 {
+    global $zc_ajax_base_dir;
     http_response_code($status); // 400 = "Bad Request"
-    if ($msg) echo $msg;
-    require('includes/application_bottom.php');
+    if ($msg) {
+        echo $msg;
+    }
+    require $zc_ajax_base_dir . 'includes/application_bottom.php';
     exit();
 }
 // --- support functions ------------------
@@ -85,4 +88,4 @@ if (!method_exists($class, $_GET['method'])) {
 $result = call_user_func(array($class, $_GET['method']));
 $result = utf8_encode_recurse($result);
 echo json_encode($result);
-require('includes/application_bottom.php');
+require $zc_ajax_base_dir . 'includes/application_bottom.php';


### PR DESCRIPTION
Call the `includes/application_bottom.php` file applicable to the side of the store used to open the ajax load.

Do away with nested if/elseif logic where return is used for true evaluation.

Eliminate single line if statements and add parentheses to support expanded logic grouping.

Eliminate the parentheses around the filename for calls of `require`.

Fixes #5800.