### PR TITLE
order email: correct format onetime charge

### DIFF
--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -1264,11 +1264,10 @@ class order extends base
                 (!empty($this->products_ordered_attributes) ? "\n" . '<nobr>' . '<small><em>' . nl2br($this->products_ordered_attributes) . '</em></small>' . '</nobr>' : '') .
                 '</td>' . "\n" .
                 '<td class="product-details-num" valign="top" align="right">' .
-                $currencies->display_price($this->products[$i]['final_price'], $this->products[$i]['tax'], $this->products[$i]['qty']) .
+                $currencies->display_price($this->products[$i]['final_price'], $this->products[$i]['tax'], $this->products[$i]['qty']) . '</td>' . "\n" . '</tr>' . "\n" .
                 ($this->products[$i]['onetime_charges'] != 0 ?
-                    '</td></tr>' . "\n" . '<tr><td class="product-details">' . nl2br(TEXT_ONETIME_CHARGES_EMAIL) . '</td>' . "\n" .
-                    '<td>' . $currencies->display_price($this->products[$i]['onetime_charges'], $this->products[$i]['tax'], 1) : '') .
-                '</td></tr>' . "\n";
+                    '<tr>'. "\n" . '<td class="product-details" colspan="2">' . nl2br(TEXT_ONETIME_CHARGES_EMAIL) . '</td>' . "\n" .
+                    '<td valign="top" align="right">' . $currencies->display_price($this->products[$i]['onetime_charges'], $this->products[$i]['tax'], 1) . '</td>' . "\n" . '</tr>' . "\n": '');
         }
 
         $order_total_modules->apply_credit();//ICW ADDED FOR CREDIT CLASS SYSTEM


### PR DESCRIPTION
Before:
```
    <div class="order-detail-area"><table class="product-details" border="0" width="100%" cellspacing="0" cellpadding="2"><tr>
<td class="product-details" align="right" valign="top" width="30">1&nbsp;x</td>
<td class="product-details" valign="top">One Time Charge (ONETIME) 
<nobr><small><em><br />
	Color Red</em></small></nobr></td>
<td class="product-details-num" valign="top" align="right">&euro;34.79</td></tr>
<tr><td class="product-details">	*onetime charges = </td>
<td>&euro;3.87</td></tr>
<tr>
<td class="product-details" align="right" valign="top" width="30">1&nbsp;x</td>
<td class="product-details" valign="top">Microsoft Internet Keyboard PS/2 (MSINTKB) </td>
<td class="product-details-num" valign="top" align="right">&euro;54.10</td></tr>
</table></div>
```

After
```
    <div class="order-detail-area"><table class="product-details" border="0" width="100%" cellspacing="0" cellpadding="2"><tr>
<td class="product-details" align="right" valign="top" width="30">1&nbsp;x</td>
<td class="product-details" valign="top">One Time Charge (ONETIME) 
<nobr><small><em><br />
	Color Red</em></small></nobr></td>
<td class="product-details-num" valign="top" align="right">&euro;34.79</td>
</tr>
<tr>
<td class="product-details" colspan="2">	*onetime charges = </td>
<td valign="top" align="right">&euro;3.87</td>
</tr>
<tr>
<td class="product-details" align="right" valign="top" width="30">1&nbsp;x</td>
<td class="product-details" valign="top">Microsoft Internet Keyboard PS/2 (MSINTKB) </td>
<td class="product-details-num" valign="top" align="right">&euro;54.10</td>
</tr>
</table></div>
```
Fixes: https://github.com/zencart/zencart/issues/4446