### PR TITLE
Permit additional images without main image

### DIFF
--- a/includes/extra_datafiles/dist-site_specific_overrides.php
+++ b/includes/extra_datafiles/dist-site_specific_overrides.php
@@ -52,3 +52,14 @@
 // true ..... no link will be created.
 // false .... a <link> element will load the v4-shims.min.css file.
 //$disableFontAwesomeV4Compatibility = true;
+
+// Provide a default value for $ignore_products_image allowing entry into the
+// template area where both the main image and additional images files exist.
+// $ignore_products_image was originally considered to be an integer to allow
+// nearly unlimited choices instead of just a boolean (true/false).
+// $ignore_products_image = 1 would allow processing the responsive_classic
+// template's tpl_modules_additional_images file to access associated
+// available features such as the additional images without having
+// a primary image. Doing nothing treats this value as 0.
+// $ignore_products_image = 1;
+

--- a/includes/modules/pages/document_general_info/main_template_vars.php
+++ b/includes/modules/pages/document_general_info/main_template_vars.php
@@ -70,6 +70,9 @@
   if ($product_info->fields['products_image'] != '' || PRODUCTS_IMAGE_NO_IMAGE_STATUS != '1') {
     $products_image = $product_info->fields['products_image'];
   }
+  if (!isset($ignore_products_image)) {
+    $ignore_products_image = 0;
+  }
 
   $products_url = $product_info->fields['products_url'];
   $products_date_available = $product_info->fields['products_date_available'];

--- a/includes/modules/pages/document_product_info/main_template_vars.php
+++ b/includes/modules/pages/document_product_info/main_template_vars.php
@@ -70,6 +70,9 @@
   if ($product_info->fields['products_image'] != '' || PRODUCTS_IMAGE_NO_IMAGE_STATUS != '1') {
     $products_image = $product_info->fields['products_image'];
   }
+  if (!isset($ignore_products_image)) {
+    $ignore_products_image = 0;
+  }
 
   $products_url = $product_info->fields['products_url'];
   $products_date_available = $product_info->fields['products_date_available'];

--- a/includes/modules/pages/product_free_shipping_info/main_template_vars.php
+++ b/includes/modules/pages/product_free_shipping_info/main_template_vars.php
@@ -70,6 +70,9 @@
   if ($product_info->fields['products_image'] != '' || PRODUCTS_IMAGE_NO_IMAGE_STATUS != '1') {
     $products_image = $product_info->fields['products_image'];
   }
+  if (!isset($ignore_products_image)) {
+    $ignore_products_image = 0;
+  }
 
   $products_url = $product_info->fields['products_url'];
   $products_date_available = $product_info->fields['products_date_available'];

--- a/includes/modules/pages/product_info/main_template_vars.php
+++ b/includes/modules/pages/product_info/main_template_vars.php
@@ -70,6 +70,9 @@
         if ($product_info->fields['products_image'] != '' || PRODUCTS_IMAGE_NO_IMAGE_STATUS != '1') {
             $products_image = $product_info->fields['products_image'];
         }
+        if (!isset($ignore_products_image)) {
+          $ignore_products_image = 0;
+        }
 
         $products_url = $product_info->fields['products_url'];
         $products_date_available = $product_info->fields['products_date_available'];

--- a/includes/modules/pages/product_music_info/main_template_vars.php
+++ b/includes/modules/pages/product_music_info/main_template_vars.php
@@ -70,6 +70,9 @@
   if ($product_info->fields['products_image'] != '' || PRODUCTS_IMAGE_NO_IMAGE_STATUS != '1') {
     $products_image = $product_info->fields['products_image'];
   }
+  if (!isset($ignore_products_image)) {
+    $ignore_products_image = 0;
+  }
 
   $products_url = $product_info->fields['products_url'];
   $products_date_available = $product_info->fields['products_date_available'];

--- a/includes/templates/responsive_classic/templates/tpl_document_general_info_display.php
+++ b/includes/templates/responsive_classic/templates/tpl_document_general_info_display.php
@@ -47,13 +47,15 @@ require($template->get_template_dir('/tpl_products_next_previous.php',DIR_WS_TEM
 <div id="pinfo-left">
 <!--bof Main Product Image -->
 <?php
-  if (!empty($products_image)) {
+  if (!empty($products_image) || !empty($ignore_products_image)) {
   ?>
 <?php
 /**
  * display the main product image
  */
-   require($template->get_template_dir('/tpl_modules_main_product_image.php',DIR_WS_TEMPLATE, $current_page_base,'templates'). '/tpl_modules_main_product_image.php'); ?>
+  if (!empty($products_image)) {
+   require($template->get_template_dir('/tpl_modules_main_product_image.php',DIR_WS_TEMPLATE, $current_page_base,'templates'). '/tpl_modules_main_product_image.php');
+  } ?>
 <!--eof Main Product Image-->
 
 <!--bof Additional Product Images -->

--- a/includes/templates/responsive_classic/templates/tpl_document_product_info_display.php
+++ b/includes/templates/responsive_classic/templates/tpl_document_product_info_display.php
@@ -47,13 +47,15 @@ require($template->get_template_dir('/tpl_products_next_previous.php',DIR_WS_TEM
 <div id="pinfo-left">
 <!--bof Main Product Image -->
 <?php
-  if (!empty($products_image)) {
+  if (!empty($products_image) || !empty($ignore_products_image)) {
   ?>
 <?php
 /**
  * display the main product image
  */
-   require($template->get_template_dir('/tpl_modules_main_product_image.php',DIR_WS_TEMPLATE, $current_page_base,'templates'). '/tpl_modules_main_product_image.php'); ?>
+  if (!empty($products_image)) {
+   require($template->get_template_dir('/tpl_modules_main_product_image.php',DIR_WS_TEMPLATE, $current_page_base,'templates'). '/tpl_modules_main_product_image.php');
+  } ?>
 
 <!--eof Main Product Image-->
 

--- a/includes/templates/responsive_classic/templates/tpl_product_free_shipping_info_display.php
+++ b/includes/templates/responsive_classic/templates/tpl_product_free_shipping_info_display.php
@@ -47,13 +47,15 @@ require($template->get_template_dir('/tpl_products_next_previous.php',DIR_WS_TEM
 <div id="pinfo-left">
 <!--bof Main Product Image -->
 <?php
-  if (!empty($products_image)) {
+  if (!empty($products_image) || !empty($ignore_products_image)) {
   ?>
 <?php
 /**
  * display the main product image
  */
-   require($template->get_template_dir('/tpl_modules_main_product_image.php',DIR_WS_TEMPLATE, $current_page_base,'templates'). '/tpl_modules_main_product_image.php'); ?>
+  if (!empty($products_image)) {
+    require($template->get_template_dir('/tpl_modules_main_product_image.php',DIR_WS_TEMPLATE, $current_page_base,'templates'). '/tpl_modules_main_product_image.php');
+  } ?>
 <!--eof Main Product Image-->
 
 <!--bof Additional Product Images -->

--- a/includes/templates/responsive_classic/templates/tpl_product_info_display.php
+++ b/includes/templates/responsive_classic/templates/tpl_product_info_display.php
@@ -49,13 +49,15 @@ require($template->get_template_dir('/tpl_products_next_previous.php',DIR_WS_TEM
 <div id="pinfo-left" class="group">
 <!--bof Main Product Image -->
 <?php
-  if (!empty($products_image)) {
+  if (!empty($products_image) || !empty($ignore_products_image)) {
   ?>
 <?php
 /**
  * display the main product image
  */
-   require($template->get_template_dir('/tpl_modules_main_product_image.php',DIR_WS_TEMPLATE, $current_page_base,'templates'). '/tpl_modules_main_product_image.php'); ?>
+  if (!empty($products_image)) {
+    require($template->get_template_dir('/tpl_modules_main_product_image.php',DIR_WS_TEMPLATE, $current_page_base,'templates'). '/tpl_modules_main_product_image.php');
+  } ?>
 <!--eof Main Product Image-->
 
 <!--bof Additional Product Images -->

--- a/includes/templates/responsive_classic/templates/tpl_product_music_info_display.php
+++ b/includes/templates/responsive_classic/templates/tpl_product_music_info_display.php
@@ -47,13 +47,15 @@ require($template->get_template_dir('/tpl_products_next_previous.php',DIR_WS_TEM
 <div id="pinfo-left">
 <!--bof Main Product Image -->
 <?php
-  if (!empty($products_image)) {
+  if (!empty($products_image) || !empty($ignore_products_image)) {
   ?>
 <?php
 /**
  * display the main product image
  */
-   require($template->get_template_dir('/tpl_modules_main_product_image.php',DIR_WS_TEMPLATE, $current_page_base,'templates'). '/tpl_modules_main_product_image.php'); ?>
+  if (!empty($products_image)) {
+    require($template->get_template_dir('/tpl_modules_main_product_image.php',DIR_WS_TEMPLATE, $current_page_base,'templates'). '/tpl_modules_main_product_image.php');
+  }?>
 <!--eof Main Product Image-->
 
 <!--bof Additional Product Images -->


### PR DESCRIPTION
So since the determination was to not undo the previous entry, this instead extends it.

Offers a new variable that can be overridden in advance of the associated code section allowing execution of the inner code section but not requiring a `$products_image` to hold a value at the point where this begins. As a result of work that has historically gone into offering the code the way it was, this extends that previous capability that has been removed by #5656.

Fixes #5799

Required by users of Additional Product Images plugin: https://www.zen-cart.com/downloads.php?do=file&id=1063
