### PR TITLE
Check that provided cID, pID exist, redirect if not - fixes #5743

### DIFF
--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -35,6 +35,20 @@ if (isset($_GET['product_type'])) {
 }
 if (isset($_GET['cID'])) {
   $_GET['cID'] = (int)$_GET['cID'];
+  if ($sniffer->rowExists(TABLE_CATEGORIES, 'categories_id', $_GET['cID'])) {
+    zen_redirect(zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING));
+  }
+}
+if (isset($_GET['pID'])) {
+  $_GET['pID'] = (int)$_GET['pID'];
+  if (!$sniffer->rowExists(TABLE_PRODUCTS, 'products_id', $_GET['pID'])) {
+    zen_redirect(zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING));
+  }
+}
+if (isset($current_category_id) && isset($_GET['pID'])) {
+  if (!$sniffer->rowExistsComposite(TABLE_PRODUCTS_TO_CATEGORIES, [ 'products_id', 'categories_id' ], [ $_GET['pID'], $current_category_id ])){
+    zen_redirect(zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING));
+  }
 }
 
 if (!isset($_SESSION['categories_products_sort_order'])) {
@@ -837,7 +851,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
                 $cPath = $product['master_categories_id'];
               }
 
-              if ((!isset($_GET['pID']) && !isset($_GET['cID']) || (isset($_GET['pID']) && ($_GET['pID'] === $product['products_id']))) && !isset($pInfo) && !isset($cInfo) && (strpos($action, 'new')
+              if ((!isset($_GET['pID']) && !isset($_GET['cID']) || (isset($_GET['pID']) && ($_GET['pID'] === (int)$product['products_id']))) && !isset($pInfo) && !isset($cInfo) && (strpos($action, 'new')
                       !== 0)) {
                 $pInfo = new objectInfo($product);
               }

--- a/includes/classes/sniffer.php
+++ b/includes/classes/sniffer.php
@@ -74,5 +74,53 @@ class sniffer extends base {
     }
     return false;
   }
+
+    /**
+     * Return true if the specified row exists in the table.
+     *
+     * @param string $table_name The table to query.
+     * @param string $key_name The key to check.
+     * @param int    $key_value The value that key_name must equal.
+     * @return void
+     */
+    public function rowExists(string $table_name, string $key_name, int $key_value): bool
+    {
+        global $db;
+        $sql = 'SELECT COUNT(*) AS cc FROM :table_name WHERE :key_name = :key_value;';
+        $sql = $db->bindVars($sql, ':key_name', $key_name, 'passthru');
+        $sql = $db->bindVars($sql, ':key_value', $key_value, 'integer');
+        $sql = $db->bindVars($sql, ':table_name', $table_name, 'passthru');
+        $rs = $db->Execute($sql);
+        return $rs->fields['cc'] != 0;
+    }
+
+    /**
+     * Return true if the specified row exists in the table.
+     * Key column names taken from $key_names are matched against equivalent
+     * key values in $key_values.
+     *
+     * @param string $table_name The table to query.
+     * @param array  $key_names The array of keys to check.
+     * @param array  $key_values The array of values that key_names must equal.
+     * @return void
+     */
+    public function rowExistsComposite(string $table_name, array $key_names, array $key_values): bool
+    {
+        global $db;
+        $sql = 'SELECT COUNT(*) AS cc FROM :table_name WHERE ';
+        $sql .= join(' AND ', array_map(
+            function ($key, $value) {
+                global $db;
+                $bit = ':key = :value';
+                $bit = $db->bindVars($bit, ':key', $key, 'passthru');
+                $bit = $db->bindVars($bit, ':value', $value, 'integer');
+                return $bit;
+            },
+            $key_names,
+            $key_values
+        ));
+        $sql = $db->bindVars($sql, ':table_name', $table_name, 'passthru');
+        $rs = $db->Execute($sql);
+        return $rs->fields['cc'] != 0;
+    }
 }
-?>


### PR DESCRIPTION
Guards against using 'back' button to revisit page with previous values that are no longer valid, e.g. after move_product to another category.