### PR TITLE
Fix layout of search_box elements.

### DIFF
--- a/admin/includes/modules/search_box.php
+++ b/admin/includes/modules/search_box.php
@@ -36,18 +36,18 @@ if (isset($_GET['search']) && zen_not_null($_GET['search'])) {
   </div>
     <?php
     if (file_exists($searchBoxJs)) {
-        ?>
+    ?>
         <div class="row">
-            <div class="form-group col-xs-6 col-sm-12" id="searchRestrictIds">
-                <div class="col-sm-9 control-label"><label for="restrictIDs"><?= TEXT_INFO_SEARCH_FILTER_RESTRICT_IDS; ?></label></div>
-                <div class="col-sm-1">
-                    <?= zen_draw_checkbox_field('restrictIDs', '', (!empty($_GET['restrictIDs']) && $_GET['restrictIDs'] === 'on'), '', ' id="restrictIDs"'); ?>
+            <div class="form-horizontal col-xs-6">
+                <div class="form-group" id="searchRestrictIds">
+                    <label for="restrictIDs" class="col-xs-11 control-label"><?= TEXT_INFO_SEARCH_FILTER_RESTRICT_IDS; ?></label>
+                    <?= zen_draw_checkbox_field('restrictIDs', '', (!empty($_GET['restrictIDs']) && $_GET['restrictIDs'] === 'on'), '', ' id="restrictIDs" class="col-xs-1"'); ?>
                 </div>
             </div>
-            <div class="form-group col-xs-6 col-sm-12" id="searchTermRepopulate">
-                <div class="col-sm-9 control-label"><label for="repopulateSearch"><?= TEXT_INFO_SEARCH_FILTER_REPOPULATE; ?></label></div>
-                <div class="col-sm-1">
-                    <?= zen_draw_checkbox_field('repopulateSearch', '', (!empty($_GET['repopulateSearch']) && $_GET['repopulateSearch'] === 'on'), '', ' id="repopulateSearch"'); ?>
+            <div class="form-horizontal col-xs-6">
+                <div class="form-group" id="searchTermRepopulate">
+                    <label for="repopulateSearch" class="col-xs-11 control-label"><?= TEXT_INFO_SEARCH_FILTER_REPOPULATE; ?></label>
+                    <?= zen_draw_checkbox_field('repopulateSearch', '', (!empty($_GET['repopulateSearch']) && $_GET['repopulateSearch'] === 'on'), '', ' id="repopulateSearch" class="col-xs-1"'); ?>
                 </div>
             </div>
         </div>

--- a/admin/includes/modules/search_box.php
+++ b/admin/includes/modules/search_box.php
@@ -38,13 +38,13 @@ if (isset($_GET['search']) && zen_not_null($_GET['search'])) {
     if (file_exists($searchBoxJs)) {
         ?>
         <div class="row">
-            <div class="form-group col-md-4" id="searchRestrictIds">
+            <div class="form-group col-xs-6 col-sm-12" id="searchRestrictIds">
                 <div class="col-sm-9 control-label"><label for="restrictIDs"><?= TEXT_INFO_SEARCH_FILTER_RESTRICT_IDS; ?></label></div>
                 <div class="col-sm-1">
                     <?= zen_draw_checkbox_field('restrictIDs', '', (!empty($_GET['restrictIDs']) && $_GET['restrictIDs'] === 'on'), '', ' id="restrictIDs"'); ?>
                 </div>
             </div>
-            <div class="form-group col-md-4" id="searchTermRepopulate">
+            <div class="form-group col-xs-6 col-sm-12" id="searchTermRepopulate">
                 <div class="col-sm-9 control-label"><label for="repopulateSearch"><?= TEXT_INFO_SEARCH_FILTER_REPOPULATE; ?></label></div>
                 <div class="col-sm-1">
                     <?= zen_draw_checkbox_field('repopulateSearch', '', (!empty($_GET['repopulateSearch']) && $_GET['repopulateSearch'] === 'on'), '', ' id="repopulateSearch"'); ?>


### PR DESCRIPTION
The container, outside of search_box.php for example customers.php, is col-md-4 which means it will be 4/12 width in medium breakpoint, and full page width in smaller breakpoints.  The columns here were also set to col-md-4, so they were 4/12 each in a space that was already quite narrow. In small breakpoints they jumped to 100% width which is also not optimal.

The approach here is:
- extra small and small, 50% width so the checkboxes lay out side by side.
- other breakpoints - 100% width so the checkboxes stack on top of each other in the narrow screen space they have been allotted by their parent.

Screenshots:
Small screen - before, the checkboxes are on top of each other:
![230605-search-box-small-before](https://github.com/zencart/zencart/assets/266415/bc7c202b-dafd-417d-bfcb-bcdd3b1726c8)
Small screen - after, the checkboxes are side by side, saving some vertical screen space:
![230605-search-box-small-after](https://github.com/zencart/zencart/assets/266415/3917209d-16f3-462f-a0fb-ba05454b62c0)

Wide screen - before, the checkboxes are squished into 4/12 the available width:
![230605-search-box-medium-before](https://github.com/zencart/zencart/assets/266415/ab940cf0-0ab3-46c4-aa67-28c1c805cfbc)
Wide screen - after, the checkboxes are allowed to lay out horizontally:
![230605-search-box-medium-after](https://github.com/zencart/zencart/assets/266415/ea470f02-3588-4e9b-95e4-8b28a06213a8)
