### PR TITLE
unset customer_default_address when doing an hmac admin login

### DIFF
--- a/includes/modules/pages/login/header_php.php
+++ b/includes/modules/pages/login/header_php.php
@@ -42,6 +42,7 @@ if (isset($_GET['action']) && $_GET['action'] == 'process') {
         }
         unset($_SESSION['billto']);
         unset($_SESSION['sendto']);
+        unset($_SESSION['customer_default_address_id']);
         $loginAuthorized = true;
         $_SESSION['emp_admin_login'] = true;
         $_SESSION['emp_admin_id'] = $adminId;


### PR DESCRIPTION
see #5698 

pretty sure this one is the missing element.