### PR TITLE
Allow intended error logging before `$_SESSION` set

### DIFF
--- a/includes/extra_configures/enable_error_logging.php
+++ b/includes/extra_configures/enable_error_logging.php
@@ -81,7 +81,7 @@ function zen_debug_error_handler($errno, $errstr, $errfile, $errline)
     if (!empty($backtrace)) {
         $backtrace = PHP_EOL . rtrim($backtrace);
     }
-    $language_info = ', Language id ' . $_SESSION['languages_id'];
+    $language_info = ', Language id ' . ($_SESSION['languages_id'] ?? 'not set');
     $message = date('[d-M-Y H:i:s e]') . ' Request URI: ' . ($_SERVER['REQUEST_URI'] ?? 'not set') . ', IP address: ' . ($_SERVER['REMOTE_ADDR'] ?? 'not set')  . $language_info . $backtrace;
 
     $message .= PHP_EOL . "--> PHP $error_type: $errstr in $errfile on line $errline.";


### PR DESCRIPTION
If a log is requested to be generated before `$_SESSION` has been set or specifically if `$_SESSION['languages_id']` is not set, then the absence of that data causes an issue/error such as the below:

[Date Time Timezone] PHP Warning:  Undefined global variable $_SESSION in /catalog-path/includes/extra_configures/enable_error_logging.php on line 84
[Date Time Timezone] PHP Warning:  Trying to access array offset on value of type null in /catalog-path/includes/extra_configures/enable_error_logging.php on line 84

This commit allows that to not exist and adds more information onto the reporting to indicate that it didn't exist at the time of log generation.