### PR TITLE
ot_group_discount: Correct tax calculations when "Calculate Tax" when "None"

### DIFF
--- a/includes/modules/order_total/ot_group_pricing.php
+++ b/includes/modules/order_total/ot_group_pricing.php
@@ -160,7 +160,7 @@ class ot_group_pricing {
        */
       switch ($this->calculate_tax) {
         case 'None':
-          if ($this->include_tax) {
+          if ($this->include_tax === 'true') {
             foreach ($order->info['tax_groups'] as $key=>$value) {
               $od_amount['tax_groups'][$key] = $order->info['tax_groups'][$key] * $ratio;
             }


### PR DESCRIPTION
The `include_tax` property is set to the value of the configuration setting, a 'true' or 'false' string, so its value is always interpreted as _truthy_.

Add a strict comparison to determine whether/not the taxes are to be included.  As the module currently sits, tax is _always_ included in the deduction when the "Calculate Tax" setting is "None".