### PR TITLE
Remove usage of the deprecated `utf8_encode`

### DIFF
--- a/admin/includes/classes/class.admin.zcObserverLogEventListener.php
+++ b/admin/includes/classes/class.admin.zcObserverLogEventListener.php
@@ -74,7 +74,6 @@ class zcObserverLogEventListener extends base {
      */
     $postdata = $_POST;
     $postdata = self::filterArrayElements($postdata);
-    $postdata = self::ensureDataIsUtf8($postdata);
     $notes = self::parseForMaliciousContent(print_r($postdata, true));
     /**
      * Since the POST data was an array, we json-encode the parsed POST data for storage in the logging system
@@ -90,7 +89,6 @@ class zcObserverLogEventListener extends base {
       if (is_array($message_to_log))
       {
         $data = self::filterArrayElements($data);
-        $data = self::ensureDataIsUtf8($data);
         $data = print_r($data, true);
       }
       $specific_message = $data;
@@ -157,22 +155,6 @@ class zcObserverLogEventListener extends base {
   {
     foreach ($data as $key=>$nul) {
       if (in_array($key, array('x','y','secur'.'ityTo'.'ken','admi'.'n_p'.'ass','pass'.'word','confirm', 'newpwd-'.$_SESSION['securityToken'],'oldpwd-'.$_SESSION['securityToken'],'confpwd-'.$_SESSION['securityToken']))) unset($data[$key]);
-    }
-    return $data;
-  }
-  /**
-   * In order to json_encode the data for storage, it must be utf8, so we encode each element
-   */
-  static function ensureDataIsUtf8($data) {
-    if (strtolower(CHARSET) == 'utf-8') return $data;
-    foreach ($data as $key=>$nul) {
-        if (is_string($nul)) $data[$key] = utf8_encode($nul);
-        if (is_array($nul)) {
-          foreach ($nul as $key2=>$val) {
-            if (is_string($val)) $data[$key][$key2] = utf8_encode($val);
-          if (is_array($val)) $data[$key][$key2] = utf8_encode(print_r($val, true));
-        }
-      }
     }
     return $data;
   }

--- a/ajax.php
+++ b/ajax.php
@@ -33,23 +33,6 @@ header("Access-Control-Allow-Headers: X-Requested-With");
 
 
 // --- support functions ------------------
-if (!function_exists('utf8_encode_recurse')) {
-    function utf8_encode_recurse($mixed_value)
-    {
-        if (strtolower(CHARSET) == 'utf-8') {
-            return $mixed_value;
-        }
-        if (!is_array($mixed_value)) {
-            return utf8_encode((string)$mixed_value);
-        }
-        $result = array();
-        foreach ($mixed_value as $key => $value) {
-            $result[$key] = utf8_encode($value);
-        }
-        return $result;
-    }
-}
-
 function ajaxAbort($status = 400, $msg = null)
 {
     global $zc_ajax_base_dir;
@@ -86,6 +69,5 @@ if (!method_exists($class, $_GET['method'])) {
 
 // Accepted request, so execute and return appropriate response:
 $result = call_user_func(array($class, $_GET['method']));
-$result = utf8_encode_recurse($result);
 echo json_encode($result);
 require $zc_ajax_base_dir . 'includes/application_bottom.php';

--- a/includes/classes/observers/auto.downloads_via_aws.php
+++ b/includes/classes/observers/auto.downloads_via_aws.php
@@ -206,7 +206,7 @@ class zcObserverDownloadsViaAws extends base {
     $expires = time() + $this->link_expiry_time;
 
     $raw_request = "GET\n\n\n" . $expires . "\n/" . $bucketAndFilename;
-    $sig = urlencode(base64_encode((hash_hmac("sha1", utf8_encode($raw_request), $this->aws_secret, true))));
+    $sig = urlencode(base64_encode((hash_hmac('sha1', $raw_request, $this->aws_secret, true))));
 
     $params = 'AWSAccessKeyId=' . $this->aws_key . '&Expires=' . $expires . '&Signature=' . $sig;
 

--- a/includes/functions/functions_dates.php
+++ b/includes/functions/functions_dates.php
@@ -63,11 +63,7 @@ function zen_date_long($raw_date)
     $second = (int)substr($raw_date, 17, 2);
 
     global $zcDate;
-    $retVal = $zcDate->output(DATE_FORMAT_LONG, mktime($hour, $minute, $second, $month, $day, $year));
-    if (stristr(PHP_OS, 'win') === 0) {
-       return utf8_encode($retVal);
-    }
-    return $retVal;
+    return $zcDate->output(DATE_FORMAT_LONG, mktime($hour, $minute, $second, $month, $day, $year));
 }
 
 

--- a/includes/functions/functions_strings.php
+++ b/includes/functions/functions_strings.php
@@ -312,22 +312,13 @@ function htmlentities_recurse($mixed_value, $flags = ENT_QUOTES, $encoding = 'ut
 /**
  * @param mixed $mixed_value
  * @return array|false|string
+ *
+ * Deprecated after Zen Cart 1.5.8a
  */
 function utf8_encode_recurse($mixed_value)
 {
-    if (strtolower(CHARSET) == 'utf-8') {
-        return $mixed_value;
-    }
-
-    if (!is_array($mixed_value)) {
-        return utf8_encode((string)$mixed_value);
-    }
-
-    $result = [];
-    foreach ($mixed_value as $key => $value) {
-        $result[$key] = utf8_encode($value);
-    }
-    return $result;
+    trigger_error('Function utf8_encode_recurse is deprecated for Zen Cart versions after 1.5.8a.', E_USER_DEPRECATED);
+    return $mixed_value;
 }
 
 /**

--- a/not_for_release/testFramework/Unit/testsNotifiers/AdminLoggingTest.php
+++ b/not_for_release/testFramework/Unit/testsNotifiers/AdminLoggingTest.php
@@ -72,20 +72,6 @@ class AdminLoggingTest extends zcUnitTestCase
         $this->assertArrayNotHasKey('password', $result);
     }
 
-    public function testEnsureDataIsUtf8()
-    {
-        define('CHARSET', 'iso-8859-1');
-        $data = array(
-            'key1' => 'abc',
-            'key2' => iconv('UTF-8', 'ISO-8859-1', 'façade'),
-            'key3' => array('r' => iconv('UTF-8', 'ISO-8859-1', 'égale'))
-        );
-        $observer = new zcObserverLogEventListener();
-        $result = $observer::ensureDataIsUtf8($data);
-        $this->assertEquals($result['key2'], 'façade');
-        $this->assertEquals($result['key3']['r'], 'égale');
-    }
-
     public function testParseForMaliciousContent()
     {
         define('CHARSET', 'utf-8');


### PR DESCRIPTION
Fixes #5387

Notes:
- Issuing an `E_USER_DEPRECATED` log for any usage of `utf8_encode_recurse`, just in case some plugin is using that function.
- The removal of the `testEnsureDataIsUtf8` method from the test framework's AdminLoggingTest.php will most likely result in a unit-test failure.  I don't know where that test is invoked!