### PR TITLE
admin: correct category sort below top category

### DIFF
--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -33,7 +33,7 @@ if (isset($_GET['page'])) {
 if (isset($_GET['product_type'])) {
   $_GET['product_type'] = (int)$_GET['product_type'];
 }
-if (isset($_GET['cID'])) {
+if (!empty($_GET['cID'])) {
   $_GET['cID'] = (int)$_GET['cID'];
   if (!$sniffer->rowExists(TABLE_CATEGORIES, 'categories_id', $_GET['cID'])) {
     zen_redirect(zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING));


### PR DESCRIPTION
Mentioned here: https://www.zen-cart.com/showthread.php?229613-category_product_listing-issue&p=1396101#post1396101

When in the subcategory immediately below the TOP, the sorting options redirect to the TOP category due to this:
```
if (isset($_GET['cID'])) {
  $_GET['cID'] = (int)$_GET['cID'];
}
```
$_GET['cID'] is set, but an empty string, but there is no category 0 so it redirects to the top, maintaining the previous sort order.

So a change to 
```
if (!empty($_GET['cID'])) {
  $_GET['cID'] = (int)$_GET['cID'];

```
seems a fix: both category and product sort as selected.


