### PR TITLE
Add ability to count distinct products for category counts

### DIFF
--- a/includes/extra_datafiles/dist-site_specific_overrides.php
+++ b/includes/extra_datafiles/dist-site_specific_overrides.php
@@ -61,3 +61,9 @@
 // false ... Additional images are displayed *only* if a product's 'main' image is defined (i.e. not `''`); this is the default.
 //
 //$enable_additional_images_without_main_image = false;
+
+// -----
+// Make category counts count distinct products.
+// If a product is in two different sub categories of parent category it will only be counted once.
+//
+//define('COUNT_DISTINCT_PRODUCTS', true);


### PR DESCRIPTION
Currently, the category count counts the number of products in each sub category individually. This means that if you have a product in more than one sub category of the parent category, it is counted once for each category that it is in. If, like me, you have products that you put into many sub categories to allow searching by a feature of the product, the category count can get highly inflated. 
This mod counts the distinct products_id(s) in a category and all its sub categories.