### PR TITLE
Fix version-check compare for minor number

### DIFF
--- a/admin/includes/classes/VersionServer.php
+++ b/admin/includes/classes/VersionServer.php
@@ -86,9 +86,11 @@ class VersionServer
         if (trim($newVersionInfo['versionMajor']) > PROJECT_VERSION_MAJOR) {
             return false;
         }
-        if (trim($newVersionInfo['versionMinor']) > PROJECT_VERSION_MINOR) {
+
+        if ((int)trim($newVersionInfo['versionMajor']) === (int)PROJECT_VERSION_MAJOR && trim($newVersionInfo['versionMinor']) > PROJECT_VERSION_MINOR) {
             return false;
         }
+
         return true;
     }
 


### PR DESCRIPTION
While it was correctly handling `1 < 2`, it wasn't subsequently correctly handling `5.8 < 0.0`.