### PR TITLE
Refactoring init_add_crumbs.php

### DIFF
--- a/includes/init_includes/init_add_crumbs.php
+++ b/includes/init_includes/init_add_crumbs.php
@@ -63,7 +63,7 @@ foreach ($get_terms as $next_get_term) {
 /**
  * add the products name to the breadcrumb trail
  */
-if (isset($_GET['products_id'], $cPath)) {
+if (isset($_GET['products_id'])) {
     $productname_query =
         "SELECT products_name
            FROM " . TABLE_PRODUCTS_DESCRIPTION . "

--- a/includes/init_includes/init_add_crumbs.php
+++ b/includes/init_includes/init_add_crumbs.php
@@ -16,23 +16,21 @@ $breadcrumb->add(HEADER_TITLE_CATALOG, zen_href_link(FILENAME_DEFAULT));
 /**
  * add category names or the manufacturer name to the breadcrumb trail
  */
-if (!isset($robotsNoIndex)) {
-    $robotsNoIndex = false;
-}
+$robotsNoIndex = $robotsNoIndex ?? false;
 
 // might need isset($_GET['cPath']) later ... right now need $cPath or breaks breadcrumb from sidebox etc.
-if (isset($cPath_array) && isset($cPath)) {
-    for ($i = 0, $n = sizeof($cPath_array); $i < $n; $i++) {
+if (isset($cPath_array, $cPath)) {
+    for ($i = 0, $n = count($cPath_array); $i < $n; $i++) {
         $categories_query =
             "SELECT categories_name
                FROM " . TABLE_CATEGORIES_DESCRIPTION . "
-              WHERE categories_id = '" . (int)$cPath_array[$i] . "'
-                AND language_id = '" . (int)$_SESSION['languages_id'] . "'";
+              WHERE categories_id = " . (int)$cPath_array[$i] . "
+                AND language_id = " . (int)$_SESSION['languages_id'];
+        $categories = $db->Execute($categories_query, 1);
 
-        $categories = $db->Execute($categories_query);
-        if ($categories->RecordCount() > 0) {
-            $breadcrumb->add($categories->fields['categories_name'], zen_href_link(FILENAME_DEFAULT, 'cPath=' . implode('_', array_slice($cPath_array, 0, ($i+1)))));
-        } elseif (SHOW_CATEGORIES_ALWAYS == 0) {
+        if (!$categories->EOF) {
+            $breadcrumb->add($categories->fields['categories_name'], zen_href_link(FILENAME_DEFAULT, 'cPath=' . implode('_', array_slice($cPath_array, 0, ($i + 1)))));
+        } elseif (SHOW_CATEGORIES_ALWAYS === '0') {
             // if invalid, set the robots noindex/nofollow for this page
             $robotsNoIndex = true;
             break;
@@ -47,33 +45,33 @@ $sql =
     "SELECT *
        FROM " . TABLE_GET_TERMS_TO_FILTER;
 $get_terms = $db->Execute($sql);
-while (!$get_terms->EOF) {
-    if (isset($_GET[$get_terms->fields['get_term_name']])) {
+foreach ($get_terms as $next_get_term) {
+    $next_get_term_name = $next_get_term['get_term_name'];
+    if (isset($_GET[$next_get_term_name])) {
         $sql =
-            "SELECT " . $get_terms->fields['get_term_name_field'] . "
-               FROM " . constant($get_terms->fields['get_term_table']) . "
-              WHERE " . $get_terms->fields['get_term_name'] . " =  " . (int)$_GET[$get_terms->fields['get_term_name']];
-        $get_term_breadcrumb = $db->Execute($sql);
-        if ($get_term_breadcrumb->RecordCount() > 0) {
-            $breadcrumb->add($get_term_breadcrumb->fields[$get_terms->fields['get_term_name_field']], zen_href_link(FILENAME_DEFAULT, $get_terms->fields['get_term_name'] . "=" . $_GET[$get_terms->fields['get_term_name']]));
+            "SELECT " . $next_get_term['get_term_name_field'] . "
+               FROM " . constant($next_get_term['get_term_table']) . "
+              WHERE " . $next_get_term_name . " = " . (int)$_GET[$next_get_term_name];
+        $get_term_breadcrumb = $db->Execute($sql, 1);
+
+        if (!$get_term_breadcrumb->EOF) {
+            $breadcrumb->add($get_term_breadcrumb->fields[$next_get_term['get_term_name_field']], zen_href_link(FILENAME_DEFAULT, $next_get_term_name . '=' . $_GET[$next_get_term_name]));
         }
     }
-    $get_terms->MoveNext();
 }
 
 /**
- * add the products model to the breadcrumb trail
+ * add the products name to the breadcrumb trail
  */
-if (isset($_GET['products_id'])) {
+if (isset($_GET['products_id'], $cPath)) {
     $productname_query =
         "SELECT products_name
            FROM " . TABLE_PRODUCTS_DESCRIPTION . "
-          WHERE products_id = '" . (int)$_GET['products_id'] . "'
-            AND language_id = '" . $_SESSION['languages_id'] . "'";
+          WHERE products_id = " . (int)$_GET['products_id'] . "
+            AND language_id = " . (int)$_SESSION['languages_id'];
+    $productname = $db->Execute($productname_query, 1);
 
-    $productname = $db->Execute($productname_query);
-
-    if ($productname->RecordCount() > 0) {
+    if (!$productname->EOF) {
         $breadcrumb->add($productname->fields['products_name'], zen_href_link(zen_get_info_page($_GET['products_id']), 'cPath=' . $cPath . '&products_id=' . $_GET['products_id']));
     }
 }


### PR DESCRIPTION
- Using null-coalesce where appropriate
- Use `count` instead of `sizeof`
- Using multiple variables on `isset` where appropriate
- Use foreach instead of while/$db->MoveNext on multiple-record query.
- Gather a single query where either a single or no record is expected to be returned
- Use `===` instead of `==`
- Simplify the 'get-terms-to-filter' section
- Ensure that `$cPath` is set for the product-name portion
- Use $result->EOF instead of $result->RecordCount()

Next up, adding a notification so that **_Ceon URI Mappings_** can discontinue its use of an unwanted override of this file!