### PR TITLE
Add link-parameter notification for init_add_crumbs.php

### DIFF
--- a/includes/init_includes/init_add_crumbs.php
+++ b/includes/init_includes/init_add_crumbs.php
@@ -55,7 +55,13 @@ foreach ($get_terms as $next_get_term) {
         $get_term_breadcrumb = $db->Execute($sql, 1);
 
         if (!$get_term_breadcrumb->EOF) {
-            $breadcrumb->add($get_term_breadcrumb->fields[$next_get_term['get_term_name_field']], zen_href_link(FILENAME_DEFAULT, $next_get_term_name . '=' . $_GET[$next_get_term_name]));
+            // -----
+            // Enable a watching observer to modify the parameters to a breadcrumb link.
+            //
+            $link_parameters = $next_get_term_name . '=' . $_GET[$next_get_term_name];
+            $zco_notifier->notify('NOTIFY_INIT_ADD_CRUMBS_GET_TERMS_LINK_PARAMETERS', $next_get_term, $link_parameters);
+
+            $breadcrumb->add($get_term_breadcrumb->fields[$next_get_term['get_term_name_field']], zen_href_link(FILENAME_DEFAULT, $link_parameters));
         }
     }
 }


### PR DESCRIPTION
As previously mentioned, this can be used by the "Ceon URI Mapping" plugin so that it doesn't have to overwrite the file to include its custom parameters.