### PR TITLE
Move paypal date-functions to core

### DIFF
--- a/includes/functions/functions_dates.php
+++ b/includes/functions/functions_dates.php
@@ -453,3 +453,28 @@ function zen_count_days($start_date, $end_date, $lookup = 'm')
     }
     return $counter;
 }
+
+if (!function_exists('datetime_to_sql_format')) {
+    /**
+     * Used especially for converting PayPal-IPN dates to a standard format for db storage
+     */
+    function datetime_to_sql_format(string $dateString, string $format = 'H:i:s M d, Y e'): string
+    {
+        $dateTime = DateTime::createFromFormat($format, $dateString);
+        $dateTime->setTimezone((new DateTime)->getTimezone());
+        return $dateTime->format('Y-m-d H:i:s');
+    }
+}
+
+if (!function_exists('convertToLocalTimeZone')) {
+    /** Used primarily to convert a time value from one timezone to another
+     *  particularly when no timezone component is included in the time value.
+     *  Mainly needed for converting 3rd party Zulu time values to local time
+     */
+    function convertToLocalTimeZone(string $dateTime, string $fromTz = 'UTC', string $outputFormat = 'Y-m-d H:i:s'): string
+    {
+        $localDateTime = new DateTime($dateTime, new DateTimeZone($fromTz));
+        $localDateTime->setTimezone((new DateTime)->getTimezone());
+        return $localDateTime->format($outputFormat);
+    }
+}

--- a/includes/modules/payment/paypal/paypal_functions.php
+++ b/includes/modules/payment/paypal/paypal_functions.php
@@ -10,18 +10,30 @@
  */
 
 // Functions for paypal processing
-function datetime_to_sql_format(string $dateString): string
-{
-    $dateTime = DateTime::createFromFormat('H:i:s M d, Y e', $dateString);
-    $dateTime->setTimezone((new DateTime)->getTimezone());
-    return $dateTime->format('Y-m-d H:i:s');
+
+if (!function_exists('datetime_to_sql_format')) {
+    /**
+     * Used especially for converting PayPal-IPN dates to a standard format for db storage
+     */
+    function datetime_to_sql_format(string $dateString, string $format = 'H:i:s M d, Y e'): string
+    {
+        $dateTime = DateTime::createFromFormat($format, $dateString);
+        $dateTime->setTimezone((new DateTime)->getTimezone());
+        return $dateTime->format('Y-m-d H:i:s');
+    }
 }
 
-function convertToLocalTime(string $dateTime, string $fromTz = 'UTC'): string
-{
-    $localDateTime = new DateTime($dateTime, new DateTimeZone($fromTz));
-    $localDateTime->setTimezone((new DateTime)->getTimezone());
-    return $localDateTime->format('Y-m-d H:i:s');
+if (!function_exists('convertToLocalTimeZone')) {
+    /** Used primarily to convert a time value from one timezone to another
+     *  particularly when no timezone component is included in the time value.
+     *  Mainly needed for converting 3rd party Zulu time values to local time
+     */
+    function convertToLocalTimeZone(string $dateTime, string $fromTz = 'UTC', string $outputFormat = 'Y-m-d H:i:s'): string
+    {
+        $localDateTime = new DateTime($dateTime, new DateTimeZone($fromTz));
+        $localDateTime->setTimezone((new DateTime)->getTimezone());
+        return $localDateTime->format($outputFormat);
+    }
 }
 
   function ipn_debug_email($message, $email_address = '', $always_send = false, $subjecttext = 'IPN DEBUG message') {

--- a/includes/modules/payment/paypaldp.php
+++ b/includes/modules/payment/paypaldp.php
@@ -1059,7 +1059,7 @@ class paypaldp extends base {
                           'payer_email' => $_SESSION['paypal_ec_payer_info']['payer_email'],
                           'payer_id' => $_SESSION['paypal_ec_payer_id'],
                           'payer_status' => $_SESSION['paypal_ec_payer_info']['payer_status'],
-                          'payment_date' => convertToLocalTime(trim(preg_replace('/[^0-9-:]/', ' ', $this->payment_time))),
+                          'payment_date' => convertToLocalTimeZone(trim(preg_replace('/[^0-9-:]/', ' ', $this->payment_time))),
                           'business' => '',
                           'receiver_email' => (MODULE_PAYMENT_PAYPALWPP_PFVENDOR != '' ? MODULE_PAYMENT_PAYPALWPP_PFVENDOR : str_replace('_api1', '', MODULE_PAYMENT_PAYPALWPP_APIUSERNAME)),
                           'receiver_id' => '',

--- a/includes/modules/payment/paypalwpp.php
+++ b/includes/modules/payment/paypalwpp.php
@@ -568,7 +568,7 @@ if (false) { // disabled until clarification is received about coupons in PayPal
                           'payer_email' => $_SESSION['paypal_ec_payer_info']['payer_email'],
                           'payer_id' => $_SESSION['paypal_ec_payer_id'],
                           'payer_status' => $_SESSION['paypal_ec_payer_info']['payer_status'],
-                          'payment_date' => convertToLocalTime(trim(preg_replace('/[^0-9-:]/', ' ', $this->payment_time))),
+                          'payment_date' => convertToLocalTimeZone(trim(preg_replace('/[^0-9-:]/', ' ', $this->payment_time))),
                           'business' => '',
                           'receiver_email' => (substr(MODULE_PAYMENT_PAYPALWPP_MODULE_MODE,0,7) == 'Payflow' ? MODULE_PAYMENT_PAYPALWPP_PFVENDOR : str_replace('_api1', '', MODULE_PAYMENT_PAYPALWPP_APIUSERNAME)),
                           'receiver_id' => '',


### PR DESCRIPTION
While currenly only used directly by PayPal modules, these functions could be used elsewhere. And making them part of functions_dates makes them accessible to all paypal modules equally.

Fixes #5931
Updates #5929
Ref #5927