### PR TITLE
Cart Update: link to top of cart table

### DIFF
--- a/includes/templates/responsive_classic/templates/tpl_shopping_cart_default.php
+++ b/includes/templates/responsive_classic/templates/tpl_shopping_cart_default.php
@@ -31,7 +31,7 @@
 
 <?php if ($messageStack->size('shopping_cart') > 0) echo $messageStack->output('shopping_cart'); ?>
 
-<?php echo zen_draw_form('cart_quantity', zen_href_link(FILENAME_SHOPPING_CART, 'action=update_product', $request_type), 'post', 'id="shoppingCartForm"'); ?>
+<?php echo zen_draw_form('cart_quantity', zen_href_link(FILENAME_SHOPPING_CART, 'action=update_product' . '#cartInstructionsDisplay', $request_type), 'post', 'id="shoppingCartForm"'); ?>
 <div id="cartInstructionsDisplay" class="content"><?php
 /**
  * require the html_define for the shopping_cart page

--- a/includes/templates/template_default/templates/tpl_shopping_cart_default.php
+++ b/includes/templates/template_default/templates/tpl_shopping_cart_default.php
@@ -28,7 +28,7 @@
 
 <?php if ($messageStack->size('shopping_cart') > 0) echo $messageStack->output('shopping_cart'); ?>
 
-<?php echo zen_draw_form('cart_quantity', zen_href_link(FILENAME_SHOPPING_CART, 'action=update_product', $request_type), 'post', 'id="shoppingCartForm"'); ?>
+<?php echo zen_draw_form('cart_quantity', zen_href_link(FILENAME_SHOPPING_CART, 'action=update_product' . '#cartInstructionsDisplay', $request_type), 'post', 'id="shoppingCartForm"'); ?>
 <div id="cartInstructionsDisplay" class="content"><?php
 /**
  * require the html_define for the shopping_cart page


### PR DESCRIPTION
so on an Update, the cart table is the main part of the viewport, instead of the top of the page, and having to scroll down.
(A similar thing is done for the shipping estimator)

I found that linking to the actual table id left the top of the table obscured by the header in bootstrap.