### PR TITLE
module shipping_estimator: cast result (as $_POST['zone_country_id'] may not be set)

### DIFF
--- a/includes/modules/shipping_estimator.php
+++ b/includes/modules/shipping_estimator.php
@@ -136,7 +136,7 @@ if ($_SESSION['cart']->count_contents() > 0) {
                 ],
                 'country_id' => STORE_COUNTRY,
                 'zone_id' => $state_zone_id,
-                'format_id' => zen_get_address_format_id((int)$_POST['zone_country_id'] ?? 0),
+                'format_id' => zen_get_address_format_id((int)STORE_COUNTRY),
             ];
         }
         // set the cost to be able to calculate free shipping


### PR DESCRIPTION
Strict reporting, php8.3.0beta2, vanilla shop, set shipping estimator to display on cart page, add product, go to cart:

[25-Aug-2023 09:09:03 UTC] Request URI: /zencart/index.php?main_page=shopping_cart, IP address: 127.0.0.1, Language id 1
#0 D:\Github\zencart\includes\modules\shipping_estimator.php(139): zen_debug_error_handler()
#1 D:\Github\zencart\includes\templates\responsive_classic\templates\tpl_shopping_cart_default.php(204): require('D:\\Github\\zenca...')
#2 D:\Github\zencart\includes\templates\responsive_classic\common\tpl_main_page.php(178): require('D:\\Github\\zenca...')
#3 D:\Github\zencart\index.php(94): require('D:\\Github\\zenca...')
--> PHP Warning: Undefined array key "zone_country_id" in D:\Github\zencart\includes\modules\shipping_estimator.php on line 139.


when $_POST['zone_country_id'] is not set, the int casting on $_POST['zone_country_id'] causes a debug, so cast the result instead.
