### PR TITLE
Auto-expire specials/featured/sales once per admin session/day

### DIFF
--- a/admin/featured.php
+++ b/admin/featured.php
@@ -15,6 +15,11 @@ $action = (isset($_GET['action']) ? $_GET['action'] : '');
 $currentPage = (isset($_GET['page']) && $_GET['page'] != '' ? (int)$_GET['page'] : 0);
 
 if (!empty($action)) {
+  // -----
+  // Set an indicator for init_special_funcs.php to perform auto-enable/expiration.
+  //
+  $_SESSION['expirationsNeedUpdate'] = true;
+
   switch ($action) {
     case 'setflag':
       if (isset($_POST['flag']) && ($_POST['flag'] === '1' || $_POST['flag'] === '0')) {

--- a/admin/includes/init_includes/init_special_funcs.php
+++ b/admin/includes/init_includes/init_special_funcs.php
@@ -12,24 +12,21 @@ if (!defined('IS_ADMIN_FLAG')) {
 // set a default time limit
 zen_set_time_limit(GLOBAL_SET_TIME_LIMIT);
 
-// auto activate and expire banners
-require DIR_FS_CATALOG . DIR_WS_FUNCTIONS . 'banner.php';
-zen_activate_banners();
-zen_expire_banners();
-
 // -----
-// Functions are still needed for specials/featured/salemaker tools'
-// processing!
+// Load required "special" function-files, associated with features that
+// auto-expire and auto-activate.
 //
+require DIR_FS_CATALOG . DIR_WS_FUNCTIONS . 'banner.php';
 require DIR_FS_CATALOG . DIR_WS_FUNCTIONS . 'specials.php';
 require DIR_FS_CATALOG . DIR_WS_FUNCTIONS . 'featured.php';
 require DIR_FS_CATALOG . DIR_WS_FUNCTIONS . 'salemaker.php';
 
+// auto activate and expire banners
+zen_activate_banners();
+zen_expire_banners();
+
 /**
- * only process once per session do not include banners as banners expire per click as well as per date
- * require the banner functions, auto-activate and auto-expire.
- *
- * this is processed in the admin for dates that expire while being worked on
+ * only process once per session, do not include banners as banners expire per click as well as per date
  */
 // check if a reset on one time sessions settings should occur due to the midnight hour happening
 if (!isset($_SESSION['today_is'])) {
@@ -41,6 +38,10 @@ if ($_SESSION['today_is'] !== date('Y-m-d')) {
     $_SESSION['expirationsNeedUpdate'] = true;
 }
 
+// -----
+// Note: the expirationsNeedUpdate is also set while an admin is working on
+// Specials, Featured Products and SaleMaker sales.
+//
 if (!isset($_SESSION['expirationsNeedUpdate']) || $_SESSION['expirationsNeedUpdate'] === true) {
     // auto expire special products
     zen_start_specials();

--- a/admin/includes/init_includes/init_special_funcs.php
+++ b/admin/includes/init_includes/init_special_funcs.php
@@ -6,29 +6,53 @@
  * @version $Id: DrByte 2020 Jul 10 Modified in v1.5.8-alpha $
  */
 if (!defined('IS_ADMIN_FLAG')) {
-  die('Illegal Access');
+    die('Illegal Access');
 }
+
 // set a default time limit
-  zen_set_time_limit(GLOBAL_SET_TIME_LIMIT);
+zen_set_time_limit(GLOBAL_SET_TIME_LIMIT);
 
 // auto activate and expire banners
-  require(DIR_FS_CATALOG . DIR_WS_FUNCTIONS . 'banner.php');
-  zen_activate_banners();
-  zen_expire_banners();
+require DIR_FS_CATALOG . DIR_WS_FUNCTIONS . 'banner.php';
+zen_activate_banners();
+zen_expire_banners();
 
-// auto expire special products
-  require(DIR_FS_CATALOG . DIR_WS_FUNCTIONS . 'specials.php');
-  zen_start_specials();
-  zen_expire_specials();
+// -----
+// Functions are still needed for specials/featured/salemaker tools'
+// processing!
+//
+require DIR_FS_CATALOG . DIR_WS_FUNCTIONS . 'specials.php';
+require DIR_FS_CATALOG . DIR_WS_FUNCTIONS . 'featured.php';
+require DIR_FS_CATALOG . DIR_WS_FUNCTIONS . 'salemaker.php';
 
-// auto expire featured products
-  require(DIR_FS_CATALOG . DIR_WS_FUNCTIONS . 'featured.php');
-  zen_start_featured();
-  zen_expire_featured();
+/**
+ * only process once per session do not include banners as banners expire per click as well as per date
+ * require the banner functions, auto-activate and auto-expire.
+ *
+ * this is processed in the admin for dates that expire while being worked on
+ */
+// check if a reset on one time sessions settings should occur due to the midnight hour happening
+if (!isset($_SESSION['today_is'])) {
+    $_SESSION['today_is'] = date('Y-m-d');
+}
 
-// auto expire salemaker sales
-  require(DIR_FS_CATALOG . DIR_WS_FUNCTIONS . 'salemaker.php');
-  zen_start_salemaker();
-  zen_expire_salemaker();
+if ($_SESSION['today_is'] !== date('Y-m-d')) {
+    $_SESSION['today_is'] = date('Y-m-d');
+    $_SESSION['expirationsNeedUpdate'] = true;
+}
 
-?>
+if (!isset($_SESSION['expirationsNeedUpdate']) || $_SESSION['expirationsNeedUpdate'] === true) {
+    // auto expire special products
+    zen_start_specials();
+    zen_expire_specials();
+
+    // auto expire featured products
+    zen_start_featured();
+    zen_expire_featured();
+
+    // auto expire salemaker sales
+    zen_start_salemaker();
+    zen_expire_salemaker();
+
+    $_SESSION['expirationsNeedUpdate'] = false;
+}

--- a/admin/salemaker.php
+++ b/admin/salemaker.php
@@ -26,6 +26,11 @@ $deduction_type_array = array(
 $action = (isset($_GET['action']) ? $_GET['action'] : '');
 
 if (!empty($action)) {
+  // -----
+  // Set an indicator for init_special_funcs.php to perform auto-enable/expiration.
+  //
+  $_SESSION['expirationsNeedUpdate'] = true;
+
   switch ($action) {
     case 'setflag':
       if (isset($_POST['flag']) && ($_POST['flag'] == 1 || $_POST['flag'] == 0)) {

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -15,6 +15,11 @@ $action = (isset($_GET['action']) ? $_GET['action'] : '');
 $currentPage = (isset($_GET['page']) && $_GET['page'] != '' ? (int)$_GET['page'] : 0);
 
 if (!empty($action)) {
+  // -----
+  // Set an indicator for init_special_funcs.php to perform auto-enable/expiration.
+  //
+  $_SESSION['expirationsNeedUpdate'] = true;
+
   switch ($action) {
     case 'setflag':
       if (isset($_POST['flag']) && ($_POST['flag'] === '1' || $_POST['flag'] === '0')) {


### PR DESCRIPTION
Semi-replicating the once-per-day/session handing on the storefront for the specials/featured/salemaker auto-enable/expire checks.  Otherwise, the expirations (which normally happen only once/day) are checked on *every* admin page-load.

Discovered this issue on a zc158 site whose admin was taking 1-2 seconds to load each-and-every admin page.  The site had minimal (i.e. < 20) of these automatic updates to perform, but adding this change, the other pages in the admin averaged less than 250ms to load.