### PR TITLE
Handle loading product_reviews page where products_id not specified

### DIFF
--- a/includes/modules/pages/product_reviews/header_php.php
+++ b/includes/modules/pages/product_reviews/header_php.php
@@ -11,6 +11,11 @@
   // This should be first line of the script:
   $zco_notifier->notify('NOTIFY_HEADER_START_PRODUCT_REVIEWS');
 
+  // if no product specified, go to all reviews page
+  if (empty($_GET['products_id'])) {
+      zen_redirect(zen_href_link(FILENAME_REVIEWS)); 
+  }
+
 // check product exists and current
 // if product does not exist or is status 0 send to _info page
     $products_reviews_check_query = "SELECT count(*) AS count


### PR DESCRIPTION
Avoid this log:

--> PHP Warning: Undefined array key "products_id" in /home/client/public_html/includes/modules/pages/product_reviews/header_php.php on line 25.

Occurs when someone modifies the URL 

index.php?main_page=product_reviews&products_id=85

to remove products_id parameter (presumably in hopes of seeing all reviews). 