### PR TITLE
Adding a back button to the About Us page

### DIFF
--- a/includes/templates/template_default/templates/tpl_about_us_default.php
+++ b/includes/templates/template_default/templates/tpl_about_us_default.php
@@ -26,4 +26,5 @@
 
     </div>
 
+    <div class="buttonRow back"><?php echo zen_back_link() . zen_image_button(BUTTON_IMAGE_BACK, BUTTON_BACK_ALT) . '</a>'; ?></div>
 </div>


### PR DESCRIPTION
The majority of the define pages already have a back button, especially those of a similar ilk  - privacy, conditions,pages 2,3,4, shipping.