### PR TITLE
Admin/orders: Limit when single order, correct layout

### DIFF
--- a/admin/orders.php
+++ b/admin/orders.php
@@ -59,7 +59,7 @@ if (isset($_POST['oID'])) {
 if ($oID) {
   $orders = $db->Execute("SELECT orders_id
                           FROM " . TABLE_ORDERS . "
-                          WHERE orders_id = " . $oID);
+                          WHERE orders_id = " . $oID, 1);
   $order_exists = true;
   if ($orders->RecordCount() <= 0) {
     $order_exists = false;
@@ -553,7 +553,7 @@ if (!empty($action) && $order_exists === true) {
           <div class="col-sm-3 col-lg-4 text-left noprint">
             <?php echo $left_side_buttons; ?>
           </div>
-          <div class="col-sm-6 col-lg-6 noprint">
+          <div class="col-sm-6 col-lg-4 noprint">
             <div class="input-group">
               <span class="input-group-btn">
                   <?php echo $prev_button; ?>


### PR DESCRIPTION
On a site that has 120K+ orders, adding the 'limit 1' when a specific order is being viewed is a significant performance improvement.

For the orders' button row, change the middle section to have a large-viewport column-width of 4 (so the column-counts are 4/4/4).  Otherwise, site-specific button additions will overflow.