### PR TITLE
Return string-type from zen_get_products_url

### DIFF
--- a/includes/functions/functions_products.php
+++ b/includes/functions/functions_products.php
@@ -675,7 +675,7 @@ function zen_get_products_url($product_id, $language_id)
                              WHERE products_id = " . (int)$product_id . "
                              AND language_id = " . (int)$language_id, 1);
     if ($product->EOF) return '';
-    return $product->fields['products_url'];
+    return (string)$product->fields['products_url'];
 }
 
 /**


### PR DESCRIPTION
Since that value can be `null`, returning a string prevents PHP deprecated issues like
```
--> PHP Deprecated: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in C:\xampp\htdocs\zc200\admin\includes\modules\collect_info.php on line 419.
```