### PR TITLE
Manufactures Sidebox not correctly checking for products/active status

### DIFF
--- a/includes/modules/sideboxes/manufacturers.php
+++ b/includes/modules/sideboxes/manufacturers.php
@@ -8,7 +8,7 @@
  * @version $Id: lat9 2022 Jul 05 Modified in v1.5.8-alpha $
  */
 // only check products if requested - this may slow down the processing of the manufacturers sidebox
-if (PRODUCTS_MANUFACTURERS_STATUS === 1) {
+if ((int)PRODUCTS_MANUFACTURERS_STATUS === 1) {
     $manufacturer_sidebox_query =
         "SELECT DISTINCT m.manufacturers_id, m.manufacturers_name
                     FROM " . TABLE_MANUFACTURERS . " m

--- a/includes/modules/sideboxes/manufacturers.php
+++ b/includes/modules/sideboxes/manufacturers.php
@@ -8,7 +8,7 @@
  * @version $Id: lat9 2022 Jul 05 Modified in v1.5.8-alpha $
  */
 // only check products if requested - this may slow down the processing of the manufacturers sidebox
-if (PRODUCTS_MANUFACTURERS_STATUS === '1') {
+if (PRODUCTS_MANUFACTURERS_STATUS === 1) {
     $manufacturer_sidebox_query =
         "SELECT DISTINCT m.manufacturers_id, m.manufacturers_name
                     FROM " . TABLE_MANUFACTURERS . " m


### PR DESCRIPTION
Fixes the bug
Manufactures Sidebox dosn't check for products/active status even when set in admin.
Setting ADMIN-->CONFIGURATION-->MAXIUMVALUES-->Manufacturers List - Verify Product Exist to true (1)
should filter the manufactures side box to exlude manufactures with no active products
it dosnt work

issues #5961