### PR TITLE
Capture payment module final status in order

### DIFF
--- a/includes/modules/checkout_process.php
+++ b/includes/modules/checkout_process.php
@@ -96,7 +96,15 @@ if (!isset($_SESSION['payment']) && $credit_covers === FALSE) {
 
 // load the before_process function from the payment modules
 $payment_modules->before_process();
+
+// -----
+// Account for any order-status change based on the payment module's processing.
+//
+if (isset($GLOBALS[$_SESSION['payment']]->order_status) && ((int)$GLOBALS[$_SESSION['payment']]->order_status) > 0) {
+    $order->info['order_status'] = (int)$GLOBALS[$_SESSION['payment']]->order_status;
+}
 $zco_notifier->notify('NOTIFY_CHECKOUT_PROCESS_AFTER_PAYMENT_MODULES_BEFOREPROCESS');
+
 // create the order record
 $insert_id = $order->create($order_totals);
 $zco_notifier->notify('NOTIFY_CHECKOUT_PROCESS_AFTER_ORDER_CREATE', $insert_id);


### PR DESCRIPTION
If a payment module, e.g. `authorizenet_aim`, sets a different status during its `before_process` method, that status is not initially recorded into the order &mdash; which can cause customer confusion.

For instance, if an a.net/aim transaction is being held for review, a specific a.net/aim order-status can be set.  Currently, the order's initial status (viewable by the customer) indicates that the order is awaiting processing, but a subsequent (hidden) status-update by the a.net/aim payment module sets the order's status to its "Under Review" setting.

This update corrects that issue.