### PR TITLE
Add mysql version check

### DIFF
--- a/zc_install/includes/classes/class.systemChecker.php
+++ b/zc_install/includes/classes/class.systemChecker.php
@@ -757,7 +757,7 @@ class systemChecker
                 $checkVersion = $parameters['mysqlVersion'];
             } else {
                 // mariaDb Check version must remove -MariaDB from the version 
-                // as version compare treates -... as a lower version than N.N.N
+                // as version compare treats -... as a lower version than N.N.N
                 $version = substr($version, 0, strripos($version, '-MariaDB'));
                 $checkVersion = $parameters['mariaDBVersion'];
             }

--- a/zc_install/includes/languages/en_us/main.php
+++ b/zc_install/includes/languages/en_us/main.php
@@ -170,6 +170,7 @@ return [
 'TEXT_ERROR_SUCCESS_EXISTING_CONFIGURE_NO_UPDATE' => 'An existing configure.php file was found. However, your database seems to be current. This suggests you are on a live site. Proceeding with Install will delete the current database contents! Are you sure you want to continue with Install?',
 'TEXT_ERROR_MULTIPLE_ADMINS_NONE_SELECTED' => 'Multiple Admin directories seem to exist. Either remove the duplicate admin directories and click Refresh or select the correct admin directory below and click Refresh.',
 'TEXT_ERROR_MULTIPLE_ADMINS_SELECTED' => 'Multiple Admin directories seem to exist. If the selected directory below is incorrect, please choose another and click Refresh.',
+'TEXT_ERROR_MYSQL_VERSION' => 'The server database does not meet the minimum version. MySQL: %s or MariaDB: %s',
 'TEXT_ERROR_SUCCESS_NO_ERRORS' => 'No errors were detected on your system. You may continue with the installation.',
 'TEXT_UPGRADE_INFO' => '%%TEXT_UPGRADE%%: will inspect your database and subsequently offer the steps required to upgrade to the current version (adding new fields/modifying existing fields). This is intended to be a non-destructive process, but as with all modifications you must ensure you have a verified backup of your database available before proceeding.',
 'TEXT_CLEAN_INSTALL_INFO' => '%%TEXT_CLEAN_INSTALL%%: will revert the database to a new state, deleting all data. Optionally, the demonstration data may be loaded as part of this process.',

--- a/zc_install/includes/systemChecks.yml
+++ b/zc_install/includes/systemChecks.yml
@@ -199,6 +199,16 @@ systemChecks:
     mainErrorText: <?php echo TEXT_ERROR_DB_CONNECTION_DEFAULT .PHP_EOL; ?>
     methods:
       checkDBConnection:
+  checkMysqlVersion:
+    runLevel: always
+    errorLevel: FAIL
+    criticalError: true
+    mainErrorText: <?php echo sprintf(TEXT_ERROR_MYSQL_VERSION, '5.7.8', '10.2.7') . PHP_EOL; ?>
+    methods:
+      checkMysqlVersion:
+        parameters:
+          mysqlVersion: 5.7.8
+          mariaDBVersion: 10.2.7
   checkjson:
     runLevel: always
     errorLevel: FAIL


### PR DESCRIPTION
Add a check into the install to ensure that the database is at least the minimum version of Mysql of MariaDB. The check only fails if it is able to perform a version check and the version is less than that specified in systemChecks.yml.

fixes  #6002