### PR TITLE
functions_products, refactoring and product removal correction

### DIFF
--- a/includes/functions/functions_products.php
+++ b/includes/functions/functions_products.php
@@ -19,7 +19,9 @@ function zen_get_product_details($product_id, $language_id = null)
 {
     global $db, $zco_notifier;
 
-    if ($language_id === null) $language_id = $_SESSION['languages_id'];
+    if ($language_id === null) {
+        $language_id = $_SESSION['languages_id'] ?? 1;
+    }
 
     $sql = "SELECT p.*, pd.*, pt.allow_add_to_cart, pt.type_handler
             FROM " . TABLE_PRODUCTS . " p
@@ -50,14 +52,16 @@ function zen_product_set_header_response($product_id, $product_info = null)
     }
 
     $response_code = 200;
+    
+    $product_not_found = $product_info->EOF;
+    $should_throw_404 = $product_not_found;
 
-    $should_throw_404 = $product_not_found = $product_info->EOF;
-    if ($should_throw_404) {
+    if ($should_throw_404 === true) {
         $response_code = 404;
     }
 
     global $product_status;
-    $product_status = !$product_info->EOF && $product_info->fields['products_status'] ? (int)$product_info->fields['products_status'] : 0;
+    $product_status = !$product_not_found && $product_info->fields['products_status'] ? (int)$product_info->fields['products_status'] : 0;
 
     if ($product_status === 0) {
         $response_code = 410;
@@ -97,8 +101,6 @@ function zen_product_set_header_response($product_id, $product_info = null)
         header('HTTP/1.1 410 Gone');
         return;
     }
-
-    if ($response_code === 200) return;
 }
 
 /**
@@ -113,7 +115,7 @@ function zen_set_disabled_upcoming_status($products_id, $status)
             SET products_status = " . (int)$status . ", products_date_available = NULL
             WHERE products_id = " . (int)$products_id;
 
-    $db->Execute($sql);
+    $db->Execute($sql, 1);
 }
 
 /**
@@ -124,7 +126,9 @@ function zen_enable_disabled_upcoming($datetime = null)
 {
     global $db;
 
-    if (empty($datetime)) $datetime = time();
+    if (empty($datetime)) {
+        $datetime = time();
+    }
 
     $zc_disabled_upcoming_date = date('Ymd', $datetime);
 
@@ -175,22 +179,21 @@ function zen_get_new_date_range($time_limit = false)
 
     $zc_new_date = date('Ymd', $date_range);
     switch (true) {
-        case (SHOW_NEW_PRODUCTS_LIMIT == 0):
+        case (SHOW_NEW_PRODUCTS_LIMIT === '0'):
             $new_range = '';
             break;
-        case (SHOW_NEW_PRODUCTS_LIMIT == 1):
+        case (SHOW_NEW_PRODUCTS_LIMIT === '1'):
             $zc_new_date = date('Ym', time()) . '01';
-            $new_range = ' and p.products_date_added >=' . $zc_new_date;
+            $new_range = ' AND p.products_date_added >= ' . $zc_new_date;
             break;
         default:
-            $new_range = ' and p.products_date_added >=' . $zc_new_date;
+            $new_range = ' AND p.products_date_added >= ' . $zc_new_date;
+            break;
     }
 
-    if (SHOW_NEW_PRODUCTS_UPCOMING_MASKED == 0) {
-        // do nothing upcoming shows in new
-    } else {
+    if (SHOW_NEW_PRODUCTS_UPCOMING_MASKED !== '0') {
         // do not include upcoming in new
-        $new_range .= " and (p.products_date_available <=" . $upcoming_mask . " or p.products_date_available IS NULL)";
+        $new_range .= " AND (p.products_date_available <= " . $upcoming_mask . " OR p.products_date_available IS NULL)";
     }
     return $new_range;
 }
@@ -205,30 +208,31 @@ function zen_get_products_new_timelimit($time_limit = false)
     if ($time_limit == false) {
         $time_limit = SHOW_NEW_PRODUCTS_LIMIT;
     }
-    switch (true) {
-        case ($time_limit == '0'):
+    $time_limit = (int)$time_limit;
+    switch ($time_limit) {
+        case 1:
+            $display_limit = " AND date_format(p.products_date_added, '%Y%m') >= date_format(now(), '%Y%m')";
+            break;
+        case 7:
+            $display_limit = ' AND TO_DAYS(NOW()) - TO_DAYS(p.products_date_added) <= 7';
+            break;
+        case 14:
+            $display_limit = ' AND TO_DAYS(NOW()) - TO_DAYS(p.products_date_added) <= 14';
+            break;
+        case 30:
+            $display_limit = ' AND TO_DAYS(NOW()) - TO_DAYS(p.products_date_added) <= 30';
+            break;
+        case 60:
+            $display_limit = ' AND TO_DAYS(NOW()) - TO_DAYS(p.products_date_added) <= 60';
+            break;
+        case 90:
+            $display_limit = ' AND TO_DAYS(NOW()) - TO_DAYS(p.products_date_added) <= 90';
+            break;
+        case 120:
+            $display_limit = ' AND TO_DAYS(NOW()) - TO_DAYS(p.products_date_added) <= 120';
+            break;
+        default:
             $display_limit = '';
-            break;
-        case ($time_limit == '1'):
-            $display_limit = " and date_format(p.products_date_added, '%Y%m') >= date_format(now(), '%Y%m')";
-            break;
-        case ($time_limit == '7'):
-            $display_limit = ' and TO_DAYS(NOW()) - TO_DAYS(p.products_date_added) <= 7';
-            break;
-        case ($time_limit == '14'):
-            $display_limit = ' and TO_DAYS(NOW()) - TO_DAYS(p.products_date_added) <= 14';
-            break;
-        case ($time_limit == '30'):
-            $display_limit = ' and TO_DAYS(NOW()) - TO_DAYS(p.products_date_added) <= 30';
-            break;
-        case ($time_limit == '60'):
-            $display_limit = ' and TO_DAYS(NOW()) - TO_DAYS(p.products_date_added) <= 60';
-            break;
-        case ($time_limit == '90'):
-            $display_limit = ' and TO_DAYS(NOW()) - TO_DAYS(p.products_date_added) <= 90';
-            break;
-        case ($time_limit == '120'):
-            $display_limit = ' and TO_DAYS(NOW()) - TO_DAYS(p.products_date_added) <= 120';
             break;
     }
     return $display_limit;
@@ -243,7 +247,9 @@ function zen_get_products_new_timelimit($time_limit = false)
 function zen_get_products_category_id($product_id)
 {
     $result = zen_get_product_details($product_id);
-    if ($result->EOF) return '';
+    if ($result->EOF) {
+        return '';
+    }
     return $result->fields['master_categories_id'];
 }
 
@@ -338,6 +344,9 @@ function zen_get_linked_products_for_category($category_id, $first_only = false)
             FROM " . TABLE_PRODUCTS_TO_CATEGORIES . "
             WHERE categories_id = " . (int)$category_id . "
             ORDER BY products_id";
+    if ($first_only) {
+        $sql .= ' LIMIT 1';
+    }
     $results = $db->Execute($sql);
 
     if ($first_only) {
@@ -388,14 +397,15 @@ function zen_unlink_product_from_all_linked_categories($product_id, $master_cate
     if ($master_category_id === null) {
         $master_category_id = zen_get_products_category_id($product_id);
     }
-    if (empty($master_category_id)) return;
+    if (empty($master_category_id)) {
+        return;
+    }
 
     $sql = "DELETE FROM " . TABLE_PRODUCTS_TO_CATEGORIES . "
             WHERE products_id = " . (int)$product_id . "
             AND categories_id != " . (int)$master_category_id;
     $db->Execute($sql);
 }
-
 
 /**
  * Return a product ID with attributes hash
@@ -438,7 +448,6 @@ function zen_get_uprid($prid, $params)
     return $prid . ':' . $md_uprid;
 }
 
-
 /**
  * Return a product ID from a product ID with attributes
  * Alternate: simply (int) the product id
@@ -451,21 +460,14 @@ function zen_get_prid(string $uprid)
     return (int)$pieces[0];
 }
 
-
 /**
  * @param int|string $product_id (while a hashed string is accepted, only the (int) portion is used)
  * Check if product_id exists in database
  */
 function zen_products_id_valid($product_id)
 {
-    global $db;
-    $sql = "SELECT products_id
-            FROM " . TABLE_PRODUCTS . "
-            WHERE products_id = " . (int)$product_id;
-
-    $result = $db->Execute($sql, 1);
-
-    return !$result->EOF;
+    $product = zen_get_product_details($product_id);
+    return !$product->EOF;
 }
 
 /**
@@ -474,23 +476,11 @@ function zen_products_id_valid($product_id)
  * @param int $product_id The product id of the product who's name we want
  * @param int $language_id The language id to use. Defaults to current language
  */
-function zen_get_products_name($product_id, $language_id = 0)
+function zen_get_products_name($product_id, $language_id = null)
 {
-    global $db;
-
-    if (empty($language_id)) $language_id = $_SESSION['languages_id'];
-
-    $sql = "SELECT products_name
-            FROM " . TABLE_PRODUCTS_DESCRIPTION . "
-            WHERE products_id = " . (int)$product_id . "
-            AND language_id = " . (int)$language_id;
-
-    $result = $db->Execute($sql, 1);
-    if ($result->EOF) return '';
-
-    return $result->fields['products_name'];
+    $product = zen_get_product_details($product_id, $language_id);
+    return ($product->EOF) ? '' : $product->fields['products_name'];
 }
-
 
 /**
  * lookup attributes model
@@ -498,14 +488,9 @@ function zen_get_products_name($product_id, $language_id = 0)
  */
 function zen_get_products_model($product_id)
 {
-    global $db;
-    $check = $db->Execute("SELECT products_model
-                    FROM " . TABLE_PRODUCTS . "
-                    WHERE products_id=" . (int)$product_id, 1);
-    if ($check->EOF) return '';
-    return $check->fields['products_model'];
+    $product = zen_get_product_details($product_id);
+    return ($product->EOF) ? '' : $product->fields['products_model'];
 }
-
 
 /**
  * Get the status of a product
@@ -513,11 +498,8 @@ function zen_get_products_model($product_id)
  */
 function zen_get_products_status($product_id)
 {
-    global $db;
-    $sql = "SELECT products_status FROM " . TABLE_PRODUCTS . (!empty($product_id) ? " where products_id=" . (int)$product_id : "");
-    $check_status = $db->Execute($sql, 1);
-    if ($check_status->EOF) return '';
-    return $check_status->fields['products_status'];
+   $product = zen_get_product_details($product_id);
+   return ($product->EOF) ? '' : $product->fields['products_status'];
 }
 
 /**
@@ -533,7 +515,7 @@ function zen_get_product_is_linked($product_id, $show_count = 'false')
     $sql = "SELECT * FROM " . TABLE_PRODUCTS_TO_CATEGORIES . (!empty($product_id) ? " where products_id=" . (int)$product_id : "");
     $check_linked = $db->Execute($sql);
     if ($check_linked->RecordCount() > 1) {
-        if ($show_count == 'true') {
+        if ($show_count === 'true') {
             return $check_linked->RecordCount();
         } else {
             return 'true';
@@ -542,7 +524,6 @@ function zen_get_product_is_linked($product_id, $show_count = 'false')
         return 'false';
     }
 }
-
 
 /**
  * Return a product's stock-on-hand
@@ -566,13 +547,8 @@ function zen_get_products_stock($products_id)
         return $products_quantity;
     }
     $products_id = zen_get_prid($products_id);
-    $stock_query = "SELECT products_quantity
-                    FROM " . TABLE_PRODUCTS . "
-                    WHERE products_id = " . (int)$products_id . " LIMIT 1";
-
-    $stock_values = $db->Execute($stock_query);
-
-    return $stock_values->fields['products_quantity'];
+    $product = zen_get_product_details($products_id);
+    return ($product->EOF) ? '0' : $product->fields['products_quantity'];
 }
 
 /**
@@ -605,7 +581,6 @@ function zen_check_stock($products_id, $products_quantity)
     return $the_message;
 }
 
-
 /**
  * Return a product's manufacturer's name, from ID
  * @param int $product_id
@@ -622,7 +597,7 @@ function zen_get_products_manufacturers_name($product_id)
 
     $product = $db->Execute($sql, 1);
 
-    return ($product->RecordCount() > 0) ? $product->fields['manufacturers_name'] : '';
+    return (!$product->EOF) ? $product->fields['manufacturers_name'] : '';
 }
 
 /**
@@ -651,15 +626,8 @@ function zen_get_products_manufacturers_image($product_id)
  */
 function zen_get_products_manufacturers_id($product_id)
 {
-    global $db;
-
-    $product_query = "SELECT p.manufacturers_id
-                      FROM " . TABLE_PRODUCTS . " p
-                      WHERE p.products_id = " . (int)$product_id;
-
-    $product = $db->Execute($product_query, 1);
-
-    return (int)$product->fields['manufacturers_id'];
+    $product = zen_get_product_details($product_id);
+    return ($product->EOF) ? 0 : (int)$product->fields['manufacturers_id'];
 }
 
 /**
@@ -669,13 +637,8 @@ function zen_get_products_manufacturers_id($product_id)
  */
 function zen_get_products_url($product_id, $language_id)
 {
-    global $db;
-    $product = $db->Execute("SELECT products_url
-                             FROM " . TABLE_PRODUCTS_DESCRIPTION . "
-                             WHERE products_id = " . (int)$product_id . "
-                             AND language_id = " . (int)$language_id, 1);
-    if ($product->EOF) return '';
-    return (string)$product->fields['products_url'];
+    $product = zen_get_product_details($product_id, $language_id);
+    return ($product->EOF) ? '' : (string)$product->fields['products_url'];
 }
 
 /**
@@ -684,19 +647,13 @@ function zen_get_products_url($product_id, $language_id)
  * @param int $language_id
  * @return string
  */
-function zen_get_products_description($product_id, $language_id = 0)
+function zen_get_products_description($product_id, $language_id = null)
 {
-    global $db, $zco_notifier;
+    global $zco_notifier;
 
-    if (empty($language_id)) {
-        $language_id = $_SESSION['languages_id'];
-    }
+    $product = zen_get_product_details($product_id, $language_id);
 
-    $product = $db->Execute("SELECT products_description
-                             FROM " . TABLE_PRODUCTS_DESCRIPTION . "
-                             WHERE products_id = " . (int)$product_id . "
-                             AND language_id = " . (int)$language_id, 1);
-//Allow an observer to modify the description
+    //Allow an observer to modify the description
     $zco_notifier->notify('NOTIFY_GET_PRODUCTS_DESCRIPTION', $product_id, $product);
     return ($product->EOF) ? '' : $product->fields['products_description'];
 }
@@ -709,8 +666,8 @@ function zen_get_products_description($product_id, $language_id = 0)
 function zen_get_info_page($product_id)
 {
     global $db;
-    $sql = "SELECT products_type FROM " . TABLE_PRODUCTS . " WHERE products_id = " . (int)$product_id;
-    $result = $db->Execute($sql, 1);
+
+    $result = zen_get_product_details($product_id);
     if ($result->EOF) {
         return 'product_info';
     }
@@ -720,7 +677,6 @@ function zen_get_info_page($product_id)
     return $result->fields['type_handler'] . '_info';
 }
 
-
 /**
  * get products_type for specified $product_id
  * @param int $product_id
@@ -728,13 +684,9 @@ function zen_get_info_page($product_id)
  */
 function zen_get_products_type($product_id)
 {
-    global $db;
-
-    $result = $db->Execute("SELECT products_type FROM " . TABLE_PRODUCTS . " WHERE products_id=" . (int)$product_id, 1);
-    if ($result->EOF) return '';
-    return (int)$result->fields['products_type'];
+    $result = zen_get_product_details($product_id);
+    return ($result->EOF) ? '' : (int)$result->fields['products_type'];
 }
-
 
 /**
  * look up a products image and send back the image's IMG tag
@@ -745,16 +697,12 @@ function zen_get_products_type($product_id)
  */
 function zen_get_products_image($product_id, $width = SMALL_IMAGE_WIDTH, $height = SMALL_IMAGE_HEIGHT)
 {
-    global $db;
+    $result = zen_get_product_details($product_id);
+    if ($result->EOF) {
+        return '';
+    }
 
-    $sql = "SELECT p.products_image
-            FROM " . TABLE_PRODUCTS . " p
-            WHERE products_id=" . (int)$product_id;
-    $result = $db->Execute($sql, 1);
-
-    if ($result->EOF) return '';
-
-    if (IS_ADMIN_FLAG) {
+    if (IS_ADMIN_FLAG === true) {
         return $result->fields['products_image'];
     }
     return zen_image(DIR_WS_IMAGES . $result->fields['products_image'], zen_get_products_name($product_id), $width, $height);
@@ -767,12 +715,8 @@ function zen_get_products_image($product_id, $width = SMALL_IMAGE_WIDTH, $height
  */
 function zen_get_products_virtual($product_id)
 {
-    global $db;
-
-    $sql = "SELECT p.products_virtual FROM " . TABLE_PRODUCTS . " p  WHERE p.products_id=" . (int)$product_id;
-    $look_up = $db->Execute($sql, 1);
-
-    return $look_up->fields['products_virtual'] == '1';
+    $result = zen_get_product_details($product_id);
+    return !empty($result->fields['products_virtual']);
 }
 
 /**
@@ -784,18 +728,14 @@ function zen_get_products_allow_add_to_cart($product_id)
 {
     global $db, $zco_notifier;
 
-    $sql = "SELECT p.*, pt.allow_add_to_cart FROM " . TABLE_PRODUCTS . " p
-            LEFT JOIN " . TABLE_PRODUCT_TYPES . " pt ON (p.products_type = pt.type_id)
-            WHERE products_id=" . (int)$product_id;
-
-    $product_query_results = $db->Execute($sql, 1);
+    $product_query_results = zen_get_product_details($product_id);
 
     // If product found, and product_type's allow_add_to_cart is not 'N', allow
-    $allow_add_to_cart = !$product_query_results->EOF && $product_query_results->fields['allow_add_to_cart'] != 'N';
+    $allow_add_to_cart = !$product_query_results->EOF && $product_query_results->fields['allow_add_to_cart'] !== 'N';
 
 
     // If product is encoded as GV but GV feature is turned off, disallow add-to-cart
-    if ($allow_add_to_cart && preg_match('/^GIFT/', addslashes($product_query_results->fields['products_model']))) {
+    if ($allow_add_to_cart === true && strpos($product_query_results->fields['products_model'], 'GIFT') === 0) {
         if (!defined('MODULE_ORDER_TOTAL_GV_STATUS') || MODULE_ORDER_TOTAL_GV_STATUS !== 'true') {
             $allow_add_to_cart = false;
         }
@@ -824,7 +764,7 @@ function zen_get_show_product_switch($lookup, $field, $prefix = 'SHOW_', $suffix
     $zv_key_value = $db->Execute($sql, 1);
 //echo 'I CAN SEE - look ' . $lookup . ' - field ' . $field . ' - key ' . $keyName . ' value ' . $zv_key_value->fields['configuration_value'] .'<br>';
 
-    if ($zv_key_value->RecordCount() > 0) {
+    if (!$zv_key_value->EOF) {
         return $zv_key_value->fields['configuration_value'];
     }
     $sql = "SELECT configuration_key, configuration_value FROM " . TABLE_CONFIGURATION . " WHERE configuration_key='" . zen_db_input($keyName) . "'";
@@ -834,42 +774,6 @@ function zen_get_show_product_switch($lookup, $field, $prefix = 'SHOW_', $suffix
     }
     return '';
 }
-
-//
-///**
-// * Look up SHOW_XXX_INFO switch for product ID and product type
-// */
-//function zen_get_show_product_switch($lookup, $field, $prefix = 'SHOW_', $suffix = '_INFO', $field_prefix = '_', $field_suffix = '')
-//{
-//    global $db;
-//
-//    $sql = "select products_type from " . TABLE_PRODUCTS . " where products_id='" . $lookup . "'";
-//    $type_lookup = $db->Execute($sql);
-//
-//    if ($type_lookup->RecordCount() == 0) {
-//        return false;
-//    }
-//
-//    $sql = "select type_handler from " . TABLE_PRODUCT_TYPES . " where type_id = '" . $type_lookup->fields['products_type'] . "'";
-//    $show_key = $db->Execute($sql);
-//
-//
-//    $keyName = strtoupper($prefix . $show_key->fields['type_handler'] . $suffix . $field_prefix . $field . $field_suffix);
-//
-//    $sql = "select configuration_key, configuration_value from " . TABLE_PRODUCT_TYPE_LAYOUT . " where configuration_key='" . $keyName . "'";
-//    $zv_key_value = $db->Execute($sql);
-//    if ($zv_key_value->RecordCount() > 0) {
-//        return $zv_key_value->fields['configuration_value'];
-//    } else {
-//        $sql = "select configuration_key, configuration_value from " . TABLE_CONFIGURATION . " where configuration_key='" . $keyName . "'";
-//        $zv_key_value = $db->Execute($sql);
-//        if ($zv_key_value->RecordCount() > 0) {
-//            return $zv_key_value->fields['configuration_value'];
-//        } else {
-//            return false;
-//        }
-//    }
-//}
 
 /**
  * return switch name
@@ -881,93 +785,58 @@ function zen_get_show_product_switch_name($lookup, $field, $prefix = 'SHOW_', $s
     $type_handler = '';
     $sql = "SELECT products_type FROM " . TABLE_PRODUCTS . " WHERE products_id=" . (int)$lookup;
     $result = $db->Execute($sql, 1);
-    if (!$result->EOF) $type_lookup = $result->fields['products_type'];
+    if (!$result->EOF) {
+        $type_lookup = $result->fields['products_type'];
+    }
 
     $sql = "SELECT type_handler FROM " . TABLE_PRODUCT_TYPES . " WHERE type_id = " . (int)$type_lookup;
     $result = $db->Execute($sql, 1);
-    if (!$result->EOF) $type_handler = $result->fields['type_handler'];
+    if (!$result->EOF) {
+        $type_handler = $result->fields['type_handler'];
+    }
     $keyName = strtoupper($prefix . $type_handler . $suffix . $field_prefix . $field . $field_suffix);
 
     return $keyName;
 }
 
-//
-///**
-// * Look up SHOW_XXX_INFO switch for product ID and product type
-// */
-//function zen_get_show_product_switch_name($lookup, $field, $prefix = 'SHOW_', $suffix = '_INFO', $field_prefix = '_', $field_suffix = '')
-//{
-//    global $db;
-//
-//    $sql = "select products_type from " . TABLE_PRODUCTS . " where products_id='" . (int)$lookup . "'";
-//    $type_lookup = $db->Execute($sql);
-//
-//    $sql = "select type_handler from " . TABLE_PRODUCT_TYPES . " where type_id = '" . (int)$type_lookup->fields['products_type'] . "'";
-//    $show_key = $db->Execute($sql);
-//
-//
-//    $keyName = strtoupper($prefix . $show_key->fields['type_handler'] . $suffix . $field_prefix . $field . $field_suffix);
-//
-//    return $keyName;
-//}
-
 /**
- * @TODO - refactor to use zen_get_product_details()
  * Look up whether a product is always free shipping
  * @param int $product_id
  */
 function zen_get_product_is_always_free_shipping($product_id): bool
 {
-    global $db;
-
-    $sql = "SELECT p.product_is_always_free_shipping FROM " . TABLE_PRODUCTS . " p  WHERE p.products_id=" . (int)$product_id;
-    $look_up = $db->Execute($sql, 1);
-
-    return ($look_up->fields['product_is_always_free_shipping'] == '1');
+    $look_up = zen_get_product_details($product_id);
+    return (!$look_up->EOF && $look_up->fields['product_is_always_free_shipping'] === '1');
 }
 
-
 /**
- * @TODO - refactor to product object? or at least leverage zen_get_product_details() instead.
- * Return any field from products or products_description table
+ * Return any field from products or products_description table.
+ *
  * @param int $product_id
  * @param string $what_field
  * @param int $language ID
  */
-function zen_products_lookup($product_id, $what_field = 'products_name', $language = 0)
+function zen_products_lookup($product_id, $what_field = 'products_name', $language = null)
 {
-    global $db;
-
-    if (empty($language)) $language = $_SESSION['languages_id'];
-
-    $product_lookup = $db->Execute("SELECT " . zen_db_input($what_field) . " AS lookup_field
-                              FROM " . TABLE_PRODUCTS . " p
-                              INNER JOIN " . TABLE_PRODUCTS_DESCRIPTION . " pd ON (pd.products_id = p.products_id AND pd.language_id = " . (int)$language .")
-                              WHERE  p.products_id = " . (int)$product_id);
-    if ($product_lookup->EOF) return '';
-    return $product_lookup->fields['lookup_field'];
+    $product_lookup = zen_get_product_details($product_id, $language);
+    if ($product_lookup->EOF || !array_key_exists($what_field, $product_lookup->fields)) {
+        return '';
+    }
+    return $product_lookup->fields[$what_field];
 }
 
-
 /**
- * @TODO - refactor to use zen_get_product_details()
  * Lookup and return product's master_categories_id
  * @param int $product_id
  * @return mixed|int
  */
 function zen_get_parent_category_id($product_id)
 {
-    global $db;
-
-    $categories_lookup = $db->Execute("SELECT master_categories_id
-                                FROM " . TABLE_PRODUCTS . "
-                                WHERE products_id = " . (int)$product_id, 1);
-    if ($categories_lookup->EOF) return '';
-    return $categories_lookup->fields['master_categories_id'];
+    $result = zen_get_product_details($product_id);
+    return ($result->EOF) ? '' : $result->fields['master_categories_id'];
 }
 
 /**
- * @TODO - refactor to use zen_get_product_details()
  * @TODO - check to see whether true/false string responses can be changed to boolean
  * check if products has quantity-discounts defined
  * @param int $product_id
@@ -981,7 +850,7 @@ function zen_has_product_discounts($product_id)
     $check_discount = $db->Execute($check_discount_query, 1);
 
     // @TODO - check calling references in application code to see whether true/false string responses can be changed to boolean
-    return ($check_discount->RecordCount()) ? 'true' : 'false';
+    return (!$check_discount->EOF) ? 'true' : 'false';
 }
 
 /**
@@ -994,12 +863,14 @@ function zen_has_product_discounts($product_id)
 function zen_set_product_status($product_id, $status)
 {
     global $db;
-    $db->Execute("UPDATE " . TABLE_PRODUCTS . "
-                SET products_status = " . (int)$status . ",
-                    products_last_modified = now()
-                WHERE products_id = " . (int)$product_id);
+    $db->Execute(
+        "UPDATE " . TABLE_PRODUCTS . "
+            SET products_status = " . (int)$status . ",
+                products_last_modified = now()
+          WHERE products_id = " . (int)$product_id . "
+          LIMIT 1"
+    );
 }
-
 
 /**
  * @TODO - can the ptc string 'true' be changed to boolean?
@@ -1009,91 +880,89 @@ function zen_set_product_status($product_id, $status)
 function zen_remove_product($product_id, $ptc = 'true')
 {
     global $db, $zco_notifier;
-    $zco_notifier->notify('NOTIFIER_ADMIN_ZEN_REMOVE_PRODUCT', array(), $product_id, $ptc);
+    $zco_notifier->notify('NOTIFIER_ADMIN_ZEN_REMOVE_PRODUCT', [], $product_id, $ptc);
 
-    $product_image = $db->Execute("SELECT products_image
-                                   FROM " . TABLE_PRODUCTS . "
-                                   WHERE products_id = " . (int)$product_id);
+    $product_id = (int)$product_id;
+    $product_image = $db->Execute(
+        "SELECT products_image
+           FROM " . TABLE_PRODUCTS . "
+          WHERE products_id = $product_id
+            AND products_image IS NOT NULL
+            AND products_image != ''
+            AND products_image NOT LIKE '%" . zen_db_input(PRODUCTS_IMAGE_NO_IMAGE) . "'
+          LIMIT 1"
+    );
 
-    $duplicate_image = $db->Execute("SELECT count(*) as total
-                                     FROM " . TABLE_PRODUCTS . "
-                                     WHERE products_image = '" . zen_db_input($product_image->fields['products_image']) . "'");
+    if (!$product_image->EOF) {
+        $duplicate_image = $db->Execute(
+            "SELECT COUNT(*) as total
+               FROM " . TABLE_PRODUCTS . "
+              WHERE products_image = '" . zen_db_input($product_image->fields['products_image']) . "'"
+        );
 
-    if ($duplicate_image->fields['total'] < 2 and $product_image->fields['products_image'] != '' && PRODUCTS_IMAGE_NO_IMAGE != substr($product_image->fields['products_image'], strrpos($product_image->fields['products_image'], '/') + 1)) {
-        $products_image = $product_image->fields['products_image'];
-        $products_image_extension = substr($products_image, strrpos($products_image, '.'));
-        $products_image_base = preg_replace('/' . $products_image_extension . '/', '', $products_image);
+        if ($duplicate_image->fields['total'] < 2) {
+            $products_image = $product_image->fields['products_image'];
+            $image_parts = pathinfo($products_image);
+            $products_image_extension = '.' . $image_parts['extension'];
+            $products_image_base = $image_parts['dirname'] . DIRECTORY_SEPARATOR  . $image_parts['filename'];
 
-        $filename_medium = 'medium/' . $products_image_base . IMAGE_SUFFIX_MEDIUM . $products_image_extension;
-        $filename_large = 'large/' . $products_image_base . IMAGE_SUFFIX_LARGE . $products_image_extension;
+            $filename_medium = 'medium/' . $products_image_base . IMAGE_SUFFIX_MEDIUM . $products_image_extension;
+            $filename_large = 'large/' . $products_image_base . IMAGE_SUFFIX_LARGE . $products_image_extension;
 
-        if (file_exists(DIR_FS_CATALOG_IMAGES . $product_image->fields['products_image'])) {
-            @unlink(DIR_FS_CATALOG_IMAGES . $product_image->fields['products_image']);
-        }
-        if (file_exists(DIR_FS_CATALOG_IMAGES . $filename_medium)) {
-            @unlink(DIR_FS_CATALOG_IMAGES . $filename_medium);
-        }
-        if (file_exists(DIR_FS_CATALOG_IMAGES . $filename_large)) {
-            @unlink(DIR_FS_CATALOG_IMAGES . $filename_large);
+            if (file_exists(DIR_FS_CATALOG_IMAGES . $products_image)) {
+                @unlink(DIR_FS_CATALOG_IMAGES . $products_image);
+            }
+            if (file_exists(DIR_FS_CATALOG_IMAGES . $filename_medium)) {
+                @unlink(DIR_FS_CATALOG_IMAGES . $filename_medium);
+            }
+            if (file_exists(DIR_FS_CATALOG_IMAGES . $filename_large)) {
+                @unlink(DIR_FS_CATALOG_IMAGES . $filename_large);
+            }
         }
     }
 
-    $db->Execute("DELETE FROM " . TABLE_SPECIALS . "
-                  WHERE products_id = " . (int)$product_id);
+    $db->Execute("DELETE FROM " . TABLE_SPECIALS . " WHERE products_id = $product_id");
 
-    $db->Execute("DELETE FROM " . TABLE_PRODUCTS . "
-                  WHERE products_id = " . (int)$product_id);
+    $db->Execute("DELETE FROM " . TABLE_PRODUCTS . " WHERE products_id = $product_id LIMIT 1");
 
 //    if ($ptc == 'true') {
-    $db->Execute("DELETE FROM " . TABLE_PRODUCTS_TO_CATEGORIES . "
-                    WHERE products_id = " . (int)$product_id);
+    $db->Execute("DELETE FROM " . TABLE_PRODUCTS_TO_CATEGORIES . " WHERE products_id = $product_id");
 //    }
 
-    $db->Execute("DELETE FROM " . TABLE_PRODUCTS_DESCRIPTION . "
-                  WHERE products_id = " . (int)$product_id);
+    $db->Execute("DELETE FROM " . TABLE_PRODUCTS_DESCRIPTION . " WHERE products_id = $product_id");
 
-    $db->Execute("DELETE FROM " . TABLE_META_TAGS_PRODUCTS_DESCRIPTION . "
-                  WHERE products_id = " . (int)$product_id);
+    $db->Execute("DELETE FROM " . TABLE_META_TAGS_PRODUCTS_DESCRIPTION . " WHERE products_id = $product_id");
 
     zen_products_attributes_download_delete($product_id);
 
-    $db->Execute("DELETE FROM " . TABLE_PRODUCTS_ATTRIBUTES . "
-                  WHERE products_id = " . (int)$product_id);
+    $db->Execute("DELETE FROM " . TABLE_PRODUCTS_ATTRIBUTES . " WHERE products_id = $product_id");
 
-    $db->Execute("DELETE FROM " . TABLE_CUSTOMERS_BASKET . "
-                  WHERE products_id = " . (int)$product_id);
+    $db->Execute("DELETE FROM " . TABLE_CUSTOMERS_BASKET . " WHERE products_id LIKE '$product_id:%'");
 
-    $db->Execute("DELETE FROM " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . "
-                  WHERE products_id LIKE '" . (int)$product_id . ":%'");
+    $db->Execute("DELETE FROM " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . " WHERE products_id LIKE '$product_id:%'");
 
-
-    $product_reviews = $db->Execute("SELECT reviews_id
-                                     FROM " . TABLE_REVIEWS . "
-                                     WHERE products_id = " . (int)$product_id);
-
+    $product_reviews = $db->Execute(
+        "SELECT reviews_id
+           FROM " . TABLE_REVIEWS . "
+          WHERE products_id = $product_id"
+    );
     foreach ($product_reviews as $row) {
-        $db->Execute("DELETE FROM " . TABLE_REVIEWS_DESCRIPTION . "
-                    WHERE reviews_id = " . (int)$row['reviews_id']);
+        $db->Execute("DELETE FROM " . TABLE_REVIEWS_DESCRIPTION . " WHERE reviews_id = " . $row['reviews_id']);
     }
-    $db->Execute("DELETE FROM " . TABLE_REVIEWS . "
-                  WHERE products_id = " . (int)$product_id);
 
-    $db->Execute("DELETE FROM " . TABLE_FEATURED . "
-                  WHERE products_id = " . (int)$product_id);
+    $db->Execute("DELETE FROM " . TABLE_REVIEWS . " WHERE products_id = $product_id");
 
-    $db->Execute("DELETE FROM " . TABLE_PRODUCTS_DISCOUNT_QUANTITY . "
-                  WHERE products_id = " . (int)$product_id);
+    $db->Execute("DELETE FROM " . TABLE_FEATURED . " WHERE products_id = $product_id");
 
-    $db->Execute("DELETE FROM " . TABLE_COUPON_RESTRICT . "
-                  WHERE product_id = " . (int)$product_id);
+    $db->Execute("DELETE FROM " . TABLE_PRODUCTS_DISCOUNT_QUANTITY . " WHERE products_id = $product_id");
 
-    $db->Execute("DELETE FROM " . TABLE_PRODUCTS_NOTIFICATIONS . "
-                  WHERE products_id = " . (int)$product_id);
+    $db->Execute("DELETE FROM " . TABLE_COUPON_RESTRICT . " WHERE product_id = $product_id");
 
-    $db->Execute("DELETE FROM " . TABLE_COUNT_PRODUCT_VIEWS . "
-                  WHERE product_id = " . (int)$product_id);
+    $db->Execute("DELETE FROM " . TABLE_PRODUCTS_NOTIFICATIONS . " WHERE products_id = $product_id");
 
-    zen_record_admin_activity('Deleted product ' . (int)$product_id . ' from database via admin console.', 'warning');
+    $db->Execute("DELETE FROM " . TABLE_COUNT_PRODUCT_VIEWS . " WHERE product_id = $product_id");
+
+    zen_record_admin_activity("Deleted product $product_id from database via admin console.", 'warning');
 }
 
 /**
@@ -1104,14 +973,13 @@ function zen_remove_product($product_id, $ptc = 'true')
 function zen_products_attributes_download_delete($product_id)
 {
     global $db, $zco_notifier;
-    $zco_notifier->notify('NOTIFIER_ADMIN_ZEN_PRODUCTS_ATTRIBUTES_DOWNLOAD_DELETE', array(), $product_id);
+    $zco_notifier->notify('NOTIFIER_ADMIN_ZEN_PRODUCTS_ATTRIBUTES_DOWNLOAD_DELETE', [], $product_id);
 
     $results = $db->Execute("SELECT products_attributes_id FROM " . TABLE_PRODUCTS_ATTRIBUTES . " WHERE products_id= " . (int)$product_id);
     foreach ($results as $row) {
         $db->Execute("DELETE FROM " . TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD . " WHERE products_attributes_id= " . (int)$row['products_attributes_id']);
     }
 }
-
 
 /**
  * copy quantity-discounts from one product to another
@@ -1142,7 +1010,7 @@ function zen_copy_discounts_to_product($copy_from, $copy_to)
 
 function zen_products_sort_order($includeOrderBy = true): string
 {
-    switch(PRODUCT_INFO_PREVIOUS_NEXT_SORT) {
+    switch (PRODUCT_INFO_PREVIOUS_NEXT_SORT) {
         case (0):
             $productSort = 'LPAD(p.products_id,11,"0")';
             $productSort = 'p.products_id';


### PR DESCRIPTION
- Also includes some minor reformatting
  - array() to []
  - No one-line conditionals
  - Use ->EOF instead of ->RecordCount() where appropriate
  - Use `===` where appropriate
- Refacturing
  - Use zen_get_product_details when possible (reduces unique database queries)
  - Functions that take a language input, default that input to null so that the above function deals with a language not specified
- `zen_remove_product`, customers_basket entry for attributed products not removed, since that table's product_id field is tinytext and can be set to a uprid.