### PR TITLE
Shopping cart performance enhancements

### DIFF
--- a/includes/classes/shopping_cart.php
+++ b/includes/classes/shopping_cart.php
@@ -107,51 +107,50 @@ class shoppingCart extends base
         $this->notify('NOTIFIER_CART_RESTORE_CONTENTS_START');
         // insert current cart contents in database
         if (is_array($this->contents)) {
-            foreach ($this->contents as $products_id => $data) {
-                // $products_id = urldecode($products_id);
-                $qty = $this->contents[$products_id]['qty'];
+            foreach ($this->contents as $uprid => $data) {
+                $uprid_db = zen_db_input($uprid);
+                $qty = $data['qty'];
                 $sql = "SELECT products_id
                         FROM " . TABLE_CUSTOMERS_BASKET . "
                         WHERE customers_id = " . (int)$_SESSION['customer_id'] . "
-                        AND products_id = '" . zen_db_input($products_id) . "'";
+                        AND products_id = '" . $uprid_db . "'";
 
                 $product = $db->Execute($sql);
 
-                if ($product->RecordCount() <= 0) {
-                    $sql = "INSERT INTO " . TABLE_CUSTOMERS_BASKET . "
-                            (customers_id, products_id, customers_basket_quantity,
-                             customers_basket_date_added)
-                             VALUES (" . (int)$_SESSION['customer_id'] . ", '" . zen_db_input($products_id) . "', '" .
-                        $qty . "', '" . date('Ymd') . "')";
+                if ($product->EOF) {
+                    $sql =
+                        "INSERT INTO " . TABLE_CUSTOMERS_BASKET . "
+                            (customers_id, products_id, customers_basket_quantity, customers_basket_date_added)
+                         VALUES
+                            (" . (int)$_SESSION['customer_id'] . ", '$uprid_db', $qty, '" . date('Ymd') . "')";
 
                     $db->Execute($sql);
 
-                    if (isset($this->contents[$products_id]['attributes'])) {
-
-                        foreach ($this->contents[$products_id]['attributes'] as $option => $value) {
+                    if (isset($data['attributes'])) {
+                        foreach ($data['attributes'] as $option => $value) {
 
                             // include attribute value: needed for text attributes
-                            $attr_value = isset($this->contents[$products_id]['attributes_values'][$option]) ? $this->contents[$products_id]['attributes_values'][$option] : '';
+                            $attr_value = $data['attributes_values'][$option] ?? '';
 
-                            $products_options_sort_order = zen_get_attributes_options_sort_order(zen_get_prid($products_id), $option, $value);
+                            $products_options_sort_order = zen_get_attributes_options_sort_order(zen_get_prid($uprid), $option, $value);
                             if ($attr_value) {
                                 $attr_value = zen_db_input($attr_value);
                             }
-                            $sql = "INSERT INTO " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . "
-                                    (customers_id, products_id, products_options_id,
-                                     products_options_value_id, products_options_value_text, products_options_sort_order)
-                                     VALUES (" . (int)$_SESSION['customer_id'] . ", '" . zen_db_input($products_id) . "', '" .
-                                    $option . "', '" . $value . "', '" . $attr_value . "', '" . $products_options_sort_order . "')";
+                            $sql =
+                                "INSERT INTO " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . "
+                                    (customers_id, products_id, products_options_id, products_options_value_id, products_options_value_text, products_options_sort_order)
+                                 VALUES
+                                    (" . (int)$_SESSION['customer_id'] . ", '$uprid_db', '$option', '$value', '$attr_value', '$products_options_sort_order')";
 
                             $db->Execute($sql);
                         }
                     }
                 } else {
                     $sql = "UPDATE " . TABLE_CUSTOMERS_BASKET . "
-                            SET customers_basket_quantity = '" . $qty . "'
+                            SET customers_basket_quantity = $qty
                             WHERE customers_id = " . (int)$_SESSION['customer_id'] . "
-                            AND products_id = '" . zen_db_input($products_id) . "'";
-                    $db->Execute($sql);
+                            AND products_id = '$uprid_db'";
+                    $db->Execute($sql, 1);
 
                 }
             }
@@ -166,26 +165,28 @@ class shoppingCart extends base
                 ORDER BY customers_basket_id";
         $products = $db->Execute($sql);
 
-        while (!$products->EOF) {
-            $this->contents[$products->fields['products_id']] = ['qty' => $products->fields['customers_basket_quantity']];
+        foreach ($products as $next_product) {
+            $uprid = $next_product['products_id'];
+            $this->contents[$uprid] = ['qty' => $next_product['customers_basket_quantity']];
 
             // set contents in sort order
-            $order_by = ' order by LPAD(products_options_sort_order,11,"0")';
+            $order_by = ' ORDER BY LPAD(products_options_sort_order,11,"0")';
 
-            $attributes = $db->Execute("SELECT products_options_id, products_options_value_id, products_options_value_text
-                                         FROM " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . "
-                                         WHERE customers_id = " . (int)$_SESSION['customer_id'] . "
-                                         AND products_id = '" . zen_db_input($products->fields['products_id']) . "' " . $order_by);
+            $attributes = $db->Execute(
+                "SELECT products_options_id, products_options_value_id, products_options_value_text
+                   FROM " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . "
+                  WHERE customers_id = " . (int)$_SESSION['customer_id'] . "
+                    AND products_id = '" . zen_db_input($uprid) . "' " .
+                    $order_by
+            );
 
-            while (!$attributes->EOF) {
-                $this->contents[$products->fields['products_id']]['attributes'][$attributes->fields['products_options_id']] = $attributes->fields['products_options_value_id'];
+            foreach ($attributes as $next_att) {
+                $this->contents[$uprid]['attributes'][$next_att['products_options_id']] = $next_att['products_options_value_id'];
                 // text attributes set additional information
-                if ($attributes->fields['products_options_value_id'] == PRODUCTS_OPTIONS_VALUES_TEXT_ID) {
-                    $this->contents[$products->fields['products_id']]['attributes_values'][$attributes->fields['products_options_id']] = $attributes->fields['products_options_value_text'];
+                if ($next_att['products_options_value_id'] === PRODUCTS_OPTIONS_VALUES_TEXT_ID) {
+                    $this->contents[$uprid]['attributes_values'][$next_att['products_options_id']] = $next_att['products_options_value_text'];
                 }
-                $attributes->MoveNext();
             }
-            $products->MoveNext();
         }
         $this->cartID = $this->generate_cart_id();
         $this->notify('NOTIFIER_CART_RESTORE_CONTENTS_END');
@@ -249,8 +250,10 @@ class shoppingCart extends base
     public function add_cart($product_id, $qty = '1', $attributes = [], $notify = true)
     {
         global $db, $messageStack;
-        if ($this->display_debug_messages) $messageStack->add_session('header', 'FUNCTION ' . __FUNCTION__, 'caution');
-        if (zen_has_product_attributes($product_id, false) && empty($attributes)) {
+        if ($this->display_debug_messages) {
+            $messageStack->add_session('header', 'FUNCTION ' . __FUNCTION__, 'caution');
+        }
+        if (empty($attributes) && zen_has_product_attributes($product_id, false)) {
             if (!zen_requires_attribute_selection($product_id)) {
                 // Build attributes array; determine correct qty
                 $attributes = [];
@@ -263,34 +266,43 @@ class shoppingCart extends base
         }
         if (!is_numeric($qty) || $qty < 0) {
             // adjust quantity when not a value
-            $chk_link = '<a href="' .
-                zen_href_link(zen_get_info_page($product_id),
-                    'cPath=' . (zen_get_generated_category_path_rev(zen_get_products_category_id($product_id))) .
-                    '&products_id=' . $product_id)
-                . '">' . zen_get_products_name($product_id) . '</a>';
+            $chk_link =
+                '<a href="' .
+                    zen_href_link(
+                        zen_get_info_page($product_id),
+                        'cPath=' . (zen_get_generated_category_path_rev(zen_get_products_category_id($product_id))) .
+                        '&products_id=' . $product_id
+                    ) .
+                '">' .
+                    zen_get_products_name($product_id) .
+                '</a>';
             $messageStack->add_session('header', ERROR_CORRECTIONS_HEADING . ERROR_PRODUCT_QUANTITY_UNITS_SHOPPING_CART . $chk_link . ' ' . PRODUCTS_ORDER_QTY_TEXT . zen_output_string_protected($qty), 'caution');
             $qty = 0;
         }
         $this->notify('NOTIFIER_CART_ADD_CART_START', null, $product_id, $qty, $attributes, $notify);
-        $product_id = zen_get_uprid($product_id, $attributes);
+        $uprid = zen_get_uprid($product_id, $attributes);
         if ($notify) {
-            $_SESSION['new_products_id_in_cart'] = $product_id;
+            $_SESSION['new_products_id_in_cart'] = $uprid;
         }
 
-        $qty = $this->adjust_quantity($qty, $product_id, 'shopping_cart');
+        $qty = $this->adjust_quantity($qty, $uprid, 'shopping_cart');
 
-        if ($this->in_cart($product_id)) {
-            $this->update_quantity($product_id, $qty, $attributes);
+        if ($this->in_cart($uprid)) {
+            $this->update_quantity($uprid, $qty, $attributes);
         } else {
-            $this->contents[] = [$product_id];  // @TODO - why is this line here? Appears to be removed in the call to cleanup(), so doesn't really serve any purpose here.
-            $this->contents[$product_id] = ['qty' => (float)$qty];
+            $this->contents[] = [$uprid];  // @TODO - why is this line here? Appears to be removed in the call to cleanup(), so doesn't really serve any purpose here.
+            $this->contents[$uprid] = ['qty' => (float)$qty];
+
+            $uprid_db = zen_db_input($uprid);
+            $prid = zen_get_prid($uprid);
+
             // insert into database
             if (zen_is_logged_in() && !zen_in_guest_checkout()) {
-                $sql = "INSERT INTO " . TABLE_CUSTOMERS_BASKET . "
-                        (customers_id, products_id, customers_basket_quantity,
-                        customers_basket_date_added)
-                        VALUES (" . (int)$_SESSION['customer_id'] . ", '" . zen_db_input($product_id) . "', '" .
-                        $qty . "', '" . date('Ymd') . "')";
+                $sql =
+                    "INSERT INTO " . TABLE_CUSTOMERS_BASKET . "
+                        (customers_id, products_id, customers_basket_quantity, customers_basket_date_added)
+                    VALUES
+                        (" . (int)$_SESSION['customer_id'] . ", '$uprid_db', $qty, '" . date('Ymd') . "')";
                 $db->Execute($sql);
             }
 
@@ -301,8 +313,8 @@ class shoppingCart extends base
                     //add htmlspecialchars processing.  This handles quotes and other special chars in the user input.
                     $attr_value = null;
                     $blank_value = false;
-                    if (strstr($option, TEXT_PREFIX)) {
-                        if (trim($value) == null) {
+                    if (strpos($option, TEXT_PREFIX) === 0) {
+                        if (trim($value) === '') {
                             $blank_value = true;
                         } else {
                             $option = substr($option, strlen(TEXT_PREFIX));
@@ -315,39 +327,44 @@ class shoppingCart extends base
                                 if (strlen($attr_value) > $check->fields['products_options_length']) {
                                     $attr_value = zen_trunc_string($attr_value, $check->fields['products_options_length'], '');
                                 }
-                                $this->contents[$product_id]['attributes_values'][$option] = $attr_value;
+                                $this->contents[$uprid]['attributes_values'][$option] = $attr_value;
                             }
                         }
                     }
 
-                    if (!$blank_value) {
+                    if ($blank_value === false) {
                         if (is_array($value)) {
                             foreach ($value as $opt => $val) {
-                                $this->contents[$product_id]['attributes'][$option . '_chk' . $val] = $val;
+                                $this->contents[$uprid]['attributes'][$option . '_chk' . $val] = $val;
                             }
                         } else {
-                            $this->contents[$product_id]['attributes'][$option] = $value;
+                            $this->contents[$uprid]['attributes'][$option] = $value;
                         }
 
                         if (zen_is_logged_in() && !zen_in_guest_checkout()) {
+                            $customer_id = (int)$_SESSION['customer_id'];
+                            $option = (int)$option;
                             if (is_array($value)) {
                                 foreach ($value as $opt => $val) {
-                                    $products_options_sort_order = zen_get_attributes_options_sort_order(zen_get_prid($product_id), $option, $opt);
-                                    $sql = "INSERT INTO " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . "
+                                    $products_options_sort_order = zen_get_attributes_options_sort_order($prid, $option, $opt);
+                                    $val = (int)$val;
+                                    $sql =
+                                        "INSERT INTO " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . "
                                             (customers_id, products_id, products_options_id, products_options_value_id, products_options_sort_order)
-                                            VALUES (" . (int)$_SESSION['customer_id'] . ", '" . zen_db_input($product_id) . "',
-                                            '" . (int)$option . '_chk' . (int)$val . "', '" . (int)$val . "',  '" . $products_options_sort_order . "')";
+                                        VALUES
+                                            ($customer_id, '$uprid_db', '" . $option . '_chk' . $val . "', $val, '$products_options_sort_order')";
                                     $db->Execute($sql);
                                 }
                             } else {
                                 if ($attr_value) {
                                     $attr_value = zen_db_input($attr_value);
                                 }
-                                $products_options_sort_order = zen_get_attributes_options_sort_order(zen_get_prid($product_id), $option, $value);
-                                $sql = "INSERT INTO " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . "
+                                $products_options_sort_order = zen_get_attributes_options_sort_order($prid, $option, $value);
+                                $sql =
+                                    "INSERT INTO " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . "
                                         (customers_id, products_id, products_options_id, products_options_value_id, products_options_value_text, products_options_sort_order)
-                                        VALUES (" . (int)$_SESSION['customer_id'] . ", '" . zen_db_input($product_id) . "',
-                                        '" . (int)$option . "', '" . (int)$value . "', '" . $attr_value . "', '" . $products_options_sort_order . "')";
+                                     VALUES
+                                        ($customer_id, '$uprid_db', '$option', " . (int)$value . ", '$attr_value', '$products_options_sort_order')";
                                 $db->Execute($sql);
                             }
                         }
@@ -369,42 +386,52 @@ class shoppingCart extends base
      * a new value. Also updates the database stored cart if customer is
      * logged in.
      *
-     * @param mixed $product_id product ID of item to update
+     * @param mixed $uprid product 'uprid' of item to update
      * @param int|float $quantity the quantity to update the item to
      * @param array $attributes product attributes attached to the item
      * @return bool
      */
-    function update_quantity($product_id, $quantity = '', $attributes = [])
+    function update_quantity($uprid, $quantity = '', $attributes = [])
     {
         global $db, $messageStack;
-        if ($this->display_debug_messages) $messageStack->add_session('header', 'FUNCTION ' . __FUNCTION__ . ' $products_id: ' . $product_id . ' $quantity: ' . $quantity, 'caution');
+        if ($this->display_debug_messages) {
+            $messageStack->add_session('header', 'FUNCTION ' . __FUNCTION__ . ' $products_id: ' . $uprid . ' $quantity: ' . $quantity, 'caution');
+        }
 
         if (!is_numeric($quantity) || $quantity < 0) {
             // adjust quantity when not a value
-            $chk_link = '<a href="' . zen_href_link(zen_get_info_page($product_id), 'cPath=' . (zen_get_generated_category_path_rev(zen_get_products_category_id($product_id))) . '&products_id=' . $product_id) . '">' . zen_get_products_name($product_id) . '</a>';
+            $chk_link =
+                '<a href="' . zen_href_link(zen_get_info_page($uprid), 'cPath=' . (zen_get_generated_category_path_rev(zen_get_products_category_id($uprid))) . '&products_id=' . $uprid) . '">' .
+                    zen_get_products_name($uprid) .
+                '</a>';
             $messageStack->add_session('header', ERROR_CORRECTIONS_HEADING . ERROR_PRODUCT_QUANTITY_UNITS_SHOPPING_CART . $chk_link . ' ' . PRODUCTS_ORDER_QTY_TEXT . zen_output_string_protected($quantity), 'caution');
             $quantity = 0;
         }
-        $this->notify('NOTIFIER_CART_UPDATE_QUANTITY_START', null, $product_id, $quantity, $attributes);
-        if (empty($quantity)) return true; // nothing needs to be updated if theres no quantity, so we return true..
+        $this->notify('NOTIFIER_CART_UPDATE_QUANTITY_START', null, $uprid, $quantity, $attributes);
+        if (empty($quantity)) {
+            return true; // nothing needs to be updated if theres no quantity, so we return true.
+        }
 
         // ensure quantity added to cart is never more than what is in-stock
-        $chk_current_qty = zen_get_products_stock($product_id);
-        if (STOCK_ALLOW_CHECKOUT == 'false' && ($quantity > $chk_current_qty)) {
+        $chk_current_qty = zen_get_products_stock($uprid);
+        if (STOCK_ALLOW_CHECKOUT === 'false' && $quantity > $chk_current_qty) {
             $quantity = $chk_current_qty;
             if (!$this->flag_duplicate_msgs_set) {
-                $messageStack->add_session('shopping_cart', ($this->display_debug_messages ? '$_GET[main_page]: ' . $_GET['main_page'] . ' FUNCTION ' . __FUNCTION__ . ': ' : '') . WARNING_PRODUCT_QUANTITY_ADJUSTED . zen_get_products_name($product_id), 'caution');
+                $messageStack->add_session('shopping_cart', ($this->display_debug_messages ? '$_GET[main_page]: ' . $_GET['main_page'] . ' FUNCTION ' . __FUNCTION__ . ': ' : '') . WARNING_PRODUCT_QUANTITY_ADJUSTED . zen_get_products_name($uprid), 'caution');
             }
         }
 
-        $this->contents[$product_id] = ['qty' => (float)$quantity];
+        $this->contents[$uprid] = ['qty' => (float)$quantity];
+        $uprid_db = zen_db_input($uprid);
+        $prid = zen_get_prid($uprid);
 
         if (zen_is_logged_in() && !zen_in_guest_checkout()) {
-            $sql = "UPDATE " . TABLE_CUSTOMERS_BASKET . "
+            $sql =
+                "UPDATE " . TABLE_CUSTOMERS_BASKET . "
                     SET customers_basket_quantity = '" . (float)$quantity . "'
-                    WHERE customers_id = " . (int)$_SESSION['customer_id'] . "
-                    AND products_id = '" . zen_db_input($product_id) . "'";
-            $db->Execute($sql);
+                  WHERE customers_id = " . (int)$_SESSION['customer_id'] . "
+                    AND products_id = '$uprid_db'";
+            $db->Execute($sql, 1);
         }
 
         if (is_array($attributes)) {
@@ -414,24 +441,24 @@ class shoppingCart extends base
                 //add htmlspecialchars processing.  This handles quotes and other special chars in the user input.
                 $attr_value = null;
                 $blank_value = false;
-                if (strstr($option, TEXT_PREFIX)) {
-                    if (trim($value) == null) {
+                if (strpos($option, TEXT_PREFIX) === 0) {
+                    if (trim($value) === '') {
                         $blank_value = true;
                     } else {
                         $option = substr($option, strlen(TEXT_PREFIX));
                         $attr_value = stripslashes($value);
                         $value = PRODUCTS_OPTIONS_VALUES_TEXT_ID;
-                        $this->contents[$product_id]['attributes_values'][$option] = $attr_value;
+                        $this->contents[$uprid]['attributes_values'][$option] = $attr_value;
                     }
                 }
 
-                if (!$blank_value) {
+                if ($blank_value === false) {
                     if (is_array($value)) {
                         foreach ($value as $opt => $val) {
-                            $this->contents[$product_id]['attributes'][$option . '_chk' . $val] = $val;
+                            $this->contents[$uprid]['attributes'][$option . '_chk' . $val] = $val;
                         }
                     } else {
-                        $this->contents[$product_id]['attributes'][$option] = $value;
+                        $this->contents[$uprid]['attributes'][$option] = $value;
                     }
 
                     if (zen_is_logged_in() && !zen_in_guest_checkout()) {
@@ -440,19 +467,21 @@ class shoppingCart extends base
                         }
                         if (is_array($value)) {
                             foreach ($value as $opt => $val) {
-                                $products_options_sort_order = zen_get_attributes_options_sort_order(zen_get_prid($product_id), $option, $opt);
-                                $sql = "UPDATE " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . "
+                                $products_options_sort_order = zen_get_attributes_options_sort_order($prid, $option, $opt);
+                                $sql =
+                                    "UPDATE " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . "
                                         SET products_options_value_id = '" . (int)$val . "'
-                                        WHERE customers_id = " . (int)$_SESSION['customer_id'] . "
-                                        AND products_id = '" . zen_db_input($product_id) . "'
+                                      WHERE customers_id = " . (int)$_SESSION['customer_id'] . "
+                                        AND products_id = '$uprid_db'
                                         AND products_options_id = '" . (int)$option . '_chk' . (int)$val . "'";
                                 $db->Execute($sql);
                             }
                         } else {
-                            $sql = "UPDATE " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . "
-                                    SET products_options_value_id = " . (int)$value . ", products_options_value_text = '" . $attr_value . "'
-                                    WHERE customers_id = " . (int)$_SESSION['customer_id'] . "
-                                    AND products_id = '" . zen_db_input($product_id) . "'
+                            $sql =
+                                "UPDATE " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . "
+                                    SET products_options_value_id = " . (int)$value . ", products_options_value_text = '$attr_value'
+                                  WHERE customers_id = " . (int)$_SESSION['customer_id'] . "
+                                    AND products_id = '$uprid_db'
                                     AND products_options_id = '" . (int)$option . "'"; // intentionally passing a string
                             $db->Execute($sql);
                         }
@@ -476,26 +505,40 @@ class shoppingCart extends base
      */
     function cleanup()
     {
-        global $db;
         $this->notify('NOTIFIER_CART_CLEANUP_START');
         foreach ($this->contents as $key => $data) {
             if (!isset($this->contents[$key]['qty']) || $this->contents[$key]['qty'] <= 0) {
-                unset($this->contents[$key]);
-
-                if (zen_is_logged_in() && !zen_in_guest_checkout()) {
-                    $sql = "DELETE FROM " . TABLE_CUSTOMERS_BASKET . "
-                            WHERE customers_id = " . (int)$_SESSION['customer_id'] . "
-                            AND products_id = '" . $key . "'";
-                    $db->Execute($sql);
-
-                    $sql = "DELETE FROM " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . "
-                            WHERE customers_id = " . (int)$_SESSION['customer_id'] . "
-                            AND products_id = '" . $key . "'";
-                    $db->Execute($sql);
-                }
+                $this->removeUprid($key);
             }
         }
         $this->notify('NOTIFIER_CART_CLEANUP_END');
+    }
+
+    /**
+     * Protected method that removes a uprid from the cart.
+     *
+     * @param string|int $uprid 'uprid' of product to remove
+     * @return void
+     */
+    protected function removeUprid($uprid)
+    {
+        global $db;
+
+        unset($this->contents[$uprid]);
+
+        if (zen_is_logged_in() && !zen_in_guest_checkout()) {
+            $sql =
+                "DELETE FROM " . TABLE_CUSTOMERS_BASKET . "
+                  WHERE customers_id = " . (int)$_SESSION['customer_id'] . "
+                    AND products_id = '$uprid'";
+            $db->Execute($sql);
+
+            $sql =
+                "DELETE FROM " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . "
+                  WHERE customers_id = " . (int)$_SESSION['customer_id'] . "
+                    AND products_id = '$uprid'";
+            $db->Execute($sql);
+        }
     }
 
     /**
@@ -513,8 +556,8 @@ class shoppingCart extends base
         $this->notify('NOTIFIER_CART_COUNT_CONTENTS_START');
         $total_items = 0;
         if (is_array($this->contents)) {
-            foreach ($this->contents as $products_id => $data) {
-                $total_items += $this->get_quantity($products_id);
+            foreach ($this->contents as $uprid => $data) {
+                $total_items += $this->get_quantity($uprid);
             }
         }
         $this->notify('NOTIFIER_CART_COUNT_CONTENTS_END');
@@ -527,62 +570,49 @@ class shoppingCart extends base
      * ... and treats 12 as unique from 12:a35de52391fcb3134
      * To lookup based only on prid (ie: 12 here) regardless of the attribute hash, use another method: in_cart_product_total_quantity()
      *
-     * @param int|string $product_id product ID of item to check
+     * @param int|string $uprid product ID of item to check
      * @return int|float the quantity of the item
      */
-    public function get_quantity($product_id)
+    public function get_quantity($uprid)
     {
-        $this->notify('NOTIFIER_CART_GET_QUANTITY_START', null, $product_id);
-        if (isset($this->contents[$product_id])) {
-            $this->notify('NOTIFIER_CART_GET_QUANTITY_END_QTY', null, $product_id);
-            return $this->contents[$product_id]['qty'];
-        } else {
-            $this->notify('NOTIFIER_CART_GET_QUANTITY_END_FALSE', $product_id);
-            return 0;
+        $this->notify('NOTIFIER_CART_GET_QUANTITY_START', null, $uprid);
+        if (isset($this->contents[$uprid])) {
+            $this->notify('NOTIFIER_CART_GET_QUANTITY_END_QTY', null, $uprid);
+            return $this->contents[$uprid]['qty'];
         }
+
+        $this->notify('NOTIFIER_CART_GET_QUANTITY_END_FALSE', $uprid);
+        return 0;
     }
 
     /**
      * Check whether a product exists in the cart
      *
-     * @param mixed $product_id product ID of product to check
+     * @param mixed $uprid product ID of product to check
      * @return boolean
      */
-    public function in_cart($product_id)
+    public function in_cart($uprid)
     {
-        $this->notify('NOTIFIER_CART_IN_CART_START', null, $product_id);
-        if (isset($this->contents[$product_id])) {
-            $this->notify('NOTIFIER_CART_IN_CART_END_TRUE', null, $product_id);
+        $this->notify('NOTIFIER_CART_IN_CART_START', null, $uprid);
+        if (isset($this->contents[$uprid])) {
+            $this->notify('NOTIFIER_CART_IN_CART_END_TRUE', null, $uprid);
             return true;
         }
 
-        $this->notify('NOTIFIER_CART_IN_CART_END_FALSE', $product_id);
+        $this->notify('NOTIFIER_CART_IN_CART_END_FALSE', $uprid);
         return false;
     }
 
     /**
      * Remove a product from the cart
      *
-     * @param string|int $product_id product ID of product to remove
+     * @param string|int $uprid product ID of product to remove
      * @return void
      */
-    public function remove($product_id)
+    public function remove($uprid)
     {
-        global $db;
-        $this->notify('NOTIFIER_CART_REMOVE_START', null, $product_id);
-        unset($this->contents[$product_id]);
-        // remove from database
-        if (zen_is_logged_in() && !zen_in_guest_checkout()) {
-            $sql = "DELETE FROM " . TABLE_CUSTOMERS_BASKET . "
-                    WHERE customers_id = " . (int)$_SESSION['customer_id'] . "
-                    AND products_id = '" . zen_db_input($product_id) . "'";
-            $db->Execute($sql);
-
-            $sql = "DELETE FROM " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . "
-                    WHERE customers_id = " . (int)$_SESSION['customer_id'] . "
-                    AND products_id = '" . zen_db_input($product_id) . "'";
-            $db->Execute($sql);
-        }
+        $this->notify('NOTIFIER_CART_REMOVE_START', null, $uprid);
+        $this->removeUprid(zen_db_input($uprid));
 
         // assign a temporary unique ID to the order contents to prevent hack attempts during the checkout procedure
         $this->cartID = $this->generate_cart_id();
@@ -610,11 +640,7 @@ class shoppingCart extends base
         if (!is_array($this->contents)) {
             return '';
         }
-        $product_id_list = [];
-        foreach ($this->contents as $products_id => $data) {
-            $product_id_list[] = $products_id;
-        }
-        return implode(',', $product_id_list);
+        return implode(',', array_keys($this->contents));
     }
 
     /**
@@ -634,88 +660,84 @@ class shoppingCart extends base
         $this->free_shipping_price = 0;
         $this->free_shipping_weight = 0;
         $this->download_count = 0;
-        if (!is_array($this->contents)) return 0;
+        if (!is_array($this->contents)) {
+            return 0;
+        }
 
 // By default, Price Factor is based on Price and is called from function zen_get_attributes_price_factor
 // Setting a define for ATTRIBUTES_PRICE_FACTOR_FROM_SPECIAL to 1 to calculate the Price Factor from Special rather than Price switches this to be based on Special, if it exists
-        if (!defined('ATTRIBUTES_PRICE_FACTOR_FROM_SPECIAL')) define('ATTRIBUTES_PRICE_FACTOR_FROM_SPECIAL', 1);
-        foreach ($this->contents as $products_id => $data) {
+        zen_define_default('ATTRIBUTES_PRICE_FACTOR_FROM_SPECIAL', 1);
+        foreach ($this->contents as $uprid => $data) {
             $total_before_discounts = 0;
-            $freeShippingTotal = $productTotal = $totalOnetimeCharge = $totalOnetimeChargeNoDiscount = 0;
+            $freeShippingTotal = 0;
+            $productTotal = 0;
+            $totalOnetimeCharge = 0;
+            $totalOnetimeChargeNoDiscount = 0;
             $free_shipping_applied = false;
-            $qty = $this->contents[$products_id]['qty'];
+            $qty = $data['qty'];
+            $prid = zen_get_prid($uprid);
 
-            // products price
-            $sql = "SELECT products_id, products_price, products_tax_class_id, products_weight,
-                    products_priced_by_attribute, product_is_always_free_shipping, products_discount_type, products_discount_type_from,
-                    products_virtual, products_model
-                    FROM " . TABLE_PRODUCTS . "
-                    WHERE products_id = " . (int)$products_id;
+            $product = zen_get_product_details($prid);
+            if ($product->EOF) {
+                continue;   //-TODO: Should the product be removed from the cart if this is detected?
+            }
 
-            if ($product = $db->Execute($sql)) {
-                $prid = $product->fields['products_id'];
+            $product = $product->fields;
+            $this->notify('NOTIFY_CART_CALCULATE_PRODUCT_PRICE', $uprid, $product);
+            $prid = (int)$product['products_id'];   //-TODO: Needed?  Just in case the id was changed by the observer?
 
-                $this->notify('NOTIFY_CART_CALCULATE_PRODUCT_PRICE', $products_id, $product->fields);
+            $products_tax = zen_get_tax_rate($product['products_tax_class_id']);
+            $products_price = $product['products_price'];
 
-                $products_tax = zen_get_tax_rate($product->fields['products_tax_class_id']);
-                $products_price = $product->fields['products_price'];
+            $is_free_shipping = $product['product_is_always_free_shipping'] === '1' || $product['products_virtual'] === '1' || strpos($product['products_model'], 'GIFT') === 0;
 
-                // adjusted count for free shipping
-                if ($product->fields['product_is_always_free_shipping'] != 1 and $product->fields['products_virtual'] != 1) {
-                    $products_weight = $product->fields['products_weight'];
-                } else {
-                    $products_weight = 0;
-                }
+            // adjusted count for free shipping
+            if ($product['product_is_always_free_shipping'] !== '1' && $product['products_virtual'] !== '1') {
+                $products_weight = $product['products_weight'];
+            } else {
+                $products_weight = 0;
+            }
 
-                $special_price = zen_get_products_special_price($prid);
-                if ($special_price and $product->fields['products_priced_by_attribute'] == 0) {
-                    $products_price = $special_price;
-                } else {
-                    $special_price = 0;
-                }
+            $special_price = zen_get_products_special_price($prid);
+            if ($special_price && $product['products_priced_by_attribute'] === '0') {
+                $products_price = $special_price;
+            } else {
+                $special_price = 0;
+            }
 
-                if (zen_get_products_price_is_free($product->fields['products_id'])) {
-                    // no charge
-                    $products_price = 0;
-                }
+            if (zen_get_products_price_is_free($uprid)) {
+                // no charge
+                $products_price = 0;
+            }
 
-                // adjust price for discounts when priced by attribute
-                if ($product->fields['products_priced_by_attribute'] == '1' && zen_has_product_attributes($product->fields['products_id'], false)) {
-                    if ($special_price) {
-                        $products_price = $special_price;
-                    } else {
-                        $products_price = $product->fields['products_price'];
-                    }
-                } else {
-                    // discount qty pricing
-                    if ($product->fields['products_discount_type'] != '0') {
-                        $products_price = zen_get_products_discount_price_qty($product->fields['products_id'], $qty);
-                    }
-                }
+            // adjust price for discounts when priced by attribute
+            if ($product['products_priced_by_attribute'] === '1' && zen_has_product_attributes($prid, false)) {
+                $products_price = ($special_price) ? $special_price : $product['products_price'];
+            } elseif ($product['products_discount_type'] !== '0') {  // discount qty pricing
+                $products_price = zen_get_products_discount_price_qty($prid, $qty);
+            }
 
-                // shipping adjustments for Product
-                if ($product->fields['product_is_always_free_shipping'] === '1' || $product->fields['products_virtual'] === '1' || preg_match('/^GIFT/', addslashes($product->fields['products_model']))) {
-                    $free_shipping_applied = true;
-                    $this->free_shipping_item += $qty;
-                    $freeShippingTotal += $products_price;
-                    $this->free_shipping_weight += ($qty * $product->fields['products_weight']);
-                }
+            // shipping adjustments for Product
+            if ($is_free_shipping === true) {
+                $free_shipping_applied = true;
+                $this->free_shipping_item += $qty;
+                $freeShippingTotal += $products_price;
+                $this->free_shipping_weight += ($qty * $product['products_weight']);
+            }
 
-//        $this->total += zen_round(zen_add_tax($products_price, $products_tax),$currencies->get_decimal_places($_SESSION['currency'])) * $qty;
-                $productTotal += $products_price;
-                $this->weight += ($qty * $products_weight);
+            $productTotal += $products_price;
+            $this->weight += ($qty * $products_weight);
 
 // ****** WARNING NEED TO ADD ATTRIBUTES AND QTY
-                // calculate Product Price without Specials, Sales or Discounts
-                $total_before_discounts += $product->fields['products_price'];
-            }
+            // calculate Product Price without Specials, Sales or Discounts
+            $total_before_discounts += $product['products_price'];
 
             $adjust_downloads = 0;
             // attributes price
             $savedProductTotal = $productTotal;
             $attributesTotal = 0;
-            if (isset($this->contents[$products_id]['attributes'])) {
-                foreach ($this->contents[$products_id]['attributes'] as $option => $value) {
+            if (isset($this->contents[$uprid]['attributes'])) {
+                foreach ($this->contents[$uprid]['attributes'] as $option => $value) {
                     $productTotal = 0;
                     $adjust_downloads++;
                     /*
@@ -723,18 +745,19 @@ class shoppingCart extends base
                     attributes_display_only, product_attribute_is_free,
                     attributes_discounted
                     */
+                    $attribute_price_query =
+                        "SELECT *
+                           FROM " . TABLE_PRODUCTS_ATTRIBUTES . "
+                          WHERE products_id = $prid
+                            AND options_id = " . (int)$option . "
+                            AND options_values_id = " . (int)$value;
+                    $attribute_price = $db->Execute($attribute_price_query, 1);
 
-                    $attribute_price_query = "SELECT *
-                                      FROM " . TABLE_PRODUCTS_ATTRIBUTES . "
-                                      WHERE products_id = " . (int)$prid . "
-                                      AND options_id = " . (int)$option . "
-                                      AND options_values_id = " . (int)$value;
+                    if ($attribute_price->EOF) {
+                        continue;
+                    }
 
-                    $attribute_price = $db->Execute($attribute_price_query);
-
-                    if ($attribute_price->EOF) continue;
-
-                    $this->notify('NOTIFY_CART_CALCULATE_ATTRIBUTE_PRICE', $products_id, $attribute_price->fields);
+                    $this->notify('NOTIFY_CART_CALCULATE_ATTRIBUTE_PRICE', $uprid, $attribute_price->fields);
 
                     $new_attributes_price = 0;
                     // calculate Product Price without Specials, Sales or Discounts
@@ -744,173 +767,200 @@ class shoppingCart extends base
                     $sale_maker_discount = '';
 
                     // bottom total
-                    if ($attribute_price->fields['product_attribute_is_free'] == '1' && zen_get_products_price_is_free((int)$prid)) {
+                    if ($attribute_price->fields['product_attribute_is_free'] === '1' && zen_get_products_price_is_free($prid)) {
                         // no charge for attribute
-                    } else {
-                        // + or blank adds
-                        if ($attribute_price->fields['price_prefix'] == '-') {
-                            // appears to confuse products priced by attributes
-                            if ($product->fields['product_is_always_free_shipping'] == '1' || $product->fields['products_virtual'] == '1') {
-                                $shipping_attributes_price = zen_get_discount_calc($product->fields['products_id'], $attribute_price->fields['products_attributes_id'], $attribute_price->fields['options_values_price'], $qty);
-                                $freeShippingTotal -= $shipping_attributes_price;
-                            }
-                            if ($attribute_price->fields['attributes_discounted'] == '1') {
-                                // calculate proper discount for attributes
-                                $new_attributes_price = zen_get_discount_calc($product->fields['products_id'], $attribute_price->fields['products_attributes_id'], $attribute_price->fields['options_values_price'], $qty);
-                                $productTotal -= $new_attributes_price;
-                            } else {
-                                $productTotal -= $attribute_price->fields['options_values_price'];
-                            }
-                            // calculate Product Price without Specials, Sales or Discounts
-                //            $this->total_before_discounts -= $attribute_price->fields['options_values_price'];
-                            $total_before_discounts -= $attribute_price->fields['options_values_price'];
-                        } else {
-                            // appears to confuse products priced by attributes
-                            if ($product->fields['product_is_always_free_shipping'] == '1' || $product->fields['products_virtual'] == '1') {
-                                $shipping_attributes_price = zen_get_discount_calc($product->fields['products_id'], $attribute_price->fields['products_attributes_id'], $attribute_price->fields['options_values_price'], $qty);
-                                $freeShippingTotal += $shipping_attributes_price;
-                            }
-                            if ($attribute_price->fields['attributes_discounted'] == '1') {
-                                // calculate proper discount for attributes
-                                $new_attributes_price = zen_get_discount_calc($product->fields['products_id'], $attribute_price->fields['products_attributes_id'], $attribute_price->fields['options_values_price'] + (zen_get_products_price_is_priced_by_attributes($attribute_price->fields['products_id']) ? zen_products_lookup($attribute_price->fields['products_id'], 'products_price') : 0), $qty);
-                                $new_attributes_price = $new_attributes_price - (zen_get_products_price_is_priced_by_attributes($attribute_price->fields['products_id']) ? zen_products_lookup($attribute_price->fields['products_id'], 'products_price') : 0);
-                                $productTotal += $new_attributes_price;
-                            } else {
-                                $productTotal += $attribute_price->fields['options_values_price'];
-                            }
-                            // calculate Product Price without Specials, Sales or Discounts
-                            $total_before_discounts += $attribute_price->fields['options_values_price'];
-                        } // eof: attribute price
-                        // adjust for downloads
-                        // adjust products price
-                        $check_attribute = $attribute_price->fields['products_attributes_id'];
-                        $sql = "SELECT products_attributes_id
-                                FROM " . TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD . "
-                                WHERE products_attributes_id = " . (int)$check_attribute;
-                        $check_download = $db->Execute($sql);
-                        if ($check_download->RecordCount()) {
-                            // count number of downloads
-                            $this->download_count += ($check_download->RecordCount() * $qty);
-                            // do not count download as free when set to product/download combo
-                            if ($free_shipping_applied === false && $adjust_downloads === 1 && $product->fields['product_is_always_free_shipping'] !== '2') {
-                                $freeShippingTotal += $products_price;
-                                $this->free_shipping_item += $qty;
-                            }
-                            // adjust for attributes price
-                            $freeShippingTotal += $new_attributes_price;
-                        }
-
-                        ////////////////////////////////////////////////
-                        // calculate additional attribute charges
-                        $chk_price = zen_get_products_base_price($products_id);
-                        $chk_special = zen_get_products_special_price($products_id, false);
-                        // products_options_value_text
-                        if (ATTRIBUTES_ENABLED_TEXT_PRICES == 'true' && zen_get_attributes_type($attribute_price->fields['products_attributes_id']) == PRODUCTS_OPTIONS_TYPE_TEXT) {
-                            $text_words = zen_get_word_count_price($this->contents[$products_id]['attributes_values'][$attribute_price->fields['options_id']], $attribute_price->fields['attributes_price_words_free'], $attribute_price->fields['attributes_price_words']);
-                            $text_letters = zen_get_letters_count_price($this->contents[$products_id]['attributes_values'][$attribute_price->fields['options_id']], $attribute_price->fields['attributes_price_letters_free'], $attribute_price->fields['attributes_price_letters']);
-
-                            $productTotal += $text_letters;
-                            $productTotal += $text_words;
-                            if (($product->fields['product_is_always_free_shipping'] == 1) || ($product->fields['products_virtual'] == 1) || (preg_match('/^GIFT/', addslashes($product->fields['products_model'])))) {
-                                $freeShippingTotal += $text_letters;
-                                $freeShippingTotal += $text_words;
-                            }
-                            // calculate Product Price without Specials, Sales or Discounts
-                            $total_before_discounts += $text_letters;
-                            $total_before_discounts += $text_words;
-                        }
-
-                        // attributes_price_factor
-                        $added_charge = 0;
-                        if ($attribute_price->fields['attributes_price_factor'] > 0) {
-                            //echo 'products_id: ' . $product->fields['products_id'] . ' Prices ' . '$chk_price: ' . $chk_price . ' $chk_special: ' . $chk_special . ' attributes_price_factor:' . $attribute_price->fields['attributes_price_factor'] . ' attributes_price_factor_offset: ' . $attribute_price->fields['attributes_price_factor_offset'] . '<br>';
-                            $added_charge = zen_get_attributes_price_factor($chk_price, $chk_special, $attribute_price->fields['attributes_price_factor'], $attribute_price->fields['attributes_price_factor_offset']);
-
-                            $productTotal += $added_charge;
-                            if (($product->fields['product_is_always_free_shipping'] == 1) || ($product->fields['products_virtual'] == 1) || (preg_match('/^GIFT/', addslashes($product->fields['products_model'])))) {
-                                $freeShippingTotal += $added_charge;
-                            }
-                            // calculate Product Price without Specials, Sales or Discounts
-                            $added_charge = zen_get_attributes_price_factor($chk_price, $chk_price, $attribute_price->fields['attributes_price_factor'], $attribute_price->fields['attributes_price_factor_offset']);
-                            $total_before_discounts += $added_charge;
-                        }
-
-                        // attributes_qty_prices
-                        $added_charge = 0;
-                        if ($attribute_price->fields['attributes_qty_prices'] != '') {
-                            $added_charge = zen_get_attributes_qty_prices_onetime($attribute_price->fields['attributes_qty_prices'], $qty);
-
-                            $productTotal += $added_charge;
-                            if (($product->fields['product_is_always_free_shipping'] == 1) || ($product->fields['products_virtual'] == 1) || (preg_match('/^GIFT/', addslashes($product->fields['products_model'])))) {
-                                $freeShippingTotal += $added_charge;
-                            }
-                            // calculate Product Price without Specials, Sales or Discounts
-                            $added_charge = zen_get_attributes_qty_prices_onetime($attribute_price->fields['attributes_qty_prices'], 1);
-                            $total_before_discounts += $attribute_price->fields['options_values_price'] + $added_charge;
-                        }
-
-                        //// one time charges
-                        // attributes_price_onetime
-                        if ($attribute_price->fields['attributes_price_onetime'] > 0) {
-                            $totalOnetimeCharge += $attribute_price->fields['attributes_price_onetime'];
-                            // calculate Product Price without Specials, Sales or Discounts
-                            $totalOnetimeChargeNoDiscount += $attribute_price->fields['attributes_price_onetime'];
-                        }
-
-                        // attributes_price_factor_onetime
-                        $added_charge = 0;
-                        if ($attribute_price->fields['attributes_price_factor_onetime'] > 0) {
-                            $chk_price = zen_get_products_base_price($products_id);
-                            $chk_special = zen_get_products_special_price($products_id, false);
-                            $added_charge = zen_get_attributes_price_factor($chk_price, $chk_special, $attribute_price->fields['attributes_price_factor_onetime'], $attribute_price->fields['attributes_price_factor_onetime_offset']);
-
-                            $totalOnetimeCharge += $added_charge;
-                            // calculate Product Price without Specials, Sales or Discounts
-                            $added_charge = zen_get_attributes_price_factor($chk_price, $chk_price, $attribute_price->fields['attributes_price_factor_onetime'], $attribute_price->fields['attributes_price_factor_onetime_offset']);
-                            $totalOnetimeChargeNoDiscount += $added_charge;
-                        }
-                        // attributes_qty_prices_onetime
-                        $added_charge = 0;
-                        if ($attribute_price->fields['attributes_qty_prices_onetime'] != '') {
-                            $added_charge = zen_get_attributes_qty_prices_onetime($attribute_price->fields['attributes_qty_prices_onetime'], $qty);
-                            $totalOnetimeCharge += $added_charge;
-                            // calculate Product Price without Specials, Sales or Discounts
-                            $added_charge = zen_get_attributes_qty_prices_onetime($attribute_price->fields['attributes_qty_prices_onetime'], 1);
-                            $totalOnetimeChargeNoDiscount += $added_charge;
-                        }
-                        ////////////////////////////////////////////////
+                        continue;
                     }
+
+                    // + or blank adds
+                    $attributes_id = $attribute_price->fields['products_attributes_id'];
+                    $options_values_price = $attribute_price->fields['options_values_price'];
+                    if ($attribute_price->fields['price_prefix'] === '-') {
+                        // appears to confuse products priced by attributes
+                        if ($product['product_is_always_free_shipping'] === '1' || $product['products_virtual'] === '1') {
+                            $shipping_attributes_price = zen_get_discount_calc($prid, $attributes_id, $options_values_price, $qty);
+                            $freeShippingTotal -= $shipping_attributes_price;
+                        }
+                        if ($attribute_price->fields['attributes_discounted'] === '1') {
+                            // calculate proper discount for attributes
+                            $new_attributes_price = zen_get_discount_calc($prid, $attributes_id, $options_values_price, $qty);
+                            $productTotal -= $new_attributes_price;
+                        } else {
+                            $productTotal -= $options_values_price;
+                        }
+                        // calculate Product Price without Specials, Sales or Discounts
+                        $total_before_discounts -= $options_values_price;
+                    } else {
+                        // appears to confuse products priced by attributes
+                        if ($product['product_is_always_free_shipping'] === '1' || $product['products_virtual'] === '1') {
+                            $shipping_attributes_price = zen_get_discount_calc($prid, $attributes_id, $options_values_price, $qty);
+                            $freeShippingTotal += $shipping_attributes_price;
+                        }
+                        if ($attribute_price->fields['attributes_discounted'] === '1') {
+                            // calculate proper discount for attributes
+                            $products_base_price = zen_get_products_price_is_priced_by_attributes($prid) ? zen_products_lookup($prid, 'products_price') : 0;
+                            $new_attributes_price = zen_get_discount_calc($prid, $attributes_id, $options_values_price + $products_base_price, $qty);
+                            $new_attributes_price = $new_attributes_price - $products_base_price;
+                            $productTotal += $new_attributes_price;
+                        } else {
+                            $productTotal += $options_values_price;
+                        }
+                        // calculate Product Price without Specials, Sales or Discounts
+                        $total_before_discounts += $attribute_price->fields['options_values_price'];
+                    } // eof: attribute price
+
+                    // adjust for downloads
+                    // adjust products price
+                    $sql = "SELECT products_attributes_id
+                            FROM " . TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD . "
+                            WHERE products_attributes_id = $attributes_id";
+                    $check_download = $db->Execute($sql, 1);
+                    if (!$check_download->EOF) {
+                        // count number of downloads
+                        $this->download_count += ($check_download->RecordCount() * $qty);
+                        // do not count download as free when set to product/download combo
+                        if ($free_shipping_applied === false && $adjust_downloads === 1 && $product['product_is_always_free_shipping'] !== '2') {
+                            $freeShippingTotal += $products_price;
+                            $this->free_shipping_item += $qty;
+                        }
+                        // adjust for attributes price
+                        $freeShippingTotal += $new_attributes_price;
+                    }
+
+                    ////////////////////////////////////////////////
+                    // calculate additional attribute charges
+                    $chk_price = zen_get_products_base_price($uprid);
+                    $chk_special = zen_get_products_special_price($uprid, false);
+                    // products_options_value_text
+                    if (ATTRIBUTES_ENABLED_TEXT_PRICES === 'true' && zen_get_attributes_type($check_attribute) == PRODUCTS_OPTIONS_TYPE_TEXT) {
+                        $text_words = zen_get_word_count_price(
+                            $this->contents[$uprid]['attributes_values'][$attribute_price->fields['options_id']],
+                            $attribute_price->fields['attributes_price_words_free'],
+                            $attribute_price->fields['attributes_price_words']
+                        );
+                        $text_letters = zen_get_letters_count_price(
+                            $this->contents[$uprid]['attributes_values'][$attribute_price->fields['options_id']],
+                            $attribute_price->fields['attributes_price_letters_free'],
+                            $attribute_price->fields['attributes_price_letters']
+                        );
+
+                        $productTotal += $text_letters;
+                        $productTotal += $text_words;
+                        if ($is_free_shipping === true) {
+                            $freeShippingTotal += $text_letters;
+                            $freeShippingTotal += $text_words;
+                        }
+                        // calculate Product Price without Specials, Sales or Discounts
+                        $total_before_discounts += $text_letters;
+                        $total_before_discounts += $text_words;
+                    }
+
+                    // attributes_price_factor
+                    if ($attribute_price->fields['attributes_price_factor'] > 0) {
+                        $added_charge = zen_get_attributes_price_factor(
+                            $chk_price,
+                            $chk_special,
+                            $attribute_price->fields['attributes_price_factor'],
+                            $attribute_price->fields['attributes_price_factor_offset']
+                        );
+
+                        $productTotal += $added_charge;
+                        if ($is_free_shipping === true) {
+                            $freeShippingTotal += $added_charge;
+                        }
+                        // calculate Product Price without Specials, Sales or Discounts
+                        $added_charge = zen_get_attributes_price_factor(
+                            $chk_price,
+                            $chk_price,
+                            $attribute_price->fields['attributes_price_factor'],
+                            $attribute_price->fields['attributes_price_factor_offset']
+                        );
+                        $total_before_discounts += $added_charge;
+                    }
+
+                    // attributes_qty_prices
+                    if (!empty($attribute_price->fields['attributes_qty_prices'])) {
+                        $added_charge = zen_get_attributes_qty_prices_onetime($attribute_price->fields['attributes_qty_prices'], $qty);
+
+                        $productTotal += $added_charge;
+                        if ($is_free_shipping === true) {
+                            $freeShippingTotal += $added_charge;
+                        }
+                        // calculate Product Price without Specials, Sales or Discounts
+                        $added_charge = zen_get_attributes_qty_prices_onetime($attribute_price->fields['attributes_qty_prices'], 1);
+                        $total_before_discounts += $attribute_price->fields['options_values_price'] + $added_charge;
+                    }
+
+                    //// one time charges
+                    // attributes_price_onetime
+                    if ($attribute_price->fields['attributes_price_onetime'] > 0) {
+                        $totalOnetimeCharge += $attribute_price->fields['attributes_price_onetime'];
+                        // calculate Product Price without Specials, Sales or Discounts
+                        $totalOnetimeChargeNoDiscount += $attribute_price->fields['attributes_price_onetime'];
+                    }
+
+                    // attributes_price_factor_onetime
+                    if ($attribute_price->fields['attributes_price_factor_onetime'] > 0) {
+                        $chk_price = zen_get_products_base_price($uprid);
+                        $chk_special = zen_get_products_special_price($uprid, false);
+                        $added_charge = zen_get_attributes_price_factor(
+                            $chk_price,
+                            $chk_special,
+                            $attribute_price->fields['attributes_price_factor_onetime'],
+                            $attribute_price->fields['attributes_price_factor_onetime_offset']
+                        );
+
+                        $totalOnetimeCharge += $added_charge;
+                        // calculate Product Price without Specials, Sales or Discounts
+                        $added_charge = zen_get_attributes_price_factor(
+                            $chk_price,
+                            $chk_price,
+                            $attribute_price->fields['attributes_price_factor_onetime'],
+                            $attribute_price->fields['attributes_price_factor_onetime_offset']
+                        );
+                        $totalOnetimeChargeNoDiscount += $added_charge;
+                    }
+
+                    // attributes_qty_prices_onetime
+                    if (!empty($attribute_price->fields['attributes_qty_prices_onetime'])) {
+                        $added_charge = zen_get_attributes_qty_prices_onetime($attribute_price->fields['attributes_qty_prices_onetime'], $qty);
+                        $totalOnetimeCharge += $added_charge;
+                        // calculate Product Price without Specials, Sales or Discounts
+                        $added_charge = zen_get_attributes_qty_prices_onetime($attribute_price->fields['attributes_qty_prices_onetime'], 1);
+                        $totalOnetimeChargeNoDiscount += $added_charge;
+                    }
+                    ////////////////////////////////////////////////
+
                     $attributesTotal += zen_round($productTotal, $decimalPlaces);
-                } // eof while
+                } // eof foreach
             } // attributes price
             $productTotal = $savedProductTotal + $attributesTotal;
 
             // attributes weight
-            if (isset($this->contents[$products_id]['attributes'])) {
-                foreach ($this->contents[$products_id]['attributes'] as $option => $value) {
+            if (isset($this->contents[$uprid]['attributes'])) {
+                foreach ($this->contents[$uprid]['attributes'] as $option => $value) {
                     $sql = "SELECT products_attributes_weight, products_attributes_weight_prefix
                             FROM " . TABLE_PRODUCTS_ATTRIBUTES . "
-                            WHERE products_id = " . (int)$prid . "
+                            WHERE products_id = $prid
                             AND options_id = " . (int)$option . "
                             AND options_values_id = " . (int)$value;
 
                     $attribute_weight = $db->Execute($sql);
-
                     if ($attribute_weight->EOF) {
                         continue;
                     }
 
-                    $this->notify('NOTIFY_CART_CALCULATE_ATTRIBUTE_WEIGHT', ['products_id' => $products_id, 'options_id' => $option], $attribute_weight->fields);
+                    $this->notify('NOTIFY_CART_CALCULATE_ATTRIBUTE_WEIGHT', ['products_id' => $uprid, 'options_id' => $option], $attribute_weight->fields);
 
                     // adjusted count for free shipping
-                    if ($product->fields['product_is_always_free_shipping'] != 1) {
+                    if ($product['product_is_always_free_shipping'] !== '1') {
                         $new_attributes_weight = $attribute_weight->fields['products_attributes_weight'];
                     } else {
                         $new_attributes_weight = 0;
                     }
 
                     // shipping adjustments for Attributes
-                    if (($product->fields['product_is_always_free_shipping'] == 1) || ($product->fields['products_virtual'] == 1) || (preg_match('/^GIFT/', addslashes($product->fields['products_model'])))) {
+                    if ($is_free_shipping === true) {
                         if ($attribute_weight->fields['products_attributes_weight_prefix'] == '-') {
                             $this->free_shipping_weight -= ($qty * $attribute_weight->fields['products_attributes_weight']);
                         } else {
@@ -919,7 +969,7 @@ class shoppingCart extends base
                     }
 
                     // + or blank adds
-                    if ($attribute_weight->fields['products_attributes_weight_prefix'] == '-') {
+                    if ($attribute_weight->fields['products_attributes_weight_prefix'] === '-') {
                         $this->weight -= $qty * $new_attributes_weight;
                     } else {
                         $this->weight += $qty * $new_attributes_weight;
@@ -931,23 +981,21 @@ class shoppingCart extends base
             // uncomment for odd shipping requirements needing this:
 
                   // if 0 weight defined as free shipping adjust for functions free_shipping_price and free_shipping_item
-                  if (($product->fields['products_weight'] == 0 && ORDER_WEIGHT_ZERO_STATUS == 1) && !($product->fields['products_virtual'] == 1) && !(preg_match('/^GIFT/', addslashes($product->fields['products_model']))) && !($product->fields['product_is_always_free_shipping'] == 1)) {
+                  if ($product['products_weight'] == 0 && ORDER_WEIGHT_ZERO_STATUS === '1' && $is_free_shipping === false) {
                     $freeShippingTotal += $products_price;
                     $this->free_shipping_item += $qty;
                   }
             */
-//echo 'shopping_cart class Price: ' . $productTotal . ' qty: ' . $qty . '<br>';
 
             $this->total += zen_round(zen_add_tax($productTotal, $products_tax), $decimalPlaces) * $qty;
             $this->total += zen_round(zen_add_tax($totalOnetimeCharge, $products_tax), $decimalPlaces);
             $this->free_shipping_price += zen_round(zen_add_tax($freeShippingTotal, $products_tax), $decimalPlaces) * $qty;
-            if (($product->fields['product_is_always_free_shipping'] == 1) || ($product->fields['products_virtual'] == 1) || (preg_match('/^GIFT/', addslashes($product->fields['products_model'])))) {
+            if ($is_free_shipping === true) {
                 $this->free_shipping_price += zen_round(zen_add_tax($totalOnetimeCharge, $products_tax), $decimalPlaces);
             }
 
 // ******* WARNING ADD ONE TIME ATTRIBUTES, PRICE FACTOR
             // calculate Product Price without Specials, Sales or Discounts
-//echo 'Product Attribute before: ' . $new_attributes_price_before_discounts . '<br>';
             $total_before_discounts = $total_before_discounts * $qty;
             $total_before_discounts += $totalOnetimeChargeNoDiscount;
             $this->total_before_discounts += $total_before_discounts;
@@ -957,29 +1005,30 @@ class shoppingCart extends base
     /**
      * Calculate price of attributes for a given item
      *
-     * @param mixed $product_id the product ID of the item to check
+     * @param mixed $uprid the product ID of the item to check
      * @return float the price of the item's attributes
      */
-    public function attributes_price($product_id)
+    public function attributes_price($uprid)
     {
         global $db, $currencies;
 
-        $total_attributes_price = 0;
-        $qty = $this->contents[$product_id]['qty'];
+        $this->notify('NOTIFY_CART_ATTRIBUTES_PRICE_START', $uprid);
 
-        $this->notify('NOTIFY_CART_ATTRIBUTES_PRICE_START', $product_id);
-
-        if (!isset($this->contents[$product_id]['attributes'])) {
-            return $total_attributes_price;
+        if (!isset($this->contents[$uprid]['attributes'])) {
+            return 0;
         }
 
-        if (!defined('ATTRIBUTES_PRICE_FACTOR_FROM_SPECIAL')) define('ATTRIBUTES_PRICE_FACTOR_FROM_SPECIAL', 1);
+        zen_define_default('ATTRIBUTES_PRICE_FACTOR_FROM_SPECIAL', 1);
 
-        foreach ($this->contents[$product_id]['attributes'] as $option => $value) {
+        $total_attributes_price = 0;
+        $qty = $this->contents[$uprid]['qty'];
+        $prid = (int)$uprid;
+
+        foreach ($this->contents[$uprid]['attributes'] as $option => $value) {
             $attributes_price = 0;
             $attribute_price_query = "SELECT *
                                 FROM " . TABLE_PRODUCTS_ATTRIBUTES . "
-                                WHERE products_id = " . (int)$product_id . "
+                                WHERE products_id = $prid
                                 AND options_id = " . (int)$option . "
                                 AND options_values_id = " . (int)$value;
 
@@ -989,62 +1038,75 @@ class shoppingCart extends base
                 continue;
             }
 
-            $this->notify('NOTIFY_CART_ATTRIBUTES_PRICE_NEXT', $product_id, $attribute_price->fields);
+            $this->notify('NOTIFY_CART_ATTRIBUTES_PRICE_NEXT', $uprid, $attribute_price->fields);
 
             $new_attributes_price = 0;
             $discount_type_id = '';
             $sale_maker_discount = '';
 
-            if ($attribute_price->fields['product_attribute_is_free'] == '1' && zen_get_products_price_is_free((int)$product_id)) {
+            if ($attribute_price->fields['product_attribute_is_free'] === '1' && zen_get_products_price_is_free($prid)) {
                 // no charge
             } else {
                 // + or blank adds
-                if ($attribute_price->fields['price_prefix'] == '-') {
+                if ($attribute_price->fields['price_prefix'] === '-') {
                     // calculate proper discount for attributes
-                    if ($attribute_price->fields['attributes_discounted'] == '1') {
+                    if ($attribute_price->fields['attributes_discounted'] === '1') {
                         $discount_type_id = '';
                         $sale_maker_discount = '';
-                        $new_attributes_price = zen_get_discount_calc($product_id, $attribute_price->fields['products_attributes_id'], $attribute_price->fields['options_values_price'], $qty);
-                        $attributes_price -= ($new_attributes_price);
+                        $new_attributes_price = zen_get_discount_calc($prid, $attribute_price->fields['products_attributes_id'], $attribute_price->fields['options_values_price'], $qty);
+                        $attributes_price -= $new_attributes_price;
                     } else {
                         $attributes_price -= $attribute_price->fields['options_values_price'];
                     }
+                } elseif ($attribute_price->fields['attributes_discounted'] === '1') {
+                    // calculate proper discount for attributes
+                    $discount_type_id = '';
+                    $sale_maker_discount = '';
+                    $new_attributes_price = zen_get_discount_calc(
+                        $prid,
+                        $attribute_price->fields['products_attributes_id'],
+                        $attribute_price->fields['options_values_price'] +
+                            (zen_get_products_price_is_priced_by_attributes($attribute_price->fields['products_id']) ?
+                                zen_products_lookup($attribute_price->fields['products_id'], 'products_price') : 0.0),
+                        $qty
+                    );
+                    $new_attributes_price -= (zen_get_products_price_is_priced_by_attributes($prid)) ? zen_products_lookup($prid, 'products_price') : 0;
+                    $attributes_price += $new_attributes_price;
                 } else {
-                    if ($attribute_price->fields['attributes_discounted'] == '1') {
-                        // calculate proper discount for attributes
-                        $discount_type_id = '';
-                        $sale_maker_discount = '';
-                        $new_attributes_price = zen_get_discount_calc($product_id, $attribute_price->fields['products_attributes_id'], $attribute_price->fields['options_values_price'] + (zen_get_products_price_is_priced_by_attributes($attribute_price->fields['products_id']) ? zen_products_lookup($attribute_price->fields['products_id'], 'products_price') : 0.0), $qty);
-                        $new_attributes_price = $new_attributes_price - (zen_get_products_price_is_priced_by_attributes($attribute_price->fields['products_id']) ? zen_products_lookup($attribute_price->fields['products_id'], 'products_price') : 0);
-                        $attributes_price += ($new_attributes_price);
-                    } else {
-                        $attributes_price += $attribute_price->fields['options_values_price'];
-                    }
+                    $attributes_price += $attribute_price->fields['options_values_price'];
                 }
 
                 //////////////////////////////////////////////////
                 // calculate additional charges
                 // products_options_value_text
-                if (ATTRIBUTES_ENABLED_TEXT_PRICES == 'true' && zen_get_attributes_type($attribute_price->fields['products_attributes_id']) == PRODUCTS_OPTIONS_TYPE_TEXT) {
-                    $text_words = zen_get_word_count_price($this->contents[$product_id]['attributes_values'][$attribute_price->fields['options_id']], $attribute_price->fields['attributes_price_words_free'], $attribute_price->fields['attributes_price_words']);
-                    $text_letters = zen_get_letters_count_price($this->contents[$product_id]['attributes_values'][$attribute_price->fields['options_id']], $attribute_price->fields['attributes_price_letters_free'], $attribute_price->fields['attributes_price_letters']);
-                    $attributes_price += $text_letters;
-                    $attributes_price += $text_words;
+                if (ATTRIBUTES_ENABLED_TEXT_PRICES === 'true' && zen_get_attributes_type($attribute_price->fields['products_attributes_id']) == PRODUCTS_OPTIONS_TYPE_TEXT) {
+                    $text_words = zen_get_word_count_price(
+                        $this->contents[$uprid]['attributes_values'][$attribute_price->fields['options_id']],
+                        $attribute_price->fields['attributes_price_words_free'],
+                        $attribute_price->fields['attributes_price_words']
+                    );
+                    $text_letters = zen_get_letters_count_price(
+                        $this->contents[$uprid]['attributes_values'][$attribute_price->fields['options_id']],
+                        $attribute_price->fields['attributes_price_letters_free'],
+                        $attribute_price->fields['attributes_price_letters']
+                    );
+                    $attributes_price += $text_letters + $text_words;
                 }
+
                 // attributes_price_factor
-                $added_charge = 0;
                 if ($attribute_price->fields['attributes_price_factor'] > 0) {
-                    $chk_price = zen_get_products_base_price($product_id);
-                    $chk_special = zen_get_products_special_price($product_id, false);
-                    $added_charge = zen_get_attributes_price_factor($chk_price, $chk_special, $attribute_price->fields['attributes_price_factor'], $attribute_price->fields['attributes_price_factor_offset']);
+                    $added_charge = zen_get_attributes_price_factor(
+                        zen_get_products_base_price($prid),
+                        zen_get_products_special_price($prid, false),
+                        $attribute_price->fields['attributes_price_factor'],
+                        $attribute_price->fields['attributes_price_factor_offset']
+                    );
                     $attributes_price += $added_charge;
                 }
+
                 // attributes_qty_prices
-                $added_charge = 0;
-                if ($attribute_price->fields['attributes_qty_prices'] != '') {
-                    $chk_price = zen_get_products_base_price($product_id);
-                    $chk_special = zen_get_products_special_price($product_id, false);
-                    $added_charge = zen_get_attributes_qty_prices_onetime($attribute_price->fields['attributes_qty_prices'], $this->contents[$product_id]['qty']);
+                if (!empty($attribute_price->fields['attributes_qty_prices'])) {
+                    $added_charge = zen_get_attributes_qty_prices_onetime($attribute_price->fields['attributes_qty_prices'], $this->contents[$uprid]['qty']);
                     $attributes_price += $added_charge;
                 }
 
@@ -1053,7 +1115,7 @@ class shoppingCart extends base
             // Validate Attributes
             if ($attribute_price->fields['attributes_display_only']) {
                 $_SESSION['valid_to_checkout'] = false;
-                $_SESSION['cart_errors'] .= zen_get_products_name($attribute_price->fields['products_id'], $_SESSION['languages_id']) . ERROR_PRODUCT_OPTION_SELECTION . '<br>';
+                $_SESSION['cart_errors'] .= zen_get_products_name($prid, $_SESSION['languages_id']) . ERROR_PRODUCT_OPTION_SELECTION . '<br>';
             }
             /*
             //// extra testing not required on text attribute this is done in application_top before it gets to the cart
@@ -1071,75 +1133,68 @@ class shoppingCart extends base
     /**
      * Calculate one-time price of attributes for a given item
      *
-     * @param mixed $product_id the product ID of the item to check
+     * @param mixed $uprid the product ID of the item to check
      * @param float $qty item quantity
      * @return float the price of the items attributes
      */
-    public function attributes_price_onetime_charges($product_id, $qty)
+    public function attributes_price_onetime_charges($uprid, $qty)
     {
         global $db;
 
         $attributes_price_onetime = 0;
 
-        $this->notify('NOTIFY_CART_ATTRIBUTES_PRICE_ONETIME_CHARGES_START', $product_id);
+        $this->notify('NOTIFY_CART_ATTRIBUTES_PRICE_ONETIME_CHARGES_START', $uprid);
 
-        if (!isset($this->contents[$product_id]['attributes'])) {
-            return $attributes_price_onetime;
+        if (!isset($this->contents[$uprid]['attributes'])) {
+            return 0;
         }
 
-        foreach ($this->contents[$product_id]['attributes'] as $option => $value) {
-
+        $prid = (int)$uprid;
+        foreach ($this->contents[$uprid]['attributes'] as $option => $value) {
             $sql = "SELECT *
                     FROM " . TABLE_PRODUCTS_ATTRIBUTES . "
-                    WHERE products_id = " . (int)$product_id . "
+                    WHERE products_id = $prid
                     AND options_id = " . (int)$option . "
                     AND options_values_id = " . (int)$value;
 
             $attribute_price = $db->Execute($sql);
-
             if ($attribute_price->EOF) {
                 continue;
             }
 
-            $this->notify('NOTIFY_CART_ATTRIBUTES_PRICE_ONETIME_CHARGES_NEXT', $product_id, $attribute_price->fields);
+            $this->notify('NOTIFY_CART_ATTRIBUTES_PRICE_ONETIME_CHARGES_NEXT', $uprid, $attribute_price->fields);
 
-            $new_attributes_price = 0;
-            $discount_type_id = '';
-            $sale_maker_discount = '';
-
-            if ($attribute_price->fields['product_attribute_is_free'] == '1' and zen_get_products_price_is_free((int)$product_id)) {
+            if ($attribute_price->fields['product_attribute_is_free'] === '1' && zen_get_products_price_is_free($prid)) {
                 // no charge
-            } else {
-                $discount_type_id = '';
-                $sale_maker_discount = '';
-                $new_attributes_price = zen_get_discount_calc($product_id, $attribute_price->fields['products_attributes_id'], $attribute_price->fields['options_values_price'], $qty);
-
-                //////////////////////////////////////////////////
-                // calculate additional one time charges
-                //// one time charges
-                // attributes_price_onetime
-                if ($attribute_price->fields['attributes_price_onetime'] > 0) {
-                    $attributes_price_onetime += $attribute_price->fields['attributes_price_onetime'];
-                }
-                // attributes_price_factor_onetime
-                $added_charge = 0;
-                if ($attribute_price->fields['attributes_price_factor_onetime'] > 0) {
-                    $chk_price = zen_get_products_base_price($product_id);
-                    $chk_special = zen_get_products_special_price($product_id, false);
-                    $added_charge = zen_get_attributes_price_factor($chk_price, $chk_special, $attribute_price->fields['attributes_price_factor_onetime'], $attribute_price->fields['attributes_price_factor_onetime_offset']);
-
-                    $attributes_price_onetime += $added_charge;
-                }
-                // attributes_qty_prices_onetime
-                $added_charge = 0;
-                if ($attribute_price->fields['attributes_qty_prices_onetime'] != '') {
-                    $chk_price = zen_get_products_base_price($product_id);
-                    $chk_special = zen_get_products_special_price($product_id, false);
-                    $added_charge = zen_get_attributes_qty_prices_onetime($attribute_price->fields['attributes_qty_prices_onetime'], $qty);
-                    $attributes_price_onetime += $added_charge;
-                }
-                //////////////////////////////////////////////////
+                continue;
             }
+
+            //////////////////////////////////////////////////
+            // calculate additional one time charges
+            //// one time charges
+            // attributes_price_onetime
+            if ($attribute_price->fields['attributes_price_onetime'] > 0) {
+                $attributes_price_onetime += $attribute_price->fields['attributes_price_onetime'];
+            }
+
+            // attributes_price_factor_onetime
+            if ($attribute_price->fields['attributes_price_factor_onetime'] > 0) {
+                $added_charge = zen_get_attributes_price_factor(
+                    zen_get_products_base_price($prid),
+                    zen_get_products_special_price($prid, false),
+                    $attribute_price->fields['attributes_price_factor_onetime'],
+                    $attribute_price->fields['attributes_price_factor_onetime_offset']
+                );
+
+                $attributes_price_onetime += $added_charge;
+            }
+
+            // attributes_qty_prices_onetime
+            if (!empty($attribute_price->fields['attributes_qty_prices_onetime'])) {
+                $added_charge = zen_get_attributes_qty_prices_onetime($attribute_price->fields['attributes_qty_prices_onetime'], $qty);
+                $attributes_price_onetime += $added_charge;
+            }
+            //////////////////////////////////////////////////
         }
 
         return $attributes_price_onetime;
@@ -1151,22 +1206,22 @@ class shoppingCart extends base
      * @param mixed $product_id the product ID of the item to check
      * @return float the weight of the items attributes
      */
-    public function attributes_weight($product_id)
+    public function attributes_weight($uprid)
     {
         global $db;
 
-        $attribute_weight = 0;
-
-        if (!isset($this->contents[$product_id]['attributes'])) {
-            return $attribute_weight;
+        if (!isset($this->contents[$uprid]['attributes'])) {
+            return 0;
         }
 
-        $this->notify('NOTIFY_CART_ATTRIBUTES_WEIGHT_START', $product_id);
+        $this->notify('NOTIFY_CART_ATTRIBUTES_WEIGHT_START', $uprid);
 
-        foreach ($this->contents[$product_id]['attributes'] as $option => $value) {
+        $attribute_weight = 0;
+        $prid = (int)$uprid;
+        foreach ($this->contents[$uprid]['attributes'] as $option => $value) {
             $sql = "SELECT products_attributes_weight, products_attributes_weight_prefix
                     FROM " . TABLE_PRODUCTS_ATTRIBUTES . "
-                    WHERE products_id = " . (int)$product_id . "
+                    WHERE products_id = $prid
                     AND options_id = " . (int)$option . "
                     AND options_values_id = " . (int)$value;
 
@@ -1176,21 +1231,13 @@ class shoppingCart extends base
                 continue;
             }
 
-            $this->notify('NOTIFY_CART_ATTRIBUTES_WEIGHT_NEXT', $product_id, $attribute_weight_info->fields);
+            $this->notify('NOTIFY_CART_ATTRIBUTES_WEIGHT_NEXT', $uprid, $attribute_weight_info->fields);
 
-            // adjusted count for free shipping
-            $product = $db->Execute("SELECT products_id, product_is_always_free_shipping
-                                      FROM " . TABLE_PRODUCTS . "
-                                      WHERE products_id = " . (int)$product_id);
-
-            if ($product->fields['product_is_always_free_shipping'] != 1) {
-                $new_attributes_weight = $attribute_weight_info->fields['products_attributes_weight'];
-            } else {
-                $new_attributes_weight = 0;
-            }
+            $new_attributes_weight = (zen_get_product_is_always_free_shipping($prid) === false) ?
+                $attribute_weight_info->fields['products_attributes_weight'] : 0;
 
             // + or blank adds
-            if ($attribute_weight_info->fields['products_attributes_weight_prefix'] == '-') {
+            if ($attribute_weight_info->fields['products_attributes_weight_prefix'] === '-') {
                 $attribute_weight -= $new_attributes_weight;
             } else {
                 $attribute_weight += $attribute_weight_info->fields['products_attributes_weight'];
@@ -1212,181 +1259,197 @@ class shoppingCart extends base
 
         $this->notify('NOTIFIER_CART_GET_PRODUCTS_START', null, $check_for_valid_cart);
 
-        if (!is_array($this->contents)) return false;
+        if (!is_array($this->contents)) {
+            return false;
+        }
 
         $products_array = [];
-        foreach ($this->contents as $products_id => $data) {
-            $sql = "SELECT p.*, pd.products_name
-                    FROM " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_DESCRIPTION . " pd
-                    WHERE p.products_id = '" . (int)$products_id . "'
-                    AND pd.products_id = p.products_id
-                    AND pd.language_id = " . (int)$_SESSION['languages_id'];
+        foreach ($this->contents as $uprid => $data) {
+            $products = zen_get_product_details((int)$uprid);
+            if ($products->EOF) {
+                continue;   //-TODO: Product not found, should it be removed from the cart?
+            }
 
-            $products = $db->Execute($sql, 1);
-            if (!$products->EOF) {
-                $this->notify('NOTIFY_CART_GET_PRODUCTS_NEXT', $products_id, $products->fields);
+            $this->notify('NOTIFY_CART_GET_PRODUCTS_NEXT', $uprid, $products->fields);
 
-                $prid = $products->fields['products_id'];
-                $products_price = $products->fields['products_price'];
+            $prid = (int)$uprid;
+            $product = $products->fields;
 
-                $special_price = zen_get_products_special_price($prid);
-                if ($special_price && $products->fields['products_priced_by_attribute'] == 0) {
+            $products_price = $product['products_price'];
+
+            $special_price = zen_get_products_special_price($prid);
+            if ($special_price && $product['products_priced_by_attribute'] === '0') {
+                $products_price = $special_price;
+            } else {
+                $special_price = 0;
+            }
+
+            if (zen_get_products_price_is_free($prid)) {
+                // no charge
+                $products_price = 0;
+            }
+
+            // adjust price for discounts when priced by attribute
+            if ($product['products_priced_by_attribute'] === '1' && zen_has_product_attributes($prid, false)) {
+                if ($special_price) {
                     $products_price = $special_price;
                 } else {
-                    $special_price = 0;
+                    $products_price = $product['products_price'];
+                }
+            } else {
+                // discount qty pricing
+                if ($product['products_discount_type'] !== '0') {
+                    $products_price = zen_get_products_discount_price_qty($prid, $data['qty']);
+                }
+            }
+
+            // validate cart contents for checkout
+
+            if ($check_for_valid_cart == true) {
+                if (empty($this->flag_duplicate_quantity_msgs_set['keep'])) {
+                    $this->flag_duplicate_quantity_msgs_set = [];
+                }
+                $fix_once = 0;
+                // Check products_status if not already
+                if ($product['products_status'] === '0') {
+                    $fix_once++;
+                    $_SESSION['valid_to_checkout'] = false;
+                    $_SESSION['cart_errors'] .= ERROR_PRODUCT . $product['products_name'] . ERROR_PRODUCT_STATUS_SHOPPING_CART . '<br>';
+                    $this->remove($uprid);
+                    continue;
                 }
 
-                if (zen_get_products_price_is_free($products->fields['products_id'])) {
-                    // no charge
-                    $products_price = 0;
-                }
+                if (isset($data['attributes'])) {
+                    foreach ($data['attributes'] as $value) {
+                        $sql = "SELECT products_id
+                                FROM " . TABLE_PRODUCTS_ATTRIBUTES . " pa
+                                WHERE pa.products_id = $prid
+                                AND pa.options_values_id = " . (int)$value;
 
-                // adjust price for discounts when priced by attribute
-                if ($products->fields['products_priced_by_attribute'] == '1' && zen_has_product_attributes($products->fields['products_id'], false)) {
-                    if ($special_price) {
-                        $products_price = $special_price;
-                    } else {
-                        $products_price = $products->fields['products_price'];
+                        $chk_attributes_exist = $db->Execute($sql);
+                        if ($chk_attributes_exist->EOF) {
+                            $fix_once++;
+                            $_SESSION['valid_to_checkout'] = false;
+                            $chk_products_link =
+                                '<a href="' . zen_href_link(zen_get_info_page($prid), 'cPath=' . zen_get_generated_category_path_rev($product['master_categories_id']) . '&products_id=' . $prid) . '">' .
+                                    $product['products_name'] .
+                                '</a>';
+                            $_SESSION['cart_errors'] .= ERROR_PRODUCT_ATTRIBUTES . $chk_products_link . ERROR_PRODUCT_STATUS_SHOPPING_CART_ATTRIBUTES . '<br>';
+                            $this->remove($uprid);
+                            break;
+                        }
                     }
-                } else {
-                    // discount qty pricing
-                    if ($products->fields['products_discount_type'] != '0') {
-                        $products_price = zen_get_products_discount_price_qty($products->fields['products_id'], $this->contents[$products_id]['qty']);
+                }
+
+                // check only if valid products_status
+                if ($fix_once === 0) {
+                    $check_quantity = $data['qty'];
+                    $check_quantity_min = $product['products_quantity_order_min'];
+                    // Check quantity min
+                    if ($new_check_quantity = $this->in_cart_mixed($prid)) {
+                        $check_quantity = $new_check_quantity;
                     }
                 }
 
-                // validate cart contents for checkout
-
-                if ($check_for_valid_cart == true) {
-                    if (empty($this->flag_duplicate_quantity_msgs_set['keep'])) $this->flag_duplicate_quantity_msgs_set = [];
-                    $fix_once = 0;
-                    // Check products_status if not already
-                    $check_status = $products->fields['products_status'];
-                    if ($check_status == 0) {
+                // Check Quantity Max if not already an error on Minimum
+                if ($fix_once === 0) {
+                    if ($product['products_quantity_order_max'] != 0 && $check_quantity > $product['products_quantity_order_max'] && !isset($this->flag_duplicate_quantity_msgs_set[$prid]['max'])) {
                         $fix_once++;
                         $_SESSION['valid_to_checkout'] = false;
-                        $_SESSION['cart_errors'] .= ERROR_PRODUCT . $products->fields['products_name'] . ERROR_PRODUCT_STATUS_SHOPPING_CART . '<br>';
-                        $this->remove($products_id);
-                        continue;
-                    } else {
-                        if (isset($this->contents[$products_id]['attributes'])) {
-                            $chkcount = 0;
-                            foreach ($this->contents[$products_id]['attributes'] as $value) {
-                                $chkcount++;
-                                $sql = "SELECT products_id
-                                        FROM " . TABLE_PRODUCTS_ATTRIBUTES . " pa
-                                        WHERE pa.products_id = " . (int)$products_id . "
-                                        AND pa.options_values_id = " . (int)$value;
-
-                                $chk_attributes_exist = $db->Execute($sql);
-//echo 'what is it: ' . ' : ' . $products_id . ' - ' . $value . ' records: ' . $chk_attributes_exist->RecordCount() . ' vs ' . print_r($this->contents[$products_id]) . '<br>';
-                                if ($chk_attributes_exist->EOF) {
-                                    $fix_once++;
-                                    $_SESSION['valid_to_checkout'] = false;
-                                    $chk_product_attributes = $db->Execute("SELECT products_status FROM " . TABLE_PRODUCTS . " WHERE products_status = 1 AND products_id = " . (int)$products->fields["products_id"] . " LIMIT 1");
-                                    if (!$chk_product_attributes->EOF && $chk_product_attributes->fields['products_status'] == 1) {
-                                        $chk_products_link = '<a href="' . zen_href_link(zen_get_info_page($products->fields["products_id"]), 'cPath=' . zen_get_generated_category_path_rev($products->fields["master_categories_id"]) . '&products_id=' . $products->fields["products_id"]) . '">' . $products->fields['products_name'] . '</a>';
-                                    } else {
-                                        $chk_products_link = $products->fields['products_name'];
-                                    }
-                                    $_SESSION['cart_errors'] .= ERROR_PRODUCT_ATTRIBUTES . $chk_products_link . ERROR_PRODUCT_STATUS_SHOPPING_CART_ATTRIBUTES . '<br>';
-                                    $this->remove($products_id);
-                                    break;
-                                }
-                            }
-                        }
+                        $_SESSION['cart_errors'] .=
+                            ERROR_PRODUCT .
+                            $product['products_name'] .
+                            ERROR_PRODUCT_QUANTITY_MAX_SHOPPING_CART .
+                            ERROR_PRODUCT_QUANTITY_ORDERED .
+                            $check_quantity .
+                            ' <span class="alertBlack">' . zen_get_products_quantity_min_units_display($prid, false, true) . '</span> ' .
+                            '<br>';
+                        $this->flag_duplicate_quantity_msgs_set[$prid]['max'] = true;
                     }
-
-                    // check only if valid products_status
-                    if ($fix_once == 0) {
-                        $check_quantity = $this->contents[$products_id]['qty'];
-                        $check_quantity_min = $products->fields['products_quantity_order_min'];
-                        // Check quantity min
-                        if ($new_check_quantity = $this->in_cart_mixed($prid)) {
-                            $check_quantity = $new_check_quantity;
-                        }
-                    }
-
-                    // Check Quantity Max if not already an error on Minimum
-                    if ($fix_once == 0) {
-                        if ($products->fields['products_quantity_order_max'] != 0 && $check_quantity > $products->fields['products_quantity_order_max'] && !isset($this->flag_duplicate_quantity_msgs_set[(int)$prid]['max'])) {
-                            $fix_once++;
-                            $_SESSION['valid_to_checkout'] = false;
-                            $_SESSION['cart_errors'] .= ERROR_PRODUCT . $products->fields['products_name'] . ERROR_PRODUCT_QUANTITY_MAX_SHOPPING_CART . ERROR_PRODUCT_QUANTITY_ORDERED . $check_quantity . ' <span class="alertBlack">' . zen_get_products_quantity_min_units_display((int)$prid, false, true) . '</span> ' . '<br>';
-                            $this->flag_duplicate_quantity_msgs_set[(int)$prid]['max'] = true;
-                        }
-                    }
-
-                    if ($fix_once == 0) {
-                        if ($check_quantity < $check_quantity_min && !isset($this->flag_duplicate_quantity_msgs_set[(int)$prid]['min'])) {
-                            $fix_once++;
-                            $_SESSION['valid_to_checkout'] = false;
-                            $_SESSION['cart_errors'] .= ERROR_PRODUCT . $products->fields['products_name'] . ERROR_PRODUCT_QUANTITY_MIN_SHOPPING_CART . ERROR_PRODUCT_QUANTITY_ORDERED . $check_quantity . ' <span class="alertBlack">' . zen_get_products_quantity_min_units_display((int)$prid, false, true) . '</span> ' . '<br>';
-                            $this->flag_duplicate_quantity_msgs_set[(int)$prid]['min'] = true;
-                        }
-                    }
-
-                    // Check Quantity Units if not already an error on Quantity Minimum
-                    if ($fix_once == 0) {
-                        $check_units = $products->fields['products_quantity_order_units'];
-                        if (fmod_round($check_quantity, $check_units) != 0 && !isset($this->flag_duplicate_quantity_msgs_set[(int)$prid]['units'])) {
-                            $_SESSION['valid_to_checkout'] = false;
-                            $_SESSION['cart_errors'] .= ERROR_PRODUCT . $products->fields['products_name'] . ERROR_PRODUCT_QUANTITY_UNITS_SHOPPING_CART . ERROR_PRODUCT_QUANTITY_ORDERED . $check_quantity . ' <span class="alertBlack">' . zen_get_products_quantity_min_units_display((int)$prid, false, true) . '</span> ' . '<br>';
-                            $this->flag_duplicate_quantity_msgs_set[(int)$prid]['units'] = true;
-                        }
-                    }
-
-                    // Verify Valid Attributes
                 }
 
-                // convert quantity to proper decimals
-                if (QUANTITY_DECIMALS != 0) {
-                    $fix_qty = $this->contents[$products_id]['qty'];
-                    switch (true) {
-                        case (!strstr($fix_qty, '.')):
-                            $new_qty = $fix_qty;
-                            break;
-                        default:
-                            $new_qty = preg_replace('/[0]+$/', '', $this->contents[$products_id]['qty']);
-                            break;
+                if ($fix_once === 0) {
+                    if ($check_quantity < $check_quantity_min && !isset($this->flag_duplicate_quantity_msgs_set[$prid]['min'])) {
+                        $fix_once++;
+                        $_SESSION['valid_to_checkout'] = false;
+                        $_SESSION['cart_errors'] .=
+                            ERROR_PRODUCT .
+                            $product['products_name'] .
+                            ERROR_PRODUCT_QUANTITY_MIN_SHOPPING_CART .
+                            ERROR_PRODUCT_QUANTITY_ORDERED .
+                            $check_quantity .
+                            ' <span class="alertBlack">' . zen_get_products_quantity_min_units_display($prid, false, true) . '</span> ' .
+                            '<br>';
+                        $this->flag_duplicate_quantity_msgs_set[$prid]['min'] = true;
                     }
-                } else {
-                    $new_qty = $this->contents[$products_id]['qty'];
-                }
-                $check_unit_decimals = $products->fields['products_quantity_order_units'];
-                if (strstr($check_unit_decimals, '.')) {
-                    $new_qty = round($new_qty, QUANTITY_DECIMALS);
-                } else {
-                    $new_qty = round($new_qty, 0);
                 }
 
-                $products_array[] = [
-                    'id' => $products_id,
-                    'category' => $products->fields['master_categories_id'],
-                    'name' => $products->fields['products_name'],
-                    'model' => $products->fields['products_model'],
-                    'image' => $products->fields['products_image'],
-                    'price' => ($products->fields['product_is_free'] == '1' ? 0 : $products_price),
-                    'quantity' => $new_qty,
-                    'weight' => $products->fields['products_weight'] + $this->attributes_weight($products_id),
-                    'final_price' => ($products_price + $this->attributes_price($products_id)),
-                    'onetime_charges' => ($this->attributes_price_onetime_charges($products_id, $new_qty)),
-                    'tax_class_id' => $products->fields['products_tax_class_id'],
-                    'attributes' => (isset($this->contents[$products_id]['attributes']) ? $this->contents[$products_id]['attributes'] : ''),
-                    'attributes_values' => (isset($this->contents[$products_id]['attributes_values']) ? $this->contents[$products_id]['attributes_values'] : ''),
-                    'products_priced_by_attribute' => $products->fields['products_priced_by_attribute'],
-                    'product_is_free' => $products->fields['product_is_free'],
-                    'products_discount_type' => $products->fields['products_discount_type'],
-                    'products_discount_type_from' => $products->fields['products_discount_type_from'],
-                    'products_virtual' => (int)$products->fields['products_virtual'],
-                    'product_is_always_free_shipping' => (int)$products->fields['product_is_always_free_shipping'],
-                    'products_quantity_order_min' => (float)$products->fields['products_quantity_order_min'],
-                    'products_quantity_order_units' => (float)$products->fields['products_quantity_order_units'],
-                    'products_quantity_order_max' => (float)$products->fields['products_quantity_order_max'],
-                    'products_quantity_mixed' => (int)$products->fields['products_quantity_mixed'],
-                    'products_mixed_discount_quantity' => (int)$products->fields['products_mixed_discount_quantity'],
-                ];
+                // Check Quantity Units if not already an error on Quantity Minimum
+                if ($fix_once === 0) {
+                    $check_units = $product['products_quantity_order_units'];
+                    if (fmod_round($check_quantity, $check_units) != 0 && !isset($this->flag_duplicate_quantity_msgs_set[$prid]['units'])) {
+                        $_SESSION['valid_to_checkout'] = false;
+                        $_SESSION['cart_errors'] .=
+                            ERROR_PRODUCT .
+                            $product['products_name'] .
+                            ERROR_PRODUCT_QUANTITY_UNITS_SHOPPING_CART .
+                            ERROR_PRODUCT_QUANTITY_ORDERED .
+                            $check_quantity .
+                            ' <span class="alertBlack">' . zen_get_products_quantity_min_units_display($prid, false, true) . '</span> ' .
+                            '<br>';
+                        $this->flag_duplicate_quantity_msgs_set[$prid]['units'] = true;
+                    }
+                }
+                // Verify Valid Attributes
             }
+
+            // convert quantity to proper decimals
+            if (QUANTITY_DECIMALS === '0') {
+                $new_qty = $data['qty'];
+            } else {
+                $fix_qty = $data['qty'];
+                switch (true) {
+                    case (strpos($fix_qty, '.') === false):
+                        $new_qty = $fix_qty;
+                        break;
+                    default:
+                        $new_qty = preg_replace('/[0]+$/', '', $data['qty']);
+                        break;
+                }
+            }
+            $check_unit_decimals = $product['products_quantity_order_units'];
+            if (strpos($check_unit_decimals, '.') !== false) {
+                $new_qty = round($new_qty, QUANTITY_DECIMALS);
+            } else {
+                $new_qty = round($new_qty, 0);
+            }
+
+            $products_array[] = [
+                'id' => $uprid,
+                'category' => $product['master_categories_id'],
+                'name' => $product['products_name'],
+                'model' => $product['products_model'],
+                'image' => $product['products_image'],
+                'price' => ($product['product_is_free'] === '1') ? 0 : $products_price,
+                'quantity' => $new_qty,
+                'weight' => $product['products_weight'] + $this->attributes_weight($uprid),
+                'final_price' => $products_price + $this->attributes_price($uprid),
+                'onetime_charges' => $this->attributes_price_onetime_charges($uprid, $new_qty),
+                'tax_class_id' => $product['products_tax_class_id'],
+                'attributes' => $data['attributes'] ?? '',
+                'attributes_values' => $data['attributes_values'] ?? '',
+                'products_priced_by_attribute' => $product['products_priced_by_attribute'],
+                'product_is_free' => $product['product_is_free'],
+                'products_discount_type' => $product['products_discount_type'],
+                'products_discount_type_from' => $product['products_discount_type_from'],
+                'products_virtual' => (int)$product['products_virtual'],
+                'product_is_always_free_shipping' => (int)$product['product_is_always_free_shipping'],
+                'products_quantity_order_min' => (float)$product['products_quantity_order_min'],
+                'products_quantity_order_units' => (float)$product['products_quantity_order_units'],
+                'products_quantity_order_max' => (float)$product['products_quantity_order_max'],
+                'products_quantity_mixed' => (int)$product['products_quantity_mixed'],
+                'products_mixed_discount_quantity' => (int)$product['products_mixed_discount_quantity'],
+            ];
         }
         $this->notify('NOTIFIER_CART_GET_PRODUCTS_END', null, $products_array);
         return $products_array;
@@ -1451,172 +1514,139 @@ class shoppingCart extends base
         global $db;
 
         // legacy compatibility:
-        if ($gv_only === 'false') $gv_only = false;
-        if ($gv_only === 'true') $gv_only = true;
-
+        if ($gv_only === 'false') {
+            $gv_only = false;
+        } elseif ($gv_only === 'true') {
+            $gv_only = true;
+        }
 
         $this->content_type = false;
         $gift_voucher = 0;
 
-        if ($this->count_contents() > 0) {
-            foreach ($this->contents as $products_id => $data) {
-                $free_ship_check = $db->Execute("SELECT products_virtual, products_model, products_price, product_is_always_free_shipping FROM " . TABLE_PRODUCTS . " WHERE products_id = " . (int)$products_id);
-                $virtual_check = false;
-                if (preg_match('/^GIFT/', addslashes($free_ship_check->fields['products_model']))) {
+        if ($this->count_contents() === 0) {
+            $this->content_type = 'physical';
+        } else {
+            foreach ($this->contents as $uprid => $data) {
+                $prid = (int)$uprid;
+                $free_ship_check = zen_get_product_details($prid);
+                $free_ship_check = $free_ship_check->fields;
+
+                if (strpos($free_ship_check['products_model'], 'GIFT') === 0) {
 // @TODO - fix GIFT price in cart special/attribute
-                    $gift_special = zen_get_products_special_price(zen_get_prid($products_id), true);
-                    $gift_pba = zen_get_products_price_is_priced_by_attributes(zen_get_prid($products_id));
-//echo '$products_id: ' . zen_get_prid($products_id) . ' price: ' . ($free_ship_check->fields['products_price'] + $this->attributes_price($products_id)) . ' vs special price: ' . $gift_special . ' qty: ' . $this->contents[$products_id]['qty'] . ' PBA: ' . ($gift_pba ? 'YES' : 'NO') . '<br>';
-                    if (!$gift_pba && $gift_special != 0 && $gift_special != $free_ship_check->fields['products_price']) {
-                        $gift_voucher += ($gift_special * $this->contents[$products_id]['qty']);
+                    $gift_special = zen_get_products_special_price($prid, true);
+                    $gift_pba = zen_get_products_price_is_priced_by_attributes($prid);
+
+                    if (!$gift_pba && $gift_special != 0 && $gift_special != $free_ship_check['products_price']) {
+                        $gift_voucher += ($gift_special * $data['qty']);
                     } else {
-                        $gift_voucher += ($free_ship_check->fields['products_price'] + $this->attributes_price($products_id)) * $this->contents[$products_id]['qty'];
+                        $gift_voucher += ($free_ship_check['products_price'] + $this->attributes_price($uprid)) * $data['qty'];
                     }
                 }
+
+                $product_is_virtual = ($free_ship_check['products_virtual'] === '1');
+
                 // product_is_always_free_shipping = 2 is special requires shipping
                 // Example: Product with download
-                if (isset($this->contents[$products_id]['attributes']) && $free_ship_check->fields['product_is_always_free_shipping'] != 2) {
-                    foreach ($this->contents[$products_id]['attributes'] as $value) {
+                if (isset($data['attributes']) && $free_ship_check['product_is_always_free_shipping'] !== '2') {
+                    foreach ($data['attributes'] as $value) {
                         $sql = "SELECT COUNT(*) as total
                                 FROM " . TABLE_PRODUCTS_ATTRIBUTES . " pa
                                 INNER JOIN " . TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD . " pad USING (products_attributes_id)
-                                WHERE pa.products_id = " . (int)$products_id . "
+                                WHERE pa.products_id = $prid
                                 AND pa.options_values_id = " . (int)$value;
 
                         $virtual_check = $db->Execute($sql);
 
-                        if ($virtual_check->fields['total'] > 0) {
-                            switch ($this->content_type) {
-                                case 'physical':
+                        // -----
+                        // If the product has downloads, it's virtual by default.
+                        //
+                        if ($virtual_check->fields['total'] !== '0') {
+                            if ($this->content_type === 'physical') {
+                                $this->content_type = 'mixed';
+                                return ($gv_only) ? $gift_voucher : $this->content_type;
+                            }
+                            $this->content_type = 'virtual';
+                            continue;
+                        }
+
+                        // -----
+                        // If the product doesn't have downloads, its virtual setting dictates
+                        // whether it' a virtual/physical product.
+                        //
+                        switch ($this->content_type) {
+                            case 'virtual':
+                                if ($product_is_virtual === false) {
                                     $this->content_type = 'mixed';
-                                    if ($gv_only) {
-                                        return $gift_voucher;
-                                    }
-
-                                    return $this->content_type;
-                                    break;
-                                default:
-                                    $this->content_type = 'virtual';
-                                    break;
-                            }
-                        } else {
-                            switch ($this->content_type) {
-                                case 'virtual':
-                                    if ($free_ship_check->fields['products_virtual'] == '1') {
-                                        $this->content_type = 'virtual';
-                                    } else {
-                                        $this->content_type = 'mixed';
-                                        if ($gv_only) {
-                                            return $gift_voucher;
-                                        }
-
-                                        return $this->content_type;
-                                    }
-                                    break;
-                                case 'physical':
-                                    if ($free_ship_check->fields['products_virtual'] == '1') {
-                                        $this->content_type = 'mixed';
-                                        if ($gv_only) {
-                                            return $gift_voucher;
-                                        }
-
-                                        return $this->content_type;
-                                    }
-
-                                    $this->content_type = 'physical';
-                                    break;
-                                default:
-                                    if ($free_ship_check->fields['products_virtual'] == '1') {
-                                        $this->content_type = 'virtual';
-                                    } else {
-                                        $this->content_type = 'physical';
-                                    }
-                            }
+                                    return ($gv_only) ? $gift_voucher : $this->content_type;
+                                }
+                                break;
+                            case 'physical':
+                                if ($product_is_virtual === true) {
+                                    $this->content_type = 'mixed';
+                                    return ($gv_only) ? $gift_voucher : $this->content_type;
+                                }
+                                $this->content_type = 'physical';
+                                break;
+                            default:
+                                $this->content_type = ($product_is_virtual === true) ? 'virtual' : 'physical';
+                                break;
                         }
                     }
                 } else {
                     switch ($this->content_type) {
                         case 'virtual':
-                            if ($free_ship_check->fields['products_virtual'] == '1') {
-                                $this->content_type = 'virtual';
-                            } else {
+                            if ($product_is_virtual === false) {
                                 $this->content_type = 'mixed';
-                                if ($gv_only) {
-                                    return $gift_voucher;
-                                }
-
-                                return $this->content_type;
+                                return ($gv_only) ? $gift_voucher : $this->content_type;
                             }
                             break;
                         case 'physical':
-                            if ($free_ship_check->fields['products_virtual'] == '1') {
+                            if ($product_is_virtual === true) {
                                 $this->content_type = 'mixed';
-                                if ($gv_only) {
-                                    return $gift_voucher;
-                                }
-
-                                return $this->content_type;
+                                return ($gv_only) ? $gift_voucher : $this->content_type;
                             }
-
-                            $this->content_type = 'physical';
                             break;
                         default:
-                            if ($free_ship_check->fields['products_virtual'] == '1') {
-                                $this->content_type = 'virtual';
-                            } else {
-                                $this->content_type = 'physical';
-                            }
+                            $this->content_type = ($product_is_virtual === true) ? 'virtual' : 'physical';
+                            break;
                     }
                 }
             }
-        } else {
-            $this->content_type = 'physical';
         }
 
-        if ($gv_only) {
-            return $gift_voucher;
-        }
-
-        return $this->content_type;
+        return ($gv_only) ? $gift_voucher : $this->content_type;
     }
 
     /**
      * Calculate item quantity, bounded by the mixed/min units settings
      *
-     * @param bool $product_id product id of item to check
+     * @param int|string $uprid_to_check product id of item to check
      * @return float
      */
-    public function in_cart_mixed($product_id)
+    public function in_cart_mixed($uprid_to_check)
     {
-        global $db;
         // if nothing is in cart return 0
-        if (!is_array($this->contents)) return 0;
+        if (!is_array($this->contents)) {
+            return 0;
+        }
 
         // check if mixed is on
-        $product = $db->Execute("SELECT products_id, products_quantity_mixed FROM " . TABLE_PRODUCTS . " WHERE products_id=" . (int)$product_id . " limit 1");
+        $product = zen_get_product_details((int)$uprid_to_check);
 
         // if mixed attributes is off return qty for current attribute selection
-        if ($product->fields['products_quantity_mixed'] == '0') {
-            return $this->get_quantity($product_id);
+        if ($product->fields['products_quantity_mixed'] === '0') {
+            return $this->get_quantity($uprid_to_check);
         }
 
         // compute total quantity regardless of attributes
         $in_cart_mixed_qty = 0;
-        $chk_products_id = zen_get_prid($product_id);
+        $chk_products_id = zen_get_prid($uprid_to_check);
 
-// added for new code - Ajeh
-        global $messageStack;
-
-        $check_contents = $this->contents;
-        foreach ($check_contents as $prod_id => $data) {
-            $test_id = zen_get_prid($prod_id);
-//$messageStack->add_session('header', 'Product: ' . $prod_id . ' test_id: ' . $test_id . '<br>', 'error');
-            if ($test_id == $chk_products_id) {
-//$messageStack->add_session('header', 'MIXED: ' . $prod_id . ' test_id: ' . $test_id . ' qty:' . $check_contents[$products_id]['qty'] . ' in_cart_mixed_qty: ' . $in_cart_mixed_qty . '<br><br>', 'error');
-                $in_cart_mixed_qty += $check_contents[$prod_id]['qty'];
+        foreach ($this->contents as $uprid => $data) {
+            if (zen_get_prid($uprid) === $chk_products_id) {
+                $in_cart_mixed_qty += $data['qty'];
             }
         }
-//$messageStack->add_session('header', 'FINAL: in_cart_mixed_qty: ' . 'PRODUCT: ' . $test_id . ' in cart:' . $in_cart_mixed_qty . '<br><br>', 'error');
 
         return $in_cart_mixed_qty;
     }
@@ -1626,32 +1656,31 @@ class shoppingCart extends base
      *
      * @NOTE: NOT USED IN CORE CODE
      *
-     * @param bool $product_id product id of item to check
+     * @param int|string $uprid_to_check product id of item to check
      * @return float
      */
-    public function in_cart_mixed_discount_quantity($product_id)
+    public function in_cart_mixed_discount_quantity($uprid_to_check)
     {
-        global $db;
         // if nothing is in cart return 0
-        if (!is_array($this->contents)) return 0;
+        if (!is_array($this->contents)) {
+            return 0;
+        }
 
         // check if mixed is on
-        $product = $db->Execute("SELECT products_id, products_mixed_discount_quantity FROM " . TABLE_PRODUCTS . " WHERE products_id=" . (int)$product_id . " limit 1");
+        $product = zen_get_product_details((int)$uprid_to_check);
 
         // if mixed attributes is off return qty for current attribute selection
-        if ($product->fields['products_mixed_discount_quantity'] == '0') {
-            return $this->get_quantity($product_id);
+        if ($product->fields['products_mixed_discount_quantity'] === '0') {
+            return $this->get_quantity($uprid_to_check);
         }
 
         // compute total quantity regardless of attributes
         $in_cart_mixed_qty_discount_quantity = 0;
-        $chk_products_id = zen_get_prid($product_id);
+        $chk_products_id = zen_get_prid($uprid_to_check);
 
-        $check_contents = $this->contents;
-        foreach ($check_contents as $prod_id => $data) {
-            $test_id = zen_get_prid($prod_id);
-            if ($test_id == $chk_products_id) {
-                $in_cart_mixed_qty_discount_quantity += $check_contents[$prod_id]['qty'];
+        foreach ($this->contents as $uprid => $data) {
+            if (zen_get_prid($uprid) === $chk_products_id) {
+                $in_cart_mixed_qty_discount_quantity += $data['qty'];
             }
         }
         return $in_cart_mixed_qty_discount_quantity;
@@ -1670,19 +1699,18 @@ class shoppingCart extends base
      */
     public function in_cart_check($check_what, $check_value = '1')
     {
-        global $db;
         // if nothing is in cart return 0
-        if (!is_array($this->contents)) return 0;
+        if (!is_array($this->contents)) {
+            return 0;
+        }
 
         // compute total quantity for field
         $in_cart_check_qty = 0;
-
-        foreach ($this->contents as $products_id => $data) {
-            $testing_id = zen_get_prid($products_id);
+        foreach ($this->contents as $uprid => $data) {
             // check if field it true
-            $product_check = $db->Execute("SELECT " . $check_what . " AS check_it FROM " . TABLE_PRODUCTS . " WHERE products_id=" . (int)$testing_id . " LIMIT 1");
-            if ($product_check->fields['check_it'] == $check_value) {
-                $in_cart_check_qty += $this->contents[$products_id]['qty'];
+            $product_check = zen_get_product_details(zen_get_prid($uprid));
+            if (array_key_exists($check_value, $product_check->fields) && $product_check->fields[$check_what] == $check_value) {
+                $in_cart_check_qty += $data['qty'];
             }
         }
         return $in_cart_check_qty;
@@ -1751,7 +1779,9 @@ class shoppingCart extends base
     public function actionUpdateProduct($goto, $parameters)
     {
         global $messageStack;
-        if ($this->display_debug_messages) $messageStack->add_session('header', 'FUNCTION ' . __FUNCTION__, 'caution');
+        if ($this->display_debug_messages) {
+            $messageStack->add_session('header', 'FUNCTION ' . __FUNCTION__, 'caution');
+        }
 
         $change_state = [];
         $this->flag_duplicate_quantity_msgs_set = [];
@@ -1762,114 +1792,141 @@ class shoppingCart extends base
         }
         for ($i = 0, $n = count($_POST['products_id']); $i < $n; $i++) {
             $adjust_max = 'false';
+            $products_id = $_POST['products_id'][$i];
             if ($_POST['cart_quantity'][$i] == '') {
                 $_POST['cart_quantity'][$i] = 0;
             }
             if (!is_numeric($_POST['cart_quantity'][$i]) || $_POST['cart_quantity'][$i] < 0) {
                 // adjust quantity when not a value
-                $chk_link = '<a href="' . zen_href_link(zen_get_info_page($_POST['products_id'][$i]), 'cPath=' . (zen_get_generated_category_path_rev(zen_get_products_category_id($_POST['products_id'][$i]))) . '&products_id=' . $_POST['products_id'][$i]) . '">' . zen_get_products_name($_POST['products_id'][$i]) . '</a>';
-                $messageStack->add_session('header', ERROR_CORRECTIONS_HEADING . ERROR_PRODUCT_QUANTITY_UNITS_SHOPPING_CART . $chk_link . ' ' . PRODUCTS_ORDER_QTY_TEXT . zen_output_string_protected($_POST['cart_quantity'][$i]), 'caution');
-//        $_POST['cart_quantity'][$i] = 0; // On an update, if an incorrect value was given, then with expectation that product is already in the cart, then the post quantity should equal what is in the cart, not 0...
-                $_POST['cart_quantity'][$i] = $this->get_quantity($_POST['products_id'][$i]);
+                $chk_link =
+                    '<a href="' . zen_href_link(zen_get_info_page($products_id), 'cPath=' . (zen_get_generated_category_path_rev(zen_get_products_category_id($products_id))) . '&products_id=' . $products_id) . '">' .
+                        zen_get_products_name($products_id) .
+                    '</a>';
+                $messageStack->add_session(
+                    'header',
+                    ERROR_CORRECTIONS_HEADING . ERROR_PRODUCT_QUANTITY_UNITS_SHOPPING_CART . $chk_link . ' ' . PRODUCTS_ORDER_QTY_TEXT . zen_output_string_protected($_POST['cart_quantity'][$i]),
+                    'caution'
+                );
+
+                $_POST['cart_quantity'][$i] = $this->get_quantity($products_id);
                 continue;
             }
-            if (in_array($_POST['products_id'][$i], $cart_delete) || $_POST['cart_quantity'][$i] == 0) {
-                $this->remove($_POST['products_id'][$i]);
+            if (in_array($products_id, $cart_delete) || $_POST['cart_quantity'][$i] == 0) {
+                $this->remove($products_id);
             } else {
-                $add_max = zen_get_products_quantity_order_max($_POST['products_id'][$i]); // maximum allowed
-                $chk_mixed = zen_get_products_quantity_mixed($_POST['products_id'][$i]); // use mixed
+                $add_max = zen_get_products_quantity_order_max($products_id); // maximum allowed
+                $chk_mixed = zen_get_products_quantity_mixed($products_id); // use mixed
+                $prid = zen_get_prid($products_id);
+
                 // Adjust in cart quantities for product that have other cart
                 //   product dependencies and reduction of product to allow a larger increase
                 //   at each product's modification.
                 //   This will maximize the maximum product quantities available.
-                if ($chk_mixed === true && !array_key_exists(zen_get_prid($_POST['products_id'][$i]), $change_state)) {
-                    $change_check = $this->in_cart_product_mixed_changed($_POST['products_id'][$i], 'decrease'); // Returns full data on products.
-                    $change_state[zen_get_prid($_POST['products_id'][$i])] = $change_check;
-                    if (is_array($change_check) && count($change_state[zen_get_prid($_POST['products_id'][$i])]['decrease']) > 0) {
+                if ($chk_mixed === true && !array_key_exists($prid, $change_state)) {
+                    $change_check = $this->in_cart_product_mixed_changed($products_id, 'decrease'); // Returns full data on products.
+                    $change_state[$prid] = $change_check;
+                    if (is_array($change_check) && count($change_state[$prid]['decrease']) > 0) {
                         // Verify minuses are good, and affect the items to be changed
                         //  This leaves only increases or 'netzero' to be at play.
-                        foreach ($change_state[zen_get_prid($_POST['products_id'][$i])]['decrease'] as $prod_id) {
+                        foreach ($change_state[$prid]['decrease'] as $prod_id) {
                             $attributes = (!empty($_POST['id'][$prod_id]) && is_array($_POST['id'][$prod_id])) ? $_POST['id'][$prod_id] : [];
                             $this_curr_qty = $this->get_quantity($prod_id);
-                            $this_new_qty = $this_curr_qty + $change_state[zen_get_prid($_POST['products_id'][$i])]['changed'][$prod_id];
+                            $this_new_qty = $this_curr_qty + $change_state[$prid]['changed'][$prod_id];
                             $this->add_cart($prod_id, $this_new_qty, $attributes, false);
-                            if ($this->display_debug_messages) $messageStack->add_session('header', 'FUNCTION ' . __FUNCTION__ . ' Products_id: ' . $_POST['products_id'][$i] . ' prod_id: ' . $prod_id . ' this_new_qty: ' . $this_new_qty . ' this_curr_qty: ' . $this_curr_qty . ' change_state[zen_get_prid(_POST[products_id][i])][changed][prod_id]: ' . $change_state[zen_get_prid($_POST['products_id'][$i])]['changed'][$prod_id] . ' attributes: ' . print_r($attributes, true) . ' change_state: ' . print_r($change_state, true) . ' <br>', 'caution');
+                            if ($this->display_debug_messages) {
+                                $messageStack->add_session(
+                                    'header',
+                                    'FUNCTION ' . __FUNCTION__ .
+                                        ' Products_id: ' . $products_id .
+                                        ' prod_id: ' . $prod_id .
+                                        ' this_new_qty: ' . $this_new_qty .
+                                        ' this_curr_qty: ' . $this_curr_qty .
+                                        ' change_state[zen_get_prid(_POST[products_id][i])][changed][prod_id]: ' .
+                                            $change_state[$prid]['changed'][$prod_id] .
+                                        ' attributes: ' . print_r($attributes, true) .
+                                        ' change_state: ' . print_r($change_state, true) .
+                                        ' <br>',
+                                    'caution'
+                                );
+                            }
                         }
                         unset($prod_num, $prod_id, $attributes, $this_curr_qty, $this_new_qty);
                     }
                 }
-                $cart_qty = $this->in_cart_mixed($_POST['products_id'][$i]); // total currently in cart
-                if ($this->display_debug_messages) $messageStack->add_session('header', 'FUNCTION ' . __FUNCTION__ . ' Products_id: ' . $_POST['products_id'][$i] . ' cart_qty: ' . $cart_qty . ' <br>', 'caution');
-                $new_qty = $_POST['cart_quantity'][$i]; // new quantity
-                $current_qty = $this->get_quantity($_POST['products_id'][$i]); // how many currently in cart for attribute
-//        $chk_mixed = zen_get_products_quantity_mixed($_POST['products_id'][$i]); // use mixed
-
-                $new_qty = $this->adjust_quantity($new_qty, $_POST['products_id'][$i], 'shopping_cart');
-// bof: adjust new quantity to be same as current in stock
-                $chk_current_qty = zen_get_products_stock($_POST['products_id'][$i]);
-                if (STOCK_ALLOW_CHECKOUT == 'false' && ($new_qty > $chk_current_qty)) {
-                    $new_qty = $chk_current_qty;
-                    $messageStack->add_session('shopping_cart', ($this->display_debug_messages ? 'FUNCTION ' . __FUNCTION__ . ': ' : '') . WARNING_PRODUCT_QUANTITY_ADJUSTED . zen_get_products_name($_POST['products_id'][$i]), 'caution');
+                $cart_qty = $this->in_cart_mixed($products_id); // total currently in cart
+                if ($this->display_debug_messages) {
+                    $messageStack->add_session('header', 'FUNCTION ' . __FUNCTION__ . ' Products_id: ' . $products_id . ' cart_qty: ' . $cart_qty . ' <br>', 'caution');
                 }
-// eof: adjust new quantity to be same as current in stock
+                $new_qty = $_POST['cart_quantity'][$i]; // new quantity
+                $current_qty = $this->get_quantity($products_id); // how many currently in cart for attribute
 
-                if (($add_max == 1 and $cart_qty == 1) && $new_qty != $cart_qty) {
+                $new_qty = $this->adjust_quantity($new_qty, $products_id, 'shopping_cart');
+
+                // -----
+                // Adjust new quantity to be the same as what's in stock.
+                //
+                $chk_current_qty = zen_get_products_stock($products_id);
+                if (STOCK_ALLOW_CHECKOUT === 'false' && $new_qty > $chk_current_qty) {
+                    $new_qty = $chk_current_qty;
+                    $messageStack->add_session('shopping_cart', ($this->display_debug_messages ? 'FUNCTION ' . __FUNCTION__ . ': ' : '') . WARNING_PRODUCT_QUANTITY_ADJUSTED . zen_get_products_name($products_id), 'caution');
+                }
+
+                if ($add_max == 1 && $cart_qty == 1 && $new_qty != $cart_qty) {
                     // do not add
                     $adjust_max = 'true';
-                } else {
-                    if ($add_max != 0) {
-                        // adjust quantity if needed
-                        switch (true) {
-                            case ($new_qty == $current_qty): // no change
-                                $adjust_max = 'false';
-                                $new_qty = $current_qty;
-                                break;
-                            case ($new_qty > $add_max && $chk_mixed == false):
-                                $adjust_max = 'true';
-                                $new_qty = $add_max;
-                                break;
-                            case (($add_max - $cart_qty + $new_qty >= $add_max) && $new_qty > $add_max && $chk_mixed == true):
-                                $adjust_max = 'true';
-                                $requested_qty = $new_qty;
-//            $new_qty = $current_qty;
-                                $alter_qty = $add_max - $cart_qty + $current_qty;
-                                $new_qty = ($alter_qty > 0 ? $alter_qty : $current_qty);
-                                break;
-                            case (($cart_qty + $new_qty - $current_qty > $add_max) && $chk_mixed == true):
-                                $adjust_max = 'true';
-                                $requested_qty = $new_qty;
-//            $new_qty = $current_qty;
-                                $alter_qty = $add_max - $cart_qty + $current_qty;
-                                $new_qty = ($alter_qty > 0 ? $alter_qty : $current_qty);
-                                break;
-                            default:
-                                $adjust_max = 'false';
-                        }
-
-// bof: notify about adjustment to new quantity to be same as current in stock or maximum to add
-                        if ($adjust_max == 'true') {
-                            $messageStack->add_session('shopping_cart', ($this->display_debug_messages ? 'FUNCTION ' . __FUNCTION__ . ': ' : '') . WARNING_PRODUCT_QUANTITY_ADJUSTED . zen_get_products_name($_POST['products_id'][$i]), 'caution');
-                        }
-// eof: notify about adjustment to new quantity to be same as current in stock or maximum to add
-
-                        $attributes = isset($_POST['id'][$_POST['products_id'][$i]]) ? $_POST['id'][$_POST['products_id'][$i]] : [];
-                        $this->add_cart($_POST['products_id'][$i], $new_qty, $attributes, false);
-                    } else {
-                        // adjust minimum and units
-                        $attributes = isset($_POST['id'][$_POST['products_id'][$i]]) ? $_POST['id'][$_POST['products_id'][$i]] : [];
-                        $this->add_cart($_POST['products_id'][$i], $new_qty, $attributes, false);
+                } elseif ($add_max != 0) {
+                    // adjust quantity if needed
+                    switch (true) {
+                        case ($new_qty == $current_qty): // no change
+                            $adjust_max = 'false';
+                            $new_qty = $current_qty;
+                            break;
+                        case ($chk_mixed === false && $new_qty > $add_max):
+                            $adjust_max = 'true';
+                            $new_qty = $add_max;
+                            break;
+                        case ($chk_mixed == true && ($add_max - $cart_qty + $new_qty) >= $add_max && $new_qty > $add_max):
+                            $adjust_max = 'true';
+                            $requested_qty = $new_qty;
+                            $alter_qty = $add_max - $cart_qty + $current_qty;
+                            $new_qty = ($alter_qty > 0) ? $alter_qty : $current_qty;
+                            break;
+                        case ($chk_mixed === true && ($cart_qty + $new_qty - $current_qty) > $add_max):
+                            $adjust_max = 'true';
+                            $requested_qty = $new_qty;
+                            $alter_qty = $add_max - $cart_qty + $current_qty;
+                            $new_qty = ($alter_qty > 0) ? $alter_qty : $current_qty;
+                            break;
+                        default:
+                            $adjust_max = 'false';
+                            break;
                     }
-                }
-                if ($adjust_max == 'true') {
-                    if ($this->display_debug_messages) $messageStack->add_session('header', 'FUNCTION ' . __FUNCTION__ . '<br>' . ERROR_MAXIMUM_QTY . zen_get_products_name($_POST['products_id'][$i]) . '<br>requested_qty: ' . $requested_qty . ' current_qty: ' . $current_qty, 'caution');
-                    $messageStack->add_session('shopping_cart', ERROR_MAXIMUM_QTY . zen_get_products_name($_POST['products_id'][$i]), 'caution');
+
+                    // -----
+                    // Message the customer regarind the quantity adjustment.
+                    //
+                    if ($adjust_max === 'true') {
+                        $messageStack->add_session('shopping_cart', ($this->display_debug_messages ? 'FUNCTION ' . __FUNCTION__ . ': ' : '') . WARNING_PRODUCT_QUANTITY_ADJUSTED . zen_get_products_name($products_id), 'caution');
+                    }
+
+                    $this->add_cart($products_id, $new_qty, $_POST['id'][$products_id] ?? [], false);
                 } else {
-// display message if all is good and not on shopping_cart page
-                    if ((DISPLAY_CART == 'false' && $_GET['main_page'] != FILENAME_SHOPPING_CART) && $messageStack->size('shopping_cart') == 0) {
-                        $messageStack->add_session('header', ($this->display_debug_messages ? 'FUNCTION ' . __FUNCTION__ . ': ' : '') . SUCCESS_ADDED_TO_CART_PRODUCTS, 'success');
-                        $this->notify('NOTIFIER_CART_OPTIONAL_SUCCESS_UPDATED_CART', $_POST, $goto, $parameters);
-                    } else {
-                        if ($_GET['main_page'] != FILENAME_SHOPPING_CART) {
+                    // adjust minimum and units
+                    $this->add_cart($products_id, $new_qty, $_POST['id'][$products_id] ?? [], false);
+                }
+
+                if ($adjust_max === 'true') {
+                    if ($this->display_debug_messages) {
+                        $messageStack->add_session('header', 'FUNCTION ' . __FUNCTION__ . '<br>' . ERROR_MAXIMUM_QTY . zen_get_products_name($products_id) . '<br>requested_qty: ' . $requested_qty . ' current_qty: ' . $current_qty, 'caution');
+                    }
+                    $messageStack->add_session('shopping_cart', ERROR_MAXIMUM_QTY . zen_get_products_name($products_id), 'caution');
+                } else {
+                    // display message if all is good and not on shopping_cart page
+                    if ($_GET['main_page'] !== FILENAME_SHOPPING_CART) {
+                        if (DISPLAY_CART === 'false' && $messageStack->size('shopping_cart') === 0) {
+                            $messageStack->add_session('header', ($this->display_debug_messages ? 'FUNCTION ' . __FUNCTION__ . ': ' : '') . SUCCESS_ADDED_TO_CART_PRODUCTS, 'success');
+                            $this->notify('NOTIFIER_CART_OPTIONAL_SUCCESS_UPDATED_CART', $_POST, $goto, $parameters);
+                        } else {
                             zen_redirect(zen_href_link(FILENAME_SHOPPING_CART));
                         }
                     }
@@ -1888,38 +1945,62 @@ class shoppingCart extends base
     public function actionAddProduct($goto, $parameters = [])
     {
         global $db, $messageStack;
-        if ($this->display_debug_messages) $messageStack->add_session('header', 'A: FUNCTION ' . __FUNCTION__, 'caution');
+        if ($this->display_debug_messages) {
+            $messageStack->add_session('header', 'A: FUNCTION ' . __FUNCTION__, 'caution');
+        }
 
         $the_list = '';
 
         if (isset($_POST['products_id']) && is_numeric($_POST['products_id'])) {
             // verify attributes and quantity first
-            if ($this->display_debug_messages) $messageStack->add_session('header', 'A2: FUNCTION ' . __FUNCTION__, 'caution');
+            if ($this->display_debug_messages) {
+                $messageStack->add_session('header', 'A2: FUNCTION ' . __FUNCTION__, 'caution');
+            }
             $adjust_max = 'false';
-            if (isset($_POST['id'])) {
+            if (isset($_POST['id']) && is_array($_POST['id'])) {
                 foreach ($_POST['id'] as $key => $value) {
-                    $check = zen_get_attributes_valid($_POST['products_id'], $key, $value);
-                    if ($check == false) {
-                        $the_list .= TEXT_ERROR_OPTION_FOR . '<span class="alertBlack">' . zen_options_name($key) . '</span>' . TEXT_INVALID_SELECTION . '<span class="alertBlack">' . ($value == (int)PRODUCTS_OPTIONS_VALUES_TEXT_ID ? TEXT_INVALID_USER_INPUT : zen_values_name($value)) . '</span>' . '<br>';
+                    if (zen_get_attributes_valid($_POST['products_id'], $key, $value) === false) {
+                        $the_list .=
+                            TEXT_ERROR_OPTION_FOR .
+                            '<span class="alertBlack">' . zen_options_name($key) . '</span>' .
+                            TEXT_INVALID_SELECTION .
+                            '<span class="alertBlack">' .
+                                ($value == (int)PRODUCTS_OPTIONS_VALUES_TEXT_ID) ? TEXT_INVALID_USER_INPUT : zen_values_name($value) .
+                            '</span>' .
+                            '<br>';
                     }
                 }
             }
+
             if (!is_numeric($_POST['cart_quantity']) || $_POST['cart_quantity'] <= 0) {
                 // adjust quantity when not a value
                 // If use an extra_cart_actions file to prevent processing by this function,
                 //   then be sure to set $_POST['shopping_cart_zero_or_less'] to a value other than true
                 //   to display success on add to cart and not display the below message.
                 if (!isset($_POST['shopping_cart_zero_or_less'])) {
-                    $chk_link = '<a href="' . zen_href_link(zen_get_info_page($_POST['products_id']), 'cPath=' . (zen_get_generated_category_path_rev(zen_get_products_category_id($_POST['products_id']))) . '&products_id=' . $_POST['products_id']) . '">' . zen_get_products_name($_POST['products_id']) . '</a>';
-                    $messageStack->add_session('header', ERROR_CORRECTIONS_HEADING . ERROR_PRODUCT_QUANTITY_UNITS_SHOPPING_CART . $chk_link . ' ' . PRODUCTS_ORDER_QTY_TEXT . zen_output_string_protected($_POST['cart_quantity']), 'caution');
+                    $chk_link =
+                        '<a href="' . zen_href_link(zen_get_info_page($_POST['products_id']), 'cPath=' . (zen_get_generated_category_path_rev(zen_get_products_category_id($_POST['products_id']))) . '&products_id=' . $_POST['products_id']) . '">' .
+                            zen_get_products_name($_POST['products_id']) .
+                        '</a>';
+                    $messageStack->add_session(
+                        'header',
+                        ERROR_CORRECTIONS_HEADING .
+                            ERROR_PRODUCT_QUANTITY_UNITS_SHOPPING_CART .
+                            $chk_link . ' ' .
+                            PRODUCTS_ORDER_QTY_TEXT . zen_output_string_protected($_POST['cart_quantity']),
+                        'caution'
+                    );
                     $_POST['shopping_cart_zero_or_less'] = true;
                 }
                 $_POST['cart_quantity'] = 0;
             }
+
             // verify qty to add
             $add_max = zen_get_products_quantity_order_max($_POST['products_id']);
             $cart_qty = $this->in_cart_mixed($_POST['products_id']);
-            if ($this->display_debug_messages) $messageStack->add_session('header', 'B: FUNCTION ' . __FUNCTION__ . ' Products_id: ' . $_POST['products_id'] . ' cart_qty: ' . $cart_qty . ' $_POST[cart_quantity]: ' . $_POST['cart_quantity'] . ' <br>', 'caution');
+            if ($this->display_debug_messages) {
+                $messageStack->add_session('header', 'B: FUNCTION ' . __FUNCTION__ . ' Products_id: ' . $_POST['products_id'] . ' cart_qty: ' . $cart_qty . ' $_POST[cart_quantity]: ' . $_POST['cart_quantity'] . ' <br>', 'caution');
+            }
             $new_qty = $_POST['cart_quantity'];
 
             $new_qty = $this->adjust_quantity($new_qty, $_POST['products_id'], 'shopping_cart');
@@ -1927,7 +2008,7 @@ class shoppingCart extends base
             // adjust new quantity to be no more than current in stock
             $chk_current_qty = zen_get_products_stock($_POST['products_id']);
             $this->flag_duplicate_msgs_set = false;
-            if (STOCK_ALLOW_CHECKOUT == 'false' && ($cart_qty + $new_qty > $chk_current_qty)) {
+            if (STOCK_ALLOW_CHECKOUT === 'false' && ($cart_qty + $new_qty) > $chk_current_qty) {
                 $new_qty = $chk_current_qty;
                 $messageStack->add_session('shopping_cart', ($this->display_debug_messages ? 'C: FUNCTION ' . __FUNCTION__ . ': ' : '') . WARNING_PRODUCT_QUANTITY_ADJUSTED . zen_get_products_name($_POST['products_id']), 'caution');
                 $this->flag_duplicate_msgs_set = true;
@@ -1938,45 +2019,48 @@ class shoppingCart extends base
                 $new_qty = 0;
                 $adjust_max = 'true';
             } else {
-                // adjust new quantity to be no more than current in stock
-                if (STOCK_ALLOW_CHECKOUT == 'false' && ($new_qty + $cart_qty > $chk_current_qty)) {
+                if (STOCK_ALLOW_CHECKOUT === 'false' && ($new_qty + $cart_qty) > $chk_current_qty) {
+                    // adjust new quantity to be no more than current in stock
                     $adjust_new_qty = 'true';
                     $alter_qty = $chk_current_qty - $cart_qty;
-                    $new_qty = ($alter_qty > 0 ? $alter_qty : 0);
+                    $new_qty = ($alter_qty > 0) ? $alter_qty : 0;
                     if (!$this->flag_duplicate_msgs_set) {
                         $messageStack->add_session('shopping_cart', ($this->display_debug_messages ? 'D: FUNCTION ' . __FUNCTION__ . ': ' : '') . WARNING_PRODUCT_QUANTITY_ADJUSTED . zen_get_products_name($_POST['products_id']), 'caution');
                     }
                 }
 
                 // adjust quantity if needed
-                if (($new_qty + $cart_qty > $add_max) && $add_max != 0) {
+                if ($add_max != 0 && ($new_qty + $cart_qty) > $add_max) {
                     $adjust_max = 'true';
                     $new_qty = $add_max - $cart_qty;
                 }
             }
+
             if (zen_get_products_quantity_order_max($_POST['products_id']) == 1 && $this->in_cart_mixed($_POST['products_id']) == 1) {
                 // do not add
             } else {
                 // process normally
                 // bof: set error message
-                if ($the_list != '') {
+                if ($the_list !== '') {
                     $messageStack->add('product_info', ERROR_CORRECTIONS_HEADING . $the_list, 'caution');
                 } else {
                     // process normally
                     // iii 030813 added: File uploading: save uploaded files with unique file names
-                    $real_ids = isset($_POST['id']) ? $_POST['id'] : [];
+                    $real_ids = $_POST['id'] ?? [];
                     if (isset($_GET['number_of_uploads']) && $_GET['number_of_uploads'] > 0) {
                         /**
                          * Need the upload class for attribute type that allows user uploads.
                          *
                          */
-                        include_once(DIR_WS_CLASSES . 'upload.php');
+                        include_once DIR_WS_CLASSES . 'upload.php';
                         for ($i = 1, $n = $_GET['number_of_uploads']; $i <= $n; $i++) {
-                            if (isset($_POST[UPLOAD_PREFIX . $i]) && !empty($_FILES['id']['tmp_name'][TEXT_PREFIX . $_POST[UPLOAD_PREFIX . $i]]) && (!isset($_POST[UPLOAD_PREFIX . $i]) || !isset($_FILES['id']['tmp_name'][TEXT_PREFIX . $_POST[UPLOAD_PREFIX . $i]]) || ($_FILES['id']['tmp_name'][TEXT_PREFIX . $_POST[UPLOAD_PREFIX . $i]] != 'none'))) {
+                            $upload_prefix = UPLOAD_PREFIX . $i;
+                            $text_prefix = TEXT_PREFIX . ($_POST[$upload_prefix] ?? '');
+                            if (isset($_POST[$upload_prefix]) && !empty($_FILES['id']['tmp_name'][$text_prefix]) && (!isset($_POST[$upload_prefix], $_FILES['id']['tmp_name'][$text_prefix]) || $_FILES['id']['tmp_name'][$text_prefix] != 'none')) {
                                 $products_options_file = new upload('id');
                                 $products_options_file->set_destination(DIR_FS_UPLOADS);
                                 $products_options_file->set_output_messages('session');
-                                if ($products_options_file->parse(TEXT_PREFIX . $_POST[UPLOAD_PREFIX . $i])) {
+                                if ($products_options_file->parse($text_prefix)) {
                                     $products_image_extension = substr($products_options_file->filename, strrpos($products_options_file->filename, '.'));
                                     if (zen_is_logged_in()) {
                                         $db->Execute("INSERT INTO " . TABLE_FILES_UPLOADED . " (sesskey, customers_id, files_uploaded_name) VALUES ('" . zen_session_id() . "', " . (int)$_SESSION['customer_id'] . ", '" . zen_db_input($products_options_file->filename) . "')");
@@ -1984,8 +2068,8 @@ class shoppingCart extends base
                                         $db->Execute("INSERT INTO " . TABLE_FILES_UPLOADED . " (sesskey, files_uploaded_name) VALUES ('" . zen_session_id() . "', '" . zen_db_input($products_options_file->filename) . "')");
                                     }
                                     $insert_id = $db->Insert_ID();
-                                    $real_ids[TEXT_PREFIX . $_POST[UPLOAD_PREFIX . $i]] = $insert_id . ". " . $products_options_file->filename;
-                                    $products_options_file->set_filename("$insert_id" . $products_image_extension);
+                                    $real_ids[$text_prefix] = $insert_id . ". " . $products_options_file->filename;
+                                    $products_options_file->set_filename($insert_id . $products_image_extension);
                                     if (!($products_options_file->save())) {
                                         break;
                                     }
@@ -1993,15 +2077,24 @@ class shoppingCart extends base
                                     break;
                                 }
                             } else { // No file uploaded -- use previous value
-                                $real_ids[TEXT_PREFIX . $_POST[UPLOAD_PREFIX . $i]] = isset($_POST[TEXT_PREFIX . UPLOAD_PREFIX . $i]) ? $_POST[TEXT_PREFIX . UPLOAD_PREFIX . $i] : '';
-                                if (!zen_get_attributes_valid($_POST['products_id'], TEXT_PREFIX . $_POST[UPLOAD_PREFIX . $i], !empty($_POST[TEXT_PREFIX . UPLOAD_PREFIX . $i]) ? $_POST[TEXT_PREFIX . UPLOAD_PREFIX . $i] : '')) {
-                                    $the_list .= TEXT_ERROR_OPTION_FOR . '<span class="alertBlack">' . zen_options_name($_POST[UPLOAD_PREFIX . $i]) . '</span>' . TEXT_INVALID_SELECTION . '<span class="alertBlack">' . ($_POST[TEXT_PREFIX . UPLOAD_PREFIX . $i] == (int)PRODUCTS_OPTIONS_VALUES_TEXT_ID ? TEXT_INVALID_USER_INPUT : zen_values_name($value)) . '</span>' . '<br>';
+                                $real_ids[$text_prefix] = $_POST[$text_prefix] ?? '';
+                                if (!zen_get_attributes_valid($_POST['products_id'], $text_prefix, !empty($_POST[$text_prefix]) ? $_POST[$text_prefix] : '')) {
+                                    $the_list .=
+                                        TEXT_ERROR_OPTION_FOR .
+                                        '<span class="alertBlack">' .
+                                            zen_options_name($_POST[$upload_prefix]) .
+                                        '</span>' .
+                                        TEXT_INVALID_SELECTION .
+                                        '<span class="alertBlack">' .
+                                            ((int)$_POST[$text_prefix] === (int)PRODUCTS_OPTIONS_VALUES_TEXT_ID) ? TEXT_INVALID_USER_INPUT : zen_values_name($value) .
+                                        '</span>' .
+                                        '<br>';
                                     $new_qty = 0; // Don't increase the quantity of product in the cart.
                                 }
                             }
                         }
 
-                        if ($the_list != '') {
+                        if ($the_list !== '') {
                             $messageStack->add('product_info', ERROR_CORRECTIONS_HEADING . $the_list, 'caution');
                         }
 
@@ -2011,19 +2104,21 @@ class shoppingCart extends base
                     }
 
                     // do the actual add to cart
-                    $this->add_cart($_POST['products_id'], $this->get_quantity(zen_get_uprid($_POST['products_id'], $real_ids)) + ($new_qty), $real_ids);
+                    $this->add_cart($_POST['products_id'], $this->get_quantity(zen_get_uprid($_POST['products_id'], $real_ids)) + $new_qty, $real_ids);
                     // iii 030813 end of changes.
                 } // eof: set error message
             } // eof: quantity maximum = 1
 
             if ($adjust_max == 'true') {
                 $messageStack->add_session('shopping_cart', ERROR_MAXIMUM_QTY . zen_get_products_name($_POST['products_id']), 'caution');
-                if ($this->display_debug_messages) $messageStack->add_session('header', 'E: FUNCTION ' . __FUNCTION__ . '<br>' . ERROR_MAXIMUM_QTY . zen_get_products_name($_POST['products_id']), 'caution');
+                if ($this->display_debug_messages) {
+                    $messageStack->add_session('header', 'E: FUNCTION ' . __FUNCTION__ . '<br>' . ERROR_MAXIMUM_QTY . zen_get_products_name($_POST['products_id']), 'caution');
+                }
             }
         }
         if (empty($the_list)) { // no errors
             // display message if all is good and not on shopping_cart page
-            if (DISPLAY_CART == 'false' && $_GET['main_page'] != FILENAME_SHOPPING_CART && $messageStack->size('shopping_cart') == 0) {
+            if (DISPLAY_CART === 'false' && $_GET['main_page'] !== FILENAME_SHOPPING_CART && $messageStack->size('shopping_cart') === 0) {
                 if (!isset($_POST['shopping_cart_zero_or_less']) || $_POST['shopping_cart_zero_or_less'] !== true) {
                     $messageStack->add_session('header', ($this->display_debug_messages ? 'FUNCTION ' . __FUNCTION__ . ': ' : '') . SUCCESS_ADDED_TO_CART_PRODUCT, 'success');
                     $this->notify('NOTIFIER_CART_OPTIONAL_SUCCESS_PRODUCT_ADDED_TO_CART', $_POST, $goto, $parameters);
@@ -2047,34 +2142,37 @@ class shoppingCart extends base
     public function actionBuyNow($goto, $parameters = [])
     {
         global $messageStack;
-        if ($this->display_debug_messages) $messageStack->add_session('header', 'FUNCTION ' . __FUNCTION__ . ' $_GET[products_id]: ' . $_GET['products_id'], 'caution');
+        if ($this->display_debug_messages) {
+            $messageStack->add_session('header', 'FUNCTION ' . __FUNCTION__ . ' $_GET[products_id]: ' . $_GET['products_id'], 'caution');
+        }
 
-        $this->flag_duplicate_msgs_set = FALSE;
+        $this->flag_duplicate_msgs_set = false;
         $allow_into_cart = 'N';
         if (isset($_GET['products_id'])) {
             if (zen_requires_attribute_selection($_GET['products_id'])) {
                 zen_redirect(zen_href_link(zen_get_info_page($_GET['products_id']), 'products_id=' . $_GET['products_id']));
             }
             $allow_into_cart = zen_get_products_allow_add_to_cart((int)$_GET['products_id']);
-            if ($allow_into_cart == 'Y') {
+            if ($allow_into_cart === 'Y') {
                 $add_max = zen_get_products_quantity_order_max($_GET['products_id']);
                 $cart_qty = $this->in_cart_mixed($_GET['products_id']);
                 $new_qty = zen_get_buy_now_qty($_GET['products_id']);
                 if (!is_numeric($new_qty) || $new_qty < 0) {
                     // adjust quantity when not a value
-                    $chk_link = '<a href="' . zen_href_link(zen_get_info_page($_GET['products_id']), 'cPath=' . (zen_get_generated_category_path_rev(zen_get_products_category_id($_GET['products_id']))) . '&products_id=' . $_GET['products_id']) . '">' . zen_get_products_name($_GET['products_id']) . '</a>';
+                    $chk_link =
+                        '<a href="' . zen_href_link(zen_get_info_page($_GET['products_id']), 'cPath=' . (zen_get_generated_category_path_rev(zen_get_products_category_id($_GET['products_id']))) . '&products_id=' . $_GET['products_id']) . '">' .
+                            zen_get_products_name($_GET['products_id']) .
+                        '</a>';
                     $messageStack->add_session('header', ERROR_CORRECTIONS_HEADING . ERROR_PRODUCT_QUANTITY_UNITS_SHOPPING_CART . $chk_link . ' ' . PRODUCTS_ORDER_QTY_TEXT . zen_output_string_protected($new_qty), 'caution');
                     $new_qty = 0;
                 }
-                if (($add_max == 1 and $cart_qty == 1)) {
+                if ($add_max == 1 && $cart_qty == 1) {
                     // do not add
                     $new_qty = 0;
-                } else {
-                    // adjust quantity if needed
-                    if (($new_qty + $cart_qty > $add_max) && $add_max != 0) {
-                        $new_qty = $add_max - $cart_qty;
-                    }
+                } elseif ($add_max != 0 && ($new_qty + $cart_qty > $add_max)) { // adjust quantity if needed
+                    $new_qty = $add_max - $cart_qty;
                 }
+
                 if ((zen_get_products_quantity_order_max($_GET['products_id']) == 1 && $this->in_cart_mixed($_GET['products_id']) == 1)) {
                     // do not add
                 } else {
@@ -2083,16 +2181,18 @@ class shoppingCart extends base
                 }
             }
         }
+
         // display message if all is good and not on shopping_cart page
-        if ((DISPLAY_CART == 'false' && $_GET['main_page'] != FILENAME_SHOPPING_CART) && $messageStack->size('shopping_cart') == 0 && ($allow_into_cart == 'Y')) {
-            $messageStack->add_session('header', ($this->display_debug_messages ? 'FUNCTION ' . __FUNCTION__ . ': ' : '') . SUCCESS_ADDED_TO_CART_PRODUCTS, 'success');
-            $this->notify('NOTIFIER_CART_OPTIONAL_SUCCESS_BUYNOW_ADDED_TO_CART', $_GET, $goto, $parameters);
-        } else {
-            if (DISPLAY_CART == 'false'  && ($allow_into_cart !== 'Y')) {
+        if (DISPLAY_CART === 'false') {
+            if ($_GET['main_page'] !== FILENAME_SHOPPING_CART && $allow_into_cart === 'Y' && $messageStack->size('shopping_cart') === 0) {
+                $messageStack->add_session('header', ($this->display_debug_messages ? 'FUNCTION ' . __FUNCTION__ . ': ' : '') . SUCCESS_ADDED_TO_CART_PRODUCTS, 'success');
+                $this->notify('NOTIFIER_CART_OPTIONAL_SUCCESS_BUYNOW_ADDED_TO_CART', $_GET, $goto, $parameters);
+            } elseif ($allow_into_cart !== 'Y') {
                 //zen_redirect(zen_href_link(FILENAME_SHOPPING_CART));
                 $messageStack->add_session('header', ($this->display_debug_messages ? 'FUNCTION ' . __FUNCTION__ . ': ' : '') . FAILED_TO_ADD_UNAVAILABLE_PRODUCTS, 'error');
             }
         }
+
         $exclude[] = 'action';
         zen_redirect(zen_href_link($goto, zen_get_all_get_params($exclude)));
     }
@@ -2106,7 +2206,9 @@ class shoppingCart extends base
     public function actionMultipleAddProduct($goto, $parameters = [])
     {
         global $messageStack;
-        if ($this->display_debug_messages) $messageStack->add_session('header', 'FUNCTION ' . __FUNCTION__, 'caution');
+        if ($this->display_debug_messages) {
+            $messageStack->add_session('header', 'FUNCTION ' . __FUNCTION__, 'caution');
+        }
 
         $addCount = 0;
         if (!empty($_POST['products_id']) && is_array($_POST['products_id'])) {
@@ -2122,50 +2224,55 @@ class shoppingCart extends base
 
                     // adjust new quantity to be no more than current in stock
                     $chk_current_qty = zen_get_products_stock($prodId);
-                    if (STOCK_ALLOW_CHECKOUT == 'false' && ($new_qty > $chk_current_qty)) {
+                    if (STOCK_ALLOW_CHECKOUT === 'false' && $new_qty > $chk_current_qty) {
                         $new_qty = $chk_current_qty;
                         $messageStack->add_session('shopping_cart', ($this->display_debug_messages ? 'FUNCTION ' . __FUNCTION__ . ': ' : '') . WARNING_PRODUCT_QUANTITY_ADJUSTED . zen_get_products_name($prodId), 'caution');
                     }
 
-                    if (($add_max == 1 and $cart_qty == 1)) {
+                    if ($add_max == 1 && $cart_qty == 1) {
                         // do not add
                         $adjust_max = 'true';
                     } else {
                         // adjust new quantity to be no more than current in stock
-                        if (STOCK_ALLOW_CHECKOUT == 'false' && ($new_qty + $cart_qty > $chk_current_qty)) {
+                        if (STOCK_ALLOW_CHECKOUT === 'false' && ($new_qty + $cart_qty) > $chk_current_qty) {
                             $adjust_new_qty = 'true';
                             $alter_qty = $chk_current_qty - $cart_qty;
-                            $new_qty = ($alter_qty > 0 ? $alter_qty : 0);
+                            $new_qty = ($alter_qty > 0) ? $alter_qty : 0;
                             $messageStack->add_session('shopping_cart', ($this->display_debug_messages ? 'FUNCTION ' . __FUNCTION__ . ': ' : '') . WARNING_PRODUCT_QUANTITY_ADJUSTED . zen_get_products_name($prodId), 'caution');
                         }
 
                         // adjust quantity if needed
-                        if ((($new_qty + $cart_qty > $add_max) && $add_max != 0)) {
+                        if ($add_max != 0 && ($new_qty + $cart_qty) > $add_max) {
                             $adjust_max = 'true';
                             $new_qty = $add_max - $cart_qty;
                         }
                         $this->add_cart($prodId, $this->get_quantity($prodId) + ($new_qty));
                         $addCount++;
                     }
-                    if ($adjust_max == 'true') {
-                        if ($this->display_debug_messages) $messageStack->add_session('header', 'FUNCTION ' . __FUNCTION__ . '<br>' . ERROR_MAXIMUM_QTY . zen_get_products_name($prodId), 'caution');
+                    if ($adjust_max === 'true') {
+                        if ($this->display_debug_messages) {
+                            $messageStack->add_session('header', 'FUNCTION ' . __FUNCTION__ . '<br>' . ERROR_MAXIMUM_QTY . zen_get_products_name($prodId), 'caution');
+                        }
                         $messageStack->add_session('shopping_cart', ERROR_MAXIMUM_QTY . zen_get_products_name($prodId), 'caution');
                     }
                 }
                 if (!is_numeric($val) || $val < 0) {
                     // adjust quantity when not a value
-                    $chk_link = '<a href="' . zen_href_link(zen_get_info_page($prodId), 'cPath=' . (zen_get_generated_category_path_rev(zen_get_products_category_id($prodId))) . '&products_id=' . $prodId) . '">' . zen_get_products_name($prodId) . '</a>';
+                    $chk_link =
+                        '<a href="' . zen_href_link(zen_get_info_page($prodId), 'cPath=' . (zen_get_generated_category_path_rev(zen_get_products_category_id($prodId))) . '&products_id=' . $prodId) . '">' .
+                            zen_get_products_name($prodId) .
+                        '</a>';
                     $messageStack->add_session('header', ERROR_CORRECTIONS_HEADING . ERROR_PRODUCT_QUANTITY_UNITS_SHOPPING_CART . $chk_link . ' ' . PRODUCTS_ORDER_QTY_TEXT . zen_output_string_protected($val), 'caution');
                     $val = 0;
                 }
             }
 
             // display message if all is good and not on shopping_cart page
-            if (($addCount && DISPLAY_CART == 'false' && $_GET['main_page'] != FILENAME_SHOPPING_CART) && $messageStack->size('shopping_cart') == 0) {
-                $messageStack->add_session('header', ($this->display_debug_messages ? 'FUNCTION ' . __FUNCTION__ . ': ' : '') . SUCCESS_ADDED_TO_CART_PRODUCTS, 'success');
-                $this->notify('NOTIFIER_CART_OPTIONAL_SUCCESS_MULTIPLE_ADDED_TO_CART', $products_list, $goto, $parameters);
-            } else {
-                if (DISPLAY_CART == 'false') {
+            if (DISPLAY_CART === 'false') {
+                if ($addCount && $_GET['main_page'] !== FILENAME_SHOPPING_CART && $messageStack->size('shopping_cart') === 0) {
+                    $messageStack->add_session('header', ($this->display_debug_messages ? 'FUNCTION ' . __FUNCTION__ . ': ' : '') . SUCCESS_ADDED_TO_CART_PRODUCTS, 'success');
+                    $this->notify('NOTIFIER_CART_OPTIONAL_SUCCESS_MULTIPLE_ADDED_TO_CART', $products_list, $goto, $parameters);
+                } else {
                     zen_redirect(zen_href_link(FILENAME_SHOPPING_CART));
                 }
             }
@@ -2185,36 +2292,27 @@ class shoppingCart extends base
     {
         global $db;
         if (zen_is_logged_in() && !zen_in_guest_checkout()) {
-            if (isset($_GET['products_id'])) {
-                $notify = $_GET['products_id'];
-            } elseif (isset($_GET['notify'])) {
-                $notify = $_GET['notify'];
-            } elseif (isset($_POST['notify'])) {
-                $notify = $_POST['notify'];
-            } else {
-                return zen_redirect(zen_href_link($_GET['main_page'], zen_get_all_get_params(['action', 'notify', 'main_page'])));
+            $notify = $_GET['products_id'] ?? $_GET['notify'] ?? $_POST['notify'] ?? null;
+            if ($notify === null) {
+                zen_redirect(zen_href_link($_GET['main_page'], zen_get_all_get_params(['action', 'notify', 'main_page'])));
             }
 
-            if (!is_array($notify)) $notify = [$notify];
+            if (!is_array($notify)) {
+                $notify = [$notify];
+            }
             foreach ($notify as $product_id) {
-                $sql = "SELECT count(*) AS count
-                        FROM " . TABLE_PRODUCTS_NOTIFICATIONS . "
-                        WHERE products_id = " . (int)$product_id . "
-                        AND customers_id = " . (int)$_SESSION['customer_id'];
-                $check = $db->Execute($sql);
-                if ($check->fields['count'] < 1) {
-                    $sql = "INSERT INTO " . TABLE_PRODUCTS_NOTIFICATIONS . "
-                            (products_id, customers_id, date_added)
-                            VALUES (" . (int)$product_id . ", " . (int)$_SESSION['customer_id'] . ", now())";
-                    $db->Execute($sql);
-                }
+                $sql =
+                    "INSERT IGNORE INTO " . TABLE_PRODUCTS_NOTIFICATIONS . "
+                        (products_id, customers_id, date_added)
+                     VALUES
+                        (" . (int)$product_id . ", " . (int)$_SESSION['customer_id'] . ", now())";
+                $db->Execute($sql);
             }
-            return zen_redirect(zen_href_link($_GET['main_page'], zen_get_all_get_params(['action', 'notify', 'main_page'])));
-
+            zen_redirect(zen_href_link($_GET['main_page'], zen_get_all_get_params(['action', 'notify', 'main_page'])));
         }
 
         $_SESSION['navigation']->set_snapshot();
-        return zen_redirect(zen_href_link(FILENAME_LOGIN, '', 'SSL'));
+        zen_redirect(zen_href_link(FILENAME_LOGIN, '', 'SSL'));
     }
 
     /**
@@ -2229,23 +2327,16 @@ class shoppingCart extends base
     {
         global $db;
         if (zen_is_logged_in() && !zen_in_guest_checkout() && isset($_GET['products_id'])) {
-            $sql = "SELECT count(*) AS count
-                    FROM " . TABLE_PRODUCTS_NOTIFICATIONS . "
-                    WHERE products_id = " . (int)$_GET['products_id'] . "
+            $sql =
+                "DELETE FROM " . TABLE_PRODUCTS_NOTIFICATIONS . "
+                  WHERE products_id = " . (int)$_GET['products_id'] . "
                     AND customers_id = " . (int)$_SESSION['customer_id'];
-            $check = $db->Execute($sql);
-
-            if ($check->fields['count'] > 0) {
-                $sql = "DELETE FROM " . TABLE_PRODUCTS_NOTIFICATIONS . "
-                        WHERE products_id = " . (int)$_GET['products_id'] . "
-                        AND customers_id = " . (int)$_SESSION['customer_id'];
-                $db->Execute($sql);
-            }
+            $db->Execute($sql, 1);
             zen_redirect(zen_href_link($_GET['main_page'], zen_get_all_get_params(['action', 'main_page'])));
-        } else {
-            $_SESSION['navigation']->set_snapshot();
-            zen_redirect(zen_href_link(FILENAME_LOGIN, '', 'SSL'));
         }
+
+        $_SESSION['navigation']->set_snapshot();
+        zen_redirect(zen_href_link(FILENAME_LOGIN, '', 'SSL'));
     }
 
     /**
@@ -2256,8 +2347,10 @@ class shoppingCart extends base
      */
     public function actionCustomerOrder($goto, $parameters)
     {
-        global $zco_page, $messageStack;
-        if ($this->display_debug_messages) $messageStack->add_session('header', 'FUNCTION ' . __FUNCTION__, 'caution');
+        global $messageStack;
+        if ($this->display_debug_messages) {
+            $messageStack->add_session('header', 'FUNCTION ' . __FUNCTION__, 'caution');
+        }
 
         if (zen_is_logged_in() && isset($_GET['pid'])) {
             if (zen_has_product_attributes($_GET['pid'])) {
@@ -2267,10 +2360,10 @@ class shoppingCart extends base
             }
         }
         // display message if all is good and not on shopping_cart page
-        if ((DISPLAY_CART == 'false' && $_GET['main_page'] != FILENAME_SHOPPING_CART) && $messageStack->size('shopping_cart') == 0) {
-            $messageStack->add_session('header', ($this->display_debug_messages ? 'FUNCTION ' . __FUNCTION__ . ': ' : '') . SUCCESS_ADDED_TO_CART_PRODUCTS, 'success');
-        } else {
-            if (DISPLAY_CART == 'false') {
+        if (DISPLAY_CART === 'false') {
+            if ($_GET['main_page'] !== FILENAME_SHOPPING_CART && $messageStack->size('shopping_cart') === 0) {
+                $messageStack->add_session('header', ($this->display_debug_messages ? 'FUNCTION ' . __FUNCTION__ . ': ' : '') . SUCCESS_ADDED_TO_CART_PRODUCTS, 'success');
+            } else {
                 zen_redirect(zen_href_link(FILENAME_SHOPPING_CART));
             }
         }
@@ -2285,7 +2378,9 @@ class shoppingCart extends base
      */
     public function actionRemoveProduct($goto, $parameters)
     {
-        if (!empty($_GET['product_id'])) $this->remove($_GET['product_id']);
+        if (!empty($_GET['product_id'])) {
+            $this->remove($_GET['product_id']);
+        }
         $parameters[] = 'product_id';
         zen_redirect(zen_href_link($goto, zen_get_all_get_params($parameters)));
     }
@@ -2314,25 +2409,22 @@ class shoppingCart extends base
     public function adjust_quantity($check_qty, $product_id, $messageStackPosition = 'shopping_cart')
     {
         global $messageStack;
-        if ($messageStackPosition == '' || $messageStackPosition == false) $messageStackPosition = 'shopping_cart';
+        if ($messageStackPosition == '' || $messageStackPosition == false) {
+            $messageStackPosition = 'shopping_cart';
+        }
         $old_quantity = $check_qty;
-        if (QUANTITY_DECIMALS != 0) {
+        if (QUANTITY_DECIMALS !== '0') {
             $fix_qty = $check_qty;
-            switch (true) {
-                case (!strstr($fix_qty, '.')):
-                    $new_qty = $fix_qty;
-                    break;
-                default:
-                    $new_qty = preg_replace('/[0]+$/', '', $check_qty);
-                    break;
-            }
-        } else {
-            if ($check_qty != round($check_qty, QUANTITY_DECIMALS)) {
-                $new_qty = round($check_qty, QUANTITY_DECIMALS);
-                $messageStack->add_session($messageStackPosition, ERROR_QUANTITY_ADJUSTED . zen_get_products_name($product_id) . ERROR_QUANTITY_CHANGED_FROM . $old_quantity . ERROR_QUANTITY_CHANGED_TO . $new_qty, 'caution');
+            if (strpos($fix_qty, '.') !== false) {
+                $new_qty = $fix_qty;
             } else {
-                $new_qty = $check_qty;
+                $new_qty = preg_replace('/[0]+$/', '', $check_qty);
             }
+        } elseif ($check_qty != round($check_qty, QUANTITY_DECIMALS)) {
+            $new_qty = round($check_qty, QUANTITY_DECIMALS);
+            $messageStack->add_session($messageStackPosition, ERROR_QUANTITY_ADJUSTED . zen_get_products_name($product_id) . ERROR_QUANTITY_CHANGED_FROM . $old_quantity . ERROR_QUANTITY_CHANGED_TO . $new_qty, 'caution');
+        } else {
+            $new_qty = $check_qty;
         }
         return $new_qty;
     }
@@ -2349,17 +2441,18 @@ class shoppingCart extends base
     public function in_cart_check_attrib_quantity($check_option_id, $check_option_values_id)
     {
         // if nothing is in cart return 0
-        if (!is_array($this->contents)) return 0;
+        if (!is_array($this->contents)) {
+            return 0;
+        }
 
         $in_cart_check_qty = 0;
         // get products in cart to check
         $chk_products = $this->get_products();
-        for ($i = 0, $n = count($chk_products); $i < $n; $i++) {
-            if (is_array($chk_products[$i]['attributes'])) {
-                foreach ($chk_products[$i]['attributes'] as $option => $value) {
+        foreach ($chk_products as $next_chk) {
+            if (is_array($next_chk['attributes'])) {
+                foreach ($next_chk['attributes'] as $option => $value) {
                     if ($option == $check_option_id && $value == $check_option_values_id) {
-                        //          echo 'Attribute FOUND FOR $option: ' . $option . ' $value: ' . $value . ' quantity: ' . $chk_products[$i]['quantity'] . '<br><br>';
-                        $in_cart_check_qty += $chk_products[$i]['quantity'];
+                        $in_cart_check_qty += $next_chk['quantity'];
                     }
                 }
             }
@@ -2379,15 +2472,10 @@ class shoppingCart extends base
     {
         $products = $this->get_products();
         $in_cart_product_price = 0;
-//echo '<pre>'; echo print_r($products); echo '</pre>';
+
         foreach ($products as $key => $val) {
-            $productsName = $products[$key]['name'];
-            $ppe = $products[$key]['final_price'];
-            $ppt = $ppe * $val['quantity'];
-            $productsPriceEach = $ppe + $val['onetime_charges'];
-            $productsPriceTotal = $ppt + $val['onetime_charges'];
-            if ((int)$product_id == (int)$val['id']) {
-                $in_cart_product_price += $productsPriceTotal;
+            if ((int)$product_id === (int)$val['id']) {
+                $in_cart_product_price += ($val['final_price'] * $val['quantity']) + $val['onetime_charges'];
             }
         }
         return $in_cart_product_price;
@@ -2404,11 +2492,11 @@ class shoppingCart extends base
     public function in_cart_product_total_quantity($product_id)
     {
         $products = $this->get_products();
-//echo '<pre>'; echo print_r($products); echo '</pre>';
+
         $in_cart_product_quantity = 0;
         foreach ($products as $key => $val) {
-            if ((int)$product_id == (int)$val['id']) {
-                $in_cart_product_quantity += $products[$key]['quantity'];
+            if ((int)$product_id === (int)$val['id']) {
+                $in_cart_product_quantity += $val['quantity'];
             }
         }
         return $in_cart_product_quantity;
@@ -2427,7 +2515,7 @@ class shoppingCart extends base
         $products = $this->get_products();
         $in_cart_product_weight = 0;
         foreach ($products as $product) {
-            if ((int)$product_id == (int)$product['id']) {
+            if ((int)$product_id === (int)$product['id']) {
                 $in_cart_product_weight += $product['weight'] * $product['quantity'];
             }
         }
@@ -2447,7 +2535,7 @@ class shoppingCart extends base
         $products = $this->get_products();
         $in_cart_product_weight = 0;
         foreach ($products as $product) {
-            if ($product['category'] == $category_id) {
+            if ($product['category'] === $category_id) {
                 $in_cart_product_weight += $product['weight'] * $product['quantity'];
             }
         }
@@ -2466,15 +2554,10 @@ class shoppingCart extends base
     {
         $products = $this->get_products();
         $in_cart_product_price = 0;
-//echo '<pre>'; echo print_r($products); echo '</pre>';
+
         foreach ($products as $key => $val) {
-            $productsName = $products[$key]['name'];
-            $ppe = $products[$key]['final_price'];
-            $ppt = $ppe * $val['quantity'];
-            $productsPriceEach = $ppe + $val['onetime_charges'];
-            $productsPriceTotal = $ppt + $val['onetime_charges'];
             if ($val['category'] == $category_id) {
-                $in_cart_product_price += $productsPriceTotal;
+                $in_cart_product_price += ($val['final_price'] * $val['quantity']) + $val['onetime_charges'];
             }
         }
         return $in_cart_product_price;
@@ -2491,11 +2574,11 @@ class shoppingCart extends base
     public function in_cart_product_total_quantity_category($category_id)
     {
         $products = $this->get_products();
-//echo '<pre>'; echo print_r($products); echo '</pre>';
+
         $in_cart_product_quantity = 0;
         foreach ($products as $key => $val) {
             if ($val['category'] == $category_id) {
-                $in_cart_product_quantity += $products[$key]['quantity'];
+                $in_cart_product_quantity += $val['quantity'];
             }
         }
         return $in_cart_product_quantity;
@@ -2511,16 +2594,15 @@ class shoppingCart extends base
      */
     public function in_cart_product_total_weight_category_sub($category_id)
     {
+        if (!zen_has_category_subcategories($category_id)) {
+           return $this->in_cart_product_total_weight_category($category_id);
+        }
+
+        $subcategories_array = [];
+        zen_get_subcategories($subcategories_array, $category_id); // parent categories_id
         $chk_cart_weight = 0;
-        if (zen_has_category_subcategories($category_id)) {
-            $subcategories_array = [];
-            $chk_cat = $category_id; // parent categories_id
-            zen_get_subcategories($subcategories_array, $chk_cat);
-            foreach ($subcategories_array as $category) {
-                $chk_cart_weight += $this->in_cart_product_total_weight_category($category);
-            }
-        } else {
-            $chk_cart_weight = $this->in_cart_product_total_weight_category($category_id);
+        foreach ($subcategories_array as $category) {
+            $chk_cart_weight += $this->in_cart_product_total_weight_category($category);
         }
         return $chk_cart_weight;
     }
@@ -2535,16 +2617,15 @@ class shoppingCart extends base
      */
     public function in_cart_product_total_price_category_sub($category_id)
     {
+        if (!zen_has_category_subcategories($category_id)) {
+            return $this->in_cart_product_total_price_category($category_id);
+        }
+
+        $subcategories_array = [];
+        zen_get_subcategories($subcategories_array, $category_id); // parent categories_id
         $chk_cart_price = 0;
-        if (zen_has_category_subcategories($category_id)) {
-            $subcategories_array = [];
-            $chk_cat = $category_id; // parent categories_id
-            zen_get_subcategories($subcategories_array, $chk_cat);
-            foreach ($subcategories_array as $category) {
-                $chk_cart_price += $this->in_cart_product_total_price_category($category);
-            }
-        } else {
-            $chk_cart_price = $this->in_cart_product_total_price_category($category_id);
+        foreach ($subcategories_array as $category) {
+            $chk_cart_price += $this->in_cart_product_total_price_category($category);
         }
         return $chk_cart_price;
     }
@@ -2559,16 +2640,15 @@ class shoppingCart extends base
      */
     public function in_cart_product_total_quantity_category_sub($category_id)
     {
+        if (!zen_has_category_subcategories($category_id)) {
+            return $this->in_cart_product_total_quantity_category($category_id);
+        }
+
+        $subcategories_array = [];
+        zen_get_subcategories($subcategories_array, $category_id); // parent categories_id
         $chk_cart_quantity = 0;
-        if (zen_has_category_subcategories($category_id)) {
-            $subcategories_array = [];
-            $chk_cat = $category_id; // parent categories_id
-            zen_get_subcategories($subcategories_array, $chk_cat);
-            foreach ($subcategories_array as $category) {
-                $chk_cart_quantity += $this->in_cart_product_total_quantity_category($category);
-            }
-        } else {
-            $chk_cart_quantity = $this->in_cart_product_total_quantity_category($category_id);
+        foreach ($subcategories_array as $category) {
+            $chk_cart_quantity += $this->in_cart_product_total_quantity_category($category);
         }
         return $chk_cart_quantity;
     }
@@ -2595,10 +2675,10 @@ class shoppingCart extends base
         }
 
         // check if mixed is on
-        $product = $db->Execute("SELECT products_id, products_quantity_mixed FROM " . TABLE_PRODUCTS . " WHERE products_id=" . (int)$pr_id, 1);
+        $product = zen_get_product_details((int)$pr_id);
 
         // if mixed attributes is off identify that this product is the last of its kind (which is also the first of its kind).
-        if ($product->fields['products_quantity_mixed'] == '0') {
+        if ($product->fields['products_quantity_mixed'] === '0') {
             return true;
         }
 
@@ -2632,14 +2712,14 @@ class shoppingCart extends base
                 }
 
                 switch (true) {
-                    case ($chk == 'increase'): // track only increases
+                    case ($chk === 'increase'): // track only increases
                         if ($_POST['cart_quantity'][$i] > $current_qty) {
                             $product_tracked_changed[$products_id] = true;  // Identify that the specific product changed
                             $product_last_changed[$prs_id] = $products_id; // Identify what the last changed product was.
                             $product_increase[] = $products_id;
                         }
                         break;
-                    case ($chk == 'decrease'): // track only decreases
+                    case ($chk === 'decrease'): // track only decreases
                         if ($_POST['cart_quantity'][$i] < $current_qty) {
                             $product_tracked_changed[$products_id] = true;  // Identify that the specific product changed
                             $product_last_changed[$prs_id] = $products_id; // Identify what the last changed product was.
@@ -2655,6 +2735,7 @@ class shoppingCart extends base
                         if ($_POST['cart_quantity'][$i] < $current_qty) {
                             $product_decrease[] = $products_id;
                         }
+                        break;
                 }
             }
         }


### PR DESCRIPTION
Reformatting
- Use null coalescing (??) operator where indicated
- Use short array syntax
- No one-line conditionals
- No one-line multiple assignments

Refactoring
- Since the `contents` property is keyed on a 'uprid', change the `$products_id` key to be `$uprid` on foreach traversals of that array.  That makes it more obvious when viewing the code as to what the `contents` array is keyed on.
- Limit MySQL updates to a single row for unique operations.
- Use `===` where warranted.
- Use `zen_define_default` where warranted.
- Use `strpos` instead of `preg_match` when checking for gift-certificates in the cart.
- Remove redundant code.
- Use `zen_get_product_details` where warranted to get maximum cached queries.  Results in a roughly 50% reduction in time taken to add/remove/update a product as well as the cart's overall calculations!

Corrections
- `calculate` didn't process a 'base' product pricing if a product wasn't found, but *did* process the attributes!  Should the product be removed from the cart if this condition is found?