### PR TITLE
TrafficDashboardWidget: mktime parameters must be ints

### DIFF
--- a/admin/includes/modules/dashboard_widgets/TrafficDashboardWidget.php
+++ b/admin/includes/modules/dashboard_widgets/TrafficDashboardWidget.php
@@ -10,9 +10,8 @@
 
 $maxRows = 15;
 
-
 $i = 0;
-$visit_history = array();
+$visit_history = [];
 //  Get the visitor history data
 $visits_query = "SELECT startdate, counter, session_counter FROM " . TABLE_COUNTER_HISTORY . " ORDER BY startdate DESC";
 $visits = $db->Execute($visits_query, (int)$maxRows, true, 1800);
@@ -20,13 +19,13 @@ $counterData = '';
 foreach ($visits as $data) {
     // table
     $countdate = $data['startdate'];
-    $visit_date = $zcDate->output(DATE_FORMAT_SHORT, mktime(0, 0, 0, substr($countdate, 4, 2), substr($countdate, -2), substr($countdate, 0, 4)));
-    $visit_history[] = array('date' => $visit_date, 'sessions' => $data['session_counter'], 'count' => $data['counter']);
+    $visit_date = $zcDate->output(DATE_FORMAT_SHORT, mktime(0, 0, 0, (int)substr($countdate, 4, 2), (int)substr($countdate, -2), (int)substr($countdate, 0, 4)));
+    $visit_history[] = ['date' => $visit_date, 'sessions' => $data['session_counter'], 'count' => $data['counter']];
     // graph
     if ($i > 0) {
-        $counterData = "," . $counterData;
+        $counterData = ',' . $counterData;
     }
-    $date = $zcDate->output('%a %d', mktime(0, 0, 0, substr($data['startdate'], 4, 2), substr($data['startdate'], -2)));
+    $date = $zcDate->output('%a %d', mktime(0, 0, 0, (int)substr($data['startdate'], 4, 2), (int)substr($data['startdate'], -2)));
     $counterData = "['$date'," . $data['session_counter'] . "," . $data['counter'] . "]" . $counterData;
     $i++;
 }


### PR DESCRIPTION
... for PHP 8.2 and later.  Seeing logs like
```
[15-Oct-2023 08:38:27 America/New_York] PHP Fatal error:  Uncaught TypeError: mktime(): Argument #4 ($month) must be of type ?int, string given in C:\xampp\htdocs\zc200\admin200\includes\modules\dashboard_widgets\TrafficDashboardWidget.php:23
Stack trace:
#0 C:\xampp\htdocs\zc200\admin200\includes\modules\dashboard_widgets\TrafficDashboardWidget.php(23): mktime(0, 0, 0, 'my', 'tt', '`php')
#1 C:\xampp\htdocs\zc200\admin200\index_dashboard.php(65): include('C:\\xampp\\htdocs...')
#2 C:\xampp\htdocs\zc200\admin200\home.php(25): require('C:\\xampp\\htdocs...')
#3 C:\xampp\htdocs\zc200\admin200\index.php(11): require('C:\\xampp\\htdocs...')
#4 {main}
  thrown in C:\xampp\htdocs\zc200\admin200\includes\modules\dashboard_widgets\TrafficDashboardWidget.php on line 23
```