### PR TITLE
Correct sorting on admin's Specials and Featured tools

### DIFF
--- a/admin/featured.php
+++ b/admin/featured.php
@@ -253,12 +253,7 @@ if (!empty($action)) {
             <div class="form-group">
               <?php echo zen_draw_label(TEXT_FEATURED_PRODUCT, 'products_id', 'class="col-sm-3 control-label"'); ?>
               <div class="col-sm-9 col-md-6">
-                <?php
-                if (empty($prev_next_order)) {
-                  $prev_next_order = ' ORDER BY products_model'; // set sort order of dropdown
-                }
-                echo zen_draw_pulldown_products('products_id', 'required size="15" class="form-control" id="products_id"', $featured_array, true, (!empty($_GET['add_products_id']) ? $_GET['add_products_id'] : ''), true);
-                ?>
+                <?= zen_draw_pulldown_products('products_id', 'required size="15" class="form-control" id="products_id"', $featured_array, true, (!empty($_GET['add_products_id']) ? $_GET['add_products_id'] : ''), true); ?>
               </div>
             </div>
           <?php } ?>

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -324,12 +324,7 @@ if (!empty($action)) {
             <div class="form-group">
               <?php echo zen_draw_label(TEXT_SPECIALS_PRODUCT, 'products_id', 'class="col-sm-3 control-label"'); ?>
               <div class="col-sm-9 col-md-6">
-                <?php
-                if (empty($prev_next_order)) {
-                  $prev_next_order = ' ORDER BY products_model'; // set sort order of dropdown
-                }
-                echo zen_draw_pulldown_products('products_id', 'required size="15" class="form-control" id="products_id"', $specials_array, true, (!empty($_GET['add_products_id']) ? $_GET['add_products_id'] : ''), true);
-                ?>
+                <?= zen_draw_pulldown_products('products_id', 'required size="15" class="form-control" id="products_id"', $specials_array, true, (!empty($_GET['add_products_id']) ? $_GET['add_products_id'] : ''), true); ?>
               </div>
             </div>
           <?php } ?>

--- a/includes/functions/functions_categories.php
+++ b/includes/functions/functions_categories.php
@@ -61,7 +61,7 @@ function zen_count_products_in_category($category_id, $include_inactive = false)
     if ($distinct === true) {
         return zen_count_distinct_products_in_category($category_id, $include_inactive);
     }
-    
+
     global $db;
     $products_count = 0;
 
@@ -355,7 +355,7 @@ function zen_product_in_parent_category($product_id, $cat_id, $parent_cat_id)
  */
 function zen_draw_pulldown_products($field_name, $parameters = '', $exclude = [], $show_id = false, $set_selected = 0, $show_model = false, $show_current_category = false, $order_by = '', $filter_by_option_name = null)
 {
-    global $prev_next_order, $current_category_id;
+    global $current_category_id;
 
     $only_active = false;
 
@@ -364,7 +364,7 @@ function zen_draw_pulldown_products($field_name, $parameters = '', $exclude = []
     }
 
     if (empty($order_by)) {
-        $order_by = zen_products_sort_order(false);
+        $order_by = str_replace(['pd.', 'p.'], '', zen_products_sort_order(false));
     }
 
     $sort_array = array_map('trim', array_filter(explode(',', str_ireplace('order by ', '', $order_by))));


### PR DESCRIPTION
persuant to [this conversation on the forum](https://www.zen-cart.com/showthread.php?229738-Admin-Specials-and-Featured-Sort-order&p=1397342#post1397342), the sorting of product pulldowns was not working.  this code addresses that problem.

in addition, it removes the var `$prev_next_order` from a couple of scripts.  it is not used as the pulldown function grabs the config value and sorts the pulldown accordingly within the zen_draw_pulldown_products function (line 367: `zen_products_sort_order(false)`).

i also would like to note that DESC sorting is currently not supported in the pulldowns (there is no DESC sort in the config value for `PRODUCT_INFO_PREVIOUS_NEXT_SORT`).  supporting a DESC sort would require a rethinking/refactoring of the `setSort` function within the pulldown class.