### PR TITLE
Enable override of admin pages' HTML 'title' attribute

### DIFF
--- a/admin/includes/init_includes/init_templates.php
+++ b/admin/includes/init_includes/init_templates.php
@@ -46,4 +46,4 @@ if ($pagename == '') {
   $pagename = STORE_NAME;
 }
 $title = TEXT_ADMIN_TAB_PREFIX . ' ' . $pagename;
-define('TITLE', $title);
+zen_define_default('TITLE', $title);


### PR DESCRIPTION
I've got a client, for instance, that wants the invoice/packingslip `title` attribute to reflect the associated order so that a "Save to PDF" print will automatically have a suggested unique filename.