### PR TITLE
Payment class, correct PHP deprecation by using the correct variable

### DIFF
--- a/includes/classes/payment.php
+++ b/includes/classes/payment.php
@@ -131,7 +131,7 @@ class payment extends base {
       if (isset($credit_covers) && $credit_covers === true) {
           $credit_is_covered = true;
           $this->modules = '';
-          $this->selected_method = '';
+          $this->selected_module = '';
       }
       return $credit_is_covered;
   }


### PR DESCRIPTION
Seeing logs similar to the following due to variable-name 'misspelling':
```
[25-Oct-2023 11:38:20 America/Chicago] Request URI: /index.php?main_page=checkout_process, IP address: x.x.x.x, Language id 1
#0 /home/mystore/public_html/includes/classes/payment.php(134): zen_debug_error_handler()
#1 /home/mystore/public_html/includes/modules/checkout_process.php(84): payment->checkCreditCovered()
#2 /home/mystore/public_html/includes/modules/pages/checkout_process/header_php.php(13): require('/home/mystore/...')
#3 /home/mystore/public_html/index.php(35): require('/home/mystore/...')
--> PHP Deprecated: Creation of dynamic property payment::$selected_method is deprecated in /home/mystore/public_html/includes/classes/payment.php on line 134.
```