### PR TITLE
Protect admin against invalid cPath

### DIFF
--- a/admin/includes/init_includes/init_category_path.php
+++ b/admin/includes/init_includes/init_category_path.php
@@ -10,19 +10,22 @@ if (!defined('IS_ADMIN_FLAG')) {
 }
 
 // calculate category path
-if (isset($_POST['cPath'])) {
-    $cPath = $_POST['cPath'];
-} elseif (isset($_GET['cPath'])) {
-    $cPath = $_GET['cPath'];
-} else {
-    $cPath = '';
-}
+$cPath = $_POST['cPath'] ?? $_GET['cPath'] ?? '';
 
-if (zen_not_null($cPath)) {
+if (empty($cPath)) {
+    $cPath_array = [];
+    $current_category_id = TOPMOST_CATEGORY_PARENT_ID;
+} else {
     $cPath_array = zen_parse_category_path($cPath);
     $cPath = implode('_', $cPath_array);
     $current_category_id = $cPath_array[(count($cPath_array) - 1)];
-} else {
-    $cPath_array = [];
-    $current_category_id = TOPMOST_CATEGORY_PARENT_ID;
+
+    // -----
+    // If the current category_id is invalid (i.e. not present in the database),
+    // issue a message and redirect the admin to the category_product_listing page.
+    //
+    if (zen_get_categories_status($current_category_id) === '') {
+        $messageStack->add_session(sprintf(WARNING_CATEGORY_DOES_NOT_EXIST, (int)$current_category_id), 'warning');
+        zen_redirect(zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING));
+    }
 }

--- a/admin/includes/languages/lang.english.php
+++ b/admin/includes/languages/lang.english.php
@@ -618,6 +618,7 @@ $define = [
     'WARNING_ATTRIBUTE_COPY_INVALID_ID' => 'Warning: Attribute Copy to Product ID#%u aborted. Invalid ID',
     'WARNING_ATTRIBUTE_COPY_NO_ATTRIBUTES' => 'Warning: Attribute Copy aborted. No Attributes found for source Product ID#%u, "%s".',
     'WARNING_ATTRIBUTE_COPY_SAME_ID' => 'Warning: Attribute Copy aborted. Cannot copy from Product ID#%u to Product ID#%u (same ID).',
+    'WARNING_CATEGORY_DOES_NOT_EXIST' => 'Warning: Category ID#%u is invalid, it does not exist.',
     'WARNING_CONFIG_FILE_WRITEABLE' => 'Warning: Your configuration file: %s is writeable. This is a potential security risk - please set the right user permissions on this file (read-only, CHMOD 644 or 444 are typical). You may need to use your webhost control panel/file-manager to change the permissions effectively. Contact your webhost for assistance. <a href="https://docs.zen-cart.com/user/miscellaneous/configure/" rel="noopener" target="_blank">See this FAQ</a>',
     'WARNING_COULD_NOT_LOCATE_LANG_FILE' => 'WARNING: Could not locate language file: ',
     'WARNING_DATABASE_VERSION_OUT_OF_DATE' => 'Your database appears to need patching to a higher level. See Tools->' . '%%BOX_TOOLS_SERVER_INFO%%' . ' to review patch levels.',


### PR DESCRIPTION
If an invalid `cPath` is provided to the category_product_listing (e.g. cPath=999999), the listing page displays an empty category to which other categories or products can be added.

If, in this case, a category is added that newly-added category's `parent_id` reflects that invalid (non-existent) category; if a product is added, the product's `master_categories_id` reflects that invalid category.

This PR corrects that issue.