### PR TITLE
Refactor search SQL operations into helper class, catalog side.

### DIFF
--- a/includes/auto_loaders/config.core.php
+++ b/includes/auto_loaders/config.core.php
@@ -73,6 +73,10 @@ if (!defined('USE_PCONNECT')) define('USE_PCONNECT', 'false');
   $autoLoadConfig[0][] = array('autoType'=>'class',
                                'loadFile'=>'Customer.php');
   $autoLoadConfig[0][] = [
+    'autoType'=>'class',
+    'loadFile'=>'class.search.php'
+  ];
+  $autoLoadConfig[0][] = [
     'autoType' => 'class',
     'loadFile' => 'zcDate.php'
   ];
@@ -170,6 +174,11 @@ $autoLoadConfig[55][] = [
                                 'objectName'=>'cart',
                                 'checkInstantiated'=>true,
                                 'classSession'=>true);
+  $autoLoadConfig[80][] = [
+    'autoType'=>'classInstantiate',
+    'className'=>'Zencart\Search\Search',
+    'objectName'=>'search'
+  ];
 /**
  * Breakpoint 90.
  *

--- a/includes/classes/Exceptions/SearchException.php
+++ b/includes/classes/Exceptions/SearchException.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @copyright Copyright 2003-2023 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: $
+ */
+
+namespace Zencart\Exceptions;
+
+class SearchException extends \Exception
+{
+};

--- a/includes/classes/class.search.php
+++ b/includes/classes/class.search.php
@@ -1,0 +1,461 @@
+<?php
+/**
+ * Product search SQL operations.
+ *
+ * @copyright Copyright 2003-2023 Zen Cart Development Team
+ * @copyright Portions Copyright 2003 osCommerce
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: pRose on charmes 2023 Feb 03 Modified in v1.5.8a $
+ */
+
+namespace Zencart\Search;
+
+use Zencart\Exceptions\SearchException;
+
+/**
+ * Search Options for when searching the product catalogue.
+ * Constructor attempts to initialise from $_GET query parameters, or
+ * alternatively the fields may be set directly.
+ */
+class SearchOptions
+{
+    public string $keywords;
+    public string $dfrom;
+    public string $dto;
+    public float $pfrom;
+    public float $pto;
+    public int $categories_id;
+    public bool $inc_subcat;
+    public bool $search_in_description;
+    public ?int $manufacturers_id;
+    public int $alpha_filter_id;
+    public string $sort;
+
+    /**
+     * Attempt to initialise from $_GET.
+     * May throw SearchException if fields fail to parse.
+     */
+    public function __construct()
+    {
+        $this->keywords = $_GET['keyword'] ?? '';
+        $this->dfrom = $_GET['dfrom'] ?? '';
+        $this->dto = $_GET['dto'] ?? '';
+        $this->categories_id = (int)($_GET['categories_id'] ?? 0);
+        $this->inc_subcat = ($_GET['inc_subcat'] ?? '0') === '1';
+        $this->search_in_description = ($_GET['search_in_description'] ?? '0') === '1';
+        $this->manufacturers_id = (int)($_GET['manufacturers_id'] ?? 0);
+        $this->alpha_filter_id = (int)($_GET['alpha_filter_id'] ?? 0);
+        $this->sort = $_GET['sort'] ?? '';
+
+        // Parse inputs that might fail due to syntax.
+        if (!empty($_GET['pfrom']) && !is_numeric($_GET['pfrom'])) {
+            throw new SearchException(ERROR_PRICE_FROM_MUST_BE_NUM);
+        }
+        $this->pfrom = (float)($_GET['pfrom'] ?? '');
+
+        if (!empty($_GET['pto']) && !is_numeric($_GET['pto'])) {
+            throw new SearchException(ERROR_PRICE_TO_MUST_BE_NUM);
+        }
+        $this->pto = (float)($_GET['pto'] ?? '');
+    }
+}
+
+/**
+ * Helper class to perform searches of the product catalogue.
+ */
+class Search extends \base
+{
+    /** Options used for our building operations. */
+    protected SearchOptions $searchOptions;
+
+    /**
+     * Return the current SearchOptions, if any.
+     *
+     * @return SearchOptions
+     */
+    public function getSearchOptions(): SearchOptions
+    {
+        return $this->searchOptions;
+    }
+
+    /**
+     * Set the SearchOptions to be used in operations.
+     *
+     * @param SearchOptions $searchOptions
+     * @return void
+     */
+    public function setSearchOptions(SearchOptions $searchOptions)
+    {
+        $this->searchOptions = $searchOptions;
+    }
+
+    /**
+     * Builds SQL for searching the product catalogue, given SearchOptions.
+     * Note: Sets the global $column_list, needed by product_listing template.
+     *
+     * @param SearchOptions $searchOptions The options for the search.
+     * @return string The built SQL.
+     */
+    public function buildSearchSQL() {
+        global $db, $messageStack, $currencies, $column_list;
+
+        if (empty($this->searchOptions)) {
+            throw new SearchException(ERROR_MISSING_SEARCH_OPTIONS);
+        }
+
+        // -----
+        // Give an observer the chance to indicate that there's another element to the search
+        // that **is** provided, enabling the search to continue.
+        //
+        $search_additional_clause = false;
+        $this->notify('NOTIFY_ADVANCED_SEARCH_RESULTS_ADDL_CLAUSE', [], $search_additional_clause);
+
+        if ($search_additional_clause === false &&
+            empty($this->searchOptions->keywords) &&
+            (
+                (empty($this->searchOptions->dfrom) && empty($this->searchOptions->dto)) &&
+                (empty($this->searchOptions->pfrom) || $this->searchOptions->pfrom <= 0) &&
+                (empty($this->searchOptions->pto) || $this->searchOptions->pto <= 0)
+            )) {
+            throw new SearchException(ERROR_AT_LEAST_ONE_INPUT);
+        } else {
+            $dfrom_array = [];
+            $dto_array = [];
+
+            if (!empty($this->searchOptions->dfrom) &&
+                !zen_checkdate($this->searchOptions->dfrom, DOB_FORMAT_STRING, $dfrom_array)) {
+                throw new SearchException(ERROR_INVALID_FROM_DATE);
+            }
+
+            if (!empty($this->searchOptions->dto) &&
+                !zen_checkdate($this->searchOptions->dto, DOB_FORMAT_STRING, $dto_array)) {
+                throw new SearchException(ERROR_INVALID_TO_DATE);
+            }
+
+            if (!empty($this->searchOptions->dfrom) && !empty($this->searchOptions->dto)) {
+                if (mktime(0, 0, 0, $dfrom_array[1], $dfrom_array[2], $dfrom_array[0]) > mktime(0, 0, 0, $dto_array[1], $dto_array[2], $dto_array[0])) {
+                    throw new SearchException(ERROR_TO_DATE_LESS_THAN_FROM_DATE);
+                }
+            }
+
+            if ($this->searchOptions->pfrom > $this->searchOptions->pto) {
+                throw new SearchException(ERROR_PRICE_TO_LESS_THAN_PRICE_FROM);
+            }
+
+            if (!empty($this->searchOptions->keywords) &&
+                !zen_parse_search_string(stripslashes($this->searchOptions->keywords), $search_keywords)) {
+                throw new SearchException(ERROR_INVALID_KEYWORDS);
+            }
+        }
+
+        if (empty($this->searchOptions->dfrom) && empty($this->searchOptions->dto) &&
+            empty($this->searchOptions->pfrom) && empty($this->searchOptions->pto) &&
+            empty($this->searchOptions->keywords) && $search_additional_clause === false) {
+            throw new SearchException(ERROR_AT_LEAST_ONE_INPUT);
+        }
+
+        $define_list = [
+            'PRODUCT_LIST_MODEL' => PRODUCT_LIST_MODEL,
+            'PRODUCT_LIST_NAME' => PRODUCT_LIST_NAME,
+            'PRODUCT_LIST_MANUFACTURER' => PRODUCT_LIST_MANUFACTURER,
+            'PRODUCT_LIST_PRICE' => PRODUCT_LIST_PRICE,
+            'PRODUCT_LIST_QUANTITY' => PRODUCT_LIST_QUANTITY,
+            'PRODUCT_LIST_WEIGHT' => PRODUCT_LIST_WEIGHT,
+            'PRODUCT_LIST_IMAGE' => PRODUCT_LIST_IMAGE
+        ];
+
+        asort($define_list);
+
+        $column_list = [];
+        foreach ($define_list as $column => $value) {
+            if ($value) {
+                $column_list[] = $column;
+            }
+        }
+
+        $select_column_list = '';
+
+        foreach ($column_list as $column) {
+            if (in_array($column, ['PRODUCT_LIST_NAME', 'PRODUCT_LIST_PRICE'])) {
+                continue;
+            }
+
+            if (!empty($select_column_list)) {
+                $select_column_list .= ', ';
+            }
+
+            switch ($column) {
+                case 'PRODUCT_LIST_MODEL':
+                    $select_column_list .= 'p.products_model';
+                    break;
+                case 'PRODUCT_LIST_MANUFACTURER':
+                    $select_column_list .= 'm.manufacturers_name';
+                    break;
+                case 'PRODUCT_LIST_QUANTITY':
+                    $select_column_list .= 'p.products_quantity';
+                    break;
+                case 'PRODUCT_LIST_IMAGE':
+                    $select_column_list .= 'p.products_image';
+                    break;
+                case 'PRODUCT_LIST_WEIGHT':
+                    $select_column_list .= 'p.products_weight';
+                    break;
+            }
+        }
+        /*
+        // always add quantity regardless of whether or not it is in the listing for add to cart buttons
+        if (PRODUCT_LIST_QUANTITY < 1) {
+        $select_column_list .= ', p.products_quantity ';
+        }
+        */
+
+        // always add quantity regardless of whether or not it is in the listing for add to cart buttons
+        if (PRODUCT_LIST_QUANTITY < 1) {
+            if (empty($select_column_list)) {
+                $select_column_list .= ' p.products_quantity ';
+            } else {
+                $select_column_list .= ', p.products_quantity ';
+            }
+        }
+
+        if (!empty($select_column_list)) {
+            $select_column_list .= ', ';
+        }
+
+        // Notifier Point
+        $this->notify('NOTIFY_SEARCH_COLUMNLIST_STRING', $select_column_list, $select_column_list);
+
+        $select_str = "SELECT DISTINCT " . $select_column_list .
+            " p.products_sort_order, m.manufacturers_id, p.products_id, pd.products_name,
+            p.products_price, p.products_tax_class_id, p.products_price_sorter,
+            p.products_qty_box_status, p.master_categories_id, p.product_is_call ";
+
+        if ((DISPLAY_PRICE_WITH_TAX == 'true') && (!empty($this->searchOptions->pfrom) || !empty($this->searchOptions->pto))) {
+            $select_str .= ", SUM(tr.tax_rate) AS tax_rate ";
+        }
+
+        // Notifier Point
+        $this->notify('NOTIFY_SEARCH_SELECT_STRING', $select_str, $select_str);
+
+        $from_str = "FROM (" . TABLE_PRODUCTS . " p
+                    LEFT JOIN " . TABLE_MANUFACTURERS . " m
+                    USING(manufacturers_id), " . TABLE_PRODUCTS_DESCRIPTION . " pd, " . TABLE_CATEGORIES . " c, " . TABLE_PRODUCTS_TO_CATEGORIES . " p2c )";
+
+        if (ADVANCED_SEARCH_INCLUDE_METATAGS == 'true') {
+            $from_str .=
+                " LEFT JOIN " . TABLE_META_TAGS_PRODUCTS_DESCRIPTION . " mtpd
+                    ON (mtpd.products_id= p2c.products_id AND mtpd.language_id = :languagesID)";
+            $from_str = $db->bindVars($from_str, ':languagesID', $_SESSION['languages_id'], 'integer');
+        }
+
+        if ((DISPLAY_PRICE_WITH_TAX == 'true') && !empty($this->searchOptions->pfrom) || !empty($this->searchOptions->pto)) {
+            if (empty($_SESSION['customer_country_id'])) {
+                $_SESSION['customer_country_id'] = STORE_COUNTRY;
+                $_SESSION['customer_zone_id'] = STORE_ZONE;
+            }
+            $from_str .= " LEFT JOIN " . TABLE_TAX_RATES . " tr
+                        ON p.products_tax_class_id = tr.tax_class_id
+                        LEFT JOIN " . TABLE_ZONES_TO_GEO_ZONES . " gz
+                        ON tr.tax_zone_id = gz.geo_zone_id
+                        AND (gz.zone_country_id IS null OR gz.zone_country_id = 0 OR gz.zone_country_id = :zoneCountryID)
+                        AND (gz.zone_id IS null OR gz.zone_id = 0 OR gz.zone_id = :zoneID)";
+
+            $from_str = $db->bindVars($from_str, ':zoneCountryID', $_SESSION['customer_country_id'], 'integer');
+            $from_str = $db->bindVars($from_str, ':zoneID', $_SESSION['customer_zone_id'], 'integer');
+        }
+
+        // Notifier Point
+        $this->notify('NOTIFY_SEARCH_FROM_STRING', $from_str, $from_str);
+
+        $where_str = " WHERE (p.products_status = 1
+                    AND p.products_id = pd.products_id
+                    AND pd.language_id = :languagesID
+                    AND p.products_id = p2c.products_id
+                    AND p2c.categories_id = c.categories_id ";
+
+        $where_str = $db->bindVars($where_str, ':languagesID', $_SESSION['languages_id'], 'integer');
+
+        // reset previous selection
+
+        if (!empty($this->searchOptions->categories_id)) {
+            if ($this->searchOptions->inc_subcat) {
+                $subcategories_array = [];
+                zen_get_subcategories($subcategories_array, $this->searchOptions->categories_id);
+                $where_str .= " AND p2c.products_id = p.products_id
+                                AND p2c.products_id = pd.products_id
+                                AND (p2c.categories_id = :categoriesID";
+
+                $where_str = $db->bindVars($where_str, ':categoriesID', $this->searchOptions->categories_id, 'integer');
+
+                if (count($subcategories_array) > 0) {
+                    $where_str .= " OR p2c.categories_id in (";
+                    for ($i = 0, $n = count($subcategories_array); $i < $n; $i++) {
+                        $where_str .= " :categoriesID";
+                        if ($i + 1 < $n) {
+                            $where_str .= ",";
+                        }
+                        $where_str = $db->bindVars($where_str, ':categoriesID', $subcategories_array[$i], 'integer');
+                    }
+                    $where_str .= ")";
+                }
+                $where_str .= ")";
+            } else {
+                $where_str .= " AND p2c.products_id = p.products_id
+                                AND p2c.products_id = pd.products_id
+                                AND pd.language_id = :languagesID
+                                AND p2c.categories_id = :categoriesID";
+
+                $where_str = $db->bindVars($where_str, ':categoriesID', $this->searchOptions->categories_id, 'integer');
+                $where_str = $db->bindVars($where_str, ':languagesID', $_SESSION['languages_id'], 'integer');
+            }
+        }
+
+        if (!empty($this->searchOptions->manufacturers_id)) {
+            $where_str .= " AND m.manufacturers_id = :manufacturersID";
+            $where_str = $db->bindVars($where_str, ':manufacturersID', $this->searchOptions->manufacturers_id, 'integer');
+        }
+
+        if (!empty($this->searchOptions->keywords)) {
+            $keyword_search_fields = [
+                'pd.products_name',
+                'p.products_model',
+                'm.manufacturers_name',
+            ];
+
+            if (ADVANCED_SEARCH_INCLUDE_METATAGS == 'true') {
+                $keyword_search_fields[] = 'mtpd.metatags_keywords';
+                $keyword_search_fields[] = 'mtpd.metatags_description';
+            }
+
+            if ($this->searchOptions->search_in_description) {
+                $keyword_search_fields[] = 'pd.products_description';
+            }
+
+            $this->notify('NOTIFY_SEARCH_MATCHING_KEYWORD_FIELDS', '', $keyword_search_fields);
+
+            $where_str .= zen_build_keyword_where_clause($keyword_search_fields, trim($this->searchOptions->keywords));
+        }
+        $where_str .= ')';
+        if (!empty($this->searchOptions->alpha_filter_id)) {
+            $alpha_sort = " and (pd.products_name LIKE '" . chr($this->searchOptions->alpha_filter_id) . "%') ";
+            $where_str .= $alpha_sort;
+        } else {
+            $alpha_sort = '';
+            $where_str .= $alpha_sort;
+        }
+
+        if (!empty($this->searchOptions->dfrom)) {
+            $where_str .= " AND p.products_date_added >= :dateAdded";
+            $where_str = $db->bindVars($where_str, ':dateAdded', zen_date_raw($this->searchOptions->dfrom), 'date');
+        }
+
+        if (!empty($this->searchOptions->dto)) {
+            $where_str .= " and p.products_date_added <= :dateAdded";
+            $where_str = $db->bindVars($where_str, ':dateAdded', zen_date_raw($this->searchOptions->dto), 'date');
+        }
+
+        $rate = $currencies->get_value($_SESSION['currency']);
+
+        if ($rate) {
+            if (!empty($this->searchOptions->pfrom)) {
+                $this->searchOptions->pfrom = $this->searchOptions->pfrom / $rate;
+            }
+            if (!empty($this->searchOptions->pto)) {
+                $this->searchOptions->pto = $this->searchOptions->pto / $rate;
+            }
+        }
+
+        if (DISPLAY_PRICE_WITH_TAX == 'true') {
+            if (!empty($this->searchOptions->pfrom)) {
+                $where_str .= " AND (p.products_price_sorter * IF(gz.geo_zone_id IS null, 1, 1 + (tr.tax_rate / 100)) >= :price)";
+                $where_str = $db->bindVars($where_str, ':price', $this->searchOptions->pfrom, 'float');
+            }
+            if (!empty($this->searchOptions->pto)) {
+                $where_str .= " AND (p.products_price_sorter * IF(gz.geo_zone_id IS null, 1, 1 + (tr.tax_rate / 100)) <= :price)";
+                $where_str = $db->bindVars($where_str, ':price', $this->searchOptions->pto, 'float');
+            }
+        } else {
+            if (!empty($this->searchOptions->pfrom)) {
+                $where_str .= " and (p.products_price_sorter >= :price)";
+                $where_str = $db->bindVars($where_str, ':price', $this->searchOptions->pfrom, 'float');
+            }
+            if (!empty($this->searchOptions->pto)) {
+                $where_str .= " and (p.products_price_sorter <= :price)";
+                $where_str = $db->bindVars($where_str, ':price', $this->searchOptions->pto, 'float');
+            }
+        }
+
+
+        $order_str = '';
+
+        // Notifier Point
+        $this->notify('NOTIFY_SEARCH_WHERE_STRING', $this->searchOptions->keywords, $where_str, $keyword_search_fields);
+
+
+        if ((DISPLAY_PRICE_WITH_TAX == 'true') && (!empty($this->searchOptions->pfrom)) || !empty($this->searchOptions->pto)) {
+            $where_str .= " group by p.products_id, tr.tax_priority";
+        }
+
+        // set the default sort order setting from the Admin when not defined by customer
+        if (empty($this->searchOptions->sort) and PRODUCT_LISTING_DEFAULT_SORT_ORDER != '') {
+            $this->searchOptions->sort = PRODUCT_LISTING_DEFAULT_SORT_ORDER;
+        }
+        if (empty($this->searchOptions->sort) ||
+            (!preg_match('/[1-8][ad]/', $this->searchOptions->sort)) ||
+            (substr($this->searchOptions->sort, 0, 1) > count($column_list))) {
+            for ($col = 0, $n = sizeof($column_list); $col < $n; $col++) {
+                if ($column_list[$col] == 'PRODUCT_LIST_NAME') {
+                    $this->searchOptions->sort = $col + 1 . 'a';
+                    $order_str .= ' ORDER BY pd.products_name';
+                    break;
+                } else {
+                    // sort by products_sort_order when PRODUCT_LISTING_DEFAULT_SORT_ORDER ia left blank
+                    // for reverse, descending order use:
+                    //       $listing_sql .= " order by p.products_sort_order desc, pd.products_name";
+                    $order_str .= " order by p.products_sort_order, pd.products_name";
+                    break;
+                }
+            }
+            // if set to nothing use products_sort_order and PRODUCTS_LIST_NAME is off
+            if (PRODUCT_LISTING_DEFAULT_SORT_ORDER == '') {
+                $this->searchOptions->sort = '20a';
+            }
+        } else {
+            $sort_col = substr($this->searchOptions->sort, 0, 1);
+            $sort_order = substr($this->searchOptions->sort, -1);
+            $order_str = ' order by ';
+            switch ($column_list[$sort_col - 1]) {
+                case 'PRODUCT_LIST_MODEL':
+                    $order_str .= "p.products_model " . ($sort_order == 'd' ? "desc" : "") . ", pd.products_name";
+                    break;
+                case 'PRODUCT_LIST_NAME':
+                    $order_str .= "pd.products_name " . ($sort_order == 'd' ? "desc" : "");
+                    break;
+                case 'PRODUCT_LIST_MANUFACTURER':
+                    $order_str .= "m.manufacturers_name " . ($sort_order == 'd' ? "desc" : "") . ", pd.products_name";
+                    break;
+                case 'PRODUCT_LIST_QUANTITY':
+                    $order_str .= "p.products_quantity " . ($sort_order == 'd' ? "desc" : "") . ", pd.products_name";
+                    break;
+                case 'PRODUCT_LIST_IMAGE':
+                    $order_str .= "pd.products_name";
+                    break;
+                case 'PRODUCT_LIST_WEIGHT':
+                    $order_str .= "p.products_weight " . ($sort_order == 'd' ? "desc" : "") . ", pd.products_name";
+                    break;
+                case 'PRODUCT_LIST_PRICE':
+                    //        $order_str .= "final_price " . ($sort_order == 'd' ? "desc" : "") . ", pd.products_name";
+                    $order_str .= "p.products_price_sorter " . ($sort_order == 'd' ? "desc" : "") . ", pd.products_name";
+                    break;
+            }
+        }
+
+        $this->notify('NOTIFY_SEARCH_REAL_ORDERBY_STRING', $order_str, $order_str);
+
+        $listing_sql = $select_str . $from_str . $where_str . $order_str;
+        // Notifier Point
+        $this->notify('NOTIFY_SEARCH_ORDERBY_STRING', $listing_sql);
+
+        return $listing_sql;
+    }
+}

--- a/includes/init_includes/init_sanitize.php
+++ b/includes/init_includes/init_sanitize.php
@@ -117,7 +117,7 @@ $saniGroup3 = [
     'pto',   //- Searches, price-to (float)
 ];
 foreach ($saniGroup3 as $key) {
-    if (isset($_GET[$key]) && !preg_match('/^\d+(\.\d+)/', $_GET[$key])) {
+    if (isset($_GET[$key]) && !preg_match('/^\d+(\.\d+)?/', $_GET[$key])) {
         $_GET[$key] = '';
         if (isset($_REQUEST[$key])) {
             $_REQUEST[$key] = '';

--- a/includes/languages/lang.english.php
+++ b/includes/languages/lang.english.php
@@ -187,6 +187,7 @@ $define = [
     'ERROR_INVALID_KEYWORDS' => 'Invalid keywords.',
     'ERROR_INVALID_TO_DATE' => 'Invalid To Date.',
     'ERROR_MAXIMUM_QTY' => 'The quantity added to your cart has been adjusted because of a restriction on maximum you are allowed. See this item:<br>',
+    'ERROR_MISSING_SEARCH_OPTIONS' => 'Missing search options',
     'ERROR_NO_PAYMENT_MODULE_SELECTED' => 'Please select a payment method for your order.',
     'ERROR_PRICE_FROM_MUST_BE_NUM' => 'Price From must be a number.',
     'ERROR_PRICE_TO_LESS_THAN_PRICE_FROM' => 'Price To must be greater than or equal to Price From.',

--- a/includes/modules/pages/search/header_php.php
+++ b/includes/modules/pages/search/header_php.php
@@ -13,13 +13,14 @@ $breadcrumb->add(NAVBAR_TITLE_1);
 //test:
 //&keyword=die+hard&categories_id=10&inc_subcat=1&manufacturers_id=4&pfrom=1&pto=50&dfrom=01%2F01%2F2003&dto=12%2F20%2F2005
 
+$sData = [];
 $sData['keyword'] = stripslashes(isset($_GET['keyword']) ? zen_output_string_protected($_GET['keyword']) : '');
 $sData['search_in_description'] = (isset($_GET['search_in_description']) ? zen_output_string((int)$_GET['search_in_description']) : 1);
 $sData['categories_id'] = (isset($_GET['categories_id']) ? zen_output_string((int)$_GET['categories_id']) : 0);
 $sData['inc_subcat'] = (isset($_GET['inc_subcat']) ? zen_output_string((int)$_GET['inc_subcat']) : 1);
 $sData['manufacturers_id'] = (isset($_GET['manufacturers_id']) ? zen_output_string((int)$_GET['manufacturers_id']) : 0);
-$sData['dfrom'] = (isset($_GET['dfrom']) ? zen_output_string($_GET['dfrom']) : zen_output_string(DOB_FORMAT_STRING));
-$sData['dto'] = (isset($_GET['dto']) ? zen_output_string($_GET['dto']) : zen_output_string(DOB_FORMAT_STRING));
+$sData['dfrom'] = (isset($_GET['dfrom']) ? zen_output_string($_GET['dfrom']) : '');
+$sData['dto'] = (isset($_GET['dto']) ? zen_output_string($_GET['dto']) : '');
 $sData['pfrom'] = (isset($_GET['pfrom']) ? zen_output_string($_GET['pfrom']) : '');
 $sData['pto'] = (isset($_GET['pto']) ? zen_output_string($_GET['pto']) : '');
 

--- a/includes/modules/pages/search_result/header_php.php
+++ b/includes/modules/pages/search_result/header_php.php
@@ -5,8 +5,9 @@
  * @copyright Copyright 2003-2022 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: DrByte 2020 Dec 25 New in v1.5.8-alpha $
+ * @version $Id:  Modified in v2.0.0 $
  */
+
 use Zencart\Search\SearchOptions;
 use Zencart\Exceptions\SearchException;
 
@@ -60,8 +61,8 @@ try {
         zen_redirect(zen_href_link(zen_get_info_page($result->fields['products_id']), 'cPath=' . zen_get_product_path($result->fields['products_id']) . '&products_id=' . $result->fields['products_id']));
     }
 
-} catch (SearchException $ex) {
-    $messageStack->add_session('search', $ex->getMessage());
+} catch (SearchException $e) {
+    $messageStack->add_session('search', $e->getMessage());
     zen_redirect(zen_href_link(FILENAME_SEARCH, zen_get_all_get_params(), 'NONSSL', true, false));
 }
 

--- a/includes/modules/pages/search_result/header_php.php
+++ b/includes/modules/pages/search_result/header_php.php
@@ -2,11 +2,13 @@
 /**
  * Header code file for the Search Results page
  *
- * @copyright Copyright 2003-2023 Zen Cart Development Team
+ * @copyright Copyright 2003-2022 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: pRose on charmes 2023 Feb 03 Modified in v1.5.8a $
+ * @version $Id: DrByte 2020 Dec 25 New in v1.5.8-alpha $
  */
+use Zencart\Search\SearchOptions;
+use Zencart\Exceptions\SearchException;
 
 // This should be first line of the script:
 $zco_notifier->notify('NOTIFY_HEADER_START_ADVANCED_SEARCH_RESULTS');
@@ -26,447 +28,46 @@ $missing_one_input = false;
 
 $_GET['keyword'] = isset($_GET['keyword']) ? trim($_GET['keyword']) : '';
 
-// -----
-// Give an observer the chance to indicate that there's another element to the search
-// that **is** provided, enabling the search to continue.
-//
-$search_additional_clause = false;
-$zco_notifier->notify('NOTIFY_ADVANCED_SEARCH_RESULTS_ADDL_CLAUSE', [], $search_additional_clause);
-
-if ($search_additional_clause === false &&
-    (empty($_GET['keyword']) || $_GET['keyword'] == HEADER_SEARCH_DEFAULT_TEXT || $_GET['keyword'] == KEYWORD_FORMAT_STRING) &&
-    (isset($_GET['dfrom']) && (empty($_GET['dfrom']) || ($_GET['dfrom'] == DOB_FORMAT_STRING))) &&
-    (isset($_GET['dto']) && (empty($_GET['dto']) || ($_GET['dto'] == DOB_FORMAT_STRING))) &&
-    (isset($_GET['pfrom']) && !is_numeric($_GET['pfrom'])) &&
-    (isset($_GET['pto']) && !is_numeric($_GET['pto']))
-) {
-    $error = true;
-    $missing_one_input = true;
-    $messageStack->add_session('search', ERROR_AT_LEAST_ONE_INPUT);
-} else {
-    $dfrom = '';
-    $dto = '';
-    $pfrom = '';
-    $pto = '';
-    $keywords = '';
-    $dfrom_array = [];
-    $dto_array = [];
-
-    if (isset($_GET['dfrom'])) {
-        $dfrom = (($_GET['dfrom'] == DOB_FORMAT_STRING) ? '' : $_GET['dfrom']);
-    }
-
-    if (isset($_GET['dto'])) {
-        $dto = (($_GET['dto'] == DOB_FORMAT_STRING) ? '' : $_GET['dto']);
-    }
-
-    if (isset($_GET['pfrom'])) {
-        $pfrom = $_GET['pfrom'];
-    }
-
-    if (isset($_GET['pto'])) {
-        $pto = $_GET['pto'];
-    }
-
-    if (isset($_GET['keyword']) && $_GET['keyword'] != HEADER_SEARCH_DEFAULT_TEXT && $_GET['keyword'] != KEYWORD_FORMAT_STRING) {
-        $keywords = $_GET['keyword'];
-    }
-
-    $date_check_error = false;
-    if (zen_not_null($dfrom)) {
-        if (!zen_checkdate($dfrom, DOB_FORMAT_STRING, $dfrom_array)) {
-            $error = true;
-            $date_check_error = true;
-            $messageStack->add_session('search', ERROR_INVALID_FROM_DATE);
-        }
-    }
-
-    if (zen_not_null($dto)) {
-        if (!zen_checkdate($dto, DOB_FORMAT_STRING, $dto_array)) {
-            $error = true;
-            $date_check_error = true;
-            $messageStack->add_session('search', ERROR_INVALID_TO_DATE);
-        }
-    }
-
-    if (($date_check_error == false) && zen_not_null($dfrom) && zen_not_null($dto)) {
-        if (mktime(0, 0, 0, $dfrom_array[1], $dfrom_array[2], $dfrom_array[0]) > mktime(0, 0, 0, $dto_array[1], $dto_array[2], $dto_array[0])) {
-            $error = true;
-            $messageStack->add_session('search', ERROR_TO_DATE_LESS_THAN_FROM_DATE);
-        }
-    }
-
-    $price_check_error = false;
-    if (zen_not_null($pfrom)) {
-        if (!settype($pfrom, 'float')) {
-            $error = true;
-            $price_check_error = true;
-            $messageStack->add_session('search', ERROR_PRICE_FROM_MUST_BE_NUM);
-        }
-    }
-
-    if (zen_not_null($pto)) {
-        if (!settype($pto, 'float')) {
-            $error = true;
-            $price_check_error = true;
-            $messageStack->add_session('search', ERROR_PRICE_TO_MUST_BE_NUM);
-        }
-    }
-
-    if (($price_check_error == false) && is_float($pfrom) && is_float($pto)) {
-        if ($pfrom > $pto) {
-            $error = true;
-            $messageStack->add_session('search', ERROR_PRICE_TO_LESS_THAN_PRICE_FROM);
-        }
-    }
-
-    if (zen_not_null($keywords)) {
-        if (!zen_parse_search_string(stripslashes($keywords), $search_keywords)) {
-            $error = true;
-            $messageStack->add_session('search', ERROR_INVALID_KEYWORDS);
-        }
-    }
+if (!empty($_GET['keywords']) && $_GET['keywords'] != HEADER_SEARCH_DEFAULT_TEXT && $_GET['keywords'] != KEYWORD_FORMAT_STRING) {
+    $keywords = $_GET['keywords'];
 }
 
-if (empty($dfrom) && empty($dto) && empty($pfrom) && empty($pto) && empty($keywords) && $search_additional_clause === false) {
-    $error = true;
-    // redundant should be able to remove this
-    if (!$missing_one_input) {
-        $messageStack->add_session('search', ERROR_AT_LEAST_ONE_INPUT);
-    }
-}
+$price_check_error = false;
+try {
 
-if ($error == true) {
+    // Perform the search using the provided parameters.
+    $searchOptions = new SearchOptions();
+
+    $search->setSearchOptions($searchOptions);
+    $listing_sql = $search->buildSearchSQL();
+
+    $result = new \splitPageResults($listing_sql, MAX_DISPLAY_PRODUCTS_LISTING, 'p.products_id', 'page');
+    $zco_notifier->notify('NOTIFY_SEARCH_RESULTS', $listing_sql, $keywords, $result);
+
+    // Expose changed search options in $_GET for product listing page.
+    $_GET['sort'] = $searchOptions->sort;
+
+    // if no results were found, show a customisable message.
+    if ($result->number_of_rows == 0) {
+        $message = TEXT_NO_PRODUCTS;
+        $zco_notifier->notify('NOTIFY_SEARCH_NO_RESULTS_MESSAGE', $result, $search, $message);
+        $messageStack->add_session('search', $message, 'caution');
+        zen_redirect(zen_href_link(FILENAME_SEARCH, zen_get_all_get_params('action')));
+    }
+    // if only one product found in search results, go directly to the product page, instead of displaying a link to just one item:
+    if ($result->number_of_rows == 1 && SKIP_SINGLE_PRODUCT_CATEGORIES == 'True') {
+        $result = $db->Execute($result->sql_query);
+        zen_redirect(zen_href_link(zen_get_info_page($result->fields['products_id']), 'cPath=' . zen_get_product_path($result->fields['products_id']) . '&products_id=' . $result->fields['products_id']));
+    }
+
+} catch (SearchException $ex) {
+    $messageStack->add_session('search', $ex->getMessage());
     zen_redirect(zen_href_link(FILENAME_SEARCH, zen_get_all_get_params(), 'NONSSL', true, false));
 }
-
-
-$define_list = [
-    'PRODUCT_LIST_MODEL' => PRODUCT_LIST_MODEL,
-    'PRODUCT_LIST_NAME' => PRODUCT_LIST_NAME,
-    'PRODUCT_LIST_MANUFACTURER' => PRODUCT_LIST_MANUFACTURER,
-    'PRODUCT_LIST_PRICE' => PRODUCT_LIST_PRICE,
-    'PRODUCT_LIST_QUANTITY' => PRODUCT_LIST_QUANTITY,
-    'PRODUCT_LIST_WEIGHT' => PRODUCT_LIST_WEIGHT,
-    'PRODUCT_LIST_IMAGE' => PRODUCT_LIST_IMAGE
-];
-
-asort($define_list);
-
-$column_list = [];
-foreach ($define_list as $column => $value) {
-    if ($value) $column_list[] = $column;
-}
-
-$select_column_list = '';
-
-foreach ($column_list as $column) {
-    if (in_array($column, ['PRODUCT_LIST_NAME', 'PRODUCT_LIST_PRICE'])) {
-        continue;
-    }
-
-    if (!empty($select_column_list)) {
-        $select_column_list .= ', ';
-    }
-
-    switch ($column) {
-        case 'PRODUCT_LIST_MODEL':
-            $select_column_list .= 'p.products_model';
-            break;
-        case 'PRODUCT_LIST_MANUFACTURER':
-            $select_column_list .= 'm.manufacturers_name';
-            break;
-        case 'PRODUCT_LIST_QUANTITY':
-            $select_column_list .= 'p.products_quantity';
-            break;
-        case 'PRODUCT_LIST_IMAGE':
-            $select_column_list .= 'p.products_image';
-            break;
-        case 'PRODUCT_LIST_WEIGHT':
-            $select_column_list .= 'p.products_weight';
-            break;
-    }
-}
-/*
-// always add quantity regardless of whether or not it is in the listing for add to cart buttons
-if (PRODUCT_LIST_QUANTITY < 1) {
-  $select_column_list .= ', p.products_quantity ';
-}
-*/
-
-// always add quantity regardless of whether or not it is in the listing for add to cart buttons
-if (PRODUCT_LIST_QUANTITY < 1) {
-    if (empty($select_column_list)) {
-        $select_column_list .= ' p.products_quantity ';
-    } else {
-        $select_column_list .= ', p.products_quantity ';
-    }
-}
-
-if (!empty($select_column_list)) {
-    $select_column_list .= ', ';
-}
-
-// Notifier Point
-$zco_notifier->notify('NOTIFY_SEARCH_COLUMNLIST_STRING', $select_column_list, $select_column_list);
-
-
-//  $select_str = "select distinct " . $select_column_list . " m.manufacturers_id, p.products_id, pd.products_name, p.products_price, p.products_tax_class_id, IF(s.status = 1, s.specials_new_products_price, NULL) as specials_new_products_price, IF(s.status = 1, s.specials_new_products_price, p.products_price) as final_price ";
-$select_str = "SELECT DISTINCT " . $select_column_list .
-    " p.products_sort_order, m.manufacturers_id, p.products_id, pd.products_name,
-      p.products_price, p.products_tax_class_id, p.products_price_sorter,
-      p.products_qty_box_status, p.master_categories_id, p.product_is_call ";
-
-if ((DISPLAY_PRICE_WITH_TAX == 'true') && ((isset($_GET['pfrom']) && zen_not_null($_GET['pfrom'])) || (isset($_GET['pto']) && zen_not_null($_GET['pto'])))) {
-    $select_str .= ", SUM(tr.tax_rate) AS tax_rate ";
-}
-
-// Notifier Point
-$zco_notifier->notify('NOTIFY_SEARCH_SELECT_STRING', $select_str, $select_str);
-
-
-//  $from_str = "from " . TABLE_PRODUCTS . " p left join " . TABLE_MANUFACTURERS . " m using(manufacturers_id), " . TABLE_PRODUCTS_DESCRIPTION . " pd left join " . TABLE_SPECIALS . " s on p.products_id = s.products_id, " . TABLE_CATEGORIES . " c, " . TABLE_PRODUCTS_TO_CATEGORIES . " p2c";
-$from_str = "FROM (" . TABLE_PRODUCTS . " p
-             LEFT JOIN " . TABLE_MANUFACTURERS . " m
-             USING(manufacturers_id), " . TABLE_PRODUCTS_DESCRIPTION . " pd, " . TABLE_CATEGORIES . " c, " . TABLE_PRODUCTS_TO_CATEGORIES . " p2c )";
-
-if (ADVANCED_SEARCH_INCLUDE_METATAGS == 'true') {
-    $from_str .=
-        " LEFT JOIN " . TABLE_META_TAGS_PRODUCTS_DESCRIPTION . " mtpd
-            ON (mtpd.products_id= p2c.products_id AND mtpd.language_id = :languagesID)";
-    $from_str = $db->bindVars($from_str, ':languagesID', $_SESSION['languages_id'], 'integer');
-}
-
-if ((DISPLAY_PRICE_WITH_TAX == 'true') && ((isset($_GET['pfrom']) && zen_not_null($_GET['pfrom'])) || (isset($_GET['pto']) && zen_not_null($_GET['pto'])))) {
-    if (empty($_SESSION['customer_country_id'])) {
-        $_SESSION['customer_country_id'] = STORE_COUNTRY;
-        $_SESSION['customer_zone_id'] = STORE_ZONE;
-    }
-    $from_str .= " LEFT JOIN " . TABLE_TAX_RATES . " tr
-                   ON p.products_tax_class_id = tr.tax_class_id
-                   LEFT JOIN " . TABLE_ZONES_TO_GEO_ZONES . " gz
-                   ON tr.tax_zone_id = gz.geo_zone_id
-                   AND (gz.zone_country_id IS null OR gz.zone_country_id = 0 OR gz.zone_country_id = :zoneCountryID)
-                   AND (gz.zone_id IS null OR gz.zone_id = 0 OR gz.zone_id = :zoneID)";
-
-    $from_str = $db->bindVars($from_str, ':zoneCountryID', $_SESSION['customer_country_id'], 'integer');
-    $from_str = $db->bindVars($from_str, ':zoneID', $_SESSION['customer_zone_id'], 'integer');
-}
-
-// Notifier Point
-$zco_notifier->notify('NOTIFY_SEARCH_FROM_STRING', $from_str, $from_str);
-
-$where_str = " WHERE (p.products_status = 1
-               AND p.products_id = pd.products_id
-               AND pd.language_id = :languagesID
-               AND p.products_id = p2c.products_id
-               AND p2c.categories_id = c.categories_id ";
-
-$where_str = $db->bindVars($where_str, ':languagesID', $_SESSION['languages_id'], 'integer');
-
-// reset previous selection
-if (!isset($_GET['inc_subcat'])) {
-    $_GET['inc_subcat'] = '0';
-}
-if (!isset($_GET['search_in_description'])) {
-    $_GET['search_in_description'] = '0';
-}
-$_GET['search_in_description'] = (int)$_GET['search_in_description'];
-
-if (!empty($_GET['categories_id'])) {
-    if ($_GET['inc_subcat'] == '1') {
-        $subcategories_array = [];
-        zen_get_subcategories($subcategories_array, $_GET['categories_id']);
-        $where_str .= " AND p2c.products_id = p.products_id
-                        AND p2c.products_id = pd.products_id
-                        AND (p2c.categories_id = :categoriesID";
-
-        $where_str = $db->bindVars($where_str, ':categoriesID', $_GET['categories_id'], 'integer');
-
-        if (count($subcategories_array) > 0) {
-            $where_str .= " OR p2c.categories_id in (";
-            for ($i = 0, $n = count($subcategories_array); $i < $n; $i++) {
-                $where_str .= " :categoriesID";
-                if ($i + 1 < $n) $where_str .= ",";
-                $where_str = $db->bindVars($where_str, ':categoriesID', $subcategories_array[$i], 'integer');
-            }
-            $where_str .= ")";
-        }
-        $where_str .= ")";
-    } else {
-        $where_str .= " AND p2c.products_id = p.products_id
-                        AND p2c.products_id = pd.products_id
-                        AND pd.language_id = :languagesID
-                        AND p2c.categories_id = :categoriesID";
-
-        $where_str = $db->bindVars($where_str, ':categoriesID', $_GET['categories_id'], 'integer');
-        $where_str = $db->bindVars($where_str, ':languagesID', $_SESSION['languages_id'], 'integer');
-    }
-}
-
-if (!empty($_GET['manufacturers_id'])) {
-    $where_str .= " AND m.manufacturers_id = :manufacturersID";
-    $where_str = $db->bindVars($where_str, ':manufacturersID', $_GET['manufacturers_id'], 'integer');
-}
-
-if (isset($keywords) && zen_not_null($keywords)) {
-    $keyword_search_fields = [
-        'pd.products_name',
-        'p.products_model',
-        'm.manufacturers_name',
-    ];
-
-    if (ADVANCED_SEARCH_INCLUDE_METATAGS == 'true') {
-        $keyword_search_fields[] = 'mtpd.metatags_keywords';
-        $keyword_search_fields[] = 'mtpd.metatags_description';
-    }
-
-    if (isset($_GET['search_in_description']) && ($_GET['search_in_description'] == '1')) {
-        $keyword_search_fields[] = 'pd.products_description';
-    }
-
-    $zco_notifier->notify('NOTIFY_SEARCH_MATCHING_KEYWORD_FIELDS', '', $keyword_search_fields);
-
-    $where_str .= zen_build_keyword_where_clause($keyword_search_fields, trim($keywords));
-}
-$where_str .= ')';
-if (isset($_GET['alpha_filter_id']) && (int)$_GET['alpha_filter_id'] > 0) {
-    $alpha_sort = " and (pd.products_name LIKE '" . chr((int)$_GET['alpha_filter_id']) . "%') ";
-    $where_str .= $alpha_sort;
-} else {
-    $alpha_sort = '';
-    $where_str .= $alpha_sort;
-}
-
-if (isset($_GET['dfrom']) && zen_not_null($_GET['dfrom']) && ($_GET['dfrom'] != DOB_FORMAT_STRING)) {
-    $where_str .= " AND p.products_date_added >= :dateAdded";
-    $where_str = $db->bindVars($where_str, ':dateAdded', zen_date_raw($dfrom), 'date');
-}
-
-if (isset($_GET['dto']) && zen_not_null($_GET['dto']) && ($_GET['dto'] != DOB_FORMAT_STRING)) {
-    $where_str .= " and p.products_date_added <= :dateAdded";
-    $where_str = $db->bindVars($where_str, ':dateAdded', zen_date_raw($dto), 'date');
-}
-
-$rate = $currencies->get_value($_SESSION['currency']);
-$pfrom = 0.0;
-$pto = 0.0;
-
-if ($rate) {
-    if (!empty($_GET['pfrom'])) {
-        $pfrom = (float)$_GET['pfrom'] / $rate;
-    }
-    if (!empty($_GET['pto'])) {
-        $pto = (float)$_GET['pto'] / $rate;
-    }
-}
-
-if (DISPLAY_PRICE_WITH_TAX == 'true') {
-    if ($pfrom) {
-        $where_str .= " AND (p.products_price_sorter * IF(gz.geo_zone_id IS null, 1, 1 + (tr.tax_rate / 100)) >= :price)";
-        $where_str = $db->bindVars($where_str, ':price', $pfrom, 'float');
-    }
-    if ($pto) {
-        $where_str .= " AND (p.products_price_sorter * IF(gz.geo_zone_id IS null, 1, 1 + (tr.tax_rate / 100)) <= :price)";
-        $where_str = $db->bindVars($where_str, ':price', $pto, 'float');
-    }
-} else {
-    if ($pfrom) {
-        $where_str .= " and (p.products_price_sorter >= :price)";
-        $where_str = $db->bindVars($where_str, ':price', $pfrom, 'float');
-    }
-    if ($pto) {
-        $where_str .= " and (p.products_price_sorter <= :price)";
-        $where_str = $db->bindVars($where_str, ':price', $pto, 'float');
-    }
-}
-
-
-$order_str = '';
-
-// Notifier Point
-$zco_notifier->notify('NOTIFY_SEARCH_WHERE_STRING', $keywords, $where_str, $keyword_search_fields);
-
-
-if ((DISPLAY_PRICE_WITH_TAX == 'true') && ((isset($_GET['pfrom']) && zen_not_null($_GET['pfrom'])) || (isset($_GET['pto']) && zen_not_null($_GET['pto'])))) {
-    $where_str .= " group by p.products_id, tr.tax_priority";
-}
-
-// set the default sort order setting from the Admin when not defined by customer
-if (!isset($_GET['sort']) and PRODUCT_LISTING_DEFAULT_SORT_ORDER != '') {
-    $_GET['sort'] = PRODUCT_LISTING_DEFAULT_SORT_ORDER;
-}
-if ((!isset($_GET['sort'])) || (!preg_match('/[1-8][ad]/', $_GET['sort'])) || (substr($_GET['sort'], 0, 1) > count($column_list))) {
-    for ($col = 0, $n = sizeof($column_list); $col < $n; $col++) {
-        if ($column_list[$col] == 'PRODUCT_LIST_NAME') {
-            $_GET['sort'] = $col + 1 . 'a';
-            $order_str .= ' ORDER BY pd.products_name';
-            break;
-        } else {
-            // sort by products_sort_order when PRODUCT_LISTING_DEFAULT_SORT_ORDER ia left blank
-            // for reverse, descending order use:
-            //       $listing_sql .= " order by p.products_sort_order desc, pd.products_name";
-            $order_str .= " order by p.products_sort_order, pd.products_name";
-            break;
-        }
-    }
-    // if set to nothing use products_sort_order and PRODUCTS_LIST_NAME is off
-    if (PRODUCT_LISTING_DEFAULT_SORT_ORDER == '') {
-        $_GET['sort'] = '20a';
-    }
-} else {
-    $sort_col = substr($_GET['sort'], 0, 1);
-    $sort_order = substr($_GET['sort'], -1);
-    $order_str = ' order by ';
-    switch ($column_list[$sort_col - 1]) {
-        case 'PRODUCT_LIST_MODEL':
-            $order_str .= "p.products_model " . ($sort_order == 'd' ? "desc" : "") . ", pd.products_name";
-            break;
-        case 'PRODUCT_LIST_NAME':
-            $order_str .= "pd.products_name " . ($sort_order == 'd' ? "desc" : "");
-            break;
-        case 'PRODUCT_LIST_MANUFACTURER':
-            $order_str .= "m.manufacturers_name " . ($sort_order == 'd' ? "desc" : "") . ", pd.products_name";
-            break;
-        case 'PRODUCT_LIST_QUANTITY':
-            $order_str .= "p.products_quantity " . ($sort_order == 'd' ? "desc" : "") . ", pd.products_name";
-            break;
-        case 'PRODUCT_LIST_IMAGE':
-            $order_str .= "pd.products_name";
-            break;
-        case 'PRODUCT_LIST_WEIGHT':
-            $order_str .= "p.products_weight " . ($sort_order == 'd' ? "desc" : "") . ", pd.products_name";
-            break;
-        case 'PRODUCT_LIST_PRICE':
-            //        $order_str .= "final_price " . ($sort_order == 'd' ? "desc" : "") . ", pd.products_name";
-            $order_str .= "p.products_price_sorter " . ($sort_order == 'd' ? "desc" : "") . ", pd.products_name";
-            break;
-    }
-}
-//$_GET['keyword'] = zen_output_string_protected($_GET['keyword']);
-$zco_notifier->notify('NOTIFY_SEARCH_REAL_ORDERBY_STRING', $order_str, $order_str);
-
-$listing_sql = $select_str . $from_str . $where_str . $order_str;
-// Notifier Point
-$zco_notifier->notify('NOTIFY_SEARCH_ORDERBY_STRING', $listing_sql, $listing_sql);
-
-
 
 $breadcrumb->add(NAVBAR_TITLE_1, zen_href_link(FILENAME_SEARCH));
 //$breadcrumb->add(NAVBAR_TITLE_2);
 $breadcrumb->add(zen_output_string_protected($keywords));
 
-$result = new splitPageResults($listing_sql, MAX_DISPLAY_PRODUCTS_LISTING, 'p.products_id', 'page');
-$zco_notifier->notify('NOTIFY_SEARCH_RESULTS', $listing_sql, $keywords, $result);
-
-if ($result->number_of_rows == 0) {
-    $messageStack->add_session('search', TEXT_NO_PRODUCTS, 'caution');
-    zen_redirect(zen_href_link(FILENAME_SEARCH, zen_get_all_get_params('action')));
-}
-// if only one product found in search results, go directly to the product page, instead of displaying a link to just one item:
-if ($result->number_of_rows == 1 && SKIP_SINGLE_PRODUCT_CATEGORIES == 'True') {
-    $result = $db->Execute($listing_sql);
-    zen_redirect(zen_href_link(zen_get_info_page($result->fields['products_id']), 'cPath=' . zen_get_product_path($result->fields['products_id']) . '&products_id=' . $result->fields['products_id']));
-}
 // This should be last line of the script:
 $zco_notifier->notify('NOTIFY_HEADER_END_ADVANCED_SEARCH_RESULTS', $keywords);

--- a/includes/templates/template_default/templates/tpl_search_result_default.php
+++ b/includes/templates/template_default/templates/tpl_search_result_default.php
@@ -15,6 +15,8 @@
 
 <h1 id="searchResultsDefaultHeading"><?php echo HEADING_TITLE; ?></h1>
 
+<?php if ($messageStack->size('search_result') > 0) echo $messageStack->output('search_result'); ?>
+
 <?php
   if ($do_filter_list || PRODUCT_LIST_ALPHA_SORTER == 'true') { ?>
       <div id="filter-wrapper" class="group">


### PR DESCRIPTION
Took the bulk of search_result/header.php which built the SQL and put it in a helper class Zencart\Search\Search.
Inputs to the search refactored into SearchOptions so they can be called programatically without needing a GET request to trigger it. Parsing of $_GET retained in the search/header.php and search_result/header.php.

New message_stack: 'search_result' for displaying a message at the top of
  the search results page (for example 'try also doing xyz').
New notifier: NOTIFY_SEARCH_NO_RESULTS_MESSAGE, given $results, $message
  For reacting to the search results e.g. add to message stack (to appear
  on the 'search' form).