### PR TITLE
Set a default locale in case the server's default is invalid or unconfigured

### DIFF
--- a/admin/includes/application_bootstrap.php
+++ b/admin/includes/application_bootstrap.php
@@ -37,7 +37,16 @@ $_SERVER['SCRIPT_NAME'] = str_replace($serverScript, '', $_SERVER['SCRIPT_NAME']
 /*
  * Get time zone info from PHP config
 */
-@date_default_timezone_set(date_default_timezone_get());
+date_default_timezone_set(date_default_timezone_get());
+
+/*
+ * Check for a valid system locale, and override if invalid or set to 'C' which means 'unconfigured'
+ * It will be overridden later via language-selection operations anyway, but a valid default must be set for zcDate class methods to work
+ */
+$detected_locale = setlocale(LC_TIME, 0);
+if ($detected_locale === false || $detected_locale === 'C') {
+    setlocale(LC_TIME, ['en_US', 'en_US.UTF-8', 'en-US', 'en']);
+}
 
 if (!defined('DIR_FS_ADMIN')) define('DIR_FS_ADMIN', preg_replace('#/includes/$#', '/', realpath(__DIR__ . '/../') . '/'));
 

--- a/includes/application_top.php
+++ b/includes/application_top.php
@@ -112,7 +112,17 @@ if (DEBUG_AUTOLOAD || (defined('STRICT_ERROR_REPORTING') && STRICT_ERROR_REPORTI
     error_reporting(0);
 }
 
-@date_default_timezone_set(date_default_timezone_get());
+date_default_timezone_set(date_default_timezone_get());
+
+/*
+ * Check for a valid system locale, and override if invalid or set to 'C' which means 'unconfigured'
+ * It will be overridden later via language-selection operations anyway, but a valid default must be set for zcDate class methods to work
+ */
+$detected_locale = setlocale(LC_TIME, 0);
+if ($detected_locale === false || $detected_locale === 'C') {
+    setlocale(LC_TIME, ['en_US', 'en_US.UTF-8', 'en-US', 'en']);
+}
+
 require('includes/application_testing.php');
 /**
  * check for and include load application parameters

--- a/zc_install/includes/application_top.php
+++ b/zc_install/includes/application_top.php
@@ -9,6 +9,14 @@
 @ini_set("arg_separator.output", "&");
 @set_time_limit(250);
 
+/*
+ * Check for a valid system locale, and override if invalid or set to 'C' which means 'unconfigured'
+ */
+$detected_locale = setlocale(LC_TIME, 0);
+if ($detected_locale === false || $detected_locale === 'C') {
+    setlocale(LC_TIME, ['en_US', 'en_US.UTF-8', 'en-US', 'en']);
+}
+
 // define the project version
 require DIR_FS_INSTALL . 'includes/version.php';
 


### PR DESCRIPTION
Required since PHP 8.3.0 RC5 and expected in all 8.3+ versions. Also required in PHP 8.1.25 and 8.2.12 (but hopefully not in 8.1.26+ and 8.2.13+)

If not configured at the server/system level, then it defaults to `'C'` (un'C'onfigured), which is invalid when IntlDateFormatter is called, which now throws an exception in such cases.

Fixes #6010 