### PR TITLE
popup images', correcting PHP warnings and deprecations

### DIFF
--- a/includes/modules/pages/popup_image/header_php.php
+++ b/includes/modules/pages/popup_image/header_php.php
@@ -49,7 +49,7 @@
       $products_image_large = '';
   } else {
       $products_image_extension = '.' . pathinfo($products_image, PATHINFO_EXTENSION);
-      $products_image_base = substr($products_image_extension, 0, -strlen($products_image_extension));
+      $products_image_base = substr($products_image, 0, -strlen($products_image_extension));
       $products_image_medium = $products_image_base . IMAGE_SUFFIX_MEDIUM . $products_image_extension;
       $products_image_large = $products_image_base . IMAGE_SUFFIX_LARGE . $products_image_extension;
   }

--- a/includes/modules/pages/popup_image/header_php.php
+++ b/includes/modules/pages/popup_image/header_php.php
@@ -42,10 +42,17 @@
     $products_image = PRODUCTS_IMAGE_NO_IMAGE;
   }
 
-  $products_image_extension = '.' . pathinfo($products_image, PATHINFO_EXTENSION);
-  $products_image_base = str_replace($products_image_extension, '', $products_image);
-  $products_image_medium = $products_image_base . IMAGE_SUFFIX_MEDIUM . $products_image_extension;
-  $products_image_large = $products_image_base . IMAGE_SUFFIX_LARGE . $products_image_extension;
+  if ($products_image === '') {
+      $products_image_extension = '';
+      $products_image_base = '';
+      $products_image_medium = '';
+      $products_image_large = '';
+  } else {
+      $products_image_extension = '.' . pathinfo($products_image, PATHINFO_EXTENSION);
+      $products_image_base = substr($products_image_extension, 0, -strlen($products_image_extension));
+      $products_image_medium = $products_image_base . IMAGE_SUFFIX_MEDIUM . $products_image_extension;
+      $products_image_large = $products_image_base . IMAGE_SUFFIX_LARGE . $products_image_extension;
+  }
 
   // check for a medium image else use small
   if (!file_exists(DIR_WS_IMAGES . 'medium/' . $products_image_medium)) {

--- a/includes/modules/pages/popup_image/header_php.php
+++ b/includes/modules/pages/popup_image/header_php.php
@@ -24,7 +24,7 @@
                             and p.products_id = :productsID
                             and pd.language_id = :languagesID ";
 
-  $products_values_query = $db->bindVars($products_values_query, ':productsID', $_GET['pID'], 'integer');
+  $products_values_query = $db->bindVars($products_values_query, ':productsID', $_GET['pID'] ?? 0, 'integer');
   $products_values_query = $db->bindVars($products_values_query, ':languagesID', $_SESSION['languages_id'], 'integer');
 
   $products_values = $db->Execute($products_values_query);
@@ -38,12 +38,12 @@
   $products_image = $products_values->fields['products_image'];
 
   //auto replace with defined missing image
-  if ($products_image == '' and PRODUCTS_IMAGE_NO_IMAGE_STATUS == '1') {
+  if ($products_image === '' && PRODUCTS_IMAGE_NO_IMAGE_STATUS === '1') {
     $products_image = PRODUCTS_IMAGE_NO_IMAGE;
   }
 
-  $products_image_extension = substr($products_image, strrpos($products_image, '.'));
-  $products_image_base = preg_replace('|'.$products_image_extension.'$|', '', $products_image);
+  $products_image_extension = '.' . pathinfo($products_image, PATHINFO_EXTENSION);
+  $products_image_base = str_replace($products_image_extension, '', $products_image);
   $products_image_medium = $products_image_base . IMAGE_SUFFIX_MEDIUM . $products_image_extension;
   $products_image_large = $products_image_base . IMAGE_SUFFIX_LARGE . $products_image_extension;
 

--- a/includes/modules/pages/popup_image_additional/header_php.php
+++ b/includes/modules/pages/popup_image_additional/header_php.php
@@ -20,7 +20,7 @@
                             and p.products_id = :productsID
                             and pd.language_id = :languagesID ";
 
-  $products_values_query = $db->bindVars($products_values_query, ':productsID', $_GET['pID'], 'integer');
+  $products_values_query = $db->bindVars($products_values_query, ':productsID', $_GET['pID'] ?? 0, 'integer');
   $products_values_query = $db->bindVars($products_values_query, ':languagesID', $_SESSION['languages_id'], 'integer');
 
   $products_values = $db->Execute($products_values_query);

--- a/includes/modules/pages/popup_image_additional/header_php.php
+++ b/includes/modules/pages/popup_image_additional/header_php.php
@@ -25,20 +25,19 @@
 
   $products_values = $db->Execute($products_values_query);
 
-
   $products_image = '';
-  
   if (!$products_values->EOF) {
     $products_image = $products_values->fields['products_image'];
   }
-  $products_image_extension = substr($products_image, strrpos($products_image, '.'));
-  $products_image_base = preg_replace('|'.$products_image_extension.'$|', '', $products_image);
+
+  $products_image_extension = '.' . pathinfo($products_image, PATHINFO_EXTENSION);
+  $products_image_base = str_replace($products_image_extension, '', $products_image);
   $products_image_medium = $products_image_base . IMAGE_SUFFIX_MEDIUM . $products_image_extension;
   $products_image_large = $products_image_base . IMAGE_SUFFIX_LARGE . $products_image_extension;
 
-  $_GET['products_image_large_additional'] = str_replace(' ', '+', stripslashes($_REQUEST['products_image_large_additional']));
+  $_GET['products_image_large_additional'] = str_replace(' ', '+', stripslashes($_REQUEST['products_image_large_additional'] ?? ''));
 
-  $basepath = "";
+  $basepath = '';
   $realBase = realpath($basepath);
   $userpath = $basepath . $_GET['products_image_large_additional'];
   $realUserPath = realpath($userpath);

--- a/includes/modules/pages/popup_image_additional/header_php.php
+++ b/includes/modules/pages/popup_image_additional/header_php.php
@@ -30,10 +30,17 @@
     $products_image = $products_values->fields['products_image'];
   }
 
-  $products_image_extension = '.' . pathinfo($products_image, PATHINFO_EXTENSION);
-  $products_image_base = str_replace($products_image_extension, '', $products_image);
-  $products_image_medium = $products_image_base . IMAGE_SUFFIX_MEDIUM . $products_image_extension;
-  $products_image_large = $products_image_base . IMAGE_SUFFIX_LARGE . $products_image_extension;
+  if ($products_image === '') {
+      $products_image_extension = '';
+      $products_image_base = '';
+      $products_image_medium = '';
+      $products_image_large = '';
+  } else {
+      $products_image_extension = '.' . pathinfo($products_image, PATHINFO_EXTENSION);
+      $products_image_base = substr($products_image, 0, -strlen($products_image_extension));
+      $products_image_medium = $products_image_base . IMAGE_SUFFIX_MEDIUM . $products_image_extension;
+      $products_image_large = $products_image_base . IMAGE_SUFFIX_LARGE . $products_image_extension;
+  }
 
   $_GET['products_image_large_additional'] = str_replace(' ', '+', stripslashes($_REQUEST['products_image_large_additional'] ?? ''));
 


### PR DESCRIPTION
If the `popup_image` or `popup_image_additional` pages' $_GET variables are 'externally' manipulated, either removing or providing an invalid value to one, various PHP Warnings and Deprecated errors are logged.

This PR corrects those situations.