### PR TITLE
Correcting auto-login on "Place Order"

### DIFF
--- a/admin/customers.php
+++ b/admin/customers.php
@@ -1933,7 +1933,8 @@ if ($action === 'edit' || $action === 'update') {
                         $hmacpostdata = [
                             'cid' => $cInfo->customers_id,
                             'aid' => $_SESSION['admin_id'],
-                            'email_address' => $cInfo->customers_email_address
+                            'email_address' => $cInfo->customers_email_address,
+                            'timestamp' => $timestamp,
                         ];
                         $hmacUri = zen_create_hmac_uri($hmacpostdata, $secret);
                         $login_form_start = '<form id="loginform" rel="noopener" target="_blank" name="login" action="' .
@@ -1945,7 +1946,7 @@ if ($action === 'edit' || $action === 'update') {
                         $hiddenFields .=
                             zen_draw_hidden_field('aid', $_SESSION['admin_id']) .
                             zen_draw_hidden_field('cid', $cInfo->customers_id) .
-                            zen_draw_hidden_field('timestamp', $timestamp, 'id="emp-timestamp"');
+                            zen_draw_hidden_field('timestamp', $timestamp);
                     }
                     $contents[] = [
                         'align' => 'text-center',


### PR DESCRIPTION
Fixes #6046

- The admin customer tool wasn't including the 'timestamp' in the generated hmac.
- For whatever reason, browsers update a posted 'timestamp' hidden field when there's also an `id=` parameter (go figure).
- The check in `zen_validate_hmac_login` needs to check its generated HMAC against that passed from the admin and ensure that the 'timestamp' value was posted.
- Includes a couple of refactorings, using multi-variable `isset` checks instead of looping.