### PR TITLE
Correct IP-address gathering when using proxies

### DIFF
--- a/admin/includes/init_includes/init_sessions.php
+++ b/admin/includes/init_includes/init_sessions.php
@@ -37,9 +37,7 @@ session_set_cookie_params([
 /**
  * Sanitize the IP address, and resolve any proxies.
  */
-$ipAddressArray = explode(',', zen_get_ip_address());
-$ipAddress = (sizeof($ipAddressArray) > 0) ? $ipAddressArray[0] : '.';
-$_SERVER['REMOTE_ADDR'] = $ipAddress;
+$_SERVER['REMOTE_ADDR'] = zen_get_ip_address();
 
 // lets start our session
   zen_session_start();

--- a/includes/functions/functions_traffic.php
+++ b/includes/functions/functions_traffic.php
@@ -5,7 +5,6 @@
  * @version $Id: Scott C Wilson 2022 Nov 20 Modified in v1.5.8a $
  */
 
-
 /**
  * Determine visitor's IP address, resolving any proxies where possible.
  *
@@ -17,23 +16,15 @@ function zen_get_ip_address() {
      * resolve any proxies
      */
     if (isset($_SERVER)) {
-        if (isset($_SERVER['HTTP_X_FORWARDED_FOR'])) {
-            $ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
-        } elseif (isset($_SERVER['HTTP_CLIENT_IP'])) {
-            $ip = $_SERVER['HTTP_CLIENT_IP'];
-        } elseif (isset($_SERVER['HTTP_X_FORWARDED'])) {
-            $ip = $_SERVER['HTTP_X_FORWARDED'];
-        } elseif (isset($_SERVER['HTTP_X_CLUSTER_CLIENT_IP'])) {
-            $ip = $_SERVER['HTTP_X_CLUSTER_CLIENT_IP'];
-        } elseif (isset($_SERVER['HTTP_FORWARDED_FOR'])) {
-            $ip = $_SERVER['HTTP_FORWARDED_FOR'];
-        } elseif (isset($_SERVER['HTTP_FORWARDED'])) {
-            $ip = $_SERVER['HTTP_FORWARDED'];
-        } elseif (isset($_SERVER['REMOTE_ADDR'])) {
-            $ip = $_SERVER['REMOTE_ADDR'];
-        }
+        $ip = $_SERVER['HTTP_X_FORWARDED_FOR'] ??
+            $_SERVER['HTTP_CLIENT_IP'] ??
+                $_SERVER['HTTP_X_FORWARDED'] ??
+                    $_SERVER['HTTP_X_CLUSTER_CLIENT_IP'] ??
+                        $_SERVER['HTTP_FORWARDED_FOR'] ??
+                            $_SERVER['HTTP_FORWARDED'] ??
+                                $_SERVER['REMOTE_ADDR'] ?? '';
     }
-    if (trim($ip) == '') {
+    if (trim($ip) === '') {
         if (getenv('HTTP_X_FORWARDED_FOR')) {
             $ip = getenv('HTTP_X_FORWARDED_FOR');
         } elseif (getenv('HTTP_CLIENT_IP')) {
@@ -47,7 +38,9 @@ function zen_get_ip_address() {
      * sanitize for validity as an IPv4 or IPv6 address
      */
     $original_ip = $ip;
-    $ip = filter_var((string)$ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 | FILTER_FLAG_IPV4);
+    $ip = explode(',', (string)$ip);
+    $ip = trim($ip[0]);
+    $ip = filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 | FILTER_FLAG_IPV4);
 
     /**
      *  If it's an invalid IP, set the value to a single dot and issue a notification.

--- a/includes/init_includes/init_sessions.php
+++ b/includes/init_includes/init_sessions.php
@@ -60,9 +60,8 @@ if (isset($_POST[zen_session_name()])) {
 /**
  * Sanitize the IP address, and resolve any proxies.
  */
-$ipAddressArray = explode(',', zen_get_ip_address());
-$ipAddress = (sizeof($ipAddressArray) > 0) ? $ipAddressArray[0] : '.';
-$_SERVER['REMOTE_ADDR'] = $ipAddress;
+$_SERVER['REMOTE_ADDR'] = zen_get_ip_address();
+
 /**
  * start the session
  */


### PR DESCRIPTION
Since the gathered IP might come back as a comma-separated list, the `zen_get_ip_address` function was finding an invalid IP when a proxy is in use.

This PR corrects that issue.