### PR TITLE
Move initialisation of $extra_headings out of conditional.

### DIFF
--- a/includes/templates/template_default/templates/tpl_account_history_info_default.php
+++ b/includes/templates/template_default/templates/tpl_account_history_info_default.php
@@ -16,12 +16,11 @@
 <?php if ($current_page != FILENAME_CHECKOUT_SUCCESS) { ?>
 <h2 id="orderHistoryDetailedOrder"><?php echo HEADING_TITLE . ORDER_HEADING_DIVIDER . sprintf(HEADING_ORDER_NUMBER, zen_output_string_protected($_GET['order_id'])); ?></h2>
 
-<?php
+<?php }
+
 $extra_headings = [];
 $zco_notifier->notify('NOTIFY_ACCOUNT_HISTORY_INFO_EXTRA_COLUMN_HEADING', $order, $extra_headings);
 ?>
-
-<?php } ?>
 
 <table id="orderHistoryHeading">
     <tr class="tableHeading">


### PR DESCRIPTION
Fixed #6058 ... accidentally put the declaration of `$extra_headings` inside an `if` block intended to test for `checkout_success` page.

I had not actually noticed the implication of this conditional when adding the `$extra_headings` code.  It would be worth noting in any documentation for the new notifiers `NOTIFY_ACCOUNT_HISTORY_INFO_EXTRA_COLUMN_HEADING` and `NOTIFY_ACCOUNT_HISTORY_INFO_EXTRA_COLUMN_DATA` that the page is called in the two contexts: 1/ new order summary in checkout_success and 2/ customer visiting order history page.  Quite possibly, any extra data added on the order history page is irrelevant on the order summary page, so any observer using these would do well to react to `$current_page`, for example by not adding any extra headings in that case.