### PR TITLE
Improve links between orders and customers screens.

### DIFF
--- a/admin/customers.php
+++ b/admin/customers.php
@@ -2014,7 +2014,7 @@ if ($action === 'edit' || $action === 'update') {
                     $cInfo->number_of_orders;
                 if ($cInfo->number_of_orders > 0) {
                     $text .= ' [ ';
-                    foreach ($customer->getOrdersSummary(5) as $order) {
+                    foreach ($customer->getRecentOrderRecords(5) as $order) {
                         $text .= '<a href="' . zen_href_link(
                             FILENAME_ORDERS,
                             'cID=' . $cInfo->customers_id . '&oID=' . $order['orders_id'] . '&action=edit',

--- a/admin/customers.php
+++ b/admin/customers.php
@@ -1844,6 +1844,8 @@ if ($action === 'edit' || $action === 'update') {
             ];
             break;
         default:
+            $customer = new Customer($cInfo->customers_id);
+
             if (isset($_GET['search'])) {
                 $_GET['search'] = zen_output_string_protected($_GET['search']);
             }
@@ -2007,11 +2009,25 @@ if ($action === 'edit' || $action === 'update') {
                         $currencies->format($cInfo->gv_balance)
                 ];
 
+                $text = '<br>' .
+                    TEXT_INFO_NUMBER_OF_ORDERS . ' ' .
+                    $cInfo->number_of_orders;
+                if ($cInfo->number_of_orders > 0) {
+                    $text .= ' [ ';
+                    foreach ($customer->getOrdersSummary(5) as $order) {
+                        $text .= '<a href="' . zen_href_link(
+                            FILENAME_ORDERS,
+                            'cID=' . $cInfo->customers_id . '&oID=' . $order['orders_id'] . '&action=edit',
+                            'NONSSL'
+                        ) . '" title="Purchased: ' . zen_date_short($order['date_purchased']) . ', status ' . $order['orders_status_name'] . '">' . $order['orders_id'] . '</a> ';
+                    }
+                    if ($cInfo->number_of_orders > 5) {
+                        $text .= ' ... ';
+                    }
+                    $text .= ' ]';
+                }
                 $contents[] = [
-                    'text' =>
-                        '<br>' .
-                        TEXT_INFO_NUMBER_OF_ORDERS . ' ' .
-                        $cInfo->number_of_orders
+                    'text' => $text
                 ];
 
                 if (!empty($cInfo->lifetime_value)) {

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -1328,7 +1328,7 @@ if (!empty($action) && $order_exists === true) {
                     ?>
                 <td class="dataTableContent text-center"><?php echo $show_difference . $orders->fields['orders_id']; ?></td>
                 <td class="dataTableContent"><?php echo $show_payment_type; ?></td>
-                <td class="dataTableContent"><?php echo '<a href="' . zen_href_link(FILENAME_CUSTOMERS, 'cID=' . $orders->fields['customers_id'], 'NONSSL') . '">' . zen_image(DIR_WS_ICONS . 'preview.gif', ICON_PREVIEW . ' ' . TABLE_HEADING_CUSTOMERS) . '</a>&nbsp;' . $orders->fields['customers_name'] . ($orders->fields['customers_company'] !== '' ? '<br>' . $orders->fields['customers_company'] : ''); ?></td>
+                <td class="dataTableContent"><?php echo '<a href="' . zen_href_link(FILENAME_CUSTOMERS, 'cID=' . $orders->fields['customers_id'], 'NONSSL') . '"><i class="fa-solid fa-magnifying-glass"></i></a>&nbsp;' . $orders->fields['customers_name'] . ($orders->fields['customers_company'] !== '' ? '<br>' . $orders->fields['customers_company'] : ''); ?></td>
 <?php if ($show_zone_info) { ?>
                 <td class="dataTableContent text-left">
 <?php echo $orders->fields['delivery_state'] . '<br>' . $orders->fields['delivery_country']; ?>
@@ -1466,7 +1466,7 @@ if (!empty($action) && $order_exists === true) {
                         '</fieldset></form>' . "\n"];
 
                     $contents[] = ['text' => '<br>' . TEXT_DATE_ORDER_CREATED . ' ' . zen_date_short($oInfo->date_purchased)];
-                    $contents[] = ['text' => '<br>' . $oInfo->customers_email_address];
+                    $contents[] = ['text' => '<br>' . '<a href="' . zen_href_link(FILENAME_CUSTOMERS, 'cID=' . $oInfo->customers_id, 'NONSSL') . '">' . $oInfo->customers_email_address . '</a>' ];
                     $contents[] = ['text' => TEXT_INFO_IP_ADDRESS . ' ' . $oInfo->ip_address];
                     if (zen_not_null($oInfo->last_modified)) {
                       $contents[] = ['text' => TEXT_DATE_ORDER_LAST_MODIFIED . ' ' . zen_date_short($oInfo->last_modified)];

--- a/includes/classes/Customer.php
+++ b/includes/classes/Customer.php
@@ -651,22 +651,25 @@ class Customer extends base
      * @param integer $limit Optional limit of the number of orders to return.
      * @return array
      */
-    public function getOrdersSummary(int $limit = 0): array {
+    public function getRecentOrderRecords(int $limit = 0): array 
+    {
         global $db;
         if (empty($this->customer_id)) {
             return [];
         }
-        $rs = $db->Execute("SELECT orders_id, date_purchased, orders_status_name
+        
+        $result = $db->Execute("SELECT orders_id, date_purchased, orders_status_name
             FROM " . TABLE_ORDERS . " o
             INNER JOIN " . TABLE_ORDERS_STATUS . " os
                 ON o.orders_status = os.orders_status_id AND os.language_id = {$_SESSION['languages_id']}
             WHERE customers_id = {$this->customer_id}
             ORDER BY date_purchased DESC" . (!empty($limit) ? " LIMIT $limit" : '') . ';');
-        $result = [];
-        foreach ($rs as $row) {
-            $result[] = $row;
+        
+        $orders = [];
+        foreach ($result as $row) {
+            $orders[] = $row;
         }
-        return $result;
+        return $orders;
     }
 
     public function setPassword(string $new_password)

--- a/includes/classes/Customer.php
+++ b/includes/classes/Customer.php
@@ -645,6 +645,30 @@ class Customer extends base
         return $result->fields['total'];
     }
 
+    /**
+     * Return a simple summary of orders for this customer, ordered most recent first.
+     *
+     * @param integer $limit Optional limit of the number of orders to return.
+     * @return array
+     */
+    public function getOrdersSummary(int $limit = 0): array {
+        global $db;
+        if (empty($this->customer_id)) {
+            return [];
+        }
+        $rs = $db->Execute("SELECT orders_id, date_purchased, orders_status_name
+            FROM " . TABLE_ORDERS . " o
+            INNER JOIN " . TABLE_ORDERS_STATUS . " os
+                ON o.orders_status = os.orders_status_id AND os.language_id = {$_SESSION['languages_id']}
+            WHERE customers_id = {$this->customer_id}
+            ORDER BY date_purchased DESC" . (!empty($limit) ? " LIMIT $limit" : '') . ';');
+        $result = [];
+        foreach ($rs as $row) {
+            $result[] = $row;
+        }
+        return $result;
+    }
+
     public function setPassword(string $new_password)
     {
         global $db;


### PR DESCRIPTION
Fixes #6054 - feel free to critique.

The more elements are turned into FontAwesome icons, the more the graphic icons such as `icon_edit.gif` and `icon_info.gif` on the orders page stand out.  I'd be happy to take a stab at converting them if there is general support from the core team to do so.