### PR TITLE
Correct `zen_cfg_password_input`

### DIFF
--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -246,7 +246,7 @@ function zen_cfg_password_input($value, $key = '')
     if (function_exists('dbenc_is_encrypted_value_key') && dbenc_is_encrypted_value_key($key)) {
         $value = dbenc_decrypt($value);
     }
-    return zen_draw_password_field('configuration[' . $key . ']', $value, 'class="form-control"');
+    return zen_draw_password_field('configuration[' . $key . ']', $value, false, 'class="form-control"');
 }
 
 function zen_cfg_password_display($value)


### PR DESCRIPTION
The function's currently passing invalid parameters to `zen_draw_password_field`,
```php
  function zen_draw_password_field($name, $value = '', $required = false, $parameters = '',$autocomplete = false) {
```
... resulting in a wonky display with that password-input being required.
![image](https://github.com/zencart/zencart/assets/2685585/9029743b-5670-4afb-bf80-47815806b344)
... with that password-input being required.