### PR TITLE
Add NotifierManager::insertContent for easy content insertion.

### DIFF
--- a/includes/classes/traits/NotifierManager.php
+++ b/includes/classes/traits/NotifierManager.php
@@ -94,6 +94,78 @@ trait NotifierManager
         }
     }
 
+    /**
+     * Requires a define page, and calls regisistered Observers for content output.
+     *
+     * @param [type] $eventID
+     * @param array $param1
+     * @param [type] ...$params
+     * @return void
+     */
+    function insertContent($eventID, $param1 = array(), &...$params)
+    {
+        global $l;
+
+        // Output any 'define_' page, e.g. CONTENT_FOO will output define_foo.php
+        $define_page_name = strtolower(str_replace('CONTENT_', 'DEFINE_', $eventID));
+        $this->outputDefinePage($define_page_name);
+
+        $observers = $this->getRegisteredObservers();
+        if (empty($observers)) {
+            return;
+        }
+        foreach ($observers as $key => $obs) {
+            // Skip observer if it's not registered for a CONTENT_ event.
+            if (!str_starts_with($obs['eventID'], 'CONTENT_')) {
+                continue;
+            }
+
+            // If there is a mapping provided on the observer from event name to define page, use it and continue.
+            if (!empty($obs['obs']->contentDefinePageMap) && array_key_exists($eventID, $obs['obs']->contentDefinePageMap)) {
+                $this->outputDefinePage($obs['obs']->contentDefinePageMap[$eventID]);
+                continue;
+            }
+
+            // Notify the listening observer that this event has been triggered
+            $snake_case_method = strtolower($eventID);
+            if (method_exists($obs['obs'], $snake_case_method)) {
+                $obs['obs']->{$snake_case_method}($this, $eventID, $params);
+            } else {
+                // If no update handler method exists then trigger an error so the problem is logged
+                $className = (is_object($obs['obs'])) ? get_class($obs['obs']) : $obs['obs'];
+                trigger_error('WARNING: No update() method (or matching alternative) found in the ' . $className . ' class for event ' . $actualEventId, E_USER_WARNING);
+            }
+        }
+    }
+
+    /**
+     * Write out a named define page, wrapping it in a <div class="define-page"> with extra
+     * classes and params defined by arguments.
+     *
+     * @param string $define_page_name The name of the define page, e.g. define_foo_bar.php
+     * @param array $classList Any classes to be added to the wrapper e.g. [ 'warning' ]
+     * @param string $params Any other params to be inserted into the <div> e.g. "id='foobar'"
+     * @return void
+     */
+    protected function outputDefinePage (string $define_page_name, array $classList = [], string $params = null) {
+        $define_page = zen_get_file_directory(DIR_WS_LANGUAGES . $_SESSION['language'] . '/html_includes/', $define_page_name, false);
+        if (!file_exists($define_page)) {
+            return; // no action
+        }
+        if (empty($classList)) {
+            $classList = [];
+        }
+        if (!empty($params)) {
+            $params = ' ' . $params;
+        }
+        $classList[] = 'define-page';
+        ob_start();
+        echo '<div class="' . implode(' ', $classList) . '"' . $params . '>';
+        require($define_page);
+        echo '</div>';
+        ob_end_flush();
+    }
+
     protected function logNotifier($eventID, $param1, $param2, $param3, $param4, $param5, $param6, $param7, $param8, $param9)
     {
         if (!defined('NOTIFIER_TRACE') || empty(NOTIFIER_TRACE) || NOTIFIER_TRACE === 'false' || NOTIFIER_TRACE === 'Off') {

--- a/includes/templates/template_default/templates/tpl_account_history_info_default.php
+++ b/includes/templates/template_default/templates/tpl_account_history_info_default.php
@@ -15,14 +15,13 @@
 
 <?php if ($current_page != FILENAME_CHECKOUT_SUCCESS) { ?>
 <h2 id="orderHistoryDetailedOrder"><?php echo HEADING_TITLE . ORDER_HEADING_DIVIDER . sprintf(HEADING_ORDER_NUMBER, zen_output_string_protected($_GET['order_id'])); ?></h2>
+<?php }
 
-<?php
+$zco_notifier->insertContent('CONTENT_ACCOUNT_HISTORY_INFO_INTRO', $order);
+
 $extra_headings = [];
 $zco_notifier->notify('NOTIFY_ACCOUNT_HISTORY_INFO_EXTRA_COLUMN_HEADING', $order, $extra_headings);
 ?>
-
-<?php } ?>
-
 <table id="orderHistoryHeading">
     <tr class="tableHeading">
         <th scope="col" id="myAccountQuantity"><?php echo HEADING_QUANTITY; ?></th>
@@ -107,6 +106,10 @@ $zco_notifier->notify('NOTIFY_ACCOUNT_HISTORY_INFO_EXTRA_COLUMN_HEADING', $order
 </div>
 
 <?php
+$zco_notifier->insertContent('CONTENT_ACCOUNT_HISTORY_INFO_POST_ORDER', $order);
+?>
+
+<?php
 /**
  * Used to display any downloads associated with the cutomers account
  */
@@ -185,4 +188,7 @@ if (!empty($order->statuses)) {
 <div><?php echo $order->info['payment_method']; ?></div>
 </div>
 <br class="clearBoth">
+<?php
+$zco_notifier->insertContent('CONTENT_ACCOUNT_HISTORY_INFO_EXTRO', $order);
+?>
 </div>


### PR DESCRIPTION
Fixes #6053 .

# Needs Review

This PR is not finished, submitted for review as a concept.  I include just a few example hooks in the Account History Info page.  We would need to scatter `$zco_notifier->insertContent('CONTENT_FOO_BAR');` calls throughout the template files, similar to how `notify()` calls were.

## Improving NotifierManager Performance

I did some work on improving the array hunting done in NotifierManager, but it involves changing the core `EventDto::$observers` data structure which I think some addons rely on (I saw Watching Observers (https://www.zen-cart.com/showthread.php?226649-Watching-Observers-Support-Thread) for example).  See https://github.com/neekfenwick/zencart/tree/content-notifiers-issue-6053

This PR is a completely separate branch, without the EventDto etc modifications.

# Description

This PR takes the idea of NotifierManager and Observers, and extends it for arbitrary content inclusion at key points on shop front pages.  We are used to e.g.:

    $zco_notifier->notify('NOTIFY_ACCOUNT_HISTORY_INFO_EXTRA_COLUMN_HEADING', $order, $extra_headings);

Observers may then register for the `NOTIFY_ACCOUNT_HISTORY_INFO_EXTRA_COLUMN_HEADING` event and be called by `NotifierManager` when that event is fired.  This PR introduces `CONTENT_FOO_BAR` events with different behaviour.

## One line define page inclusion

The main aim is to allow templates to position define page content easily in a single line of code.  For example modify `tpl_account_history_info_default.php` to have this line just under the `<h1>`:

    $zco_notifier->insertContent('CONTENT_ACCOUNT_HISTORY_INFO_INTRO', $order);

Whether or not any Observers are registered, this will attempt to replace the 'CONTENT_' with 'DEFINE_', lowercase the result, and require a define page, e.g. `define_account_history_info_intro.php`, wrapped in a suitable div, e.g.:

    <div class="define-page"> ### content here ### </div>

If a define page of that name is not found, no automatic output is made and no error is raised.

## Event name to Define Page mapping

If an Observer wants to register for an event like `CONTENT_ACCOUNT_HISTORY_INFO_INTRO` but wants to use a differently named define page, e.g. one shipped with their addon, the Observer can declare a map instead of implementing a handler function, e.g.:

    public array $contentDefinePageMap = [
        'CONTENT_ACCOUNT_HISTORY_INFO_INTRO' => 'define_my_addon_shipped_file'
    ];

You can equally handle the event in a custom handler function, and call the define page output function helper, but this is neater.

## Custom handler functions

Similar to the existing Notify system, if a method is found matching the snakeCased event name, it is invoked.  It may then use the define page output helper function, or directly output content, using data passed in.

## Difference from Existing Notifiers

All this looks a lot like what we already had before, but is conceptually and functionally different.  We can output HTML from a normal Notifier but this approach brings a couple of benefits:

- Easily output Define Pages by name, associated with the event names.  This isn't done in NOTIFY_ hooks, and doesn't really suit their purpose.
- The average user can see a hook like "CONTENT_" and easily connect it with a Define Page they see on the admin Define Pages editor.
- An addon author writing an Observer can register for both NOTIFY_ and CONTENT_ events in the same Observer, and implement the handlers differently for each task.  NOTIFY_ handlers would do data processing, email sending etc., CONTENT_ hooks would display data (or just use the `$contentDefinePageMap`).

## Example

The system allows for Observers to register, too, i.e.

`auto.content_notify_test.php:`

    <?php
    // Test file for Content Notifier.

    class zcObserverContentNotifyTest extends base
    {
        public function __construct()
        {
            $this->attach($this, array(
                'CONTENT_ACCOUNT_HISTORY_INFO_INTRO'
            ));
        }

        // If this is uncommented, then the event will cause the define page to be output and not call the handler function.
        // public array $contentDefinePageMap = [
        //     'CONTENT_ACCOUNT_HISTORY_INFO_INTRO' => 'define_some_page_name_here'
        // ];

        /**
        * Handler function called when our observed event is fired.
        *
        * @param object $callingClass
        * @param string $notifier
        * @param array $params
        * @return void
        */
        public function content_account_history_info_intro(&$callingClass, $notifier, &...$params) {
            $order = &$params[0];
            $this->outputDefinePage('define_account_history_info_intro');
            // Show a different define page content, depending on the latest status history of the order.
            $latestStatus = $order->statuses[0]['orders_status_name'] ?? 'Pending';
    ?>
            <p>This order is currently <?php echo $latestStatus ?>, please be patient.</p>
    <?php
        }

    }

`NotifierManager` had some legacy cruft relating to what methods might be on the Observer class; the `update()` function and different snake_cased method names.  This PR simplifies all that and assumes the function will be `content_<snake_cased_eventID>()`.  There is also no `'*'` event registration possible.

Note that I am using Parameter Lists `&...$params` in passing data to the observer, instead of `&$param1, &$param2, etc`.  The downside is that the handler methods no longer have named parameters, such as `$order`, `$some_data` etc.  I could go either way on that.
