### PR TITLE
Customer::getOrderHistory doesn't convert from default currency

### DIFF
--- a/includes/classes/Customer.php
+++ b/includes/classes/Customer.php
@@ -606,7 +606,7 @@ class Customer extends base
                 'order_name' => $order_name,
                 'order_country' => $order_country,
                 'orders_status_name' => $result['orders_status_name'],
-                'order_total' => $currencies->format($result['order_total'], false, $result['currency'], $result['currency_value']),
+                'order_total' => $currencies->format($result['order_total'], true, $result['currency'], $result['currency_value']),
                 'order_total_raw' => $result['order_total'],
                 'currency' => $result['currency'],
                 'currency_value' => $result['currency_value'],


### PR DESCRIPTION
If a customer places an order in a currency other than a store's default, the orders-list from the `account` and `account_history` pages displays the associated currency symbol correctly
![image](https://github.com/zencart/zencart/assets/2685585/d05e104e-9fe4-46a8-a5f5-5a8caf03fc27)

... but the amount isn't converted from the default currency to the order's currency, which it is after the correction in this PR:

![image](https://github.com/zencart/zencart/assets/2685585/fcb63299-17c8-48c8-8a35-f133e4ca3e8c)

