### PR TITLE
Missing first state/province from state dropdowns when country changed

### DIFF
--- a/includes/templates/template_default/jscript/zen_addr_pulldowns.php
+++ b/includes/templates/template_default/jscript/zen_addr_pulldowns.php
@@ -105,7 +105,7 @@ jQuery(document).ready(function() {
             }
         });
         if (countryHasZones) {
-            var split = countryZones.split('<option');
+            var split = countryZones.split('<option').filter(function(el) {return el.length != 0});
             var sorted = split.sort();
             countryZones = '<option selected="selected" value="0"><?php echo addslashes(PLEASE_SELECT); ?><' + '/option><option' + sorted.join('<option');
             jQuery('#state').hide();


### PR DESCRIPTION
If a customer changes their country from the US to Canada (or any other country that has defined 'zones'), the first entry in the state dropdown is missing (e.g. for Canada, Alberta is missing).  That's because invalid HTML is rendered by the `/includes/templates/template_default/jscript/zen_addr_pulldowns.php`'s jQuery.

The invalid HTML is created because (for whatever reason), the `countryZones.split('<option')` returns an extra (empty) string as the first element of the array.  As identified in [this](https://stackoverflow.com/questions/12836062/string-split-returns-an-array-with-more-elements-than-expected-empty-elements) SO posting, adding `.filter(function(el) {return el.length != 0})` corrects the issue.