### PR TITLE
Correct PHP deprecations in `zen_icon`

### DIFF
--- a/admin/includes/functions/html_output.php
+++ b/admin/includes/functions/html_output.php
@@ -262,7 +262,7 @@ function zen_icon(string $icon, ?string $tooltip = null, string $size = '', bool
   $iconSet = str_contains($classes, 'fa-regular') ? '' : 'fa-solid';
   $sizeClass = $size === '2x' ? ' fa-2x' : ($size === 'lg' ? ' fa-lg' : '');
   $ariaHidden = $hidden ? ' aria-hidden="true"' : '';
-  return "<i class=\"${iconSet}$sizeClass align-middle {$classes}${fw}\"{$tooltip}{$ariaHidden}></i>";
+  return "<i class=\"$iconSet$sizeClass align-middle $classes$fw\"$tooltip$ariaHidden></i>";
 }
 
 ////


### PR DESCRIPTION
Seeing logs like
```
[09-Dec-2023 14:40:04 America/New_York] Request URI: /zc200w/admin200/index.php?cmd=orders&page=1&oID=19&action=edit, IP address: 127.0.0.1, Language id not set
#0 C:\xampp\htdocs\zc200w\admin200\includes\init_includes\init_general_funcs.php(39): zen_debug_error_handler()
#1 C:\xampp\htdocs\zc200w\admin200\includes\init_includes\init_general_funcs.php(39): require()
#2 C:\xampp\htdocs\zc200w\includes\autoload_func.php(40): require_once('C:\\xampp\\htdocs...')
#3 C:\xampp\htdocs\zc200w\admin200\includes\application_top.php(42): require('C:\\xampp\\htdocs...')
#4 C:\xampp\htdocs\zc200w\admin200\orders.php(8): require('C:\\xampp\\htdocs...')
#5 C:\xampp\htdocs\zc200w\admin200\index.php(11): require('C:\\xampp\\htdocs...')
--> PHP Deprecated: Using ${var} in strings is deprecated, use {$var} instead in C:\xampp\htdocs\zc200w\admin200\includes\functions\html_output.php on line 265.
```