### PR TITLE
Use Customer::getOrderHistory for recent order info.

### DIFF
--- a/admin/customers.php
+++ b/admin/customers.php
@@ -2085,7 +2085,7 @@ if ($action === 'edit' || $action === 'update') {
                     $cInfo->number_of_orders;
                 if ($cInfo->number_of_orders > 0) {
                     $text .= ' [ ';
-                    foreach ($customer->getRecentOrderRecords(5) as $order) {
+                    foreach ($customer->getOrderHistory(5) as $order) {
                         $text .= '<a href="' . zen_href_link(
                             FILENAME_ORDERS,
                             'cID=' . $cInfo->customers_id . '&oID=' . $order['orders_id'] . '&action=edit',

--- a/includes/classes/Customer.php
+++ b/includes/classes/Customer.php
@@ -623,11 +623,13 @@ class Customer extends base
 
         $sql = $db->bindVars($sql, ':customersID', $this->customer_id, 'integer');
         $sql = $db->bindVars($sql, ':languagesID', $language, 'integer');
-        $history_split = new splitPageResults($sql, $max_number_to_return);
         if ($returned_history_split !== null) {
+            $history_split = new splitPageResults($sql, $max_number_to_return);
             $returned_history_split = $history_split;
+            $results = $db->Execute($history_split->sql_query);
+        } else {
+            $results = $db->Execute($sql, $max_number_to_return);
         }
-        $results = $db->Execute($history_split->sql_query);
 
         $ordersArray = [];
         foreach ($results as $result) {
@@ -692,33 +694,6 @@ class Customer extends base
         $result = $db->Execute($sql);
 
         return $result->fields['total'];
-    }
-
-    /**
-     * Return a simple summary of orders for this customer, ordered most recent first.
-     *
-     * @param integer $limit Optional limit of the number of orders to return.
-     * @return array
-     */
-    public function getRecentOrderRecords(int $limit = 0): array 
-    {
-        global $db;
-        if (empty($this->customer_id)) {
-            return [];
-        }
-        
-        $result = $db->Execute("SELECT orders_id, date_purchased, orders_status_name
-            FROM " . TABLE_ORDERS . " o
-            INNER JOIN " . TABLE_ORDERS_STATUS . " os
-                ON o.orders_status = os.orders_status_id AND os.language_id = {$_SESSION['languages_id']}
-            WHERE customers_id = {$this->customer_id}
-            ORDER BY date_purchased DESC" . (!empty($limit) ? " LIMIT $limit" : '') . ';');
-        
-        $orders = [];
-        foreach ($result as $row) {
-            $orders[] = $row;
-        }
-        return $orders;
     }
 
     public function setPassword(string $new_password)


### PR DESCRIPTION
This follows on from discussion on #6061 

After our discussion in your review comments, I agreed we could get rid of my new function `Customer::getRecentOrderRecords()`, and I re-wrote the original function `Customer::getOrderHistory()` so it can be used instead.  However I have hit a problem in its use of `splitPageResults` because that function does some basic string searching in the SQL for things like 'from' and splits the query so it can count rows, which fails when a subselect is used (anything with a 'from' or 'group by' clause, it seems).  The result is malformed SQL, probably an issue you've been long aware of with `splitPageResults`.

(Note, the only place I see `account_history` being linked to, and thus using this splitPageResults path, is from a "(show all orders)" link on the customer `account` page.)

So, I cannot optimise that function as I wanted to with a subselect, but I can at least remove my mostly unnecessary `getRecentOrderRecords()` function.