### PR TITLE
zen_mail: Copy text message to HTML, if not present

### DIFF
--- a/includes/functions/functions_email.php
+++ b/includes/functions/functions_email.php
@@ -133,6 +133,9 @@
                 if (empty($block['EMAIL_FROM_ADDRESS'])) {
                     $block['EMAIL_FROM_ADDRESS'] = $from_email_address;
                 }
+                if (empty($block['EMAIL_MESSAGE_HTML'])) {
+                    $block['EMAIL_MESSAGE_HTML'] = $email_text;
+                }
             }
             $email_html = (!is_array($block) && substr($block, 0, 6) == '<html>') ? $block : zen_build_html_email_from_template($module, $block);
             if (!is_array($block) && ($block === '' || $block === 'none')) {


### PR DESCRIPTION
Otherwise, a call like the following
```
zen_mail('Send to Name', 'joe@example.com', 'Test Message Subject', $email_message_text, STORE_NAME, STORE_OWNER_EMAIL_ADDRESS);
```

... when sent to an email that's configured for HTML results in the HTML email's body containing `$EMAIL_MESSAGE_HTML`.