### PR TITLE
Adding Crowdin config file

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,6 +1,6 @@
-export_languages: ["english"]
+export_languages:
+  - english
 files:
-  # Admin
   - source: /admin/includes/languages/lang.english.php
     translation: /admin/includes/languages/lang.%language%.php
     update_option: update_as_unapproved
@@ -13,8 +13,6 @@ files:
   - source: /admin/includes/languages/english/modules/newsletters/*.php
     translation: /admin/includes/languages/%language%/modules/newsletters/%original_file_name%
     update_option: update_as_unapproved
-
-  # Store Front
   - source: /includes/languages/lang.english.php
     translation: /includes/languages/lang.%language%.php
     update_option: update_as_unapproved

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -35,15 +35,15 @@ files:
     update_option: update_as_unapproved
   - source: /includes/languages/english/html_includes/*.php
     dest: /includes/languages/english/html_includes/%file_name%.txt
-    translation: /includes/languages/%language%/html_includes/%original_file_name%
+    translation: /includes/languages/%language%/html_includes/%file_name%.php
     update_option: update_as_unapproved
   - source: /includes/languages/english/html_includes/classic/*.php
     dest: /includes/languages/english/html_includes/classic/%file_name%.txt
-    translation: /includes/languages/%language%/html_includes/classic/%original_file_name%
+    translation: /includes/languages/%language%/html_includes/classic/%file_name%.php
     update_option: update_as_unapproved
   - source: /includes/languages/english/html_includes/responsive_classic/*.php
     dest: /includes/languages/english/html_includes/responsive_classic/%file_name%.txt
-    translation: /includes/languages/%language%/html_includes/responsive_classic/%original_file_name%
+    translation: /includes/languages/%language%/html_includes/responsive_classic/%file_name%.php
     update_option: update_as_unapproved
   - source: /includes/languages/english/modules/order_total/*.php
     translation: /includes/languages/%language%/modules/order_total/%original_file_name%

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,59 @@
+export_languages: ["english"]
+files:
+  # Admin
+  - source: /admin/includes/languages/lang.english.php
+    translation: /admin/includes/languages/lang.%language%.php
+    update_option: update_as_unapproved
+  - source: /admin/includes/languages/english/*.php
+    translation: /admin/includes/languages/%language%/%original_file_name%
+    update_option: update_as_unapproved
+  - source: /admin/includes/languages/english/extra_definitions/*.php
+    translation: /admin/includes/languages/%language%/extra_definitions/%original_file_name%
+    update_option: update_as_unapproved
+  - source: /admin/includes/languages/english/modules/newsletters/*.php
+    translation: /admin/includes/languages/%language%/modules/newsletters/%original_file_name%
+    update_option: update_as_unapproved
+
+  # Store Front
+  - source: /includes/languages/lang.english.php
+    translation: /includes/languages/lang.%language%.php
+    update_option: update_as_unapproved
+  - source: /includes/languages/english/*.php
+    translation: /includes/languages/%language%/%original_file_name%
+    update_option: update_as_unapproved
+  - source: /includes/languages/english/classic/*.php
+    translation: /includes/languages/%language%/classic/%original_file_name%
+    update_option: update_as_unapproved
+  - source: /includes/languages/english/extra_definitions/*.php
+    translation: /includes/languages/%language%/extra_definitions/%original_file_name%
+    update_option: update_as_unapproved
+  - source: /includes/languages/english/extra_definitions/classic/*.php
+    translation: /includes/languages/%language%/extra_definitions/classic/%original_file_name%
+    update_option: update_as_unapproved
+  - source: /includes/languages/english/extra_definitions/responsive_classic/*.php
+    translation: /includes/languages/%language%/extra_definitions/responsive_classic/%original_file_name%
+    update_option: update_as_unapproved
+  - source: /includes/languages/english/html_includes/*.php
+    dest: /includes/languages/english/html_includes/%file_name%.txt
+    translation: /includes/languages/%language%/html_includes/%original_file_name%
+    update_option: update_as_unapproved
+  - source: /includes/languages/english/html_includes/classic/*.php
+    dest: /includes/languages/english/html_includes/classic/%file_name%.txt
+    translation: /includes/languages/%language%/html_includes/classic/%original_file_name%
+    update_option: update_as_unapproved
+  - source: /includes/languages/english/html_includes/responsive_classic/*.php
+    dest: /includes/languages/english/html_includes/responsive_classic/%file_name%.txt
+    translation: /includes/languages/%language%/html_includes/responsive_classic/%original_file_name%
+    update_option: update_as_unapproved
+  - source: /includes/languages/english/modules/order_total/*.php
+    translation: /includes/languages/%language%/modules/order_total/%original_file_name%
+    update_option: update_as_unapproved
+  - source: /includes/languages/english/modules/payment/*.php
+    translation: /includes/languages/%language%/modules/payment/%original_file_name%
+    update_option: update_as_unapproved
+  - source: /includes/languages/english/modules/shipping/*.php
+    translation: /includes/languages/%language%/modules/shipping/%original_file_name%
+    update_option: update_as_unapproved
+  - source: /includes/languages/english/responsive_classic/*.php
+    translation: /includes/languages/%language%/responsive_classic/%original_file_name%
+    update_option: update_as_unapproved


### PR DESCRIPTION
Used for syncing English core language files from GitHub to Crowdin.

Note! Files in html_includes are added as txt files in Crowdin to make them translatable, since they isn't real language files with defines. On export they will be automatically renamed back to php.

_*I recommend moving flag icons out of language packs, and rather incorporate them in the core by default like other systems do._