### PR TITLE
Display currency-value on admin orders' details

### DIFF
--- a/admin/includes/languages/english/lang.orders.php
+++ b/admin/includes/languages/english/lang.orders.php
@@ -29,6 +29,7 @@ $define = [
     'ENTRY_SHIPPING_ADDRESS' => 'Shipping Address:<br><i class="fa-solid fa-2x fa-truck"></i>',
     'ENTRY_BILLING_ADDRESS' => 'Billing Address:<br><i class="fa-regular fa-2x fa-credit-card"></i>',
     'ENTRY_PAYMENT_METHOD' => 'Payment Method:',
+    'ENTRY_CURRENCY_VALUE' => 'Currency Value:',
     'ENTRY_CREDIT_CARD_TYPE' => 'Credit Card Type:',
     'ENTRY_CREDIT_CARD_OWNER' => 'Credit Card Owner:',
     'ENTRY_CREDIT_CARD_NUMBER' => 'Credit Card Number:',

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -679,6 +679,20 @@ if (!empty($action) && $order_exists === true) {
               <td class="main"><?php echo $order->info['payment_method']; ?></td>
             </tr>
             <?php
+            // -----
+            // Note: Using loose comparison since the value is recorded (currently) as decimal(14,6)
+            // and shows up in the order as (string)1.00000 if the order's placed in the store's
+            // default currency.
+            //
+            if ($order->info['currency_value'] != 1) {
+?>
+            <tr>
+              <td class="main"><strong><?php echo ENTRY_CURRENCY_VALUE; ?></strong></td>
+              <td class="main"><?php echo $order->info['currency_value']; ?></td>
+            </tr>
+<?php
+            }
+
             if (!empty($order->info['cc_type']) || !empty($order->info['cc_owner']) || !empty($order->info['cc_number'])) {
               ?>
               <tr class="noprint">


### PR DESCRIPTION
Fixes #6080.

Display the value if-and-only-if the value is not 1, implying that the order was placed in the store's default currency.