### PR TITLE
Reformat zc_install code

### DIFF
--- a/zc_install/ajaxAdminSetup.php
+++ b/zc_install/ajaxAdminSetup.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * ajaxAdminSetup.php
  * @copyright Copyright 2003-2022 Zen Cart Development Team
@@ -14,23 +16,22 @@ require(DIR_FS_INSTALL . 'includes/application_top.php');
 $adminDir = $_POST['adminDir'] ?? 'admin';
 $wordlist = file(DIR_FS_INSTALL . 'includes/wordlist.csv');
 $max = count($wordlist) - 1;
-$word1 = trim($wordlist[zen_pwd_rand(0,$max)]);
-$pos = zen_pwd_rand(0,4);
+$word1 = trim($wordlist[zen_pwd_rand(0, $max)]);
+$pos = zen_pwd_rand(0, 4);
 $word1[$pos] = strtoupper($word1[$pos]);
-$word3 = trim($wordlist[zen_pwd_rand(0,$max)]);
-$pos = zen_pwd_rand(0,4);
+$word3 = trim($wordlist[zen_pwd_rand(0, $max)]);
+$pos = zen_pwd_rand(0, 4);
 $word3[$pos] = strtoupper($word3[$pos]);
 $word2 = zen_create_random_value(3, 'chars');
 $adminNewDir = $adminDir;
-$result = FALSE;
-if ($adminDir == 'admin' && (!defined('DEVELOPER_MODE') || DEVELOPER_MODE == false))
-{
-  $adminNewDir =  $word1 . '-' . $word2 . '-' . $word3;
-  $result = @rename(DIR_FS_ROOT . $adminDir, DIR_FS_ROOT . $adminNewDir);
-  if ($result === false) {
-    $adminNewDir = $adminDir;
-  } else {
-    $adminDir = $adminNewDir;
-  }
+$result = false;
+if ($adminDir === 'admin' && (!defined('DEVELOPER_MODE') || DEVELOPER_MODE === false)) {
+    $adminNewDir = $word1 . '-' . $word2 . '-' . $word3;
+    $result = @rename(DIR_FS_ROOT . $adminDir, DIR_FS_ROOT . $adminNewDir);
+    if ($result === false) {
+        $adminNewDir = $adminDir;
+    } else {
+        $adminDir = $adminNewDir;
+    }
 }
-echo json_encode(array('changedDir'=>(int)$result, 'adminNewDir'=>$adminNewDir, 'adminDir'=>$adminDir));
+echo json_encode(['changedDir' => (int)$result, 'adminNewDir' => $adminNewDir, 'adminDir' => $adminDir]);

--- a/zc_install/ajaxGetHelpText.php
+++ b/zc_install/ajaxGetHelpText.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * ajaxGetHelpText.php
  * @package Installer
@@ -12,13 +14,12 @@ define('DIR_FS_ROOT', realpath(__DIR__ . '/../') . '/');
 
 require(DIR_FS_INSTALL . 'includes/application_top.php');
 
-if (isset($_POST['id']))
-{
-  $result = str_replace('helpId', '' , zen_output_string_protected($_POST['id']));
-  $content = "TEXT_HELP_CONTENT_" . strtoupper($result);
-  $content = "<p>".constant($content) . "</p>";
-  $title = "TEXT_HELP_TITLE_" . strtoupper($result);
-  $title = constant($title);
+if (isset($_POST['id'])) {
+    $result = str_replace('helpId', '', zen_output_string_protected($_POST['id']));
+    $content = "TEXT_HELP_CONTENT_" . strtoupper($result);
+    $content = "<p>" . constant($content) . "</p>";
+    $title = "TEXT_HELP_TITLE_" . strtoupper($result);
+    $title = constant($title);
 }
 
-echo json_encode(array('text'=>$content, 'title'=>$title));
+echo json_encode(['text' => $content, 'title' => $title]);

--- a/zc_install/ajaxGetProgressValues.php
+++ b/zc_install/ajaxGetProgressValues.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * ajaxGetProgressValues.php
  * @package Installer

--- a/zc_install/ajaxLoadMainSql.php
+++ b/zc_install/ajaxLoadMainSql.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * ajaxLoadMainSql.php
  * @copyright Copyright 2003-2022 Zen Cart Development Team
@@ -11,82 +13,111 @@ define('DIR_FS_ROOT', realpath(__DIR__ . '/../') . '/');
 
 require(DIR_FS_INSTALL . 'includes/application_top.php');
 
-$error = FALSE;
+$error = false;
 
 $db_type = 'mysql';
 
 
 require_once(DIR_FS_INSTALL . 'includes/classes/class.zcDatabaseInstaller.php');
-$options = array('db_host'=>$_POST['db_host'], 'db_user'=>$_POST['db_user'], 'db_password'=>$_POST['db_password'], 'db_name'=>$_POST['db_name'], 'db_charset'=>$_POST['db_charset'], 'db_prefix'=>$_POST['db_prefix'], 'db_type'=>$db_type);
+$options = [
+    'db_host' => $_POST['db_host'],
+    'db_user' => $_POST['db_user'],
+    'db_password' => $_POST['db_password'],
+    'db_name' => $_POST['db_name'],
+    'db_charset' => $_POST['db_charset'],
+    'db_prefix' => $_POST['db_prefix'],
+    'db_type' => $db_type,
+];
 // trim spaces from inputs
-foreach($options as $key => $val) {
-  $options[$key] = trim($val);
+foreach ($options as $key => $val) {
+    $options[$key] = trim($val);
 }
 $dbInstaller = new zcDatabaseInstaller($options);
 $result = $dbInstaller->getConnection();
-$extendedOptions = array('doJsonProgressLogging'=>TRUE, 'doJsonProgressLoggingFileName'=>DEBUG_LOG_FOLDER . '/progress.json', 'id'=>'main', 'message'=>TEXT_CREATING_DATABASE);
+$extendedOptions = [
+    'doJsonProgressLogging' => true,
+    'doJsonProgressLoggingFileName' => DEBUG_LOG_FOLDER . '/progress.json',
+    'id' => 'main',
+    'message' => TEXT_CREATING_DATABASE,
+];
 $file = DIR_FS_INSTALL . 'sql/install/mysql_zencart.sql';
 logDetails('processing file ' . $file);
 $error = $dbInstaller->parseSqlFile($file, $extendedOptions);
-if ($error)
-{
-  echo json_encode(array('error'=>$error, 'file'=>$file)); die();
+if ($error) {
+    echo json_encode(['error' => $error, 'file' => $file]);
+    die();
 }
 // localization file
 $charset = $_POST['db_charset'];
-if (!in_array($charset, array('utf8', 'latin1'))) $charset = 'utf8';
-$file = DIR_FS_INSTALL . 'sql/install/mysql_' . $charset . '.sql';
-if (file_exists($file))
-{
-  $extendedOptions = array('doJsonProgressLogging'=>TRUE, 'doJsonProgressLoggingFileName'=>DEBUG_LOG_FOLDER . '/progress.json', 'id'=>'main', 'message'=>TEXT_LOADING_CHARSET_SPECIFIC);
-  logDetails('processing file ' . $file);
-  $error = $dbInstaller->parseSqlFile($file, $extendedOptions);
+if (!in_array($charset, ['utf8', 'latin1'])) {
+    $charset = 'utf8';
 }
-if ($error)
-{
-  echo json_encode(array('error'=>$error, 'file'=>$file)); die();
+$file = DIR_FS_INSTALL . 'sql/install/mysql_' . $charset . '.sql';
+if (file_exists($file)) {
+    $extendedOptions = [
+        'doJsonProgressLogging' => true,
+        'doJsonProgressLoggingFileName' => DEBUG_LOG_FOLDER . '/progress.json',
+        'id' => 'main',
+        'message' => TEXT_LOADING_CHARSET_SPECIFIC,
+    ];
+    logDetails('processing file ' . $file);
+    $error = $dbInstaller->parseSqlFile($file, $extendedOptions);
+}
+if ($error) {
+    echo json_encode(['error' => $error, 'file' => $file]);
+    die();
 }
 // Demo data
-if (isset($_POST['demoData']))
-{
-  $extendedOptions = array('doJsonProgressLogging'=>TRUE, 'doJsonProgressLoggingFileName'=>DEBUG_LOG_FOLDER . '/progress.json', 'id'=>'main', 'message'=>TEXT_LOADING_DEMO_DATA);
-  $file = DIR_FS_INSTALL . 'sql/demo/mysql_demo.sql';
-  logDetails('processing file ' . $file);
-  $error = $dbInstaller->parseSqlFile($file, $extendedOptions);
-  // system('unzip --q demo_images/images.zip -d ../images/'); 
-  $za = new ZipArchive;
-  if ($za->open('demo_images/images.zip') === TRUE) {
-    $za->extractTo('../images');
-    $za->close();
-  }
+if (isset($_POST['demoData'])) {
+    $extendedOptions = [
+        'doJsonProgressLogging' => true,
+        'doJsonProgressLoggingFileName' => DEBUG_LOG_FOLDER . '/progress.json',
+        'id' => 'main',
+        'message' => TEXT_LOADING_DEMO_DATA,
+    ];
+    $file = DIR_FS_INSTALL . 'sql/demo/mysql_demo.sql';
+    logDetails('processing file ' . $file);
+    $error = $dbInstaller->parseSqlFile($file, $extendedOptions);
+    // system('unzip --q demo_images/images.zip -d ../images/');
+    $za = new ZipArchive;
+    if ($za->open('demo_images/images.zip') === true) {
+        $za->extractTo('../images');
+        $za->close();
+    }
 }
-if ($error)
-{
-  echo json_encode(array('error'=>$error, 'file'=>$file)); die();
+if ($error) {
+    echo json_encode(['error' => $error, 'file' => $file]);
+    die();
 }
 // Save data
 logDetails('saving cfg keys');
 $error = $dbInstaller->updateConfigKeys();
-if ($error)
-{
-  echo json_encode(array('error'=>$error, 'file'=>$file)); die();
+if ($error) {
+    echo json_encode(['error' => $error, 'file' => $file]);
+    die();
 }
 
 // Plugins
 $pluginsfolder = DIR_FS_INSTALL . 'sql/plugins/';
 if ($d = dir($pluginsfolder)) {
-  while ($entry = $d->read()) {
-    if (!is_dir($pluginsfolder . $entry)) {
-      if (preg_match('~^[^\._].*\.sql$~', $entry) > 0) {
-        $extendedOptions = array('doJsonProgressLogging'=>TRUE, 'doJsonProgressLoggingFileName'=>DEBUG_LOG_FOLDER . '/progress.json', 'id'=>'main', 'message'=>TEXT_LOADING_PLUGIN_DATA . ' ' . $entry);
-        $file = $pluginsfolder . $entry;
-        logDetails('processing file ' . $file);
-        $error = $dbInstaller->parseSqlFile($file, $extendedOptions);
-      }
+    while ($entry = $d->read()) {
+        if (!is_dir($pluginsfolder . $entry)) {
+            if (preg_match('~^[^\._].*\.sql$~', $entry) > 0) {
+                $extendedOptions = [
+                    'doJsonProgressLogging' => true,
+                    'doJsonProgressLoggingFileName' => DEBUG_LOG_FOLDER . '/progress.json',
+                    'id' => 'main',
+                    'message' => TEXT_LOADING_PLUGIN_DATA . ' ' . $entry,
+                ];
+                $file = $pluginsfolder . $entry;
+                logDetails('processing file ' . $file);
+                $error = $dbInstaller->parseSqlFile($file, $extendedOptions);
+            }
+        }
     }
-  }
-  $d->close();
+    $d->close();
 }
 
-echo json_encode(array('error'=>$error, 'file'=>$file));  die();
+echo json_encode(['error' => $error, 'file' => $file]);
+die();
 

--- a/zc_install/ajaxLoadUpdatesSql.php
+++ b/zc_install/ajaxLoadUpdatesSql.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * ajaxLoadUpdatesSql.php
  * @copyright Copyright 2003-2020 Zen Cart Development Team
@@ -11,28 +13,28 @@ define('DIR_FS_ROOT', realpath(__DIR__ . '/../') . '/');
 
 require(DIR_FS_INSTALL . 'includes/application_top.php');
 
-$error = FALSE;
-$errorList = array();
+$error = false;
+$errorList = [];
 $db_type = 'mysql';
-$updateList = array(
-        '1.2.7'=>array('required'=>'1.2.6'),
-        '1.3.0'=>array('required'=>'1.2.7'),
-        '1.3.5'=>array('required'=>'1.3.0'),
-        '1.3.6'=>array('required'=>'1.3.5'),
-        '1.3.7'=>array('required'=>'1.3.6'),
-        '1.3.8'=>array('required'=>'1.3.7'),
-        '1.3.9'=>array('required'=>'1.3.8'),
-        '1.5.0'=>array('required'=>'1.3.9'),
-        '1.5.1'=>array('required'=>'1.5.0'),
-        '1.5.2'=>array('required'=>'1.5.1'),
-        '1.5.3'=>array('required'=>'1.5.2'),
-        '1.5.4'=>array('required'=>'1.5.3'),
-        '1.5.5'=>array('required'=>'1.5.4'),
-        '1.5.6'=>array('required'=>'1.5.5'),
-        '1.5.7'=>array('required'=>'1.5.6'),
-        '1.5.8'=>array('required'=>'1.5.7'),
-        '2.0.0'=>array('required'=>'1.5.8'),
-        );
+$updateList = [
+    '1.2.7' => ['required' => '1.2.6'],
+    '1.3.0' => ['required' => '1.2.7'],
+    '1.3.5' => ['required' => '1.3.0'],
+    '1.3.6' => ['required' => '1.3.5'],
+    '1.3.7' => ['required' => '1.3.6'],
+    '1.3.8' => ['required' => '1.3.7'],
+    '1.3.9' => ['required' => '1.3.8'],
+    '1.5.0' => ['required' => '1.3.9'],
+    '1.5.1' => ['required' => '1.5.0'],
+    '1.5.2' => ['required' => '1.5.1'],
+    '1.5.3' => ['required' => '1.5.2'],
+    '1.5.4' => ['required' => '1.5.3'],
+    '1.5.5' => ['required' => '1.5.4'],
+    '1.5.6' => ['required' => '1.5.5'],
+    '1.5.7' => ['required' => '1.5.6'],
+    '1.5.8' => ['required' => '1.5.7'],
+    '2.0.0' => ['required' => '1.5.8'],
+];
 
 $systemChecker = new systemChecker();
 $dbVersion = $systemChecker->findCurrentDbVersion();
@@ -42,14 +44,16 @@ $versionInfo = $updateList[$updateVersion];
 
 // $errorList[] = "I have $dbVersion. POST=" . $_POST['version'] . ' which asks for updateVersion=' . $updateVersion . '; therefore versionRequired=' . $versionInfo[required];
 
-if ($versionInfo['required'] != $dbVersion)
-{
-  $error = TRUE;
-  if (empty($versionInfo['required'])) $versionInfo['required'] = '[ ERROR: NOT READY FOR UPGRADES YET. NOTIFY DEV TEAM!] ';
-  $errorList[] = sprintf(TEXT_COULD_NOT_UPDATE_BECAUSE_ANOTHER_VERSION_REQUIRED, $updateVersion, $dbVersion, $versionInfo['required']);
+if ($versionInfo['required'] !== $dbVersion) {
+    $error = true;
+    if (empty($versionInfo['required'])) {
+        $versionInfo['required'] = '[ ERROR: NOT READY FOR UPGRADES YET. NOTIFY DEV TEAM!] ';
+    }
+    $errorList[] = sprintf(TEXT_COULD_NOT_UPDATE_BECAUSE_ANOTHER_VERSION_REQUIRED, $updateVersion, $dbVersion, $versionInfo['required']);
 }
 if ($error) {
-    echo json_encode(array('error'=>$error, 'version'=>$_POST['version'], 'errorList'=>$errorList)); die();
+    echo json_encode(['error' => $error, 'version' => $_POST['version'], 'errorList' => $errorList]);
+    die();
 }
 
 require_once(DIR_FS_INSTALL . 'includes/classes/class.zcDatabaseInstaller.php');
@@ -60,7 +64,8 @@ $result = $dbInstaller->getConnection();
 $errDates = $dbInstaller->runZeroDateSql($options);
 $errorUpg = $dbInstaller->parseSqlFile($file);
 if ($error) {
-    echo json_encode(array('error'=>$error, 'version'=>$_POST['version'], 'errorList'=>$errorList)); die();
+    echo json_encode(['error' => $error, 'version' => $_POST['version'], 'errorList' => $errorList]);
+    die();
 }
 
 // Plugins
@@ -69,10 +74,15 @@ $pluginsfolder = DIR_FS_INSTALL . 'sql/plugins/updates/';
 $sql_files = glob($pluginsfolder . '*.sql');
 if ($sql_files !== false) {
     foreach ($sql_files as $file) {
-        $extendedOptions = array('doJsonProgressLogging'=>TRUE, 'doJsonProgressLoggingFileName'=>DEBUG_LOG_FOLDER . '/progress.json', 'id'=>'main', 'message'=>TEXT_LOADING_PLUGIN_UPGRADES . ' ' . $file);
+        $extendedOptions = [
+            'doJsonProgressLogging' => true,
+            'doJsonProgressLoggingFileName' => DEBUG_LOG_FOLDER . '/progress.json',
+            'id' => 'main',
+            'message' => TEXT_LOADING_PLUGIN_UPGRADES . ' ' . $file,
+        ];
         logDetails('processing file ' . $file);
         $errorUpg = $dbInstaller->parseSqlFile($file, $extendedOptions);
     }
 }
 
-echo json_encode(array('error'=>$error, 'version'=>$_POST['version'], 'errorList'=>$errorList));
+echo json_encode(['error' => $error, 'version' => $_POST['version'], 'errorList' => $errorList]);

--- a/zc_install/ajaxTestDBConnection.php
+++ b/zc_install/ajaxTestDBConnection.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * ajaxTestDBConnection.php
  * @package Installer
@@ -14,24 +16,21 @@ require(DIR_FS_INSTALL . 'includes/application_top.php');
 
 $systemChecker = new systemChecker();
 
-$error = TRUE;
-$errorList = array();
-if (isset($_POST['db_name']))
-{
-  zcRegistry::setValue('db_host', $_POST['db_host']);
-  zcRegistry::setValue('db_user', $_POST['db_user']);
-  zcRegistry::setValue('db_password', $_POST['db_password']);
-  zcRegistry::setValue('db_name', $_POST['db_name']);
-  zcRegistry::setValue('db_charset', $_POST['db_charset']);
-  $results = $systemChecker -> runTests('database');
-  if (count($results) != 0)
-  {
-    $keys = array_keys($results);
-    $errorList = $results[$keys[0]];
-    $error = TRUE;
-  } else
-  {
-    $error  = FALSE;
-  }
+$error = true;
+$errorList = [];
+if (isset($_POST['db_name'])) {
+    zcRegistry::setValue('db_host', $_POST['db_host']);
+    zcRegistry::setValue('db_user', $_POST['db_user']);
+    zcRegistry::setValue('db_password', $_POST['db_password']);
+    zcRegistry::setValue('db_name', $_POST['db_name']);
+    zcRegistry::setValue('db_charset', $_POST['db_charset']);
+    $results = $systemChecker->runTests('database');
+    if (count($results) !== 0) {
+        $keys = array_keys($results);
+        $errorList = $results[$keys[0]];
+        $error = true;
+    } else {
+        $error = false;
+    }
 }
-echo json_encode(array('error'=>$error, 'errorList'=>$errorList));
+echo json_encode(['error' => $error, 'errorList' => $errorList]);

--- a/zc_install/ajaxTestSystemSetup.php
+++ b/zc_install/ajaxTestSystemSetup.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * ajaxTestSystemSetup.php
  * @package Installer
@@ -12,15 +14,14 @@ define('DIR_FS_ROOT', realpath(__DIR__ . '/../') . '/');
 
 require(DIR_FS_INSTALL . 'includes/application_top.php');
 
-$error = FALSE;
-$errorList = array();
+$error = false;
+$errorList = [];
 
 //physical path tests
 
-if (!file_exists($_POST['physical_path']. '/includes/vers' . 'ion.php'))
-{
-  $error = TRUE;
-  $errorList[] = TEXT_SYSTEM_SETUP_ERROR_CATALOG_PHYSICAL_PATH;
+if (!file_exists($_POST['physical_path'] . '/includes/vers' . 'ion.php')) {
+    $error = true;
+    $errorList[] = TEXT_SYSTEM_SETUP_ERROR_CATALOG_PHYSICAL_PATH;
 }
 
-echo json_encode(array('error'=>$error, 'errorList'=>$errorList));
+echo json_encode(['error' => $error, 'errorList' => $errorList]);

--- a/zc_install/ajaxValidateAdminCredentials.php
+++ b/zc_install/ajaxValidateAdminCredentials.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * ajaxValidateAdminCredentials.php
  * @copyright Copyright 2003-2022 Zen Cart Development Team

--- a/zc_install/includes/application_top.php
+++ b/zc_install/includes/application_top.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2022 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
@@ -57,7 +58,7 @@ if (!isset($_GET) && isset($_SERVER["argc"]) && $_SERVER["argc"] > 1) {
 if (!isset($debug_logging)) $debug_logging = 'file';
 if (isset($_GET['v']) && in_array($_GET['v'], array('screen', '1', 'true', 'TRUE'))) $debug_logging = 'screen';
 define('VERBOSE_SYSTEMCHECKER', $debug_logging);
-if (VERBOSE_SYSTEMCHECKER == 'screen' && $controller == 'cli') echo 'Verbose mode enabled.' . "\n";
+if (VERBOSE_SYSTEMCHECKER === 'screen' && $controller === 'cli') echo 'Verbose mode enabled.' . "\n";
 
 /**
  * read some file locations from the "store / catalog" configure.php

--- a/zc_install/includes/classes/LanguageManager.php
+++ b/zc_install/includes/classes/LanguageManager.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2023 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -8,22 +9,18 @@
 class LanguageManager
 {
     /**
-     * $langPath is the directory path to languages files
-     * @var type string
-     */
-    protected $langPath;
-    /**
      * $languagesInstalled is an array of the languages installed
-     * @var array
      */
-    protected $languagesInstalled = [];
-          
-    public function __construct($langPath = 'includes/languages/')
+    protected array $languagesInstalled = [];
+
+    /**
+     * $langPath is the directory path to languages files
+     */
+    public function __construct(protected string $langPath = 'includes/languages/')
     {
-        $this->langPath = $langPath;
     }
 
-    public function getLanguagesInstalled()
+    public function getLanguagesInstalled(): array
     {
         $infoFiles = $this->listFilesFromDirectory(DIR_FS_INSTALL . $this->langPath, '~^lng_info.*\.php$~i');
         $this->languagesInstalled = [];
@@ -31,13 +28,28 @@ class LanguageManager
             $infoData = require(DIR_FS_INSTALL . $this->langPath . $infoFile);
             $this->languagesInstalled = array_merge($this->languagesInstalled, $infoData);
         }
-	return $this->languagesInstalled;
+        return $this->languagesInstalled;
     }
 
-    public function loadLanguageDefines($lng, $currentPage, $fallback = 'en_us')
+    protected function listFilesFromDirectory(string $rootDir, string $fileRegx): array
+    {
+        if (!$dir = @dir($rootDir)) {
+            return [];
+        }
+        $fileList = [];
+        while ($file = $dir->read()) {
+            if (preg_match($fileRegx, $file) > 0) {
+                $fileList[] = basename($rootDir . '/' . $file);
+            }
+        }
+        $dir->close();
+        return $fileList;
+    }
+
+    public function loadLanguageDefines(string $lng, string $currentPage, string $fallback = 'en_us'): void
     {
         $defineListFallback = [];
-        if ($lng != $fallback) {
+        if ($lng !== $fallback) {
             $defineListFallback = $this->loadDefineFile($fallback, 'main');
         }
         $defineListMain = $this->loadDefineFile($lng, 'main');
@@ -45,7 +57,7 @@ class LanguageManager
         $this->makeConstants($defineList);
     }
 
-    public function loadDefineFile($lng, $file)
+    public function loadDefineFile($lng, $file): mixed
     {
         $defineList = [];
         $fp = DIR_FS_INSTALL . $this->langPath . $lng . '/' . $file . '.php';
@@ -55,7 +67,7 @@ class LanguageManager
         return $defineList;
     }
 
-    public function makeConstants($defines)
+    public function makeConstants($defines): void
     {
         foreach ($defines as $defineKey => $defineValue) {
             preg_match_all('/%{2}([^%]+)%{2}/', $defineValue, $matches, PREG_PATTERN_ORDER);
@@ -68,17 +80,5 @@ class LanguageManager
             }
             define($defineKey, $defineValue);
         }
-    }
-    protected function listFilesFromDirectory($rootDir, $fileRegx)
-    {
-        if (!$dir = @dir($rootDir)) return [];
-        $fileList = [];
-        while ($file = $dir->read()) {
-            if (preg_match($fileRegx, $file) > 0) {
-                $fileList[] = basename($rootDir . '/' . $file);
-            }
-        }
-        $dir->close();
-        return $fileList;
     }
 }

--- a/zc_install/includes/classes/class.zcConfigureFileReader.php
+++ b/zc_install/includes/classes/class.zcConfigureFileReader.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * file contains zcConfigureFileReader Class
  * @package Installer
@@ -6,136 +7,139 @@
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: Author: zcwilt  Sat Dec 5 18:49:20 2015 +0000 New in v1.5.5 $
  */
+
 /**
  *
  * zcConfigureFileReader Class
  *
  */
-class zcConfigureFileReader {
+class zcConfigureFileReader
+{
+    /**
+     * The cached contents of the configuration file.
+     */
+    protected ?string $fileContent;
 
-	/**
-	 * The location of the configuration file.
-	 * @var string
-	 */
-	protected $file;
+    /**
+     * Constructs a reader for Zen Cart configuration files.
+     *
+     * @param string|null $file the full path of the configuration file.
+     */
+    public function __construct(protected ?string $file = null)
+    {
+        $this->setFile($file);
+    }
 
-	/**
-	 * The cached contents of the configuration file.
-	 * @var string
-	 */
-	protected $fileContent;
+    /**
+     * Sets the configuration file this reader will operate upon.
+     * Calling this function will reset the file contents cache.
+     *
+     * @param string|null $file the full path of the configuration file.
+     */
+    public function setFile(?string $file = null): static
+    {
+        // Reset the cached file and contents
+        $this->file = null;
+        $this->fileContent = null;
 
-	/**
-	 * Constructs a reader for Zen Cart configuration files.
-	 *
-	 * @param string $file the full path of the configuration file.
-	 */
-	public function __construct($file = null) {
-		$this->setFile($file);
-	}
+        if ($file !== null) {
+            $realfile = realpath($file);
+            if (file_exists($realfile)) {
+                $this->file = $realfile;
+                $content = @file_get_contents($realfile);
+                if ($content !== false && trim($content) !== '') {
+                    $this->fileContent = $content;
+                }
+            }
+        }
 
-	/**
-	 * Sets the configuration file this reader will operate upon.
-	 * Calling this function will reset the file contents cache.
-	 *
-	 * @param string $file the full path of the configuration file.
-	 */
-	public function setFile($file = null) {
-		// Reset the cached file and contents
-		$this->file = null;
-		$this->fileContent = null;
+        return $this;
+    }
 
-		if($file !== null) {
-			$realfile = realpath($file);
-			if(file_exists($realfile)) {
-				$this->file = $realfile;
-				$content = @file_get_contents($realfile);
-				if($content !== false && trim($content) !== '')
-					$this->fileContent = $content;
-			}
-		}
+    /**
+     * Indicates if the configuration file exists.
+     *
+     * @return boolean true of the configuration file exists, false otherwise.
+     */
+    public function fileExists(): bool
+    {
+        return $this->file !== null;
+    }
 
-		return $this;
-	}
+    /**
+     * Retrieves the value of a configured constant from the configure file
+     * without loading all the define statements. The value of the defined
+     * constant will be evaluated and cached in memory. The memory cache will
+     * not be reset until the PHP script has finished running.
+     *
+     * This method takes into consideration the script is being run from the
+     * Zen Cart installer and will replace some constants prior to evaluating
+     * the defined constant.
+     *
+     * @param string $searchDefine the name / key of the constant to search for.
+     * @return mixed|NULL the value of the constant or null of the constant was not found.
+     */
+    public function getDefine(string $searchDefine): mixed
+    {
+        // If we have already retrieved this key, simply return the answer.
+        if (defined('TMP_' . $this->file . '_' . $searchDefine)) {
+            return constant('TMP_' . $this->file . '_' . $searchDefine);
+        }
 
-	/**
-	 * Indicates if the configuration file exists.
-	 *
-	 * @return boolean true of the configuration file exists, false otherwise.
-	 */
-	public function fileExists() {
-		return $this->file !== null;
-	}
+        // Validate the file exists (and content is useable)
+        $define = $this->getRawDefine($searchDefine);
+        if ($define !== null) {
+            // This replaces DIR_FS_CATALOG with DIR_FS_ROOT so filesystem
+            // based defines are correctly evaluated from the installer.
+            $define = str_replace('DIR_FS_CATALOG', 'DIR_FS_ROOT', $define);
 
-	/**
-	 * Indicates the the configuration file could be loaded into memory.
-	 *
-	 * @return boolean true if the configuration file could be loaded, false otherwise.
-	 */
-	public function fileLoaded() {
-		return $this->fileContent !== null;
-	}
+            // This code is already executing from the file when loaded
+            // So using eval the same as the configure.php file being loaded
+            // does not add any additional degree of risk / danger.
+            $define = 'define(\'' . 'TMP_' . $this->file . '_' . $searchDefine . '\',' . $define . ');';
+            eval("$define");
+            if (defined('TMP_' . $this->file . '_' . $searchDefine)) {
+                return constant('TMP_' . $this->file . '_' . $searchDefine);
+            }
+        }
 
-	/**
-	 * Retrieves the raw value of a configured constant from the configure file.
-	 * This method does not evaluate or cache the defined value.
-	 *
-	 * @param string $searchDefine the name / key of the constant to search for.
-	 * @return NULL|string the value of the constant or null of the constant was not found.
-	 */
-	public function getRawDefine($searchDefine) {
-		// Validate the file exists (and content is useable)
-		if(!$this->fileLoaded()) return null;
+        return null;
+    }
 
-		// Extract the contents of the define
-        if(preg_match('|^\s*define\(\s*[\'"]' . $searchDefine . '[\'"]\s*,\s*(?!\s*\);)(.+?)\s*\);|m', $this->fileContent, $matches)) {
+    /**
+     * Retrieves the raw value of a configured constant from the configure file.
+     * This method does not evaluate or cache the defined value.
+     *
+     * @param string $searchDefine the name / key of the constant to search for.
+     * @return NULL|string the value of the constant or null of the constant was not found.
+     */
+    public function getRawDefine(string $searchDefine): ?string
+    {
+        // Validate the file exists (and content is useable)
+        if (!$this->fileLoaded()) {
+            return null;
+        }
+
+        // Extract the contents of the define
+        if (preg_match('|^\s*define\(\s*[\'"]' . $searchDefine . '[\'"]\s*,\s*(?!\s*\);)(.+?)\s*\);|m', $this->fileContent, $matches)) {
             return $matches[1];
         }
-		return null;
-	}
+        return null;
+    }
 
-	/**
-	 * Retrieves the value of a configured constant from the configure file
-	 * without loading all the define statements. The value of the defined
-	 * constant will be evaluated and cached in memory. The memory cache will
-	 * not be reset until the PHP script has finished running.
-	 *
-	 * This method takes into consideration the script is being run from the
-	 * Zen Cart installer and will replace some constants prior to evaluating
-	 * the defined constant.
-	 *
-	 * @param string $searchDefine the name / key of the constant to search for.
-	 * @return mixed|NULL the value of the constant or null of the constant was not found.
-	 */
-	public function getDefine($searchDefine) {
-		// If we have already retrieved this key, simply return the answer.
-		if(defined('TMP_' . $this->file . '_' . $searchDefine)) {
-			return constant('TMP_' . $this->file . '_' . $searchDefine);
-		}
-
-		// Validate the file exists (and content is useable)
-		$define = $this->getRawDefine($searchDefine);
-		if($define !== null) {
-			// This replaces DIR_FS_CATALOG with DIR_FS_ROOT so filesystem
-			// based defines are correctly evaluated from the installer.
-			$define = str_replace('DIR_FS_CATALOG', 'DIR_FS_ROOT', $define);
-
-			// This code is already executing from the file when loaded
-			// So using eval the same as the configure.php file being loaded
-			// does not add an additional degree of risk / danger.
-			$define = 'define(\'' . 'TMP_' . $this->file . '_' . $searchDefine . '\',' . $define . ');';
-			eval("$define");
-			if(defined('TMP_' . $this->file . '_' . $searchDefine)) {
-				return constant('TMP_' . $this->file . '_' . $searchDefine);
-			}
-		}
-
-		return null;
-	}
-
-    public function getStoreInputsFromLegacy()
+    /**
+     * Indicates that the configuration file could be loaded into memory.
+     *
+     * @return boolean true if the configuration file could be loaded, false otherwise.
+     */
+    public function fileLoaded(): bool
     {
-        $mapper = array(
+        return $this->fileContent !== null;
+    }
+
+    public function getStoreInputsFromLegacy(): array
+    {
+        $mapper = [
             'HTTP_SERVER' => 'http_server_catalog',
             'HTTPS_SERVER' => 'https_server_catalog',
             'ENABLE_SSL' => 'enable_ssl_catalog',
@@ -146,17 +150,17 @@ class zcConfigureFileReader {
             'DB_PREFIX' => 'db_prefix',
             'DB_CHARSET' => 'db_charset',
             'DB_SERVER' => 'db_host',
-            'DB_SERVER_USERNAME'  => 'db_user',
+            'DB_SERVER_USERNAME' => 'db_user',
             'DB_SERVER_PASSWORD' => 'db_password',
             'DB_DATABASE' => 'db_name',
             'SQL_CACHE_METHOD' => 'sql_cache_method',
-        );
+        ];
         return $this->processConfigureInputsMapper($mapper);
     }
 
-    protected function processConfigureInputsMapper($mapper)
+    protected function processConfigureInputsMapper($mapper): array
     {
-        $inputs = array();
+        $inputs = [];
         foreach ($mapper as $defineKey => $inputsKey) {
             $value = $this->getRawDefine($defineKey);
             $value = trim($value, "'");

--- a/zc_install/includes/classes/class.zcConfigureFileWriter.php
+++ b/zc_install/includes/classes/class.zcConfigureFileWriter.php
@@ -1,94 +1,107 @@
 <?php
+declare(strict_types=1);
 /**
  * file contains zcConfigureFileWriter class
  * @copyright Copyright 2003-2023 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: Scott C Wilson 2022 Oct 16 Modified in v1.5.8a $
  */
+
 /**
  * zcConfigureFileWriter class
  */
 class zcConfigureFileWriter
 {
-  public $errors = [];
-  protected $inputs = [];
-  protected $replaceVars;
+    public array $errors = [];
+    protected array $replaceVars;
 
-  public function __construct($inputs)
-  {
-    $this->inputs = $inputs;
-    $replaceVars = array();
-    $replaceVars['INSTALLER_METHOD'] = (isset($inputs['installer_method'])) ? trim($inputs['installer_method']) : 'Zen Cart Installer';
-    $replaceVars['DATE_NOW'] = date('D M d Y H:i:s');
-    $replaceVars['CATALOG_HTTP_SERVER'] = trim($inputs['http_server_catalog'], '/ ');
-    $replaceVars['CATALOG_HTTPS_SERVER'] = trim($inputs['https_server_catalog'], '/ ');
-    $replaceVars['ENABLE_SSL_CATALOG'] = !empty($inputs['enable_ssl_catalog']) ? $inputs['enable_ssl_catalog'] : 'false';
-    $replaceVars['DIR_WS_CATALOG'] = preg_replace('~//~', '/', '/' . trim($inputs['dir_ws_http_catalog'], ' /\\') . '/');
-    $replaceVars['DIR_WS_HTTPS_CATALOG'] = preg_replace('~//~', '/', '/' . trim($inputs['dir_ws_https_catalog'], ' /\\') . '/');
-    $replaceVars['DIR_FS_CATALOG'] = rtrim($inputs['physical_path'], ' /\\') . '/';
+    public function __construct(protected array $inputs)
+    {
+        $replaceVars = [];
+        $replaceVars['INSTALLER_METHOD'] = (isset($inputs['installer_method'])) ? trim($inputs['installer_method']) : 'Zen Cart Installer';
+        $replaceVars['DATE_NOW'] = date('D M d Y H:i:s');
+        $replaceVars['CATALOG_HTTP_SERVER'] = trim($inputs['http_server_catalog'], '/ ');
+        $replaceVars['CATALOG_HTTPS_SERVER'] = trim($inputs['https_server_catalog'], '/ ');
+        $replaceVars['ENABLE_SSL_CATALOG'] = !empty($inputs['enable_ssl_catalog']) ? $inputs['enable_ssl_catalog'] : 'false';
+        $replaceVars['DIR_WS_CATALOG'] = preg_replace('~//~', '/', '/' . trim($inputs['dir_ws_http_catalog'], ' /\\') . '/');
+        $replaceVars['DIR_WS_HTTPS_CATALOG'] = preg_replace('~//~', '/', '/' . trim($inputs['dir_ws_https_catalog'], ' /\\') . '/');
+        $replaceVars['DIR_FS_CATALOG'] = rtrim($inputs['physical_path'], ' /\\') . '/';
 
-    $replaceVars['DB_TYPE'] = trim($inputs['db_type']);
-    if ($replaceVars['DB_TYPE'] == '') $replaceVars['DB_TYPE'] = 'mysql';
+        $replaceVars['DB_TYPE'] = trim($inputs['db_type']);
+        if (empty($replaceVars['DB_TYPE'])) {
+            $replaceVars['DB_TYPE'] = 'mysql';
+        }
 
-    $replaceVars['DB_PREFIX'] = trim($inputs['db_prefix']);
+        $replaceVars['DB_PREFIX'] = trim($inputs['db_prefix']);
 
-    $replaceVars['DB_CHARSET'] = trim($inputs['db_charset']);
-    if ($replaceVars['DB_CHARSET'] == '') $replaceVars['DB_CHARSET'] = 'utf8mb4';
+        $replaceVars['DB_CHARSET'] = trim($inputs['db_charset']);
+        if (empty($replaceVars['DB_CHARSET'])) {
+            $replaceVars['DB_CHARSET'] = 'utf8mb4';
+        }
 
-    $replaceVars['DB_SERVER'] = trim($inputs['db_host']);
-    $replaceVars['DB_SERVER_USERNAME'] = trim($inputs['db_user']);
-    $replaceVars['DB_SERVER_PASSWORD'] = trim($inputs['db_password']);
-    $replaceVars['DB_DATABASE'] = trim($inputs['db_name']);
-    $replaceVars['SQL_CACHE_METHOD'] = trim($inputs['sql_cache_method']);
-    $replaceVars['HTTP_SERVER_ADMIN'] = trim($inputs['http_server_admin']);
-    $replaceVars['SESSION_STORAGE'] = 'reserved for future use';
+        $replaceVars['DB_SERVER'] = trim($inputs['db_host']);
+        $replaceVars['DB_SERVER_USERNAME'] = trim($inputs['db_user']);
+        $replaceVars['DB_SERVER_PASSWORD'] = trim($inputs['db_password']);
+        $replaceVars['DB_DATABASE'] = trim($inputs['db_name']);
+        $replaceVars['SQL_CACHE_METHOD'] = trim($inputs['sql_cache_method']);
+        $replaceVars['HTTP_SERVER_ADMIN'] = trim($inputs['http_server_admin']);
+        $replaceVars['SESSION_STORAGE'] = 'reserved for future use';
 
-    $this->replaceVars = $replaceVars;
-    $adminDir = $inputs['adminDir'];
+        $this->replaceVars = $replaceVars;
+        $adminDir = $inputs['adminDir'];
 
 // die('<pre>' . print_r($inputs, true));
 
-    $this->processAllConfigureFiles($adminDir);
-  }
-  protected function processAllConfigureFiles($adminDir)
-  {
-    $tplFile = DIR_FS_INSTALL . 'includes/catalog-configure-template.php';
-    $outputFile = rtrim($this->inputs['physical_path'], '/') . '/includes/configure.php';
-    $outputFileLocal = rtrim($this->inputs['physical_path'], '/') . '/includes/local/configure.php';
-    if (file_exists($outputFileLocal)) $outputFile = $outputFileLocal;
-
-    $result1 = $this->transformConfigureTplFile($tplFile, $outputFile);
-    if ((int)$result1 == 0) logDetails('catalogConfig size: ' . (int)$result1 . ' (will be greater than 0 if file was written correctly)', 'store configure.php');
-
-    $tplFile = DIR_FS_INSTALL . 'includes/admin-configure-template.php';
-    $outputFile = rtrim($this->inputs['physical_path'], '/') . '/'. $adminDir . '/includes/configure.php';
-    $outputFileLocal = rtrim($this->inputs['physical_path'], '/') . '/'. $adminDir . '/includes/local/configure.php';
-    if (file_exists($outputFileLocal)) $outputFile = $outputFileLocal;
-
-    $result2 = $this->transformConfigureTplFile($tplFile, $outputFile);
-    if ((int)$result2 == 0) logDetails('adminConfig size: ' . (int)$result2 . ' (will be greater than 0 if file was written correctly)', 'admin configure.php');
-
-    // return a result indicating whether either file failed in some way: true=success; false=one-or-both-failed (bitwise '&' operand here is intentional)
-    return $result1 & $result2;
-  }
-  protected function transformConfigureTplFile($tplFile, $outputFile)
-  {
-    $tplOriginal = file_get_contents($tplFile);
-    if ($tplOriginal === false) {
-      $this->errors[] = sprintf(TEXT_ERROR_COULD_NOT_READ_CFGFILE_TEMPLATE, $tplFile);
-      logDetails('Error: Could not read file: ' . $tplFile, 'reading configure.php template');
-      return false;
+        $this->processAllConfigureFiles($adminDir);
     }
-    foreach ($this->replaceVars as $varName => $varValue)
+
+    protected function processAllConfigureFiles($adminDir): int|string
     {
-      $tplOriginal = str_replace('%%_' . $varName . '_%%', $varValue, $tplOriginal);
-    }
-    $retval = file_put_contents($outputFile, $tplOriginal);
-    if ($retval === false) {
-      $this->errors[] = sprintf(TEXT_ERROR_COULD_NOT_WRITE_CONFIGFILE, $outputFile);
-      logDetails('Error: Could not write configure.php file: ' . $outputFile, 'writing configure.php contents');
+        $tplFile = DIR_FS_INSTALL . 'includes/catalog-configure-template.php';
+        $outputFile = rtrim($this->inputs['physical_path'], '/') . '/includes/configure.php';
+        $outputFileLocal = rtrim($this->inputs['physical_path'], '/') . '/includes/local/configure.php';
+        if (file_exists($outputFileLocal)) {
+            $outputFile = $outputFileLocal;
+        }
+
+        $result1 = $this->transformConfigureTplFile($tplFile, $outputFile);
+        if ((int)$result1 === 0) {
+            logDetails('catalogConfig size: ' . (int)$result1 . ' (will be greater than 0 if file was written correctly)', 'store configure.php');
+        }
+
+        $tplFile = DIR_FS_INSTALL . 'includes/admin-configure-template.php';
+        $outputFile = rtrim($this->inputs['physical_path'], '/') . '/' . $adminDir . '/includes/configure.php';
+        $outputFileLocal = rtrim($this->inputs['physical_path'], '/') . '/' . $adminDir . '/includes/local/configure.php';
+        if (file_exists($outputFileLocal)) {
+            $outputFile = $outputFileLocal;
+        }
+
+        $result2 = $this->transformConfigureTplFile($tplFile, $outputFile);
+        if ((int)$result2 === 0) {
+            logDetails('adminConfig size: ' . (int)$result2 . ' (will be greater than 0 if file was written correctly)', 'admin configure.php');
+        }
+
+        // return a result indicating whether either file failed in some way: true=success; false=one-or-both-failed (bitwise '&' operand here is intentional)
+        return $result1 & $result2;
     }
 
-    return $retval;
-  }
+    protected function transformConfigureTplFile($tplFile, $outputFile): int|false
+    {
+        $tplOriginal = file_get_contents($tplFile);
+        if ($tplOriginal === false) {
+            $this->errors[] = sprintf(TEXT_ERROR_COULD_NOT_READ_CFGFILE_TEMPLATE, $tplFile);
+            logDetails('Error: Could not read file: ' . $tplFile, 'reading configure.php template');
+            return false;
+        }
+        foreach ($this->replaceVars as $varName => $varValue) {
+            $tplOriginal = str_replace('%%_' . $varName . '_%%', $varValue, $tplOriginal);
+        }
+        $retval = file_put_contents($outputFile, $tplOriginal);
+        if ($retval === false) {
+            $this->errors[] = sprintf(TEXT_ERROR_COULD_NOT_WRITE_CONFIGFILE, $outputFile);
+            logDetails('Error: Could not write configure.php file: ' . $outputFile, 'writing configure.php contents');
+        }
+
+        return $retval;
+    }
 }

--- a/zc_install/includes/classes/class.zcDatabaseInstaller.php
+++ b/zc_install/includes/classes/class.zcDatabaseInstaller.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2023 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -8,43 +9,41 @@
 
 class zcDatabaseInstaller
 {
-    protected $ignoreLine;
-    protected $jsonProgressLoggingCount = 0;
-    protected $basicParseStrings = [];
-    protected $collateSuffix;
-    protected $completeLine;
-    protected $db;
-    protected $dbCharset;
-    protected $dbHost;
-    protected $dbName;
-    protected $dbPassword;
-    protected $dbPrefix;
-    protected $dbType;
-    protected $dbUser;
-    protected $table;
-    protected $dieOnErrors;
-    protected $errors = [];
-    protected $extendedOptions;
-    protected $fileName;
-    protected $func;
-    protected $jsonProgressLoggingTotal;
-    protected $keepTogetherCount;
-    protected $keepTogetherLines;
-    protected $line;
-    protected $lineSplit = [];
-    protected $newLine;
-    protected $upgradeExceptions;
+    protected bool $ignoreLine = false;
+    protected int $jsonProgressLoggingCount = 0;
+    protected array $basicParseStrings = [];
+    protected string $collateSuffix;
+    protected bool $completeLine;
+    protected QueryFactory $db;
+    protected string $dbCharset;
+    protected string $dbHost;
+    protected string $dbName;
+    protected string $dbPassword;
+    protected string $dbPrefix;
+    protected string $dbType;
+    protected string $dbUser;
+    protected string $table;
+    protected bool $dieOnErrors;
+    protected array $errors = [];
+    protected array $extendedOptions;
+    protected string $fileName;
+    protected Closure $func;
+    protected int $jsonProgressLoggingTotal;
+    protected int $keepTogetherCount;
+    protected int $keepTogetherLines;
+    protected string $line;
+    protected array $lineSplit = [];
+    protected string $newLine;
+    protected array $upgradeExceptions;
 
-    public function __construct($options)
+    public function __construct(array $options)
     {
-        $this->func = function ($matches) {
-            return strtoupper($matches[1]);
-        };
-        $dbtypes = array();
+        $this->func = static fn($matches): string => strtoupper($matches[1]);
+        $dbtypes = [];
         $path = DIR_FS_ROOT . 'includes/classes/db/';
         $dir = dir($path);
         while ($entry = $dir->read()) {
-            if (is_dir($path . $entry) && substr($entry, 0, 1) != '.') {
+            if (is_dir($path . $entry) && !str_starts_with($entry, '.')) {
                 $dbtypes[] = $entry;
             }
         }
@@ -55,17 +54,17 @@ class zcDatabaseInstaller
         $this->dbPassword = $options['db_password'];
         $this->dbName = $options['db_name'];
         $this->dbPrefix = $options['db_prefix'];
-        $this->dbCharset = isset($options['db_charset']) && trim($options['db_charset']) != '' ? $options['db_charset'] : 'utf8mb4';
-        $this->dbType = in_array($options['db_type'], $dbtypes) ? $options['db_type'] : 'mysql';
-        $this->dieOnErrors = isset($options['dieOnErrors']) ? (bool)$options['dieOnErrors'] : FALSE;
-        $this->errors = array();
-        $this->basicParseStrings = array(
+        $this->dbCharset = isset($options['db_charset']) && trim($options['db_charset']) !== '' ? $options['db_charset'] : 'utf8mb4';
+        $this->dbType = in_array($options['db_type'], $dbtypes, false) ? $options['db_type'] : 'mysql';
+        $this->dieOnErrors = isset($options['dieOnErrors']) && (bool)$options['dieOnErrors'];
+        $this->errors = [];
+        $this->basicParseStrings = [
             'DROP TABLE ',
             'CREATE TABLE ',
             'REPLACE INTO ',
             'INSERT INTO ',
             'INSERT IGNORE INTO ',
-//    'ALTER IGNORE TABLE ',
+            //    'ALTER IGNORE TABLE ',
             'ALTER TABLE ',
             'TRUNCATE TABLE ',
             'RENAME TABLE ',
@@ -76,35 +75,34 @@ class zcDatabaseInstaller
             'DROP INDEX ',
             'LEFT JOIN ',
             'FROM ',
-            ') ENGINE=MYISAM'
-        );
+            ') ENGINE=MYISAM',
+        ];
     }
 
-    public function getConnection()
+    public function getConnection(): bool
     {
         require_once(DIR_FS_ROOT . 'includes/classes/db/' . $this->dbType . '/query_factory.php');
         $this->db = new queryFactory;
-        $options = array('dbCharset' => $this->dbCharset);
-        $result = $this->db->Connect($this->dbHost, $this->dbUser, $this->dbPassword, $this->dbName, 'false', $this->dieOnErrors, $options);
-        return $result;
+        $options = ['dbCharset' => $this->dbCharset];
+        return $this->db->Connect($this->dbHost, $this->dbUser, $this->dbPassword, $this->dbName, 'false', $this->dieOnErrors, $options);
     }
 
-    public function runZeroDateSql($options = null)
+    public function runZeroDateSql($options = null): ?bool
     {
         $file = DIR_FS_INSTALL . 'sql/install/zero_dates_cleanup.sql';
         return $this->parseSqlFile($file, $options);
     }
 
-    public function parseSqlFile($fileName, $options = NULL)
+    public function parseSqlFile($fileName, $options = null): bool
     {
-        $this->extendedOptions = (isset($options)) ? $options : array();
+        $this->extendedOptions = (isset($options)) ? $options : [];
         $lines = file($fileName);
-        if (FALSE === $lines) {
+        if (false === $lines) {
             logDetails('COULD NOT OPEN FILE: ' . $fileName, $fileName);
             die('HERE_BE_MONSTERS - could not open file');
         }
         $this->fileName = $fileName;
-        $this->upgradeExceptions = array();
+        $this->upgradeExceptions = [];
         if (!isset($lines) || !is_array($lines)) {
             logDetails('HERE BE MONSTERS', $fileName);
             die('HERE_BE_MONSTERS');
@@ -128,51 +126,80 @@ class zcDatabaseInstaller
 //    return (count($this->upgradeExceptions) > 0);
     }
 
-    private function processLine($line)
+    private function doJsonProgressLoggingStart($count): void
+    {
+        if (isset($this->extendedOptions['doJsonProgressLogging'])) {
+            $this->jsonProgressLoggingTotal = $count;
+            $this->jsonProgressLoggingCount = 0;
+            $fileName = $this->extendedOptions['doJsonProgressLoggingFileName'];
+            $fp = fopen($fileName, "w");
+            if ($fp) {
+                $arr = ['total' => $count, 'progress' => 0, 'message' => $this->extendedOptions['message']];
+                fwrite($fp, json_encode($arr));
+                fclose($fp);
+            }
+        }
+    }
+
+    private function processLine($line): void
     {
         $this->keepTogetherLines = 1;
         $this->line = trim($line);
-        if (substr($this->line, 0, 28) == '#NEXT_X_ROWS_AS_ONE_COMMAND:') $this->keepTogetherLines = substr($this->line, 28);
-        if (substr($this->line, 0, 1) != '#' && substr($this->line, 0, 1) != '-' && $this->line != '') {
+        if (str_starts_with($this->line, '#NEXT_X_ROWS_AS_ONE_COMMAND:')) {
+            $this->keepTogetherLines = (int)substr($this->line, 28);
+        }
+        if (!str_starts_with($this->line, '#') && !str_starts_with($this->line, '-') && $this->line !== '') {
             $this->parseLineContent();
             $this->newLine .= $this->line . ' ';
-            if (substr($this->line, -1) == ';') {
-                if (substr($this->newLine, -1) == ' ') $this->newLine = substr($this->newLine, 0, (strlen($this->newLine) - 1));
-                if (substr($this->newLine, -1) == ')') $this->newLine = substr($this->newLine, 0, (strlen($this->newLine) - 1)) . ' )';
+            if (str_ends_with($this->line, ';')) {
+                if (str_ends_with($this->newLine, ' ')) {
+                    $this->newLine = substr($this->newLine, 0, (strlen($this->newLine) - 1));
+                }
+                if (str_ends_with($this->newLine, ')')) {
+                    $this->newLine = substr($this->newLine, 0, (strlen($this->newLine) - 1)) . ' )';
+                }
                 $this->keepTogetherCount++;
-                if ($this->keepTogetherCount == $this->keepTogetherLines) {
-                    $this->completeLine = TRUE;
+                if ($this->keepTogetherCount === $this->keepTogetherLines) {
+                    $this->completeLine = true;
                     $this->keepTogetherCount = 0;
-                    if (isset($this->collateSuffix) && $this->collateSuffix != '' && (!defined('IGNORE_DB_CHARSET') || (defined('IGNORE_DB_CHARSET') && IGNORE_DB_CHARSET != FALSE))) {
+                    if (isset($this->collateSuffix) && $this->collateSuffix !== ''
+                        && (!defined('IGNORE_DB_CHARSET') || (defined('IGNORE_DB_CHARSET') && IGNORE_DB_CHARSET !== false))
+                    ) {
                         $this->newLine = rtrim($this->newLine, ';') . $this->collateSuffix . ';';
                         $this->collateSuffix = '';
                     }
                 } else {
-                    $this->completeLine = FALSE;
+                    $this->completeLine = false;
                 }
             }
 //      echo $this->newLine;
             if ($this->completeLine) {
-                $output = (trim(str_replace(';', '', $this->newLine)) != '' && !$this->ignoreLine) ? $this->tryExecute($this->newLine) : '';
+                $output = (trim(str_replace(';', '', $this->newLine)) !== '' && !$this->ignoreLine) ? $this->tryExecute($this->newLine) : '';
                 $this->doJsonProgressLoggingUpdate();
                 $this->newLine = "";
-                $this->ignoreLine = FALSE;
-                $this->completeLine = FALSE;
+                $this->ignoreLine = false;
+                $this->completeLine = false;
                 $this->keepTogetherLines = 1;
             }
         }
     }
 
-    private function parseLineContent()
+    private function parseLineContent(): void
     {
-        $this->lineSplit = explode(" ", (substr($this->line, -1) == ';') ? substr($this->line, 0, strlen($this->line) - 1) : $this->line);
-        if (!isset($this->lineSplit[3])) $this->lineSplit[3] = "";
-        if (!isset($this->lineSplit[4])) $this->lineSplit[4] = "";
-        if (!isset($this->lineSplit[5])) $this->lineSplit[5] = "";
+        $this->lineSplit = explode(" ", (str_ends_with($this->line, ';')) ? rtrim($this->line, ';') : $this->line);
+        if (!isset($this->lineSplit[3])) {
+            $this->lineSplit[3] = "";
+        }
+        if (!isset($this->lineSplit[4])) {
+            $this->lineSplit[4] = "";
+        }
+        if (!isset($this->lineSplit[5])) {
+            $this->lineSplit[5] = "";
+        }
         foreach ($this->basicParseStrings as $parseString) {
             $parseMethod = 'parser' . trim($this->camelize($parseString));
 
-            if (substr(strtoupper($this->line), 0, strlen($parseString)) == $parseString) {
+            if (str_starts_with(strtoupper($this->line), $parseString)) {
                 if ($parseMethod == 'parser)Engine=myisam') {
                     $parseMethod = 'parserEngineInnodb';
                 }
@@ -183,28 +210,97 @@ class zcDatabaseInstaller
         }
     }
 
-    public function tryExecute($sql)
+    private function camelize($parseString): array|string
+    {
+        $parseString = preg_replace_callback('/\s([0-9,a-z])/', $this->func, strtolower($parseString));
+        $parseString[0] = strtoupper($parseString[0]);
+        return $parseString;
+    }
+
+    public function tryExecute(string $sql): void
     {
 //    echo $sql;
 //    $this->writeUpgradeExceptions($this->line, '', $this->sqlFile);
 //    logDetails($sql, $this->sqlFile);
-        $result = $this->db->execute($sql);
-        if (!$result || $result->link->errno != 0) {
+        $result = $this->db->Execute($sql);
+        if (!$result || $result->link->errno !== 0) {
             $this->writeUpgradeExceptions($this->line, $this->db->error_number . ': ' . $this->db->error_text);
             error_log("MySQL error " . $this->db->error_number . " encountered during zc_install:\n" . $this->db->error_text . "\n" . $this->line . "\n---------------\n\n");
         }
     }
 
-    public function parserDropTable()
+    public function writeUpgradeExceptions($line, $message, $sqlFile = ''): queryFactoryResult
     {
-        $table = (strtoupper($this->lineSplit[2] . ' ' . $this->lineSplit[3]) == 'IF EXISTS') ? $this->lineSplit[4] : $this->lineSplit[2];
+        logDetails($line . '  ' . $message . '  ' . $sqlFile, 'upgradeException');
+        $this->upgradeExceptions[] = $message;
+        $this->createExceptionsTable();
+        $sql = "INSERT INTO " . $this->dbPrefix . TABLE_UPGRADE_EXCEPTIONS . " (sql_file, reason, errordate, sqlstatement) VALUES (:file:, :reason:, now(), :line:)";
+        $sql = $this->db->bindVars($sql, ':file:', $sqlFile, 'string');
+        $sql = $this->db->bindVars($sql, ':reason:', $message, 'string');
+        $sql = $this->db->bindVars($sql, ':line:', $line, 'string');
+        return $this->db->Execute($sql);
+    }
 
-        if (!$this->tableExists($table) && (strtoupper($this->lineSplit[2] . ' ' . $this->lineSplit[3]) != 'IF EXISTS')) {
+    public function createExceptionsTable(): void
+    {
+        if (!$this->tableExists(TABLE_UPGRADE_EXCEPTIONS)) {
+            $this->db->Execute(
+        "CREATE TABLE " . $this->dbPrefix . TABLE_UPGRADE_EXCEPTIONS . " (
+                    upgrade_exception_id SMALLINT(5) NOT NULL AUTO_INCREMENT,
+                    sql_file VARCHAR(128) DEFAULT NULL,
+                    reason TEXT DEFAULT NULL,
+                    errordate DATETIME DEFAULT NULL,
+                    sqlstatement TEXT,
+                    PRIMARY KEY  (upgrade_exception_id)
+                  ) ENGINE=MyISAM"
+            );
+        }
+    }
+
+    public function tableExists($table): bool
+    {
+        $tables = $this->db->Execute("SHOW TABLES LIKE '" . $this->dbPrefix . $table . "'");
+        return $tables->RecordCount() > 0;
+    }
+
+    private function doJsonProgressLoggingUpdate(): void
+    {
+        if (isset($this->extendedOptions['doJsonProgressLogging'])) {
+            $fileName = $this->extendedOptions['doJsonProgressLoggingFileName'];
+            $progress = ($this->jsonProgressLoggingCount / $this->jsonProgressLoggingTotal * 100);
+            $fp = fopen($fileName, "w");
+            if ($fp) {
+                $arr = ['total' => '0', 'progress' => $progress, 'message' => $this->extendedOptions['message']];
+                fwrite($fp, json_encode($arr));
+                fclose($fp);
+            }
+        }
+    }
+
+    private function doJsonProgressLoggingEnd(): void
+    {
+        if (isset($this->extendedOptions['doJsonProgressLogging'])) {
+            $this->jsonProgressLoggingCount = 0;
+            $fileName = $this->extendedOptions['doJsonProgressLoggingFileName'];
+            $fp = fopen($fileName, "w");
+            if ($fp) {
+                $arr = ['total' => '0', 'progress' => 100, 'message' => $this->extendedOptions['message']];
+                fwrite($fp, json_encode($arr));
+                fclose($fp);
+            }
+        }
+    }
+
+    public function parserDropTable(): void
+    {
+        $table = (strtoupper($this->lineSplit[2] . ' ' . $this->lineSplit[3]) === 'IF EXISTS') ? $this->lineSplit[4] : $this->lineSplit[2];
+
+        if (!$this->tableExists($table) && (strtoupper($this->lineSplit[2] . ' ' . $this->lineSplit[3]) !== 'IF EXISTS')) {
             $result = sprintf(REASON_TABLE_NOT_FOUND, $table) . ' CHECK PREFIXES!';
             $this->writeUpgradeExceptions($this->line, $result, $this->fileName);
             $this->ignoreLine = true;
         } else {
-            if (strtoupper($this->lineSplit[2] . ' ' . $this->lineSplit[3]) != 'IF EXISTS') {
+            if (strtoupper($this->lineSplit[2] . ' ' . $this->lineSplit[3]) !== 'IF EXISTS') {
                 $this->line = 'DROP TABLE ' . $this->dbPrefix . substr($this->line, 11);
             } else {
                 $this->line = 'DROP TABLE IF EXISTS ' . $this->dbPrefix . substr($this->line, 21);
@@ -212,32 +308,35 @@ class zcDatabaseInstaller
         }
     }
 
-    public function parserCreateTable()
+    public function parserCreateTable(): void
     {
-        $table = (strtoupper($this->lineSplit[2] . ' ' . $this->lineSplit[3] . ' ' . $this->lineSplit[4]) == 'IF NOT EXISTS') ? $this->lineSplit[5] : $this->lineSplit[2];
+        $table = (strtoupper($this->lineSplit[2] . ' ' . $this->lineSplit[3] . ' ' . $this->lineSplit[4]) === 'IF NOT EXISTS') ? $this->lineSplit[5] : $this->lineSplit[2];
         $this->table = $table;
         if ($this->tableExists($table)) {
-            $this->ignoreLine = TRUE;
-            if (strtoupper($this->lineSplit[2] . ' ' . $this->lineSplit[3] . ' ' . $this->lineSplit[4]) != 'IF NOT EXISTS') {
+            $this->ignoreLine = true;
+            if (strtoupper($this->lineSplit[2] . ' ' . $this->lineSplit[3] . ' ' . $this->lineSplit[4]) !== 'IF NOT EXISTS') {
                 $this->writeUpgradeExceptions($this->line, sprintf(REASON_TABLE_ALREADY_EXISTS, $table), $this->fileName);
             }
         } else {
-            $this->line = (strtoupper($this->lineSplit[2] . ' ' . $this->lineSplit[3] . ' ' . $this->lineSplit[4]) == 'IF NOT EXISTS')
+            $this->line = (strtoupper($this->lineSplit[2] . ' ' . $this->lineSplit[3] . ' ' . $this->lineSplit[4]) === 'IF NOT EXISTS')
                 ? 'CREATE TABLE IF NOT EXISTS ' . $this->dbPrefix . substr($this->line, 27) : 'CREATE TABLE ' . $this->dbPrefix . substr($this->line, 13);
-            if (!stristr($this->line, ' COLLATE ')) {
-                $this->collateSuffix = (strtoupper($this->lineSplit[3]) == 'AS' || (isset($this->lineSplit[6]) && strtoupper($this->lineSplit[6]) == 'AS')) ? ''
+            if (stripos($this->line, ' COLLATE ') === false) {
+                $this->collateSuffix = (strtoupper($this->lineSplit[3]) === 'AS' || (isset($this->lineSplit[6]) && strtoupper($this->lineSplit[6]) === 'AS'))
+                    ? ''
                     : ' COLLATE ' . $this->dbCharset . '_general_ci';
             }
         }
     }
 
-    public function parserInsertInto()
+    public function parserInsertInto(): void
     {
-        if (($this->lineSplit[2] == 'configuration' && ($result = $this->checkConfigKey($this->line))) ||
-            ($this->lineSplit[2] == 'product_type_layout' && ($result = $this->checkProductTypeLayoutKey($this->line))) ||
-            ($this->lineSplit == 'configuration_group' && ($result = $this->checkCfggroupKey($this->line))) ||
+        if (($this->lineSplit[2] === 'configuration' && ($result = $this->checkConfigKey($this->line))) ||
+            ($this->lineSplit[2] === 'product_type_layout' && ($result = $this->checkProductTypeLayoutKey($this->line))) ||
+            ($this->lineSplit === 'configuration_group' && ($result = $this->checkCfggroupKey($this->line))) ||
             (!$this->tableExists($this->lineSplit[2]))) {
-            if (!isset($result)) $result = sprintf(REASON_TABLE_NOT_FOUND, $this->lineSplit[2]) . ' CHECK PREFIXES!';
+            if (!isset($result)) {
+                $result = sprintf(REASON_TABLE_NOT_FOUND, $this->lineSplit[2]) . ' CHECK PREFIXES!';
+            }
             $this->writeUpgradeExceptions($this->line, $result, $this->fileName);
             $this->ignoreLine = true;
         } else {
@@ -245,10 +344,60 @@ class zcDatabaseInstaller
         }
     }
 
-    public function parserInsertIgnoreInto()
+    public function checkConfigKey($line): bool|string
+    {
+        $values = explode("'", $line);
+        //INSERT INTO configuration blah blah blah VALUES ('title','key', blah blah blah);
+        //[0]=INSERT INTO.....
+        //[1]=title
+        //[2]=,
+        //[3]=key
+        //[4]=blah blah
+        $title = $values[1];
+        $key = $values[3];
+        $sql = "SELECT configuration_title FROM " . $this->dbPrefix . "configuration WHERE configuration_key='" . $key . "'";
+        $result = $this->db->Execute($sql);
+        if ($result->RecordCount() > 0) {
+            return sprintf(REASON_CONFIG_KEY_ALREADY_EXISTS, $key);
+        }
+        return false;
+    }
+
+    public function checkProductTypeLayoutKey($line): bool|string
+    {
+        $values = explode("'", $line);
+        $title = $values[1];
+        $key = $values[3];
+        $sql = "SELECT configuration_title FROM " . $this->dbPrefix . "product_type_layout WHERE configuration_key='" . $key . "'";
+        $result = $this->db->Execute($sql);
+        if ($result->RecordCount() > 0) {
+            return sprintf(REASON_PRODUCT_TYPE_LAYOUT_KEY_ALREADY_EXISTS, $key);
+        }
+        return false;
+    }
+
+    public function checkCfggroupKey($line): bool|string
+    {
+        $values = explode("'", $line);
+        $id = $values[1];
+        $title = $values[3];
+        $sql = "SELECT configuration_group_title FROM " . $this->dbPrefix . "configuration_group WHERE configuration_group_title='" . $title . "'";
+        $result = $this->db->Execute($sql);
+        if ($result->RecordCount() > 0) {
+            return sprintf(REASON_CONFIG_GROUP_KEY_ALREADY_EXISTS, $title);
+        }
+        $sql = "SELECT configuration_group_title FROM " . $this->dbPrefix . "configuration_group WHERE configuration_group_id='" . $id . "'";
+        $result = $this->db->Execute($sql);
+        if ($result->RecordCount() > 0) {
+            return sprintf(REASON_CONFIG_GROUP_ID_ALREADY_EXISTS, $id);
+        }
+        return false;
+    }
+
+    public function parserInsertIgnoreInto(): void
     {
         if (!$this->tableExists($this->lineSplit[3])) {
-            if (!isset($result)) $result = sprintf(REASON_TABLE_NOT_FOUND, $this->lineSplit[3]) . ' CHECK PREFIXES!';
+            $result = sprintf(REASON_TABLE_NOT_FOUND, $this->lineSplit[3]) . ' CHECK PREFIXES!';
             $this->writeUpgradeExceptions($this->line, $result, $this->fileName);
             $this->ignoreLine = true;
         } else {
@@ -256,10 +405,10 @@ class zcDatabaseInstaller
         }
     }
 
-    public function parserTruncateTable()
+    public function parserTruncateTable(): void
     {
         if (!$this->tableExists($this->lineSplit[2])) {
-            if (!isset($result)) $result = sprintf(REASON_TABLE_NOT_FOUND, $this->lineSplit[2]) . ' CHECK PREFIXES!';
+            $result = sprintf(REASON_TABLE_NOT_FOUND, $this->lineSplit[2]) . ' CHECK PREFIXES!';
             $this->writeUpgradeExceptions($this->line, $result, $this->fileName);
             $this->ignoreLine = true;
         } else {
@@ -267,10 +416,10 @@ class zcDatabaseInstaller
         }
     }
 
-    public function parserFrom()
+    public function parserFrom(): void
     {
         if (!$this->tableExists($this->lineSplit[1])) {
-            if (!isset($result)) $result = sprintf(REASON_TABLE_NOT_FOUND, $this->lineSplit[1]) . ' CHECK PREFIXES!';
+            $result = sprintf(REASON_TABLE_NOT_FOUND, $this->lineSplit[1]) . ' CHECK PREFIXES!';
             $this->writeUpgradeExceptions($this->line, $result, $this->fileName);
             $this->ignoreLine = true;
         } else {
@@ -278,10 +427,10 @@ class zcDatabaseInstaller
         }
     }
 
-    public function parserDeleteFrom()
+    public function parserDeleteFrom(): void
     {
         if (!$this->tableExists($this->lineSplit[2])) {
-            if (!isset($result)) $result = sprintf(REASON_TABLE_NOT_FOUND, $this->lineSplit[2]) . ' CHECK PREFIXES!';
+            $result = sprintf(REASON_TABLE_NOT_FOUND, $this->lineSplit[2]) . ' CHECK PREFIXES!';
             $this->writeUpgradeExceptions($this->line, $result, $this->fileName);
             $this->ignoreLine = true;
         } else {
@@ -289,13 +438,15 @@ class zcDatabaseInstaller
         }
     }
 
-    public function parserReplaceInto()
+    public function parserReplaceInto(): void
     {
-        if (($this->lineSplit[2] == 'configuration' && ($result = $this->checkConfigKey($this->line))) ||
-            ($this->lineSplit[2] == 'product_type_layout' && ($result = $this->checkProductTypeLayoutKey($this->line))) ||
-            ($this->lineSplit == 'configuration_group' && ($result = $this->checkCfggroupKey($this->line))) ||
+        if (($this->lineSplit[2] === 'configuration' && ($result = $this->checkConfigKey($this->line))) ||
+            ($this->lineSplit[2] === 'product_type_layout' && ($result = $this->checkProductTypeLayoutKey($this->line))) ||
+            ($this->lineSplit === 'configuration_group' && ($result = $this->checkCfggroupKey($this->line))) ||
             (!$this->tableExists($this->lineSplit[2]))) {
-            if (!isset($result)) $result = sprintf(REASON_TABLE_NOT_FOUND, $this->lineSplit[2]) . ' CHECK PREFIXES!';
+            if (!isset($result)) {
+                $result = sprintf(REASON_TABLE_NOT_FOUND, $this->lineSplit[2]) . ' CHECK PREFIXES!';
+            }
             $this->writeUpgradeExceptions($this->line, $result, $this->fileName);
             $this->ignoreLine = true;
         } else {
@@ -303,10 +454,10 @@ class zcDatabaseInstaller
         }
     }
 
-    public function parserUpdate()
+    public function parserUpdate(): void
     {
         if (!$this->tableExists($this->lineSplit[1])) {
-            if (!isset($result)) $result = sprintf(REASON_TABLE_NOT_FOUND, $this->lineSplit[1]) . ' CHECK PREFIXES!';
+            $result = sprintf(REASON_TABLE_NOT_FOUND, $this->lineSplit[1]) . ' CHECK PREFIXES!';
             $this->writeUpgradeExceptions($this->line, $result, $this->fileName);
             $this->ignoreLine = true;
         } else {
@@ -314,7 +465,7 @@ class zcDatabaseInstaller
         }
     }
 
-    public function parserAlterTable()
+    public function parserAlterTable(): void
     {
         if (!$this->tableExists($this->lineSplit[2])) {
             $result = sprintf(REASON_TABLE_NOT_FOUND, $this->lineSplit[2]) . ' CHECK PREFIXES!';
@@ -334,21 +485,23 @@ class zcDatabaseInstaller
                         case 'INDEX':
                         case 'KEY':
                             // Do nothing if the index_name is ommitted
-                            if ($this->lineSplit[5] != 'USING' && substr($this->lineSplit[5], 0, 1) != '(') {
+                            if ($this->lineSplit[5] !== 'USING' && !str_starts_with($this->lineSplit[5], '(')) {
                                 $exists = $this->tableIndexExists($this->lineSplit[2], $this->lineSplit[5]);
                             }
                             break;
                         case 'UNIQUE':
                         case 'FULLTEXT':
                         case 'SPATIAL':
-                            if ($this->lineSplit[6] == 'INDEX' || $this->lineSplit[6] == 'KEY') {
+                            if ($this->lineSplit[6] === 'INDEX' || $this->lineSplit[6] === 'KEY') {
                                 // Do nothing if the index_name is ommitted
-                                if ($this->lineSplit[7] != 'USING' && substr($this->lineSplit[7], 0, 1) != '(') {
+                                if ($this->lineSplit[7] !== 'USING' && !str_starts_with($this->lineSplit[7], '(')) {
                                     $exists = $this->tableIndexExists($this->lineSplit[2], $this->lineSplit[7]);
                                 }
                             } // Do nothing if the index_name is ommitted
-                            else if ($this->lineSplit[6] != 'USING' && substr($this->lineSplit[6], 0, 1) != '(') {
-                                $exists = $this->tableIndexExists($this->lineSplit[2], $this->lineSplit[6]);
+                            else {
+                                if ($this->lineSplit[6] !== 'USING' && !str_starts_with($this->lineSplit[6], '(')) {
+                                    $exists = $this->tableIndexExists($this->lineSplit[2], $this->lineSplit[6]);
+                                }
                             }
                             break;
                         case 'CONSTRAINT':
@@ -358,10 +511,12 @@ class zcDatabaseInstaller
                             break;
                         default:
                             // No known item added, MySQL defaults to column definition unless the action is to drop the item, then it is the reverse.
-                            $exists = (strtoupper($this->lineSplit[3]) != 'DROP') == $this->tableColumnExists($this->lineSplit[2], $this->lineSplit[4]);
+                            $exists = strtoupper($this->lineSplit[3]) !== 'DROP' && $this->tableColumnExists($this->lineSplit[2], $this->lineSplit[4]);
                     }
                     // Ignore this line if the column / index already exists
-                    if ($exists) $this->ignoreLine = true;
+                    if ($exists) {
+                        $this->ignoreLine = true;
+                    }
 
                     break;
                 default:
@@ -370,15 +525,41 @@ class zcDatabaseInstaller
         }
     }
 
-    public function parserRenameTable()
+    public function tableColumnExists($table, $column): bool
+    {
+        if (!defined('DB_DATABASE')) {
+            define('DB_DATABASE', $this->dbName);
+        }
+        $check = $this->db->Execute(
+            'SHOW COLUMNS FROM `' . DB_DATABASE . '`.`' . $this->dbPrefix . $this->db->prepare_input($table) . '` ' .
+            'WHERE `Field` = \'' . $this->db->prepare_input($column) . '\''
+        );
+        return !$check->EOF;
+    }
+
+    public function tableIndexExists($table, $index): bool
+    {
+        if (!defined('DB_DATABASE')) {
+            define('DB_DATABASE', $this->dbName);
+        }
+        $check = $this->db->Execute(
+            'SHOW INDEX FROM `' . DB_DATABASE . '`.`' . $this->dbPrefix . $this->db->prepare_input($table) . '` ' .
+            'WHERE `Key_name` = \'' . $this->db->prepare_input($index) . '\''
+        );
+        return !$check->EOF;
+    }
+
+    public function parserRenameTable(): void
     {
         if (!$this->tableExists($this->lineSplit[2])) {
-            if (!isset($result)) $result = sprintf(REASON_TABLE_NOT_FOUND, $this->lineSplit[2]) . ' CHECK PREFIXES!';
+            $result = sprintf(REASON_TABLE_NOT_FOUND, $this->lineSplit[2]) . ' CHECK PREFIXES!';
             $this->writeUpgradeExceptions($this->line, $result, $this->fileName);
             $this->ignoreLine = true;
         } else {
             if ($this->tableExists($this->lineSplit[4])) {
-                if (!isset($result)) $result = sprintf(REASON_TABLE_ALREADY_EXISTS, $this->lineSplit[4]);
+                if (!isset($result)) {
+                    $result = sprintf(REASON_TABLE_ALREADY_EXISTS, $this->lineSplit[4]);
+                }
                 $this->writeUpgradeExceptions($this->line, $result, $this->fileName);
                 $this->ignoreLine = true;
             } else {
@@ -387,10 +568,10 @@ class zcDatabaseInstaller
         }
     }
 
-    public function parserLeftJoin()
+    public function parserLeftJoin(): void
     {
         if (!$this->tableExists($this->lineSplit[2])) {
-            if (!isset($result)) $result = sprintf(REASON_TABLE_NOT_FOUND, $this->lineSplit[2]) . ' CHECK PREFIXES!';
+            $result = sprintf(REASON_TABLE_NOT_FOUND, $this->lineSplit[2]) . ' CHECK PREFIXES!';
             $this->writeUpgradeExceptions($this->line, $result, $this->fileName);
             error_log($result . "\n" . $this->line . "\n---------------\n\n");
         } else {
@@ -398,201 +579,58 @@ class zcDatabaseInstaller
         }
     }
 
-    public function parserEngineInnodb()
+    public function parserEngineInnodb(): void
     {
-        if (!defined('USE_INNODB') || USE_INNODB == false) {
+        if (!defined('USE_INNODB') || USE_INNODB === false) {
             return;
         }
         if (!$this->table) {
             return;
         }
         $exceptions = (defined('INNODB_BLACKLIST')) ? INNODB_BLACKLIST : [];
-        if (!is_array($exceptions)) $exceptions = [];
-        if (in_array($this->table, $exceptions)) {
+        if (!is_array($exceptions)) {
+            $exceptions = [];
+        }
+        if (in_array($this->table, $exceptions, true)) {
             return;
         }
-        $this->line =  str_replace('MyISAM', 'InnoDb', $this->line);
-    }
-    public function writeUpgradeExceptions($line, $message, $sqlFile = '')
-    {
-        logDetails($line . '  ' . $message . '  ' . $sqlFile, 'upgradeException');
-        $this->upgradeExceptions[] = $message;
-        $this->createExceptionsTable();
-        $sql = "INSERT INTO " . $this->dbPrefix . TABLE_UPGRADE_EXCEPTIONS . " (sql_file, reason, errordate, sqlstatement) VALUES (:file:, :reason:, now(), :line:)";
-        $sql = $this->db->bindVars($sql, ':file:', $sqlFile, 'string');
-        $sql = $this->db->bindVars($sql, ':reason:', $message, 'string');
-        $sql = $this->db->bindVars($sql, ':line:', $line, 'string');
-        $result = $this->db->Execute($sql);
-        return $result;
+        $this->line = str_replace('MyISAM', 'InnoDb', $this->line);
     }
 
-    public function createExceptionsTable()
-    {
-        if (!$this->tableExists(TABLE_UPGRADE_EXCEPTIONS)) {
-            $result = $this->db->Execute("CREATE TABLE " . $this->dbPrefix . TABLE_UPGRADE_EXCEPTIONS . " (
-            upgrade_exception_id smallint(5) NOT NULL auto_increment,
-            sql_file varchar(128) default NULL,
-            reason text default NULL,
-            errordate datetime default NULL,
-            sqlstatement text, PRIMARY KEY  (upgrade_exception_id)
-          ) ENGINE=MyISAM");
-            return $result;
-        }
-    }
-
-    public function checkCfggroupKey($line)
-    {
-        $values = array();
-        $values = explode("'", $line);
-        $id = $values[1];
-        $title = $values[3];
-        $sql = "select configuration_group_title from " . $this->dbPrefix . "configuration_group where configuration_group_title='" . $title . "'";
-        $result = $this->db->Execute($sql);
-        if ($result->RecordCount() > 0) return sprintf(REASON_CONFIG_GROUP_KEY_ALREADY_EXISTS, $title);
-        $sql = "select configuration_group_title from " . $this->dbPrefix . "configuration_group where configuration_group_id='" . $id . "'";
-        $result = $this->db->Execute($sql);
-        if ($result->RecordCount() > 0) return sprintf(REASON_CONFIG_GROUP_ID_ALREADY_EXISTS, $id);
-        return FALSE;
-    }
-
-    public function checkProductTypeLayoutKey($line)
-    {
-        $values = array();
-        $values = explode("'", $line);
-        $title = $values[1];
-        $key = $values[3];
-        $sql = "select configuration_title from " . $this->dbPrefix . "product_type_layout where configuration_key='" . $key . "'";
-        $result = $this->db->Execute($sql);
-        if ($result->RecordCount() > 0) return sprintf(REASON_PRODUCT_TYPE_LAYOUT_KEY_ALREADY_EXISTS, $key);
-        return FALSE;
-    }
-
-    public function checkConfigKey($line)
-    {
-        $values = array();
-        $values = explode("'", $line);
-        //INSERT INTO configuration blah blah blah VALUES ('title','key', blah blah blah);
-        //[0]=INSERT INTO.....
-        //[1]=title
-        //[2]=,
-        //[3]=key
-        //[4]=blah blah
-        $title = $values[1];
-        $key = $values[3];
-        $sql = "select configuration_title from " . $this->dbPrefix . "configuration where configuration_key='" . $key . "'";
-        $result = $this->db->Execute($sql);
-        if ($result->RecordCount() > 0) return sprintf(REASON_CONFIG_KEY_ALREADY_EXISTS, $key);
-        return FALSE;
-    }
-
-    public function tableExists($table)
-    {
-        $tables = $this->db->Execute("SHOW TABLES like '" . $this->dbPrefix . $table . "'");
-        if ($tables->RecordCount() > 0) {
-            return TRUE;
-        } else {
-            return FALSE;
-        }
-    }
-
-    public function tableColumnExists($table, $column)
-    {
-        if (!defined('DB_DATABASE')) define('DB_DATABASE', $this->dbName);
-        $check = $this->db->Execute(
-            'SHOW COLUMNS FROM `' . DB_DATABASE . '`.`' . $this->dbPrefix . $this->db->prepare_input($table) . '` ' .
-            'WHERE `Field` = \'' . $this->db->prepare_input($column) . '\''
-        );
-        return !$check->EOF;
-    }
-
-    public function tableIndexExists($table, $index)
-    {
-        if (!defined('DB_DATABASE')) define('DB_DATABASE', $this->dbName);
-        $check = $this->db->Execute(
-            'SHOW INDEX FROM `' . DB_DATABASE . '`.`' . $this->dbPrefix . $this->db->prepare_input($table) . '` ' .
-            'WHERE `Key_name` = \'' . $this->db->prepare_input($index) . '\''
-        );
-        return !$check->EOF;
-    }
-
-    public function updateConfigKeys()
+    public function updateConfigKeys(): bool
     {
         if (isset($_POST['http_server_catalog']) && $_POST['http_server_catalog'] != '') {
             $email_stub = preg_replace('~.*\/\/(www.)*~', 'YOUR_EMAIL@', $_POST['http_server_catalog']);
-            $sql = "update " . $this->dbPrefix . "configuration set configuration_value=:emailStub: where configuration_key in ('STORE_OWNER_EMAIL_ADDRESS', 'EMAIL_FROM')";
+            $sql = "UPDATE " . $this->dbPrefix . "configuration SET configuration_value=:emailStub: WHERE configuration_key IN ('STORE_OWNER_EMAIL_ADDRESS', 'EMAIL_FROM')";
             $sql = $this->db->bindVars($sql, ':emailStub:', $email_stub, 'string');
             $this->db->Execute($sql);
         }
-        return FALSE;
+        return false;
     }
 
-    public function doCompletion($options)
+    public function doCompletion($options): void
     {
         global $request_type;
-        if ($request_type == 'SSL') {
-            $sql = "UPDATE " . $this->dbPrefix . "configuration set configuration_value = '1:1', last_modified = now() where configuration_key = 'SSLPWSTATUSCHECK'";
+        if ($request_type === 'SSL') {
+            $sql = "UPDATE " . $this->dbPrefix . "configuration SET configuration_value = '1:1', last_modified = now() WHERE configuration_key = 'SSLPWSTATUSCHECK'";
             $this->db->Execute($sql);
         }
-        $sql = "update " . $this->dbPrefix . "admin set admin_name = '" . $options['admin_user'] . "', admin_email = '" . $options['admin_email'] . "', admin_pass = '" . zen_encrypt_password($options['admin_password']) . "', pwd_last_change_date = " . ($request_type == 'SSL'
-                ? 'NOW()' : 'timestamp("1970-01-01 00:00:00")') . ($request_type == 'SSL' ? ''
-                : ", reset_token = '" . (time() + (72 * 60 * 60)) . "}" . zen_encrypt_password($options['admin_password']) . "'") . " where admin_id = 1";
+        $sql = "UPDATE " . $this->dbPrefix . "admin
+                SET admin_name = '" . $options['admin_user'] . "', admin_email = '" . $options['admin_email'] . "',
+                    admin_pass = '" . zen_encrypt_password($options['admin_password']) . "',
+                    pwd_last_change_date = " . ($request_type === 'SSL' ? 'NOW()' : 'timestamp("1970-01-01 00:00:00")')
+                . ($request_type === 'SSL' ? '' : ", reset_token = '" . (time() + (72 * 60 * 60)) . "}" . zen_encrypt_password($options['admin_password']) . "'") . "
+                WHERE admin_id = 1";
         $this->db->Execute($sql);
 
         if (defined('DEVELOPER_MODE') && DEVELOPER_MODE === true && defined('DEVELOPER_CONFIGS') && is_array(DEVELOPER_CONFIGS)) {
             foreach (DEVELOPER_CONFIGS as $key => $value) {
-                if (null === $value) continue;
-                $sql = "update " . $this->dbPrefix . "configuration set configuration_value = '" . $this->db->prepareInput($value) . "' where configuration_key = '" . $this->db->prepareInput($key) . "'";
+                if (null === $value) {
+                    continue;
+                }
+                $sql = "UPDATE " . $this->dbPrefix . "configuration SET configuration_value = '" . $this->db->prepareInput($value) . "'
+                        WHERE configuration_key = '" . $this->db->prepareInput($key) . "'";
                 $this->db->Execute($sql);
-            }
-        }
-    }
-
-    private function camelize($parseString)
-    {
-        $parseString = preg_replace_callback('/\s([0-9,a-z])/', $this->func, strtolower($parseString));
-        $parseString[0] = strtoupper($parseString[0]);
-        return $parseString;
-    }
-
-    private function doJsonProgressLoggingUpdate()
-    {
-        if (isset($this->extendedOptions['doJsonProgressLogging'])) {
-            $fileName = $this->extendedOptions['doJsonProgressLoggingFileName'];
-            $progress = ($this->jsonProgressLoggingCount / $this->jsonProgressLoggingTotal * 100);
-            $fp = fopen($fileName, "w");
-            if ($fp) {
-                $arr = array('total' => '0', 'progress' => $progress, 'message' => $this->extendedOptions['message']);
-                fwrite($fp, json_encode($arr));
-                fclose($fp);
-            }
-        }
-    }
-
-    private function doJsonProgressLoggingStart($count)
-    {
-        if (isset($this->extendedOptions['doJsonProgressLogging'])) {
-            $this->jsonProgressLoggingTotal = $count;
-            $this->jsonProgressLoggingCount = 0;
-            $fileName = $this->extendedOptions['doJsonProgressLoggingFileName'];
-            $fp = fopen($fileName, "w");
-            if ($fp) {
-                $arr = array('total' => $count, 'progress' => 0, 'message' => $this->extendedOptions['message']);
-                fwrite($fp, json_encode($arr));
-                fclose($fp);
-            }
-        }
-    }
-
-    private function doJsonProgressLoggingEnd()
-    {
-        if (isset($this->extendedOptions['doJsonProgressLogging'])) {
-            $this->jsonProgressLoggingCount = 0;
-            $fileName = $this->extendedOptions['doJsonProgressLoggingFileName'];
-            $fp = fopen($fileName, "w");
-            if ($fp) {
-                $arr = array('total' => '0', 'progress' => 100, 'message' => $this->extendedOptions['message']);
-                fwrite($fp, json_encode($arr));
-                fclose($fp);
             }
         }
     }

--- a/zc_install/includes/classes/class.zcRegistry.php
+++ b/zc_install/includes/classes/class.zcRegistry.php
@@ -1,11 +1,13 @@
 <?php
+declare(strict_types=1);
 /**
  * registry class.
  *
- * @package classes
+ * @package Installer
  * @copyright Copyright 2003-2016 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  */
+
 /**
  * Registry Class
  *
@@ -21,87 +23,63 @@
  * however it is possible that 3rd party code will produce namespace clashes. Can only be overcome by a naming standard
  * for 3rd party objects.
  *
- * @package classes
+ * @package Installer
  */
 class zcRegistry extends base
 {
-  /**
-   * array used to hold registry values
-   *
-   * @var array
-   */
-  public static $values;
+    /**
+     * array used to hold registry values
+     */
+    public static array $values;
 
-  /**
-   * getter method to return a registry entry
-   *
-   * @param string $keyName
-   * @return mixed
-   */
-  public static function getValue($keyName)
-  {
-    if (isset(self::$values[$keyName]))
+    /**
+     * getter method to return a registry entry
+     */
+    public static function getValue(string $keyName): mixed
     {
-      return self::$values[$keyName];
-    } else
-    {
-      throw new zcGeneralException('zcRegistry key not set ' . $keyName, 0);
+        if (isset(self::$values[$keyName])) {
+            return self::$values[$keyName];
+        }
+
+        throw new zcGeneralException('zcRegistry key not set ' . $keyName, 0);
     }
-  }
-  /**
-   *
-   * @param string $keyName
-   * @param mixed $default
-   * @return mixed
-   */
-  public static function getValueDefault($keyName, $default = '')
-  {
-    if (isset(self::$values[$keyName]))
+
+    public static function getValueDefault(string $keyName, mixed $default = ''): mixed
     {
-      return self::$values[$keyName];
-    } else
-    {
-      return $default;
+        return self::$values[$keyName] ?? $default;
     }
-  }
-  /**
-   * method to set a registry entry
-   *
-   * @param string $keyName
-   * @param mixed $KeyValue
-   */
-  public static function setValue($keyName, $keyValue)
-  {
-    self::$values[$keyName] = $keyValue;
-  }
-  /**
-   * method to determine if registry entry has been set
-   *
-   * @param string $keyName
-   * @return boolean
-   */
-  public static function isValueSet($keyName)
-  {
-    if (isset(self::$values[$keyName]))
+
+    /**
+     * method to set a registry entry
+     */
+    public static function setValue(string $keyName, mixed $keyValue): void
     {
-      return TRUE;
-    } else
-    {
-      return FALSE;
+        self::$values[$keyName] = $keyValue;
     }
-  }
-  public static function unSetValue($keyName)
-  {
-    if (isset(self::$values[$keyName]))
+
+    /**
+     * method to determine if registry entry has been set
+     */
+    public static function isValueSet(string $keyName): bool
     {
-      unset(self::$values[$keyName]);
-    } else
-    {
-      throw new zcGeneralException('zcRegistry key not set ' . $keyName, 0);
+        if (isset(self::$values[$keyName])) {
+            return true;
+        }
+
+        return false;
     }
-  }
-  public static function getRawValues()
-  {
-    return self::$values;
-  }
+
+    public static function unSetValue($keyName): void
+    {
+        if (isset(self::$values[$keyName])) {
+            unset(self::$values[$keyName]);
+        } else {
+            throw new zcGeneralException('zcRegistry key not set ' . $keyName, 0);
+        }
+    }
+
+    public static function getRawValues(): array
+    {
+        return self::$values;
+    }
 }

--- a/zc_install/includes/cli_controller.php
+++ b/zc_install/includes/cli_controller.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2020 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
@@ -7,81 +8,89 @@
  */
 
 if (!file_exists(DIR_FS_INSTALL . 'includes/custom_settings.php')) {
-  echo 'Error: could not find the zc_install/includes/custom_settings.php file.' . "\n\n";
-  exit(1);
+    echo 'Error: could not find the zc_install/includes/custom_settings.php file.' . "\n\n";
+    exit(1);
+} else {
+    require(DIR_FS_INSTALL . 'includes/custom_settings.php');
 }
-require (DIR_FS_INSTALL . 'custom_settings.php');
 if (!isset($zc_settings) || !is_array($zc_settings)) {
-  echo 'Error: $zc_settings array not found in custom_settings.php';
-  exit(1);
+    echo 'Error: $zc_settings array not found in custom_settings.php';
+    exit(1);
 }
-$isUpgrade = FALSE;
+$isUpgrade = false;
 
-$otherConfigErrors = FALSE;
-$hasUpgradeErrors = FALSE;
+$otherConfigErrors = false;
+$hasUpgradeErrors = false;
 $selectedAdminDir = file_exists(DIR_FS_ROOT . $zc_settings['adminDir']) ? $zc_settings['adminDir'] : 'admin';
 $systemChecker = new systemChecker($selectedAdminDir);
 $dbVersion = $systemChecker->findCurrentDbVersion();
 $currentDbVersion = EXPECTED_DATABASE_VERSION_MAJOR . '.' . EXPECTED_DATABASE_VERSION_MINOR;
-$isCurrentDb = ($dbVersion == $currentDbVersion) ? TRUE : FALSE;
+$isCurrentDb = $dbVersion === $currentDbVersion;
 $hasSaneConfigFile = $systemChecker->hasSaneConfigFile();
 $hasTables = $systemChecker->hasTables();
 $hasUpdatedConfigFile = $systemChecker->hasUpdatedConfigFile();
 $errorList = $systemChecker->runTests();
-list($hasFatalErrors, $listFatalErrors) = $systemChecker->getErrorList();
-list($hasWarnErrors, $listWarnErrors) = $systemChecker->getErrorList('WARN');
-if (isset($listFatalErrors[0]['methods']))
-{
-  $res = key($listFatalErrors[0]['methods']);
-  if ($res == 'CheckWriteableAdminFile') $otherConfigErrors = TRUE;
+[$hasFatalErrors, $listFatalErrors] = $systemChecker->getErrorList();
+[$hasWarnErrors, $listWarnErrors] = $systemChecker->getErrorList('WARN');
+if (isset($listFatalErrors[0]['methods'])) {
+    $res = key($listFatalErrors[0]['methods']);
+    if ($res === 'CheckWriteableAdminFile') {
+        $otherConfigErrors = true;
+    }
 }
 $adminDirectoryList = systemChecker::getAdminDirectoryList();
-$hasMultipleAdmins = FALSE;
+$hasMultipleAdmins = false;
 $selectedAdminDir = file_exists(DIR_FS_ROOT . $zc_settings['adminDir']) ? $zc_settings['adminDir'] : 'admin';
-if (count($adminDirectoryList) > 1)
-{
-  $hasMultipleAdmins = TRUE;
-  echo 'Multiple Admin Folders Found:';
-  foreach ($adminDirectoryList as $directory)
-  {
-    echo $directory;
-    if ($directory == $zc_settings['adminDir']) echo ' (selected)';
-    echo "\n";
-  }
-} else
-{
-  $selectedAdminDir = $adminDirectoryList[0];
-  echo 'Selected Admin Folder: ' . $selectedAdminDir . "\n";
+if (count($adminDirectoryList) > 1) {
+    $hasMultipleAdmins = true;
+    echo 'Multiple Admin Folders Found:';
+    foreach ($adminDirectoryList as $directory) {
+        echo $directory;
+        if ($directory === $zc_settings['adminDir']) {
+            echo ' (selected)';
+        }
+        echo "\n";
+    }
+} else {
+    $selectedAdminDir = $adminDirectoryList[0];
+    echo 'Selected Admin Folder: ' . $selectedAdminDir . "\n";
 }
 // do auto-detections
-list($adminDir, $documentRoot, $adminServer, $catalogHttpServer, $catalogHttpUrl, $catalogHttpsServer, $catalogHttpsUrl, $dir_ws_http_catalog, $dir_ws_https_catalog) = getDetectedURIs();
+[
+    $adminDir,
+    $documentRoot,
+    $adminServer,
+    $catalogHttpServer,
+    $catalogHttpUrl,
+    $catalogHttpsServer,
+    $catalogHttpsUrl,
+    $dir_ws_http_catalog,
+    $dir_ws_https_catalog,
+] = getDetectedURIs();
 $db_type = 'mysql';
 $db_charset = 'utf8mb4';
 $db_prefix = '';
 $sql_cache_method = 'none'; // 'file', 'database'
-$db_host = isset($zc_settings['db_host']) ? $zc_settings['db_host'] : 'localhost';
-$db_name = isset($zc_settings['db_name']) ? $zc_settings['db_name'] : 'zencart';
-$db_user = isset($zc_settings['db_user']) ? $zc_settings['db_user'] : '';
-$db_password= isset($zc_settings['db_password']) ? $zc_settings['db_password'] : '';
+$db_host = $zc_settings['db_host'] ?? 'localhost';
+$db_name = $zc_settings['db_name'] ?? 'zencart';
+$db_user = $zc_settings['db_user'] ?? '';
+$db_password = $zc_settings['db_password'] ?? '';
 
-require (DIR_FS_INSTALL . 'includes/classes/class.zcDatabaseInstaller.php');
+require(DIR_FS_INSTALL . 'includes/classes/class.zcDatabaseInstaller.php');
 
 $admin_password = zen_create_PADSS_password();
 
-if (isset($_POST['http_server_catalog']))
-{
-  require (DIR_FS_INSTALL . 'includes/classes/class.zcConfigureFileWriter.php');
-  $result = new zcConfigureFileWriter($_POST);
+if (isset($_POST['http_server_catalog'])) {
+    require(DIR_FS_INSTALL . 'includes/classes/class.zcConfigureFileWriter.php');
+    $result = new zcConfigureFileWriter($_POST);
 }
 
 
-
-
-require (DIR_FS_INSTALL . 'includes/classes/class.zcDatabaseInstaller.php');
-if ($isUpgrade == FALSE) {
-  $options = $_POST;
-  $dbInstaller = new zcDatabaseInstaller($options);
-  $result = $dbInstaller->getConnection();
-  $extendedOptions = array();
-  $dbInstaller->doCompletion($options);
+require(DIR_FS_INSTALL . 'includes/classes/class.zcDatabaseInstaller.php');
+if ($isUpgrade === false) {
+    $options = $_POST;
+    $dbInstaller = new zcDatabaseInstaller($options);
+    $result = $dbInstaller->getConnection();
+    $extendedOptions = [];
+    $dbInstaller->doCompletion($options);
 }

--- a/zc_install/includes/functions/general.php
+++ b/zc_install/includes/functions/general.php
@@ -1,6 +1,7 @@
 <?php
+declare(strict_types=1);
 /**
- * general functions
+ * zc_install general functions
  *
  * @copyright Copyright 2003-2023 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
@@ -8,171 +9,156 @@
  * @version $Id: mc12345678 2022 Dec 14 Modified in v1.5.8a $
  */
 
-if (!defined('TABLE_UPGRADE_EXCEPTIONS')) define('TABLE_UPGRADE_EXCEPTIONS','upgrade_exceptions');
-
-function zen_get_select_options($optionList, $setDefault)
-{
-  $optionString = "";
-  foreach ($optionList as $option)
-  {
-    $optionString .= '<option value="' . $option['id'] . '"';
-    if ($setDefault == $option['id']) $optionString .= " SELECTED ";
-    $optionString .= '>' . $option['text'];
-    $optionString .='</option>';
-  }
-  return $optionString;
+if (!defined('TABLE_UPGRADE_EXCEPTIONS')) {
+    define('TABLE_UPGRADE_EXCEPTIONS', 'upgrade_exceptions');
 }
 
-  function logDetails($details, $location = "General") {
-      if (!isset($_SESSION['logfilename']) || $_SESSION['logfilename'] == '') $_SESSION['logfilename'] = date('m-d-Y_h-i-s-') . zen_create_random_value(6);
-      if ($fp = @fopen(DEBUG_LOG_FOLDER . '/zcInstallLog_' . $_SESSION['logfilename'] . '.log', 'a')) {
+function zen_get_select_options(array $optionList, string|int $setDefault): string
+{
+    $optionString = "";
+    foreach ($optionList as $option) {
+        $optionString .= '<option value="' . $option['id'] . '"';
+        if ((string)$setDefault === (string)$option['id']) {
+            $optionString .= " selected ";
+        }
+        $optionString .= '>' . $option['text'];
+        $optionString .= '</option>';
+    }
+    return $optionString;
+}
+
+function logDetails(string $details, string $location = "General"): void
+{
+    if (!isset($_SESSION['logfilename']) || $_SESSION['logfilename'] == '') {
+        $_SESSION['logfilename'] = date('m-d-Y_h-i-s-') . zen_create_random_value(6);
+    }
+    if ($fp = @fopen(DEBUG_LOG_FOLDER . '/zcInstallLog_' . $_SESSION['logfilename'] . '.log', 'a')) {
         fwrite($fp, '---------------' . "\n" . date('M d Y G:i') . ' -- ' . $location . "\n" . $details . "\n\n");
         fclose($fp);
-      }
     }
+}
 
-   function zen_rand($min = null, $max = null) {
+function zen_rand(int $min = null, int $max = null): int
+{
     static $seeded;
 
     if (!isset($seeded)) {
-      mt_srand((int)(microtime(true)*1000000));
-      $seeded = true;
+        mt_srand((int)(microtime(true) * 1000000));
+        $seeded = true;
     }
 
-    if (isset($min) && isset($max)) {
-      if ($min >= $max) {
-        return $min;
-      } else {
+    if (isset($min, $max)) {
+        if ($min >= $max) {
+            return $min;
+        }
         return mt_rand($min, $max);
-      }
-    } else {
-      return mt_rand();
     }
-  }
-  function zen_get_document_root() {
+
+    return mt_rand();
+}
+
+function zen_get_document_root(): string
+{
     $dir_fs_www_root = realpath(dirname(basename(__FILE__)) . "/..");
-    if ($dir_fs_www_root == '') $dir_fs_www_root = '/';
-    $dir_fs_www_root = str_replace(array('\\','//'), '/', $dir_fs_www_root);
-    return $dir_fs_www_root;
-  }
-  function zen_get_http_server()
-  {
+    if ($dir_fs_www_root === '') {
+        $dir_fs_www_root = '/';
+    }
+    return str_replace(['\\', '//'], '/', $dir_fs_www_root);
+}
+
+function zen_get_http_server(): string
+{
     $host = $_SERVER['HTTP_HOST'];
     $script = explode('/', trim($_SERVER['SCRIPT_NAME'], '/'));
-    if (substr($script[0], 0, 1) == '~') {
-      $host .= '/' . $script[0];
+    if (str_starts_with($script[0], '~')) {
+        $host .= '/' . $script[0];
     }
     return $host;
-  }
-  function zen_parse_url($url, $element = 'array', $detect_tilde = false)
-  {
+}
+
+function zen_parse_url(string $url, string $element = 'array', bool $detect_tilde = false): mixed
+{
     // Read the various elements of the URL, to use in auto-detection of admin foldername (basically a simplified parse_url equivalent which automatically supports ports and uncommon TLDs)
-    $t1 = array();
+    $parsed = [];
     // scheme
-    $s1 = explode('://', $url);
-    $t1['scheme'] = $s1[0];
+    $segment1 = explode('://', $url);
+    $parsed['scheme'] = $segment1[0];
     // host
-    $s2 = explode('/', trim($s1[1], '/'));
-    $t1['host'] = $s2[0];
-    array_shift($s2);
+    $segment2 = explode('/', trim($segment1[1], '/'));
+    $parsed['host'] = $segment2[0];
+    array_shift($segment2);
     // adjust host to accommodate /~username shared-ssl scenarios
-    if ($detect_tilde && isset($s2[0]) && strpos($s2[0], '~') === 0) {
-      $t1['host'] .= '/' . $s2[0];
-      // array_shift also therefore removes it from ['path'] below
-      array_shift($s2);
+    if ($detect_tilde && isset($segment2[0]) && str_starts_with($segment2[0], '~')) {
+        $parsed['host'] .= '/' . $segment2[0];
+        // array_shift also therefore removes it from ['path'] below
+        array_shift($segment2);
     }
     // path/uri
-    $t1['path'] = implode('/', $s2);
-    $p1 = ($t1['path'] != '') ? '/' . $t1['path'] : '';
+    $parsed['path'] = implode('/', $segment2);
+    $path = ($parsed['path'] !== '') ? '/' . $parsed['path'] : '';
 
-    switch($element) {
-      case 'scheme':
-      case 'host':
-      case 'path':
-        return $t1[$element];
-      case '/path':
-        return $p1;
-      case 'array':
-      default:
-        return $t1;
+    return match ($element) {
+        'scheme', 'host', 'path' => $parsed[$element],
+        '/path' => $path,
+        default => $parsed,
+    };
+}
+
+function zen_sanitize_request(): void
+{
+    foreach ($_POST as $key => $value) {
+        $_POST[htmlspecialchars($key, ENT_COMPAT, 'UTF-8', false)] = addslashes($value);
     }
-  }
+}
 
-  function zen_sanitize_request()
-  {
-    foreach ($_POST as $key => $value)
-    {
-      $_POST[htmlspecialchars($key, ENT_COMPAT, 'UTF-8', FALSE)] = addslashes($value);
-    }
-  }
-  /**
-   * Returns a string with conversions for security.
-   * @param string The string to be parsed
-   * @param string contains a string to be translated, otherwise just quote is translated
-   * @param boolean Do we run htmlspecialchars over the string
-   */
-  function zen_output_string($string, $translate = false, $protected = false) {
-    if ($protected == true) {
-      return htmlspecialchars($string, ENT_COMPAT, 'utf-8', TRUE);
-    } else {
-      if ($translate == false) {
-        return strtr($string, array('"' => '&quot;'));
-      } else {
-        return strtr($string, $translate);
-      }
-    }
-  }
+/**
+ * Returns a string with conversions for security.
+ *
+ * Runs htmlspecialchars over the string
+ */
+function zen_output_string_protected(string $string): string
+{
+    return htmlspecialchars($string, ENT_COMPAT, 'utf-8', true);
+}
 
-  /**
-   * Returns a string with conversions for security.
-   *
-   * Simply calls the zen_ouput_string function
-   * with parameters that run htmlspecialchars over the string
-   * and converts quotes to html entities
-   *
-   * @param string The string to be parsed
-   */
-  function zen_output_string_protected($string) {
-    return zen_output_string($string, false, true);
-  }
-
-  function zen_get_install_languages_list($lng)
-  {
+function zen_get_install_languages_list(string $lng): string
+{
     global $languagesInstalled;
     $optionString = "";
-    foreach ($languagesInstalled as $code=>$language)
-    {
-      $optionString .= '<option value="' . $code . '"';
-      if ($code == $lng)
-      {
-        $optionString .= " SELECTED ";
-      }
-      $optionString .= '>' . $language['displayName'];
-      $optionString .= "</option>";
+    foreach ($languagesInstalled as $code => $language) {
+        $optionString .= '<option value="' . $code . '"';
+        if ((string)$code === $lng) {
+            $optionString .= " selected ";
+        }
+        $optionString .= '>' . $language['displayName'];
+        $optionString .= "</option>";
     }
     return $optionString;
-  }
+}
 
-  /**
-   * helper function to detect current site URI info
-   * @return array($adminDir, $documentRoot, $adminServer, $catalogHttpServer, $catalogHttpUrl, $catalogHttpsServer, $catalogHttpsUrl, $dir_ws_http_catalog, $dir_ws_https_catalog)
-   */
-  function getDetectedURIs($adminDir = 'admin') {
+/**
+ * helper function to detect current site URI info
+ * @return array($adminDir, $documentRoot, $adminServer, $catalogHttpServer, $catalogHttpUrl, $catalogHttpsServer, $catalogHttpsUrl, $dir_ws_http_catalog, $dir_ws_https_catalog)
+ */
+function getDetectedURIs($adminDir = 'admin'): array
+{
     global $request_type;
-    if (isset($_POST['adminDir'])) $adminDir = zen_output_string_protected($_POST['adminDir']);
+    if (isset($_POST['adminDir'])) {
+        $adminDir = zen_output_string_protected($_POST['adminDir']);
+    }
     $documentRoot = zen_get_document_root();
-    $url = ($request_type == 'SSL' ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'] . str_replace('/zc_install/index.php', '', $_SERVER['SCRIPT_NAME']);
+    $url = ($request_type === 'SSL' ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'] . str_replace('/zc_install/index.php', '', $_SERVER['SCRIPT_NAME']);
     $httpServer = zen_parse_url($url, 'host', true);
-    $adminServer = ($request_type == 'SSL') ? 'https://' : 'http://';
+    $adminServer = ($request_type === 'SSL') ? 'https://' : 'http://';
     $adminServer .= $httpServer;
-    $catalogHttpServer = ($request_type == 'SSL' ? 'https://' : 'http://') . $httpServer;
-    $catalogHttpUrl = ($request_type == 'SSL' ? 'https://' :'http://') . $httpServer . '/' . zen_parse_url($url, 'path', true);
+    $catalogHttpServer = ($request_type === 'SSL' ? 'https://' : 'http://') . $httpServer;
+    $catalogHttpUrl = ($request_type === 'SSL' ? 'https://' : 'http://') . $httpServer . '/' . zen_parse_url($url, 'path', true);
     $catalogHttpsServer = 'https://' . $httpServer;
     $catalogHttpsUrl = 'https://' . $httpServer . '/' . zen_parse_url($url, 'path', true);
-    $dir_ws_http_catalog = str_replace($catalogHttpServer, '', $catalogHttpUrl) .'/';
+    $dir_ws_http_catalog = str_replace($catalogHttpServer, '', $catalogHttpUrl) . '/';
     $dir_ws_https_catalog = str_replace($catalogHttpsServer, '', $catalogHttpsUrl) . '/';
 
-    return array($adminDir, $documentRoot, $adminServer, $catalogHttpServer, $catalogHttpUrl, $catalogHttpsServer, $catalogHttpsUrl, $dir_ws_http_catalog, $dir_ws_https_catalog);
-  }
+    return [$adminDir, $documentRoot, $adminServer, $catalogHttpServer, $catalogHttpUrl, $catalogHttpsServer, $catalogHttpsUrl, $dir_ws_http_catalog, $dir_ws_https_catalog];
+}
 
 

--- a/zc_install/includes/functions/password_funcs.php
+++ b/zc_install/includes/functions/password_funcs.php
@@ -1,6 +1,7 @@
 <?php
+declare(strict_types=1);
 /**
- * password_funcs functions
+ * zc_install password_funcs functions
  *
  * @copyright Copyright 2003-2022 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
@@ -8,44 +9,42 @@
  * @version $Id: DrByte 2021 Mar 05 Modified in v1.5.8-alpha $
  */
 
-require_once (DIR_FS_ROOT . '/includes/classes/class.zcPassword.php');
+require_once(DIR_FS_ROOT . '/includes/classes/class.zcPassword.php');
 
 /**
  * Validates a plain text password with the encrpyted password
  *
- * If the encrypted password begins with '$2y$', the PHP 5.5 compatible hashing
+ * If the encrypted password begins with '$2y$', the bcrypt-compatible hashing
  * functions will be used.  Otherwise, a legacy md5-style hash is assumed.
  *
- * @param  string $plain     the plain-text password
- * @param  string $encrypted the encrypted password
- * @return bool
+ * @param string $plain the plain-text password
+ * @param string $encrypted the encrypted password
  */
-function zen_validate_password($plain, $encrypted) {
-  if (empty($plain) || empty($encrypted)) {
+function zen_validate_password(string $plain, string $encrypted): bool
+{
+    if (empty($plain) || empty($encrypted)) {
+        return false;
+    }
+
+    if (str_starts_with($encrypted, '$2y$')) {
+        return zcPassword::getInstance(PHP_VERSION)->validatePassword($plain, $encrypted);
+    }
+
+    // split apart the hash / salt
+    $stack = explode(':', $encrypted);
+    if (count($stack) === 2) {
+        return (md5($stack[1] . $plain) === $stack[0]);
+    }
+
     return false;
-  }
-
-  if (strpos($encrypted, '$2y$') === 0) {
-    return zcPassword::getInstance(PHP_VERSION)->validatePassword($plain, $encrypted);
-  }
-
-  // split apart the hash / salt
-  $stack = explode(':', $encrypted);
-  if (sizeof($stack) == 2) {
-    return (md5($stack[1] . $plain) == $stack[0]);
-  }
-
-  return false;
 }
 
 /**
  * This function makes a new password from a plaintext password.
- * if php >= 5.5.0 we use inbuilt password_hash function.
+ * we use inbuilt password_hash function if present (should always be),
  * otherwise we use zen_encrypt_password_sha256 to create a salted sha256 password.
- * @param $plain
- * @return string
  */
-function zen_encrypt_password($plain)
+function zen_encrypt_password(string $plain): string
 {
     if (function_exists('password_hash')) {
         $password = password_hash($plain, PASSWORD_DEFAULT);
@@ -56,58 +55,53 @@ function zen_encrypt_password($plain)
 }
 
 /**
- * this function makes a sha256 password from a plaintext password.
- * @param $plain
- * @return string
+ * makes a sha256 password from a plaintext password.
  */
-function zen_encrypt_password_sha256($plain)
+function zen_encrypt_password_sha256(string $plain): string
 {
     $password = '';
-    for($i = 0; $i < 40; $i ++) {
+    for ($i = 0; $i < 40; $i++) {
         $password .= zen_rand();
     }
     $salt = hash('sha256', $password);
-    $password = hash('sha256', $salt . $plain) . ':' . $salt;
-    return $password;
+    return hash('sha256', $salt . $plain) . ':' . $salt;
 }
-////
-function zen_create_random_value($length, $type = 'mixed')
+
+function zen_create_random_value(int $length, string $type = 'mixed'): false|string
 {
-  if (($type != 'mixed') && ($type != 'chars') && ($type != 'digits'))
-    return false;
-
-  $rand_value = '';
-  while (strlen($rand_value) < $length)
-  {
-    if ($type == 'digits')
-    {
-      $char = zen_rand(0, 9);
-    } else
-    {
-      $char = chr(zen_rand(0, 255));
+    if ($type !== 'mixed' && $type !== 'chars' && $type !== 'digits') {
+        return false;
     }
-    if ($type == 'mixed')
-    {
-      if (preg_match('/^[a-z0-9]$/i', $char))
-        $rand_value .= $char;
-    } elseif ($type == 'chars')
-    {
-      if (preg_match('/^[a-z]$/i', $char))
-        $rand_value .= $char;
-    } elseif ($type == 'digits')
-    {
-      if (preg_match('/^[0-9]$/', $char))
-        $rand_value .= $char;
+
+    $rand_value = '';
+    while (strlen($rand_value) < $length) {
+        if ($type === 'digits') {
+            $char = zen_rand(0, 9);
+        } else {
+            $char = chr(zen_rand(0, 255));
+        }
+        if ($type === 'mixed') {
+            if (preg_match('/^[a-z0-9]$/i', $char)) {
+                $rand_value .= $char;
+            }
+        } elseif ($type === 'chars') {
+            if (preg_match('/^[a-z]$/i', $char)) {
+                $rand_value .= $char;
+            }
+        } elseif ($type === 'digits') {
+            if (preg_match('/^[0-9]$/', $char)) {
+                $rand_value .= $char;
+            }
+        }
     }
-  }
 
-  if ($type == 'mixed' && !preg_match('/^(?=.*[\w]+.*)(?=.*[\d]+.*)[\d\w]{' . $length . ',}$/', $rand_value))
-  {
-    $rand_value .= zen_rand(0, 9);
-  }
+    if ($type === 'mixed' && !preg_match('/^(?=.*[\w]+.*)(?=.*[\d]+.*)[\d\w]{' . $length . ',}$/', $rand_value)) {
+        $rand_value .= zen_rand(0, 9);
+    }
 
-  return $rand_value;
+    return $rand_value;
 }
+
 /**
  * Returns entropy using a hash of various available methods for obtaining
  * random data. The default hash method is "sha1" and the default size is 32.
@@ -116,122 +110,123 @@ function zen_create_random_value($length, $type = 'mixed')
  * @param int $size the size of random data to use while generating the hash.
  * @return string the randomized salt
  */
-function zen_get_entropy($hash = 'sha1', $size = 32)
+function zen_get_entropy(string $hash = 'sha1', int $size = 32): string
 {
-  $data = null;
-  if (!in_array($hash, hash_algos())) $hash = 'sha1';
-  if (!is_int($size)) $size = (int) $size;
-
-  // Use openssl if available
-  if (function_exists('openssl_random_pseudo_bytes'))
-  {
-    //echo('Attempting to create entropy using openssl');
-    $entropy = openssl_random_pseudo_bytes($size, $strong);
-    if ($strong) $data = $entropy;
-    unset($strong, $entropy);
-  }
-
-  // Use mcrypt with /dev/urandom if available
-  if ($data === null && function_exists('mcrypt_create_iv'))
-  {
-    //echo('Attempting to create entropy using mcrypt');
-    $entropy = mcrypt_create_iv($size, MCRYPT_DEV_URANDOM);
-    if ($entropy !== FALSE) $data = $entropy;
-    unset($entropy);
-  }
-
-  if ($data === null)
-  {
-    // Fall back to using /dev/urandom if available
-    $fp = @fopen('/dev/urandom', 'rb');
-    if ($fp !== FALSE)
-    {
-      //echo('Attempting to create entropy using /dev/urandom');
-      $entropy = @fread($fp, $size);
-      @fclose($fp);
-      if (strlen($entropy) == $size) $data = $entropy;
-      unset($fp, $entropy);
+    $data = null;
+    if (!in_array($hash, hash_algos(), true)) {
+        $hash = 'sha1';
     }
-  }
-
-  // Final fallback (mixture of various methods)
-  if ($data === null)
-  {
-    //echo('Attempting to create entropy using FINAL FALLBACK');
-    $filename = DIR_FS_ROOT . 'includes/configure.php';
-    $stat = @stat($filename);
-    if ($stat === FALSE)
-    {
-      $stat = array(
-        'microtime' => microtime()
-      );
+    if (!is_int($size)) {
+        $size = (int)$size;
     }
-    $stat['mt_rand'] = mt_rand();
-    $stat['file_hash'] = hash_file($hash, $filename, TRUE);
 
-    // Attempt to get a random value on windows
-    // http://msdn.microsoft.com/en-us/library/aa388176(VS.85).aspx
-    if (@class_exists('COM'))
-    {
-      try
-      {
-        $CAPI_Util = new COM('CAPICOM.Utilities.1');
-        $entropy = $CAPI_Util->GetRandom($size, 0);
-
-        if ($entropy)
-        {
-          //echo('Adding random data to entrohy using CAPICOM.Utilities');
-          $stat['CAPICOM_Utilities_random'] = md5($entropy, TRUE);
+    // Use openssl if available
+    if (function_exists('openssl_random_pseudo_bytes')) {
+        //echo('Attempting to create entropy using openssl');
+        $entropy = openssl_random_pseudo_bytes($size, $strong);
+        if ($strong) {
+            $data = $entropy;
         }
-        unset($CAPI_Util, $entropy);
-      } catch (Exception $ex) { }
+        unset($strong, $entropy);
     }
 
-    //echo('Adding random data to entropy using file information and contents');
-    @shuffle($stat);
-    foreach ($stat as $value)
-    {
-      $data .= $value;
+    // Use mcrypt with /dev/urandom if available
+    if ($data === null && function_exists('mcrypt_create_iv')) {
+        //echo('Attempting to create entropy using mcrypt');
+        $entropy = mcrypt_create_iv($size, MCRYPT_DEV_URANDOM);
+        if ($entropy !== false) {
+            $data = $entropy;
+        }
+        unset($entropy);
     }
-    unset($filename, $value, $stat);
-  }
 
-  return hash($hash, $data);
-}
-function zen_create_PADSS_password($length = 8)
-{
-  $charsAlpha = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
-  $charsNum = '0123456789';
-  $charsMixed = $charsAlpha . $charsNum;
-  $password = "";
-  for ($i = 0; $i < $length; $i++)
-  {
-    $addChar = substr($charsMixed, zen_pwd_rand(0, strlen($charsMixed) - 1), 1);
-    while (strpos($password, $addChar))
-    {
-      $addChar = substr($charsMixed, zen_pwd_rand(0, strlen($charsMixed) - 1), 1);
+    if ($data === null) {
+        // Fall back to using /dev/urandom if available
+        $fp = @fopen('/dev/urandom', 'rb');
+        if ($fp !== false) {
+            //echo('Attempting to create entropy using /dev/urandom');
+            $entropy = @fread($fp, $size);
+            @fclose($fp);
+            if (strlen($entropy) == $size) {
+                $data = $entropy;
+            }
+            unset($fp, $entropy);
+        }
     }
-    $password .= $addChar;
-  }
-  if (!preg_match('/[0-9]/', $password))
-  {
-    $addChar = substr($charsNum, zen_pwd_rand(0, strlen($charsNum) - 1), 1);
-    $addPos = zen_pwd_rand(0, strlen($password) - 1);
-    $password[$addPos] = $addChar;
-  }
-  return $password;
+
+    // Final fallback (mixture of various methods)
+    if ($data === null) {
+        //echo('Attempting to create entropy using FINAL FALLBACK');
+        $filename = DIR_FS_ROOT . 'includes/configure.php';
+        $stat = @stat($filename);
+        if ($stat === false) {
+            $stat = [
+                'microtime' => microtime(),
+            ];
+        }
+        $stat['mt_rand'] = mt_rand();
+        $stat['file_hash'] = hash_file($hash, $filename, true);
+
+        // Attempt to get a random value on windows
+        // http://msdn.microsoft.com/en-us/library/aa388176(VS.85).aspx
+        if (@class_exists('COM')) {
+            try {
+                $CAPI_Util = new COM('CAPICOM.Utilities.1');
+                $entropy = $CAPI_Util->GetRandom($size, 0);
+
+                if ($entropy) {
+                    //echo('Adding random data to entrohy using CAPICOM.Utilities');
+                    $stat['CAPICOM_Utilities_random'] = md5($entropy, true);
+                }
+                unset($CAPI_Util, $entropy);
+            } catch (Exception $ex) {
+            }
+        }
+
+        //echo('Adding random data to entropy using file information and contents');
+        @shuffle($stat);
+        foreach ($stat as $value) {
+            $data .= $value;
+        }
+        unset($filename, $value, $stat);
+    }
+
+    return hash($hash, $data);
 }
-function zen_pwd_rand($min = 0, $max = 10)
+
+function zen_create_PADSS_password(int $length = 8): string
 {
-  static $seed;
-  if (!isset($seed))
-    $seed = zen_get_entropy();
-  $random = hash('sha1', zen_get_entropy() . $seed);
-  $random .= hash('sha1', zen_get_entropy() . $random);
-  $random = hash('sha1', $random);
-  $random = substr($random, 0, 8);
-  $value = abs(hexdec($random));
-  $value = $min + (($max - $min + 1) * ($value / (4294967295 + 1)));
-  $value = abs(intval($value));
-  return $value;
+    $charsAlpha = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    $charsNum = '0123456789';
+    $charsMixed = $charsAlpha . $charsNum;
+    $password = "";
+    for ($i = 0; $i < $length; $i++) {
+        $addChar = substr($charsMixed, zen_pwd_rand(0, strlen($charsMixed) - 1), 1);
+        while (strpos($password, $addChar)) {
+            $addChar = substr($charsMixed, zen_pwd_rand(0, strlen($charsMixed) - 1), 1);
+        }
+        $password .= $addChar;
+    }
+    if (!preg_match('/[0-9]/', $password)) {
+        $addChar = substr($charsNum, zen_pwd_rand(0, strlen($charsNum) - 1), 1);
+        $addPos = zen_pwd_rand(0, strlen($password) - 1);
+        $password[$addPos] = $addChar;
+    }
+    return $password;
+}
+
+function zen_pwd_rand(int $min = 0, int $max = 10): float|int
+{
+    static $seed;
+    if (!isset($seed)) {
+        $seed = zen_get_entropy();
+    }
+    $random = hash('sha1', zen_get_entropy() . $seed);
+    $random .= hash('sha1', zen_get_entropy() . $random);
+    $random = hash('sha1', $random);
+    $random = substr($random, 0, 8);
+    $value = abs(hexdec($random));
+    $value = $min + (($max - $min + 1) * ($value / (4294967295 + 1)));
+    $value = abs((int)$value);
+    return $value;
 }

--- a/zc_install/includes/modules/pages/admin_setup/header_php.php
+++ b/zc_install/includes/modules/pages/admin_setup/header_php.php
@@ -1,29 +1,27 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2022 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: DrByte 2020 Jul 10 Modified in v1.5.8-alpha $
  */
 
-  @unlink(DEBUG_LOG_FOLDER . '/progress.json');
-  require (DIR_FS_INSTALL . 'includes/classes/class.zcDatabaseInstaller.php');
-  $changedDir = (bool)$_POST['changedDir'];
-  $adminDir = $_POST['adminDir'];
-  $adminNewDir = $_POST['adminNewDir'];
-  if (defined('DEVELOPER_MODE') && DEVELOPER_MODE === true)
-  {
+@unlink(DEBUG_LOG_FOLDER . '/progress.json');
+require(DIR_FS_INSTALL . 'includes/classes/class.zcDatabaseInstaller.php');
+$changedDir = (bool)$_POST['changedDir'];
+$adminDir = $_POST['adminDir'];
+$adminNewDir = $_POST['adminNewDir'];
+if (defined('DEVELOPER_MODE') && DEVELOPER_MODE === true) {
     $admin_password = 'developer1';
-  } else {
+} else {
     $admin_password = zen_create_PADSS_password();
-  }
-  if (isset($_POST['upgrade_mode']) && $_POST['upgrade_mode'] == 'yes')
-  {
-    $isUpgrade = TRUE;
-  } else if (isset($_POST['http_server_catalog']))
-  {
-    $isUpgrade = FALSE;
-    require (DIR_FS_INSTALL . 'includes/classes/class.zcConfigureFileWriter.php');
+}
+if (isset($_POST['upgrade_mode']) && $_POST['upgrade_mode'] === 'yes') {
+    $isUpgrade = true;
+} elseif (isset($_POST['http_server_catalog'])) {
+    $isUpgrade = false;
+    require(DIR_FS_INSTALL . 'includes/classes/class.zcConfigureFileWriter.php');
     $result = new zcConfigureFileWriter($_POST);
 
     $errors = $result->errors;
-  }
+}

--- a/zc_install/includes/modules/pages/completion/header_php.php
+++ b/zc_install/includes/modules/pages/completion/header_php.php
@@ -1,65 +1,75 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2020 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: Scott C Wilson 2019 Jun 16 Modified in v1.5.7 $
  */
 
-  require (DIR_FS_INSTALL . 'includes/classes/class.zcDatabaseInstaller.php');
+require(DIR_FS_INSTALL . 'includes/classes/class.zcDatabaseInstaller.php');
 
-  $isUpgrade = FALSE;
-  $adminLink = $catalogLink = '#';
-  $adminServer = isset($_POST['http_server_admin']) ? $_POST['http_server_admin'] : '';
-  $catalogHttpServer = isset($_POST['http_server_catalog']) ? $_POST['http_server_catalog'] : '';
-  $dir_ws_http_catalog = isset($_POST['dir_ws_http_catalog']) ? $_POST['dir_ws_http_catalog'] : '';
-  $adminDir = isset($_POST['admin_directory']) ? $_POST['admin_directory'] : '';
-  if (!isset($_POST['admin_directory']) || !file_exists(DIR_FS_ROOT . $_POST['admin_directory'])) {
+$isUpgrade = false;
+$adminLink = $catalogLink = '#';
+$adminServer = $_POST['http_server_admin'] ?? '';
+$catalogHttpServer = $_POST['http_server_catalog'] ?? '';
+$dir_ws_http_catalog = $_POST['dir_ws_http_catalog'] ?? '';
+$adminDir = $_POST['admin_directory'] ?? '';
+if (!isset($_POST['admin_directory']) || !file_exists(DIR_FS_ROOT . $_POST['admin_directory'])) {
     $systemChecker = new systemChecker($adminDir);
     $adminDirectoryList = systemChecker::getAdminDirectoryList();
 // die('admin list:<pre>'.print_r($adminDirectoryList, TRUE));
-    if (count($adminDirectoryList) == 1) $adminDir = $adminDirectoryList[0];
-    list($adminDir, $documentRoot, $adminServer, $catalogHttpServer, $catalogHttpUrl, $catalogHttpsServer, $catalogHttpsUrl, $dir_ws_http_catalog, $dir_ws_https_catalog) = getDetectedURIs($adminDir);
-  }
-  $adminLink = zen_output_string_protected($adminServer) . zen_output_string_protected($dir_ws_http_catalog) . zen_output_string_protected($adminDir);
-  $catalogLink = zen_output_string_protected($catalogHttpServer) . zen_output_string_protected($dir_ws_http_catalog);
+    if (count($adminDirectoryList) === 1) {
+        $adminDir = $adminDirectoryList[0];
+    }
+    [
+        $adminDir,
+        $documentRoot,
+        $adminServer,
+        $catalogHttpServer,
+        $catalogHttpUrl,
+        $catalogHttpsServer,
+        $catalogHttpsUrl,
+        $dir_ws_http_catalog,
+        $dir_ws_https_catalog,
+    ] = getDetectedURIs($adminDir);
+}
+$adminLink = zen_output_string_protected($adminServer) . zen_output_string_protected($dir_ws_http_catalog) . zen_output_string_protected($adminDir);
+$catalogLink = zen_output_string_protected($catalogHttpServer) . zen_output_string_protected($dir_ws_http_catalog);
 
-  if (isset($_POST['upgrade_mode']) && $_POST['upgrade_mode'] == 'yes')
-  {
-    $isUpgrade = TRUE;
-  }
-  // only do the next step if there was real POST data, else bad info may be written to database
-  else if (isset($_POST['http_server_admin']) && $_POST['http_server_admin'] != '')
-  {
-    $isUpgrade = FALSE;
+if (isset($_POST['upgrade_mode']) && $_POST['upgrade_mode'] === 'yes') {
+    $isUpgrade = true;
+}
+// only do the next step if there was real POST data, else bad info may be written to database
+elseif (isset($_POST['http_server_admin']) && $_POST['http_server_admin'] !== '') {
+    $isUpgrade = false;
     $options = $_POST;
     $options['dieOnErrors'] = true;
     $dbInstaller = new zcDatabaseInstaller($options);
     $result = $dbInstaller->getConnection();
-    $extendedOptions = array();
+    $extendedOptions = [];
     $dbInstaller->doCompletion($options);
-  }
+}
 
-  // Update Nginx Conf Template
-  $ngx_temp = trim($dir_ws_http_catalog, "/");
-  $ngx_store = ($ngx_temp=="") ? "" : "/" . $ngx_temp;
-  $ngx_slash = ($ngx_temp=="") ? "/" : $ngx_store;
-  $ngx_admin = $ngx_store . '/' . trim($adminDir,"/");
-  
-  $ngx_array = array(
+// Update Nginx Conf Template
+$ngx_temp = trim($dir_ws_http_catalog, "/");
+$ngx_store = ($ngx_temp === "") ? "" : "/" . $ngx_temp;
+$ngx_slash = ($ngx_temp === "") ? "/" : $ngx_store;
+$ngx_admin = $ngx_store . '/' . trim($adminDir, "/");
+
+$ngx_array = [
     "%%admin_folder%%" => $ngx_admin,
     "%%store_folder%%" => $ngx_store,
     "%%slash_folder%%" => $ngx_slash,
-  );
-  
-  $ngx_input_file = "includes/nginx_conf/ngx_server_template.txt";
-  $ngx_output_file = "includes/nginx_conf/zencart_ngx_server.conf";
-  $fh = fopen($ngx_input_file, "r");
-  $ngx_content = fread($fh, filesize($ngx_input_file));
-  fclose($fh);
-  foreach($ngx_array as $ngx_placeholder => $ngx_string) {
-  	$ngx_content = str_replace($ngx_placeholder, $ngx_string, $ngx_content);
-  }
-  $fh = fopen($ngx_output_file, "w");
-  fwrite($fh, $ngx_content);
-  fclose($fh);
-  
+];
+
+$ngx_input_file = "includes/nginx_conf/ngx_server_template.txt";
+$ngx_output_file = "includes/nginx_conf/zencart_ngx_server.conf";
+$fh = fopen($ngx_input_file, "r");
+$ngx_content = fread($fh, filesize($ngx_input_file));
+fclose($fh);
+foreach ($ngx_array as $ngx_placeholder => $ngx_string) {
+    $ngx_content = str_replace($ngx_placeholder, $ngx_string, $ngx_content);
+}
+$fh = fopen($ngx_output_file, "w");
+fwrite($fh, $ngx_content);
+fclose($fh);

--- a/zc_install/includes/modules/pages/database/header_php.php
+++ b/zc_install/includes/modules/pages/database/header_php.php
@@ -1,21 +1,24 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2022 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: DrByte 2020 Jul 28 Modified in v1.5.8-alpha $
  */
 
-$dbCharset = array(
-                    array('id' => 'utf8mb4', 'text' => TEXT_DATABASE_SETUP_CHARSET_OPTION_UTF8MB4),
-                    array('id' => 'utf8', 'text' => TEXT_DATABASE_SETUP_CHARSET_OPTION_UTF8),
-                    array('id' => 'latin1', 'text' => TEXT_DATABASE_SETUP_CHARSET_OPTION_LATIN1),
-                );
-$dbCharsetOptions = zen_get_select_options($dbCharset, isset($db_charset) ? $db_charset : 'utf8mb4');
+$dbCharset = [
+    ['id' => 'utf8mb4', 'text' => TEXT_DATABASE_SETUP_CHARSET_OPTION_UTF8MB4],
+    ['id' => 'utf8', 'text' => TEXT_DATABASE_SETUP_CHARSET_OPTION_UTF8],
+    ['id' => 'latin1', 'text' => TEXT_DATABASE_SETUP_CHARSET_OPTION_LATIN1],
+];
+$dbCharsetOptions = zen_get_select_options($dbCharset, $db_charset ?? 'utf8mb4');
 
-$sqlCacheType = array(array('id' => 'none', 'text' => TEXT_DATABASE_SETUP_CACHE_TYPE_OPTION_NONE),
-                      array('id' => 'file', 'text' => TEXT_DATABASE_SETUP_CACHE_TYPE_OPTION_FILE),
-                      array('id' => 'database', 'text' => TEXT_DATABASE_SETUP_CACHE_TYPE_OPTION_DATABASE));
-$sqlCacheTypeOptions = zen_get_select_options($sqlCacheType, isset($sql_cache_method) ? $sql_cache_method : '');
+$sqlCacheType = [
+    ['id' => 'none', 'text' => TEXT_DATABASE_SETUP_CACHE_TYPE_OPTION_NONE],
+    ['id' => 'file', 'text' => TEXT_DATABASE_SETUP_CACHE_TYPE_OPTION_FILE],
+    ['id' => 'database', 'text' => TEXT_DATABASE_SETUP_CACHE_TYPE_OPTION_DATABASE],
+];
+$sqlCacheTypeOptions = zen_get_select_options($sqlCacheType, $sql_cache_method ?? '');
 
 $db_user_fallback = $configReader->getDefine('DB_SERVER_USERNAME');
 $db_password_fallback = $configReader->getDefine('DB_SERVER_PASSWORD');
@@ -27,42 +30,57 @@ if (defined('DEVELOPER_MODE') && DEVELOPER_MODE === true) {
     if (empty($db_user_fallback)) {
         $db_user_fallback = (defined('DEVELOPER_DBUSER_DEFAULT') ? DEVELOPER_DBUSER_DEFAULT : 'zencart');
     }
-    $db_user = (isset($db_user)) ? $db_user : $db_user_fallback;
+    $db_user = $db_user ?? $db_user_fallback;
 
     if (empty($db_password_fallback)) {
         $db_password_fallback = (defined('DEVELOPER_DBPASSWORD_DEFAULT') ? DEVELOPER_DBPASSWORD_DEFAULT : 'zencart');
     }
-    $db_password = (isset($db_password)) ? $db_password : $db_password_fallback;
+    $db_password = $db_password ?? $db_password_fallback;
 
     if (empty($db_name_fallback)) {
         $db_name_fallback = (defined('DEVELOPER_DBNAME_DEFAULT') ? DEVELOPER_DBNAME_DEFAULT : 'zencart');
     }
-    $db_name = isset($db_name) ? $db_name : $db_name_fallback;
+    $db_name = $db_name ?? $db_name_fallback;
 
     if (empty($db_host_fallback)) {
         $db_host_fallback = (defined('DEVELOPER_DBHOST_DEFAULT') ? DEVELOPER_DBHOST_DEFAULT : 'localhost');
     }
-    $db_host = isset($db_host) ? $db_host : $db_host_fallback;
+    $db_host = $db_host ?? $db_host_fallback;
 
-    if (defined('DEVELOPER_INSTALL_DEMO_DATA')) $install_demo_data = !empty(DEVELOPER_INSTALL_DEMO_DATA);
-
+    if (defined('DEVELOPER_INSTALL_DEMO_DATA')) {
+        $install_demo_data = !empty(DEVELOPER_INSTALL_DEMO_DATA);
+    }
 } else {
-    if (empty($db_user_fallback)) $db_user_fallback = 'zencart';
-    if (!isset($db_password_fallback)) $db_password_fallback = 'zencart';
-    if (empty($db_name_fallback)) $db_name_fallback = 'zencart';
+    if (empty($db_user_fallback)) {
+        $db_user_fallback = 'zencart';
+    }
+    if (!isset($db_password_fallback)) {
+        $db_password_fallback = 'zencart';
+    }
+    if (empty($db_name_fallback)) {
+        $db_name_fallback = 'zencart';
+    }
     $db_user = $db_user_fallback;
     $db_password = $db_password_fallback;
-    $db_name = isset($db_name) ? $db_name : $db_name_fallback;
+    $db_name = $db_name ?? $db_name_fallback;
 }
 
-$db_user = isset($db_user) ? $db_user : '';
-$db_password = isset($db_password) ? $db_password : '';
-$db_host = isset($db_host) ? $db_host : 'localhost';
-$db_prefix = isset($db_prefix) ? $db_prefix : '';
+$db_user = $db_user ?? '';
+$db_password = $db_password ?? '';
+$db_host = $db_host ?? 'localhost';
+$db_prefix = $db_prefix ?? '';
 
 
 // attempt to intelligently manage user-adjusted subdirectory values if they are different from detected defaults
-if (!isset($_POST['detected_http_server_catalog'])) $_POST['detected_http_server_catalog'] = '';
-if (!isset($_POST['detected_https_server_catalog'])) $_POST['detected_https_server_catalog'] = '';
-if ($_POST['http_server_catalog'] != $_POST['detected_http_server_catalog']) $_POST['dir_ws_http_catalog'] = rtrim(str_replace($_POST['http_server_catalog'], '', $_POST['http_url_catalog']), '/') .'/';
-if ($_POST['https_server_catalog'] != $_POST['detected_https_server_catalog']) $_POST['dir_ws_https_catalog'] = rtrim(str_replace($_POST['https_server_catalog'], '', $_POST['https_url_catalog']), '/') .'/';
+if (!isset($_POST['detected_http_server_catalog'])) {
+    $_POST['detected_http_server_catalog'] = '';
+}
+if (!isset($_POST['detected_https_server_catalog'])) {
+    $_POST['detected_https_server_catalog'] = '';
+}
+if ($_POST['http_server_catalog'] !== $_POST['detected_http_server_catalog']) {
+    $_POST['dir_ws_http_catalog'] = rtrim(str_replace($_POST['http_server_catalog'], '', $_POST['http_url_catalog']), '/') . '/';
+}
+if ($_POST['https_server_catalog'] !== $_POST['detected_https_server_catalog']) {
+    $_POST['dir_ws_https_catalog'] = rtrim(str_replace($_POST['https_server_catalog'], '', $_POST['https_url_catalog']), '/') . '/';
+}

--- a/zc_install/includes/modules/pages/database_upgrade/header_php.php
+++ b/zc_install/includes/modules/pages/database_upgrade/header_php.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2022 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -9,7 +10,7 @@ $systemChecker = new systemChecker();
 $dbVersion = $systemChecker->findCurrentDbVersion();
 logDetails($dbVersion, 'Version detected in database_upgrade/header_php.php');
 
-$versionArray = array();
+$versionArray = [];
 $versionArray[] = '1.2.6';
 $versionArray[] = '1.2.7';
 $versionArray[] = '1.3.0';
@@ -30,11 +31,9 @@ $versionArray[] = '1.5.8';
 $versionArray[] = '2.0.0';
 
 //print_r($versionArray);
-$key = array_search($dbVersion, $versionArray);
+$key = array_search($dbVersion, $versionArray, true);
 $newArray = array_slice($versionArray, $key + 1);
 //print_r($newArray);
-
-
 
 
 // add current IP to the view-in-maintenance-mode list

--- a/zc_install/includes/modules/pages/index/header_php.php
+++ b/zc_install/includes/modules/pages/index/header_php.php
@@ -1,12 +1,13 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2022 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: DrByte 2020 Jul 10 Modified in v1.5.8-alpha $
  */
 
-$otherConfigErrors = FALSE;
-$hasUpgradeErrors = FALSE;
+$otherConfigErrors = false;
+$hasUpgradeErrors = false;
 $selectedAdminDir = '';
 
 $adminDirectoryList = systemChecker::getAdminDirectoryList();
@@ -16,77 +17,74 @@ if (empty($adminDirectoryList)) {
     die('ERROR: unable to locate your admin directory. For simplicity, please be sure it exists and rename it to "admin" before proceeding.');
 }
 $selectedAdminDir = $adminDirectoryList[0];
-$hasMultipleAdmins = FALSE;
-if (count($adminDirectoryList) > 1)
-{
-    $hasMultipleAdmins = TRUE;
+$hasMultipleAdmins = false;
+if (count($adminDirectoryList) > 1) {
+    $hasMultipleAdmins = true;
 }
-if (isset($_POST['adminDir']))
-{
-  $selectedAdminDir = zen_output_string_protected($_POST['adminDir']);
+if (isset($_POST['adminDir'])) {
+    $selectedAdminDir = zen_output_string_protected($_POST['adminDir']);
 }
 $systemChecker = new systemChecker($selectedAdminDir);
 if (isset($_POST['updateConfigure'])) {
-    require_once (DIR_FS_INSTALL . 'includes/classes/class.zcConfigureFileReader.php');
-    require_once (DIR_FS_INSTALL . 'includes/classes/class.zcConfigureFileWriter.php');
-    if (!isset($_POST['btnsubmit']) || $_POST['btnsubmit'] != TEXT_REFRESH) {
+    require_once(DIR_FS_INSTALL . 'includes/classes/class.zcConfigureFileReader.php');
+    require_once(DIR_FS_INSTALL . 'includes/classes/class.zcConfigureFileWriter.php');
+    if (!isset($_POST['btnsubmit']) || $_POST['btnsubmit'] !== TEXT_REFRESH) {
         $configFile = DIR_FS_ROOT . 'includes/configure.php';
         $configFileLocal = DIR_FS_ROOT . 'includes/local/configure.php';
-        if (file_exists($configFileLocal)) $configFile = $configFileLocal;
+        if (file_exists($configFileLocal)) {
+            $configFile = $configFileLocal;
+        }
         $storeConfigureFileReader = new zcConfigureFileReader($configFile);
 
         $admConfigFile = DIR_FS_ROOT . $selectedAdminDir . '/includes/configure.php';
         $admConfigFileLocal = DIR_FS_ROOT . $selectedAdminDir . '/includes/local/configure.php';
-        if (file_exists($admConfigFileLocal)) $admConfigFile = $admConfigFileLocal;
+        if (file_exists($admConfigFileLocal)) {
+            $admConfigFile = $admConfigFileLocal;
+        }
         $adminConfigureFileReader = new zcConfigureFileReader($admConfigFile);
 
         $configureInputs = $storeConfigureFileReader->getStoreInputsFromLegacy();
         $configureInputs['enable_ssl_admin'] = trim($adminConfigureFileReader->getRawDefine('ENABLE_SSL_ADMIN'), "'");
-        $configureInputs['http_server_admin'] = trim($adminConfigureFileReader->getRawDefine( ($configureInputs['enable_ssl_admin'] == 'true' ? 'HTTPS_SERVER' : 'HTTP_SERVER') ), "'");
+        $configureInputs['http_server_admin'] = trim($adminConfigureFileReader->getRawDefine($configureInputs['enable_ssl_admin'] === 'true' ? 'HTTPS_SERVER' : 'HTTP_SERVER'), "'");
         $configureInputs['adminDir'] = $selectedAdminDir;
         $storeConfigureFileWriter = new zcConfigureFileWriter($configureInputs);
     }
 }
 $dbVersion = $systemChecker->findCurrentDbVersion();
 $currentDbVersion = EXPECTED_DATABASE_VERSION_MAJOR . '.' . EXPECTED_DATABASE_VERSION_MINOR;
-$isCurrentDb = ($dbVersion == $currentDbVersion) ? TRUE : FALSE;
+$isCurrentDb = $dbVersion === $currentDbVersion;
 $hasSaneConfigFile = $systemChecker->hasSaneConfigFile();
 $hasTables = $systemChecker->hasTables();
 $hasUpdatedConfigFile = $systemChecker->hasUpdatedConfigFile();
 
 
-if ($hasTables && $hasSaneConfigFile && $hasUpdatedConfigFile)
-{
-  $systemChecker->addRunLevel('upgradeDb');
+if ($hasTables && $hasSaneConfigFile && $hasUpdatedConfigFile) {
+    $systemChecker->addRunLevel('upgradeDb');
 }
 $errorList = $systemChecker->runTests();
-list($hasFatalErrors, $listFatalErrors) = $systemChecker->getErrorList();
-list($hasWarnErrors, $listWarnErrors) = $systemChecker->getErrorList('WARN');
-list($hasLocalAlerts, $listLocalAlerts) = $systemChecker->getErrorList('ALERT');
-if (isset($listFatalErrors[0]['methods']))
-{
-  $res = key($listFatalErrors[0]['methods']);
-  if ($res == 'CheckWriteableAdminFile') $otherConfigErrors = TRUE;
+[$hasFatalErrors, $listFatalErrors] = $systemChecker->getErrorList();
+[$hasWarnErrors, $listWarnErrors] = $systemChecker->getErrorList('WARN');
+[$hasLocalAlerts, $listLocalAlerts] = $systemChecker->getErrorList('ALERT');
+if (isset($listFatalErrors[0]['methods'])) {
+    $res = key($listFatalErrors[0]['methods']);
+    if ($res === 'CheckWriteableAdminFile') {
+        $otherConfigErrors = true;
+    }
 }
-if (count($listFatalErrors) == 1)
-{
-  if ($listFatalErrors[0]['runLevel'] == 'upgradeDb')
-  {
-    $hasUpgradeErrors = TRUE;
-  }
+if (count($listFatalErrors) === 1) {
+    if ($listFatalErrors[0]['runLevel'] === 'upgradeDb') {
+        $hasUpgradeErrors = true;
+    }
 }
 $formAction = 'system_setup';
-if (!$hasFatalErrors && $hasSaneConfigFile && !$hasUpgradeErrors && !$isCurrentDb)
-{
-  $formAction = 'database_upgrade';
+if (!$hasFatalErrors && $hasSaneConfigFile && !$hasUpgradeErrors && !$isCurrentDb) {
+    $formAction = 'database_upgrade';
 }
-if (!$hasUpdatedConfigFile)
-{
+if (!$hasUpdatedConfigFile) {
     $formAction = 'index';
 }
 
-$adminOptionList = array();
-foreach ($adminDirectoryList as $directory)
-{
-  $adminOptionList[] = array('id' => $directory, 'text' => $directory);
+$adminOptionList = [];
+foreach ($adminDirectoryList as $directory) {
+    $adminOptionList[] = ['id' => $directory, 'text' => $directory];
 }

--- a/zc_install/includes/modules/pages/system_setup/header_php.php
+++ b/zc_install/includes/modules/pages/system_setup/header_php.php
@@ -1,12 +1,26 @@
 <?php
+declare(strict_types=1);
+
 /**
  * @copyright Copyright 2003-2022 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: DrByte 2020 Jul 10 Modified in v1.5.8-alpha $
  */
-list($adminDir, $documentRoot, $adminServer, $catalogHttpServer, $catalogHttpUrl, $catalogHttpsServer, $catalogHttpsUrl, $dir_ws_http_catalog, $dir_ws_https_catalog) = getDetectedURIs();
+[
+    $adminDir,
+    $documentRoot,
+    $adminServer,
+    $catalogHttpServer,
+    $catalogHttpUrl,
+    $catalogHttpsServer,
+    $catalogHttpsUrl,
+    $dir_ws_http_catalog,
+    $dir_ws_https_catalog,
+] = getDetectedURIs();
+
 $db_type = 'mysql';
+
 $enableSslCatalog = '';
-if ($request_type == 'SSL') {
+if ($request_type === 'SSL') {
     $enableSslCatalog = 'checked = checked';
 }

--- a/zc_install/includes/template/common/html_header.php
+++ b/zc_install/includes/template/common/html_header.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2022 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce

--- a/zc_install/includes/template/common/main_template_vars.php
+++ b/zc_install/includes/template/common/main_template_vars.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @package Installer
  * @copyright Copyright 2003-2016 Zen Cart Development Team

--- a/zc_install/includes/template/common/tpl_main_page.php
+++ b/zc_install/includes/template/common/tpl_main_page.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2020 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -21,7 +22,7 @@
       <div class="small-12 columns small-centered">
         <div class="mainContent">
         <?php require(DIR_FS_INSTALL . DIR_WS_INSTALL_TEMPLATE . 'partials/partial_breadcrumb.php'); ?>
-        <?php if (!isset($_GET['main_page']) || $_GET['main_page'] == 'index' && count($languagesInstalled) > 1) { ?>
+        <?php if (!isset($_GET['main_page']) || $_GET['main_page'] === 'index' && count($languagesInstalled) > 1) { ?>
         <form name="language_select" id="language_select" method="GET">
           <fieldset>
            <div class="row">
@@ -37,10 +38,10 @@
         <?php } ?>
         <h1><?php echo constant('TEXT_PAGE_HEADING_' . strtoupper($_GET['main_page'])); ?></h1>
         <?php if (defined('TEXT_' . strtoupper($_GET['main_page'] . '_HEADER_MAIN'))) {
-                if (constant('TEXT_' . strtoupper($_GET['main_page'] . '_HEADER_MAIN')) != '') { ?>
+                if (constant('TEXT_' . strtoupper($_GET['main_page'] . '_HEADER_MAIN')) !== '') { ?>
         <div class="alert-box"><?php echo constant('TEXT_' . strtoupper($_GET['main_page'] . '_HEADER_MAIN')); ?></div>
         <?php  }
-             } elseif (TEXT_HEADER_MAIN != '') { ?>
+             } elseif (TEXT_HEADER_MAIN !== '') { ?>
           <div class="alert-box"><?php echo TEXT_HEADER_MAIN; ?></div>
         <?php } ?>
         <?php require($body_code); ?>

--- a/zc_install/includes/template/partials/partial_breadcrumb.php
+++ b/zc_install/includes/template/partials/partial_breadcrumb.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @package Installer
  * @copyright Copyright 2003-2016 Zen Cart Development Team
@@ -9,14 +10,14 @@
 ?>
 <div>
   <ul class="breadcrumbs">
-    <li <?php echo ($_GET['main_page'] == 'index') ? 'class="current"' : ""; ?>><a href="#"><?php echo TEXT_NAVBAR_SYSTEM_INSPECTION; ?></a></li>
-  <?php if ($_GET['main_page'] == 'database_upgrade' || (isset($_POST['upgrade_mode']) && $_POST['upgrade_mode'] == 'yes')) { ?>
-    <li <?php echo ($_GET['main_page'] == 'database_upgrade') ? 'class="current"' : ""; ?>><a href="#"><?php echo TEXT_NAVBAR_DATABASE_UPGRADE; ?></a></li>
+    <li <?php echo ($_GET['main_page'] === 'index') ? 'class="current"' : ""; ?>><a href="#"><?php echo TEXT_NAVBAR_SYSTEM_INSPECTION; ?></a></li>
+  <?php if ($_GET['main_page'] === 'database_upgrade' || (isset($_POST['upgrade_mode']) && $_POST['upgrade_mode'] === 'yes')) { ?>
+    <li <?php echo ($_GET['main_page'] === 'database_upgrade') ? 'class="current"' : ""; ?>><a href="#"><?php echo TEXT_NAVBAR_DATABASE_UPGRADE; ?></a></li>
   <?php } else { ?>
-    <li <?php echo ($_GET['main_page'] == 'system_setup') ? 'class="current"' : ""; ?>><a href="#"><?php echo TEXT_NAVBAR_SYSTEM_SETUP; ?></a></li>
-    <li <?php echo ($_GET['main_page'] == 'database') ? 'class="current"' : ""; ?>><a href="#"><?php echo TEXT_NAVBAR_DATABASE_SETUP; ?></a></li>
-    <li <?php echo ($_GET['main_page'] == 'admin_setup') ? 'class="current"' : ""; ?>><a href="#"><?php echo TEXT_NAVBAR_ADMIN_SETUP; ?></a></li>
+    <li <?php echo ($_GET['main_page'] === 'system_setup') ? 'class="current"' : ""; ?>><a href="#"><?php echo TEXT_NAVBAR_SYSTEM_SETUP; ?></a></li>
+    <li <?php echo ($_GET['main_page'] === 'database') ? 'class="current"' : ""; ?>><a href="#"><?php echo TEXT_NAVBAR_DATABASE_SETUP; ?></a></li>
+    <li <?php echo ($_GET['main_page'] === 'admin_setup') ? 'class="current"' : ""; ?>><a href="#"><?php echo TEXT_NAVBAR_ADMIN_SETUP; ?></a></li>
   <?php } ?>
-    <li <?php echo ($_GET['main_page'] == 'completion') ? 'class="current"' : ""; ?>><a href="#"><?php echo TEXT_NAVBAR_COMPLETION; ?></a></li>
+    <li <?php echo ($_GET['main_page'] === 'completion') ? 'class="current"' : ""; ?>><a href="#"><?php echo TEXT_NAVBAR_COMPLETION; ?></a></li>
   </ul>
 </div>

--- a/zc_install/includes/template/partials/partial_modal_admin_validation_errors.php
+++ b/zc_install/includes/template/partials/partial_modal_admin_validation_errors.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @package Installer
  * @copyright Copyright 2003-2016 Zen Cart Development Team

--- a/zc_install/includes/template/partials/partial_modal_connection_errors.php
+++ b/zc_install/includes/template/partials/partial_modal_connection_errors.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @package Installer
  * @copyright Copyright 2003-2016 Zen Cart Development Team

--- a/zc_install/includes/template/partials/partial_modal_help.php
+++ b/zc_install/includes/template/partials/partial_modal_help.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @package Installer
  * @copyright Copyright 2003-2016 Zen Cart Development Team

--- a/zc_install/includes/template/partials/partial_modal_install_errors.php
+++ b/zc_install/includes/template/partials/partial_modal_install_errors.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @package Installer
  * @copyright Copyright 2003-2016 Zen Cart Development Team

--- a/zc_install/includes/template/partials/partial_modal_progress_bar.php
+++ b/zc_install/includes/template/partials/partial_modal_progress_bar.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @package Installer
  * @copyright Copyright 2003-2016 Zen Cart Development Team

--- a/zc_install/includes/template/partials/partial_modal_system_setup_errors.php
+++ b/zc_install/includes/template/partials/partial_modal_system_setup_errors.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @package Installer
  * @copyright Copyright 2003-2016 Zen Cart Development Team

--- a/zc_install/includes/template/templates/admin_setup_default.php
+++ b/zc_install/includes/template/templates/admin_setup_default.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2022 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -22,8 +23,8 @@
 <form id="admin_setup" name="admin_setup" method="post" action="index.php?main_page=completion" data-abide>
   <input type="hidden" name="action" value="process">
   <input type="hidden" name="lng" value="<?php echo $installer_lng; ?>">
-  <?php foreach ($_POST as $key=>$value) {  ?>
-    <?php if ($key != 'action') { ?>
+  <?php foreach ($_POST as $key => $value) {  ?>
+    <?php if ($key !== 'action') { ?>
     <input type="hidden" name="<?php echo $key; ?>" value="<?php echo $value; ?>">
     <?php }?>
   <?php }?>
@@ -70,7 +71,7 @@
     <div class="row">
       <?php if ($changedDir) { ?>
         <div class="alert-box"><?php echo TEXT_ADMIN_SETUP_ADMIN_DIRECTORY_HELP_CHANGED; ?></div>
-      <?php } elseif (!$changedDir && $adminNewDir == 'admin') { ?>
+      <?php } elseif (!$changedDir && $adminNewDir === 'admin') { ?>
         <div class="alert-box alert"><?php echo TEXT_ADMIN_SETUP_ADMIN_DIRECTORY_HELP_DEFAULT; ?></div>
       <?php } else { ?>
         <div class="alert-box "><?php echo TEXT_ADMIN_SETUP_ADMIN_DIRECTORY_HELP_NOT_ADMIN_CHANGED; ?></div>

--- a/zc_install/includes/template/templates/completion_default.php
+++ b/zc_install/includes/template/templates/completion_default.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2020 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -12,7 +13,7 @@
 			<h6><?php echo TEXT_COMPLETION_NGINX_TEXT; ?></h6>
 		</div>
 
-<?php if ($adminDir == 'admin' && !defined('DEVELOPER_MODE')) { ?>
+<?php if ($adminDir === 'admin' && !defined('DEVELOPER_MODE')) { ?>
 		<br><br>
 		<div class="alert-box  secondary">
 			<h6><?php echo TEXT_COMPLETION_ADMIN_DIRECTORY_WARNING; ?></h6>
@@ -37,11 +38,11 @@
 		<?php echo TEXT_COMPLETION_INSTALL_COMPLETE; ?>
 
 		<br>
-	<?php if ($catalogLink != '#') echo TEXT_COMPLETION_INSTALL_LINKS_BELOW; ?>
+	<?php if ($catalogLink !== '#') echo TEXT_COMPLETION_INSTALL_LINKS_BELOW; ?>
 <?php } ?>
 
 		</h5>
-<?php if (!$isUpgrade && $catalogLink != '#') { ?>
+<?php if (!$isUpgrade && $catalogLink !== '#') { ?>
 
 		<div class="text-center">
 			<a class="radius button" href="<?php echo $adminLink; ?>" rel="noopener" target="_blank" tabindex="1">

--- a/zc_install/includes/template/templates/database_default.php
+++ b/zc_install/includes/template/templates/database_default.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2022 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -17,7 +18,7 @@
   <input type="hidden" name="action" value="process">
   <input type="hidden" name="lng" value="<?php echo $installer_lng; ?>">
   <?php foreach ($_POST as $key=>$value) {  ?>
-  <?php if ($key != 'action') { ?>
+  <?php if ($key !== 'action') { ?>
     <input type="hidden" name="<?php echo $key; ?>" value="<?php echo $value; ?>">
   <?php }?>
   <?php }?>

--- a/zc_install/includes/template/templates/database_upgrade_default.php
+++ b/zc_install/includes/template/templates/database_upgrade_default.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2022 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -9,7 +10,7 @@
 
 <?php require(DIR_FS_INSTALL . DIR_WS_INSTALL_TEMPLATE . 'partials/partial_modal_help.php'); ?>
 
-<?php if (sizeof($newArray)) { ?>
+<?php if (count($newArray)) { ?>
 <div class="upgrade-progress-area">
   <div class="alert-box" id="upgradeHeaderMessage"><?php echo TEXT_DATABASE_UPGRADE_STEPS_DETECTED; ?></div>
 </div>
@@ -19,7 +20,7 @@
 <form id="db_upgrade<?php echo (count($newArray)) ? '' : '_done'; ?>" name="db_upgrade" method="post" action="index.php?main_page=completion" data-abide="ajax">
   <input type="hidden" name="lng" value="<?php echo $installer_lng; ?>">
   <input type="hidden" name="action" value="process">
-<?php if (sizeof($newArray)) { ?>
+<?php if (count($newArray)) { ?>
   <input type="hidden" name="upgrade_mode" value="yes">
   <fieldset id="availableUpgradeSteps">
     <legend><?php echo TEXT_DATABASE_UPGRADE_LEGEND_UPGRADE_STEPS; ?></legend>
@@ -27,7 +28,7 @@
 
     <div class="small-12 columns">
     <?php foreach ($newArray as $key => $value)  { ?>
-      <?php $from = ($key == 0) ? $dbVersion : $newArray[($key - 1)]; ?>
+      <?php $from = ($key === 0) ? $dbVersion : $newArray[($key - 1)]; ?>
       <?php $to = $newArray[$key]; ?>
        <div id="label-version-<?php echo str_replace('.', '_', $newArray[$key]); ?>" class="checkbox-wrapper">
           <label for="version-<?php echo str_replace('.', '_', $newArray[$key]); ?>">

--- a/zc_install/includes/template/templates/index_default.php
+++ b/zc_install/includes/template/templates/index_default.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2022 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -10,9 +11,9 @@ $adjustWarnIssues = false;
 <form id="systemCheck" name="systemCheck" method="post" action="index.php?main_page=<?php echo $formAction; ?>">
 <input type="hidden" name="lng" value="<?php echo $installer_lng; ?>">
 <?php if ($hasMultipleAdmins) { ?>
-	<?php $adjustWarnIssues = True ?>
+	<?php $adjustWarnIssues = true ?>
     <div class="alert-box alert">
-    <?php if ($selectedAdminDir != '') { ?>
+    <?php if ($selectedAdminDir !== '') { ?>
     <?php  echo TEXT_ERROR_MULTIPLE_ADMINS_SELECTED; ?>
     <?php } else { ?>
     <?php  echo TEXT_ERROR_MULTIPLE_ADMINS_NONE_SELECTED; ?>
@@ -22,9 +23,9 @@ $adjustWarnIssues = false;
 <?php } else { ?>
 <input type="hidden" name="adminDir" value="<?php echo $selectedAdminDir; ?>">
 <?php } ?>
-<?php if ($selectedAdminDir != '') { ?>
+<?php if ($selectedAdminDir !== '') { ?>
 <?php if ($hasSaneConfigFile && !$isCurrentDb && !$otherConfigErrors && $hasUpdatedConfigFile) { ?>
-	<?php $adjustWarnIssues = True ?>
+	<?php $adjustWarnIssues = true ?>
     <div class="alert-box success">
     <?php  echo TEXT_ERROR_SUCCESS_EXISTING_CONFIGURE; ?>
     </div>
@@ -34,14 +35,14 @@ $adjustWarnIssues = false;
     </div>
 <?php } ?>
 <?php if (!$hasUpdatedConfigFile && $hasSaneConfigFile) { ?>
-	<?php $adjustWarnIssues = True ?>
+	<?php $adjustWarnIssues = true ?>
         <div class="alert-box alert">
             <?php  echo TEXT_ERROR_CONFIGURE_REQUIRES_UPDATE; ?>
         </div>
 
 <?php } ?>
 <?php if ($hasFatalErrors) { ?>
-	<?php $adjustWarnIssues = True ?>
+	<?php $adjustWarnIssues = true ?>
 <div id="fatalErrors" class="errorList">
   <h2><?php echo TEXT_INDEX_FATAL_ERRORS; ?></h2>
     <?php foreach ($listFatalErrors as $error) { ?>
@@ -57,7 +58,7 @@ $adjustWarnIssues = false;
 </div>
 <?php } ?>
 <?php if ($hasLocalAlerts) { ?>
-	<?php $adjustWarnIssues = True ?>
+	<?php $adjustWarnIssues = true ?>
 <div id="alerts" class="errorList">
   <h2><?php echo TEXT_INDEX_ALERTS; ?></h2>
     <?php foreach ($listLocalAlerts as $error) { ?>

--- a/zc_install/includes/template/templates/system_setup_default.php
+++ b/zc_install/includes/template/templates/system_setup_default.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2022 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0

--- a/zc_install/index.php
+++ b/zc_install/index.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * index.php -- This is the main controller file for the Zen Cart installer
  * @copyright Copyright 2003-2022 Zen Cart Development Team
@@ -6,39 +7,39 @@
  * @version $Id: DrByte 2021 Mar 05 Modified in v1.5.8-alpha $
  */
 
-  // Actual version check is more strict; this is just to start the program
-  // For true minimum, see includes/systemChecks.yml under checkPhpVersionMin
-  if (PHP_VERSION_ID < 70100) { // only checking for 7.1 here as a basic check. zc_install itself doesn't need higher than this at this time
-    die('Sorry, requires minimum PHP 8.0'); // the actual zc_install pages have a prettier and more informative explanation of requirements
-  }
+if (PHP_VERSION_ID < 80030) {
+    die('Sorry, requires minimum PHP 8.0');
+}
 
-  define('IS_ADMIN_FLAG',false);
+define('IS_ADMIN_FLAG', false);
 
 /* Debugging
  *  'silent': suppress all logging
  *  'screen': display-to-screen and also to the /logs/ folder  (synonyms: TRUE or 'TRUE' or 1)
  *  'file':   log-to-file-only   (synonyms: anything other than above options)
  */
-  $debug_logging = 'file';
+$debug_logging = 'file';
 
 /*
  * Ensure that the include_path can handle relative paths, before we try to load any files
  */
-  if (!strstr(ini_get('include_path'), '.')) ini_set('include_path', '.' . PATH_SEPARATOR . ini_get('include_path'));
+if (!str_contains(ini_get('include_path'), '.')) {
+    ini_set('include_path', '.' . PATH_SEPARATOR . ini_get('include_path'));
+}
 
 /*
  * Initialize system core components
  */
-  define('DIR_FS_INSTALL', __DIR__ . DIRECTORY_SEPARATOR);
-  define('DIR_FS_ROOT', dirname(__DIR__) . DIRECTORY_SEPARATOR);
+define('DIR_FS_INSTALL', __DIR__ . DIRECTORY_SEPARATOR);
+define('DIR_FS_ROOT', dirname(__DIR__) . DIRECTORY_SEPARATOR);
 
-  require DIR_FS_INSTALL . 'includes/application_top.php';
+require DIR_FS_INSTALL . 'includes/application_top.php';
 
-  if ($controller == 'cli') {
+if ($controller === 'cli') {
     require DIR_FS_INSTALL . 'includes/cli_controller.php';
-  } else {
+} else {
     require DIR_FS_INSTALL . $page_directory . '/header_php.php';
     require DIR_FS_INSTALL . DIR_WS_INSTALL_TEMPLATE . 'common/html_header.php';
     require DIR_FS_INSTALL . DIR_WS_INSTALL_TEMPLATE . 'common/main_template_vars.php';
     require DIR_FS_INSTALL . DIR_WS_INSTALL_TEMPLATE . 'common/tpl_main_page.php';
-  }
+}


### PR DESCRIPTION
Apply PSR-12 formatting, strict typing, and typehints.

Caveat: this makes zc_install no longer compatible with PHP 7, so even just to install and inspect the server requires PHP 8