### PR TITLE
Extract common db activities out of Coupon_Admin

### DIFF
--- a/admin/coupon_admin.php
+++ b/admin/coupon_admin.php
@@ -42,9 +42,9 @@ if (isset($_GET['search']) && zen_not_null($_GET['search'])) {
     ];
     $searchWords = zen_build_keyword_where_clause($keyword_search_fields, trim($keywords), true);
     $sql = "SELECT c.coupon_id, c.coupon_active
-          FROM " . TABLE_COUPONS . " c
-          LEFT JOIN " . TABLE_COUPONS_DESCRIPTION . " cd ON cd.coupon_id = c.coupon_id
-          " . $searchWords . $active;
+            FROM " . TABLE_COUPONS . " c
+            LEFT JOIN " . TABLE_COUPONS_DESCRIPTION . " cd ON cd.coupon_id = c.coupon_id
+            " . $searchWords . $active;
   $search = $db->Execute($sql);
   if ($search->EOF) {
       $messageStack->add_session(ERROR_COUPON_NOT_FOUND, 'caution');
@@ -130,6 +130,10 @@ if (!empty($_GET['mail_sent_to'])) {
   $_GET['mail_sent_to'] = '';
 }
 
+if (empty($_GET['cid']) && $_GET['action'] === 'voucheredit') {
+    $_GET['action'] = '';
+}
+
 switch ($_GET['action']) {
   case 'set_editor':
     // Reset will be done by init_html_editor.php. Now we simply redirect to refresh page properly.
@@ -138,226 +142,65 @@ switch ($_GET['action']) {
     break;
 
   case 'confirmdelete':
-// do not allow change if set to welcome coupon
+    // do not allow change if set to welcome coupon
     if ($_GET['cid'] == NEW_SIGNUP_DISCOUNT_COUPON) {
       $messageStack->add_session(ERROR_DISCOUNT_COUPON_WELCOME, 'caution');
       zen_redirect(zen_href_link(FILENAME_COUPON_ADMIN, 'cid=' . $_GET['cid'] . (isset($_GET['status']) ? '&status=' . $_GET['status'] : '') . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '')));
     }
 
-    $db->Execute("UPDATE " . TABLE_COUPONS . "
-                  SET coupon_active = 'N'
-                  WHERE coupon_id = " . (int)$_GET['cid']);
+    Coupon::disable((int)$_GET['cid']);
     $messageStack->add_session(SUCCESS_COUPON_DISABLED, 'success');
     zen_redirect(zen_href_link(FILENAME_COUPON_ADMIN));
     break;
 
   case 'confirmreactivate':
-    $db->Execute("UPDATE " . TABLE_COUPONS . "
-                  SET coupon_active = 'Y'
-                  WHERE coupon_id = " . (int)$_GET['cid']);
+    Coupon::enable((int)$_GET['cid']);
     $messageStack->add_session(SUCCESS_COUPON_REACTIVATE, 'success');
     zen_redirect(zen_href_link(FILENAME_COUPON_ADMIN, 'cid=' . $_GET['cid']));
     break;
 
   case 'confirmdeleteduplicate':
-// base code - confirm base code for duplicate codes
-// do not allow change if matches welcome coupon
-    $delete_duplicate_coupons_check = $db->Execute("SELECT coupon_id
-                                                    FROM " . TABLE_COUPONS . "
-                                                    WHERE coupon_code LIKE '" . $_POST['coupon_delete_duplicate_code'] . "%'
-                                                    AND coupon_id = " . (int)NEW_SIGNUP_DISCOUNT_COUPON);
-    if ($delete_duplicate_coupons_check->RecordCount() > 0) {
-      $messageStack->add_session(ERROR_DISCOUNT_COUPON_WELCOME, 'caution');
-    }
-    $delete_duplicate_coupons = $db->Execute("SELECT coupon_id, coupon_code
-                                              FROM " . TABLE_COUPONS . "
-                                              WHERE coupon_code LIKE '" . $_POST['coupon_delete_duplicate_code'] . "%'
-                                              AND coupon_active = 'Y'
-                                              AND coupon_id !=  " . (int)NEW_SIGNUP_DISCOUNT_COUPON . "
-                                              AND coupon_type != 'G'");
-    foreach ($delete_duplicate_coupons as $delete_duplicate_coupon) {
-//        echo 'Delete: ' . $delete_duplicate_coupons->fields['coupon_code'] . '<br>';
-      $messageStack->add_session(TEXT_DISCOUNT_COUPON_DEACTIVATED . $delete_duplicate_coupon['coupon_code'], 'caution');
-      $db->Execute("UPDATE " . TABLE_COUPONS . "
-                    SET coupon_active = 'N'
-                    WHERE coupon_code = '" . $delete_duplicate_coupon['coupon_code'] . "'
-                    AND coupon_type != 'G'");
-    }
+      $deleted = Coupon::deleteDuplicates($_POST['coupon_delete_duplicate_code']);
+      if (isset($deleted['welcome_coupon'])) {
+          $messageStack->add_session(ERROR_DISCOUNT_COUPON_WELCOME, 'caution');
+      }
+      foreach ($deleted['deleted'] ?? [] as $duplicate) {
+          $messageStack->add_session(TEXT_DISCOUNT_COUPON_DEACTIVATED . $duplicate, 'caution');
+      }
     zen_redirect(zen_href_link(FILENAME_COUPON_ADMIN));
     break;
 
   case 'confirmcopyduplicate':
 // base code - create duplicate codes from base code
-    /*
-      echo 'Build copies from coupon cid: ' . $_GET['cid'] . '<br>';
-      echo 'Base name coupon_copy_to_dup_name: ' . $_POST['coupon_copy_to_dup_name'] . '<br>';
-      echo 'Number to make coupon_copy_to_count: ' . $_POST['coupon_copy_to_count'] . '<br>';
-      echo 'Build Copy Duplicates' . '<br>';
-     */
     $zc_discount_coupons_create = (int)$_POST['coupon_copy_to_count'];
     if ($zc_discount_coupons_create < 1) {
-      $messageStack->add_session(WARNING_COUPON_DUPLICATE . $_POST['coupon_copy_to_dup_name'] . ' - ' . $_POST['coupon_copy_to_count'], 'caution');
+      $messageStack->add_session(WARNING_COUPON_DUPLICATE . $_POST['coupon_copy_to_dup_name'] . ' - x' . $_POST['coupon_copy_to_count'], 'caution');
     } else {
-      $check_new_coupon = $db->Execute("SELECT *
-                                        FROM " . TABLE_COUPONS . "
-                                        WHERE coupon_id = " . (int)$_GET['cid']);
-      for ($i = 1; $i <= $zc_discount_coupons_create; $i++) {
-        $old_code_length = strlen($_POST['coupon_copy_to_dup_name']);
-        $minimum_extra_chars = 7;
-        $delta_calculation = SECURITY_CODE_LENGTH - ($old_code_length + $minimum_extra_chars);
-        $new_code_length = ($delta_calculation > 0) ? $minimum_extra_chars + $delta_calculation : $minimum_extra_chars;
-        $new_code = zen_create_coupon_code($_POST['coupon_copy_to_dup_name'], $new_code_length, $_POST['coupon_copy_to_dup_name']);
-        if ($new_code != '') {
-          // make new coupon
-          $sql_data_array = [
-            'coupon_code' => zen_db_prepare_input($new_code),
-            'coupon_amount' => zen_db_prepare_input($check_new_coupon->fields['coupon_amount']),
-            'coupon_product_count' => zen_db_prepare_input($check_new_coupon->fields['coupon_product_count']),
-            'coupon_type' => zen_db_prepare_input($check_new_coupon->fields['coupon_type']),
-            'uses_per_coupon' => (int)$check_new_coupon->fields['uses_per_coupon'],
-            'uses_per_user' => (int)$check_new_coupon->fields['uses_per_user'],
-            'coupon_minimum_order' => (float)$check_new_coupon->fields['coupon_minimum_order'],
-            'restrict_to_products' => zen_db_prepare_input($check_new_coupon->fields['restrict_to_products']),
-            'restrict_to_categories' => zen_db_prepare_input($check_new_coupon->fields['restrict_to_categories']),
-            'coupon_start_date' => $check_new_coupon->fields['coupon_start_date'],
-            'coupon_expire_date' => $check_new_coupon->fields['coupon_expire_date'],
-            'date_created' => 'now()',
-            'date_modified' => 'now()',
-            'coupon_zone_restriction' => $check_new_coupon->fields['coupon_zone_restriction'],
-            'coupon_calc_base' => $check_new_coupon->fields['coupon_calc_base'],
-            'coupon_order_limit' => $check_new_coupon->fields['coupon_order_limit'],
-            'coupon_is_valid_for_sales' => $check_new_coupon->fields['coupon_is_valid_for_sales'],
-            'coupon_active' => 'Y',
-          ];
-          zen_db_perform(TABLE_COUPONS, $sql_data_array);
-          $cid = $db->insert_ID();
-
-          // make new description
-          $sql = "SELECT *
-                  FROM " . TABLE_COUPONS_DESCRIPTION . "
-                  WHERE coupon_id = " . (int)$_GET['cid'];
-          $new_coupon_descriptions = $db->Execute($sql);
-
-          foreach ($new_coupon_descriptions as $new_coupon_description) {
-            $sql_mdata_array = [
-              'coupon_id' => (int)$cid,
-              'language_id' => (int)$new_coupon_description['language_id'],
-              'coupon_name' => zen_db_prepare_input($new_coupon_description['coupon_name']),
-              'coupon_description' => zen_db_prepare_input($new_coupon_description['coupon_description']),
-            ];
-            zen_db_perform(TABLE_COUPONS_DESCRIPTION, $sql_mdata_array);
-          }
-
-          // add restrictions
-          $sql = "SELECT *
-                  FROM " . TABLE_COUPON_RESTRICT . "
-                  WHERE coupon_id = " . (int)$_GET['cid'];
-          $copy_coupon_restrictions = $db->Execute($sql);
-
-          foreach ($copy_coupon_restrictions as $copy_coupon_restriction) {
-            $sql_rdata_array = [
-              'coupon_id' => (int)$cid,
-              'product_id' => (int)$copy_coupon_restriction['product_id'],
-              'category_id' => (int)$copy_coupon_restriction['category_id'],
-              'coupon_restrict' => zen_db_prepare_input($copy_coupon_restriction['coupon_restrict']),
-            ];
-            zen_db_perform(TABLE_COUPON_RESTRICT, $sql_rdata_array);
-          }
-          $success = true;
+        $status = Coupon::make_duplicates((int)$_GET['cid'], $_POST['coupon_copy_to_dup_name'], $zc_discount_coupons_create);
+        if ($status === true) {
+            $messageStack->add_session(SUCCESS_COUPON_DUPLICATE . $_POST['coupon_copy_to_dup_name'] . ' - x' . $_POST['coupon_copy_to_count'], 'success');
         } else {
           // cannot create code
-          $messageStack->add_session(WARNING_COUPON_DUPLICATE_FAILED . $_POST['coupon_copy_to_dup_name'] . ' - ' . $_POST['coupon_copy_to_count'], 'caution');
-          $success = false;
-          break;
+          $messageStack->add_session(WARNING_COUPON_DUPLICATE_FAILED . $_POST['coupon_copy_to_dup_name'] . ' - x' . $_POST['coupon_copy_to_count'], 'caution');
         }
-      } // eof for
-      if ($success) {
-        $messageStack->add_session(SUCCESS_COUPON_DUPLICATE . $_POST['coupon_copy_to_dup_name'] . ' - ' . $_POST['coupon_copy_to_count'], 'success');
-      }
     }
     zen_redirect(zen_href_link(FILENAME_COUPON_ADMIN, 'cid=' . $_GET['cid'] . (isset($_GET['status']) ? '&status=' . $_GET['status'] : '') . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '')));
     break;
 
   case 'confirmcopy':
     $coupon_copy_to = trim($_POST['coupon_copy_to']);
-
-    // check if new coupon code exists
-    $sql = "SELECT *
-            FROM " . TABLE_COUPONS . "
-            WHERE coupon_code = :coupon_copy:";
-    $sql = $db->bindVars($sql, ':coupon_copy:', $coupon_copy_to, 'string');
-    $check_new_coupon = $db->Execute($sql);
-    if ($check_new_coupon->RecordCount() > 0) {
+    $result = Coupon::clone((int)$_GET['cid'], $coupon_copy_to);
+    if ($result === false) {
       $messageStack->add_session(ERROR_DISCOUNT_COUPON_DUPLICATE . $coupon_copy_to, 'caution');
       zen_redirect(zen_href_link(FILENAME_COUPON_ADMIN, 'cid=' . $_GET['cid'] . (isset($_GET['status']) ? '&status=' . $_GET['status'] : '') . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '')));
+    } else {
+        // use the new coupon id as the page to go to on success
+        $_GET['cid'] = (string)$result;
     }
-
-    $sql = "SELECT *
-            FROM " . TABLE_COUPONS . "
-            WHERE coupon_id = " . (int)$_GET['cid'];
-    $check_new_coupon = $db->Execute($sql);
-
-    // create duplicate coupon
-    $sql_data_array = [
-      'coupon_code' => zen_db_prepare_input($coupon_copy_to),
-      'coupon_amount' => zen_db_prepare_input($check_new_coupon->fields['coupon_amount']),
-      'coupon_product_count' => (int)$check_new_coupon->fields['coupon_product_count'],
-      'coupon_type' => zen_db_prepare_input($check_new_coupon->fields['coupon_type']),
-      'uses_per_coupon' => (int)$check_new_coupon->fields['uses_per_coupon'],
-      'uses_per_user' => (int)$check_new_coupon->fields['uses_per_user'],
-      'coupon_minimum_order' => (float)$check_new_coupon->fields['coupon_minimum_order'],
-      'restrict_to_products' => zen_db_prepare_input($check_new_coupon->fields['restrict_to_products']),
-      'restrict_to_categories' => zen_db_prepare_input($check_new_coupon->fields['restrict_to_categories']),
-      'coupon_start_date' => $check_new_coupon->fields['coupon_start_date'],
-      'coupon_expire_date' => $check_new_coupon->fields['coupon_expire_date'],
-      'date_created' => 'now()',
-      'date_modified' => 'now()',
-      'coupon_zone_restriction' => $check_new_coupon->fields['coupon_zone_restriction'],
-      'coupon_calc_base' => (int)$check_new_coupon->fields['coupon_calc_base'],
-      'coupon_order_limit' => $check_new_coupon->fields['coupon_order_limit'],
-      'coupon_is_valid_for_sales' => (int)$check_new_coupon->fields['coupon_is_valid_for_sales'],
-      'coupon_active' => 'Y',
-    ];
-
-    zen_db_perform(TABLE_COUPONS, $sql_data_array);
-    $cid = $db->insert_ID();
-
-    // create duplicate coupon description
-    $sql = "SELECT *
-            FROM " . TABLE_COUPONS_DESCRIPTION . "
-            WHERE coupon_id = " . (int)$_GET['cid'];
-    $new_coupon_descriptions = $db->Execute($sql);
-
-    foreach ($new_coupon_descriptions as $new_coupon_description) {
-      $sql_mdata_array = [
-        'coupon_id' => (int)$cid,
-        'language_id' => (int)$new_coupon_description['language_id'],
-        'coupon_name' => zen_db_prepare_input('COPY: ' . $new_coupon_description['coupon_name']),
-        'coupon_description' => zen_db_prepare_input($new_coupon_description['coupon_description'])
-      ];
-      zen_db_perform(TABLE_COUPONS_DESCRIPTION, $sql_mdata_array);
-    }
-
-    // copy restrictions
-    $sql = "SELECT *
-            FROM " . TABLE_COUPON_RESTRICT . "
-            WHERE coupon_id = " . (int)$_GET['cid'];
-    $copy_coupon_restrictions = $db->Execute($sql);
-
-    foreach ($copy_coupon_restrictions as $copy_coupon_restriction) {
-      $sql_rdata_array = [
-        'coupon_id' => (int)$cid,
-        'product_id' => (int)$copy_coupon_restriction['product_id'],
-        'category_id' => zen_db_prepare_input($copy_coupon_restriction['category_id']),
-        'coupon_restrict' => zen_db_prepare_input($copy_coupon_restriction['coupon_restrict'])
-      ];
-      zen_db_perform(TABLE_COUPON_RESTRICT, $sql_rdata_array);
-    }
-
-    $_GET['cid'] = $cid;
     $messageStack->add_session(SUCCESS_COUPON_DUPLICATE . $coupon_copy_to, 'success');
     zen_redirect(zen_href_link(FILENAME_COUPON_ADMIN, 'action=voucheredit' . '&cid=' . $_GET['cid'] . (isset($_GET['status']) ? '&status=' . $_GET['status'] : '')));
     break;
+
   case 'update':
     $update_errors = 0;
     $_POST['coupon_code'] = trim($_POST['coupon_code']);
@@ -390,7 +233,7 @@ switch ($_GET['action']) {
       $messageStack->add(ERROR_NO_COUPON_CODE, 'error');
     }
     if (!$_POST['coupon_code']) {
-      $coupon_code = zen_create_coupon_code();
+      $coupon_code = Coupon::generateRandomCouponCode();
     }
     if ($_POST['coupon_code']) {
       $coupon_code = $_POST['coupon_code'];

--- a/admin/gv_mail.php
+++ b/admin/gv_mail.php
@@ -79,7 +79,7 @@ if ($action != '') {
       }
 
       foreach ($mail as $row) {
-        $id1 = zen_create_coupon_code($row['customers_email_address']);
+        $id1 = Coupon::generateRandomCouponCode($row['customers_email_address']);
         $insert_query = $db->Execute("INSERT INTO " . TABLE_COUPONS . " (coupon_code, coupon_type, coupon_amount, date_created)
                                       VALUES ('" . zen_db_input($id1) . "', 'G', '" . zen_db_input($_POST['amount']) . "', now())");
 

--- a/admin/includes/auto_loaders/config.core.php
+++ b/admin/includes/auto_loaders/config.core.php
@@ -129,6 +129,16 @@ $autoLoadConfig[0][] = [
     'loadFile' => 'zcDate.php',
     'classPath' => DIR_FS_CATALOG . DIR_WS_CLASSES,
 ];
+$autoLoadConfig[0][] = [
+    'autoType' => 'class',
+    'loadFile' => 'Coupon.php',
+    'classPath' => DIR_FS_CATALOG . DIR_WS_CLASSES,
+];
+$autoLoadConfig[0][] = [
+    'autoType' => 'class',
+    'loadFile' => 'CouponValidation.php',
+    'classPath' => DIR_FS_CATALOG . DIR_WS_CLASSES,
+];
 /**
  * Breakpoint 5.
  *

--- a/includes/auto_loaders/config.core.php
+++ b/includes/auto_loaders/config.core.php
@@ -121,6 +121,14 @@ $autoLoadConfig[0][] = [
     'autoType' => 'class',
     'loadFile' => 'zcDate.php',
 ];
+$autoLoadConfig[0][] = [
+    'autoType' => 'class',
+    'loadFile' => 'Coupon.php',
+];
+$autoLoadConfig[0][] = [
+    'autoType' => 'class',
+    'loadFile' => 'CouponValidation.php',
+];
 /**
  * Breakpoint 5.
  *

--- a/includes/classes/Coupon.php
+++ b/includes/classes/Coupon.php
@@ -1,0 +1,214 @@
+<?php
+declare(strict_types=1);
+
+class Coupon extends base
+{
+    public static function codeExists(string $code): bool
+    {
+        global $db;
+
+        $sql = "SELECT coupon_code
+                FROM " . TABLE_COUPONS . "
+                WHERE coupon_code = :couponcode";
+        $sql = $db->bindVars($sql, ':couponcode', $code, 'string');
+
+        return $db->Execute($sql)->RecordCount() > 0;
+    }
+
+    public static function disable(int|string $coupon_id): void
+    {
+        global $db;
+        $sql = "UPDATE " . TABLE_COUPONS . "
+                SET coupon_active = 'N'
+                WHERE coupon_id = " . (int)$coupon_id;
+        $db->Execute($sql);
+    }
+
+    public static function enable(int|string $coupon_id): void
+    {
+        global $db;
+        $sql = "UPDATE " . TABLE_COUPONS . "
+                SET coupon_active = 'Y'
+                WHERE coupon_id = " . (int)$coupon_id;
+        $db->Execute($sql);
+    }
+
+    public static function deleteDuplicates(string $origin_prefix): array
+    {
+        global $db;
+        $results = [];
+
+        // report if attempted change matches the welcome coupon, because we will skip it
+        $sql = "SELECT coupon_id
+                FROM " . TABLE_COUPONS . "
+                WHERE coupon_code LIKE ':original_code:%'
+                AND coupon_id = " . (int)NEW_SIGNUP_DISCOUNT_COUPON;
+        $sql = $db->bindVars($sql, ':original_code:', $origin_prefix, 'noquotestring');
+        $delete_duplicate_coupons_check = $db->Execute($sql);
+        if ($delete_duplicate_coupons_check->RecordCount() > 0) {
+            $results['welcome_coupon'] = true;
+        }
+
+        // Find duplicates (that are not also the Welcome coupon) (and are not 'G' (GV) records)
+        $sql = "SELECT coupon_id, coupon_code
+                FROM " . TABLE_COUPONS . "
+                WHERE coupon_code LIKE ':original_code:%'
+                AND coupon_active = 'Y'
+                AND coupon_id !=  " . (int)NEW_SIGNUP_DISCOUNT_COUPON . "
+                AND coupon_type != 'G'";
+        $sql = $db->bindVars($sql, ':original_code:', $origin_prefix, 'noquotestring');
+        $delete_duplicate_coupons = $db->Execute($sql);
+
+        // disable them
+        foreach ($delete_duplicate_coupons as $delete_duplicate_coupon) {
+            static::disable($delete_duplicate_coupon['coupon_id']);
+            $results['deleted'][] = $delete_duplicate_coupon['coupon_code'];
+        }
+
+        return $results;
+    }
+
+    public static function make_duplicates(int|string $original_id, int|string $new_code, int $quantity): bool
+    {
+        for ($i = 1; $i <= $quantity; $i++) {
+            $old_code_length = strlen($new_code);
+            $minimum_extra_chars = 7;
+            $delta_calculation = SECURITY_CODE_LENGTH - ($old_code_length + $minimum_extra_chars);
+            $new_code_length = ($delta_calculation > 0) ? $minimum_extra_chars + $delta_calculation : $minimum_extra_chars;
+
+            $generated_code = static::generateRandomCouponCode((string)$original_id, $new_code_length, $new_code);
+            if ($generated_code === '') {
+                // cannot create code
+                return false;
+            }
+
+            static::clone($original_id, $generated_code);
+        }
+        return true;
+    }
+
+    public static function clone(int|string $original_id, string $new_code): int|false
+    {
+        global $db;
+
+        // check if new coupon code already exists
+        if (static::codeExists($new_code)) {
+            return false;
+        }
+
+        $sql = "SELECT *
+                FROM " . TABLE_COUPONS . "
+                WHERE coupon_id = " . (int)$original_id;
+        $copied_coupon = $db->Execute($sql);
+
+        // create duplicate coupon
+        $sql_data_array = [
+            'coupon_code' => zen_db_prepare_input($new_code),
+            'coupon_amount' => zen_db_prepare_input($copied_coupon->fields['coupon_amount']),
+            'coupon_product_count' => (int)$copied_coupon->fields['coupon_product_count'],
+            'coupon_type' => zen_db_prepare_input($copied_coupon->fields['coupon_type']),
+            'uses_per_coupon' => (int)$copied_coupon->fields['uses_per_coupon'],
+            'uses_per_user' => (int)$copied_coupon->fields['uses_per_user'],
+            'coupon_minimum_order' => (float)$copied_coupon->fields['coupon_minimum_order'],
+            'restrict_to_products' => zen_db_prepare_input($copied_coupon->fields['restrict_to_products']),
+            'restrict_to_categories' => zen_db_prepare_input($copied_coupon->fields['restrict_to_categories']),
+            'coupon_start_date' => $copied_coupon->fields['coupon_start_date'],
+            'coupon_expire_date' => $copied_coupon->fields['coupon_expire_date'],
+            'date_created' => 'now()',
+            'date_modified' => 'now()',
+            'coupon_zone_restriction' => (int)$copied_coupon->fields['coupon_zone_restriction'],
+            'coupon_calc_base' => (int)$copied_coupon->fields['coupon_calc_base'],
+            'coupon_order_limit' => (int)$copied_coupon->fields['coupon_order_limit'],
+            'coupon_is_valid_for_sales' => (int)$copied_coupon->fields['coupon_is_valid_for_sales'],
+            'coupon_active' => 'Y',
+        ];
+
+        zen_db_perform(TABLE_COUPONS, $sql_data_array);
+        $cid = $db->insert_ID();
+
+        // create duplicate coupon description
+        $sql = "SELECT *
+                FROM " . TABLE_COUPONS_DESCRIPTION . "
+                WHERE coupon_id = " . (int)$original_id;
+        $new_coupon_descriptions = $db->Execute($sql);
+
+        foreach ($new_coupon_descriptions as $new_coupon_description) {
+            $sql_mdata_array = [
+                'coupon_id' => (int)$cid,
+                'language_id' => (int)$new_coupon_description['language_id'],
+                'coupon_name' => zen_db_prepare_input('COPY: ' . $new_coupon_description['coupon_name']),
+                'coupon_description' => zen_db_prepare_input($new_coupon_description['coupon_description']),
+            ];
+            zen_db_perform(TABLE_COUPONS_DESCRIPTION, $sql_mdata_array);
+        }
+
+        // copy restrictions
+        $sql = "SELECT *
+                FROM " . TABLE_COUPON_RESTRICT . "
+                WHERE coupon_id = " . (int)$original_id;
+        $copy_coupon_restrictions = $db->Execute($sql);
+
+        foreach ($copy_coupon_restrictions as $copy_coupon_restriction) {
+            $sql_rdata_array = [
+                'coupon_id' => (int)$cid,
+                'product_id' => (int)$copy_coupon_restriction['product_id'],
+                'category_id' => (int)$copy_coupon_restriction['category_id'],
+                'coupon_restrict' => zen_db_prepare_input($copy_coupon_restriction['coupon_restrict']),
+            ];
+            zen_db_perform(TABLE_COUPON_RESTRICT, $sql_rdata_array);
+        }
+
+        return $cid;
+    }
+
+    /**
+     * Create a Coupon Code. Returns blank if cannot generate a unique code using the passed criteria.
+     * @param string $salt - this is an optional string to help seed the random code with greater entropy
+     * @param int $length - this is the desired length of the generated code
+     * @param string $prefix - include a prefix string if you want to force the generated code to start with a specific string
+     * @return string (new coupon code) (will be blank if the function failed)
+     */
+    public static function generateRandomCouponCode(string $salt = "secret", $length = SECURITY_CODE_LENGTH, string $prefix = ''): string
+    {
+        global $db;
+        $length = (int)$length;
+        static $max_db_length;
+
+        if (!isset($max_db_length)) {
+            // schema is normally max 32 chars for this field
+            $max_db_length = zen_field_length(TABLE_COUPONS, 'coupon_code');
+        }
+        if ($length > $max_db_length) {
+            $length = $max_db_length;
+        }
+        if (strlen($prefix) > $max_db_length) {
+            // if prefix is already too long for the db, we can't generate a new code
+            return '';
+        }
+        if (strlen($prefix) + (int)$length > $max_db_length) {
+            $length = $max_db_length - strlen($prefix);
+        }
+        if ($length < 4) {
+            // if the recalculated length (esp in respect to prefixes) is less than 4 (for very basic entropy) then abort
+            return '';
+        }
+        $random_string = bin2hex(random_bytes(128));
+        mt_srand((int)microtime() * 1000000); // seed the random number generator
+        $good_result = 0;
+        $new_code = '';
+        while ($good_result === 0) {
+            $random_start = @rand(0, (128 - $length));
+            $new_code = substr($random_string, $random_start, $length);
+
+            $new_code = strtoupper($new_code);
+
+            $result = static::codeExists($prefix . $new_code);
+            if ($result === false) {
+                $good_result = 1;
+            }
+        }
+
+        // blank means couldn't generate a unique code (typically because the max length was encountered before being able to generate unique)
+        return ($good_result === 1) ? $prefix . $new_code : '';
+    }
+}

--- a/includes/classes/CouponValidation.php
+++ b/includes/classes/CouponValidation.php
@@ -1,0 +1,182 @@
+<?php
+
+class CouponValidation
+{
+
+    /**
+     * Check whether the product is valid for the specified coupon, according to model/category/product restrictions assigned to the coupon
+     */
+    public static function is_product_valid(int $product_id, int $coupon_id): bool
+    {
+        global $db;
+
+        $product_id = (int)$product_id;
+
+        $coupons_query = "SELECT * FROM " . TABLE_COUPON_RESTRICT . "
+                          WHERE coupon_id = " . (int)$coupon_id . "
+                          ORDER BY coupon_restrict ASC";
+
+        $coupons = $db->Execute($coupons_query);
+
+        $product_query = "SELECT products_model FROM " . TABLE_PRODUCTS . "
+                          WHERE products_id = $product_id";
+
+        $product = $db->Execute($product_query);
+
+        if (str_starts_with($product->fields['products_model'], 'GIFT')) {
+            return false;
+        }
+
+        // modified to manage restrictions better - leave commented for now
+        if ($coupons->RecordCount() === 0) {
+            return true;
+        }
+        if ($coupons->RecordCount() === 1) {
+            // If product is restricted(deny) and is same as tested product deny
+            if ($coupons->fields['product_id'] > 0 && $coupons->fields['product_id'] == $product_id && $coupons->fields['coupon_restrict'] === 'Y') {
+                return false;
+            }
+            // If product is not restricted(allow) and is not same as tested product deny
+            if ($coupons->fields['product_id'] > 0 && $coupons->fields['product_id'] != $product_id && $coupons->fields['coupon_restrict'] === 'N') {
+                return false;
+            }
+            // if category is restricted(deny) and product in category deny
+            if ($coupons->fields['category_id'] > 0 && zen_product_in_category($product_id, $coupons->fields['category_id']) && $coupons->fields['coupon_restrict'] === 'Y') {
+                return false;
+            }
+            // if category is not restricted(allow) and product not in category deny
+            if ($coupons->fields['category_id'] > 0 && !zen_product_in_category($product_id, $coupons->fields['category_id']) && $coupons->fields['coupon_restrict'] === 'N') {
+                return false;
+            }
+            return true;
+        }
+
+        $allow_for_category = self::validate_for_category($product_id, $coupon_id);
+        $allow_for_product = self::validate_for_product($product_id, $coupon_id);
+//    echo '#'.$product_id . '#' . $allow_for_category;
+//    echo '#'.$product_id . '#' . $allow_for_product;
+        if ($allow_for_category === 'none') {
+            if ($allow_for_product === 'none') {
+                return true;
+            }
+            if ($allow_for_product === true) {
+                return true;
+            }
+            if ($allow_for_product === false) {
+                return false;
+            }
+        }
+        if ($allow_for_category === true) {
+            if ($allow_for_product === 'none') {
+                return true;
+            }
+            if ($allow_for_product === true) {
+                return true;
+            }
+            if ($allow_for_product === false) {
+                return false;
+            }
+        }
+        if ($allow_for_category === false) {
+            if ($allow_for_product === 'none') {
+                return false;
+            }
+            if ($allow_for_product === true) {
+                return true;
+            }
+            if ($allow_for_product === false) {
+                return false;
+            }
+        }
+        return false; //should never get here
+    }
+
+    /**
+     * Check whether the product is assigned to a category which is allowed for the coupon ID
+     */
+    public static function validate_for_category(int $product_id, int $coupon_id): bool|string
+    {
+        global $db;
+        $productCatPath = zen_get_product_path($product_id);
+        $catPathArray = array_reverse(explode('_', $productCatPath));
+        $sql = "SELECT count(*) AS total
+                FROM " . TABLE_COUPON_RESTRICT . "
+                WHERE category_id = -1
+                AND coupon_restrict = 'Y'
+                AND coupon_id = " . (int)$coupon_id;
+        $checkQuery = $db->Execute($sql, 1);
+        foreach ($catPathArray as $catPath) {
+            $sql = "SELECT * FROM " . TABLE_COUPON_RESTRICT . "
+                    WHERE category_id = " . (int)$catPath . "
+                    AND coupon_id = " . (int)$coupon_id;
+            $result = $db->Execute($sql, 1);
+            if ($result->RecordCount()) {
+                if ($result->fields['coupon_restrict'] === 'N') {
+                    return true;
+                }
+                if ($result->fields['coupon_restrict'] === 'Y') {
+                    return false;
+                }
+            }
+        }
+        if ($checkQuery->fields['total'] > 0) {
+            return false;
+        }
+
+        return 'none';
+    }
+
+    /**
+     * is coupon valid for specials and sales
+     */
+    public static function is_coupon_valid_for_sales(int $product_id, int $coupon_id): bool
+    {
+        global $db;
+        $sql = "SELECT coupon_id, coupon_is_valid_for_sales
+                FROM " . TABLE_COUPONS . "
+                WHERE coupon_id = " . (int)$coupon_id;
+
+        $result = $db->Execute($sql);
+
+        if ($result->EOF) {
+            return false;
+        }
+
+        // check whether coupon has been flagged for not valid with sales
+        if (!empty($result->fields['coupon_is_valid_for_sales'])) {
+            return true;
+        }
+
+        // check for any special on $product_id
+        $chk_product_on_sale = zen_get_products_special_price($product_id, true);
+        if (!$chk_product_on_sale) {
+            // check for any sale on $product_id
+            $chk_product_on_sale = zen_get_products_special_price($product_id, false);
+        }
+        if ($chk_product_on_sale) {
+            return false;
+        }
+        return true; // is on special or sale
+    }
+
+    /**
+     * Check whether coupon ID is valid for the specified product
+     */
+    public static function validate_for_product(int $product_id, int $coupon_id): bool|string
+    {
+        global $db;
+        $sql = "SELECT * FROM " . TABLE_COUPON_RESTRICT . "
+                WHERE product_id = " . (int)$product_id . "
+                AND coupon_id = " . (int)$coupon_id . " LIMIT 1";
+        $result = $db->Execute($sql);
+        if ($result->RecordCount()) {
+            if ($result->fields['coupon_restrict'] === 'N') {
+                return true;
+            }
+            if ($result->fields['coupon_restrict'] === 'Y') {
+                return false;
+            }
+        }
+        return 'none';
+    }
+}

--- a/includes/classes/sniffer.php
+++ b/includes/classes/sniffer.php
@@ -40,11 +40,10 @@ class sniffer extends base
         global $db;
         $sql = "SHOW FIELDS FROM " . $table_name;
         $result = $db->Execute($sql);
-        while (!$result->EOF) {
-            if ($result->fields['Field'] === $field_name) {
+        foreach ($result as $record) {
+            if ($record['Field'] === $field_name) {
                 return true; // exists, so return with no error
             }
-            $result->MoveNext();
         }
         return false;
     }
@@ -52,25 +51,22 @@ class sniffer extends base
     /**
      * Check whether a field is a specific type
      * and optionally return what type it is, if not matching what is being checked for.
-     *
-     * @return bool|string
      */
-    public function field_type(string $table_name, string $field_name, string $field_type, bool $return_found = false)
+    public function field_type(string $table_name, string $field_name, string $field_type, bool $return_found = false): bool|string
     {
         global $db;
         $sql = "SHOW FIELDS FROM " . $table_name;
         $result = $db->Execute($sql);
-        while (!$result->EOF) {
-            if ($result->fields['Field'] === $field_name) {
-                if ($result->fields['Type'] === $field_type) {
+        foreach($result as $record) {
+            if ($record['Field'] === $field_name) {
+                if ($record['Type'] === $field_type) {
                     return true; // exists and matches required type, so return with no error
                 }
 
                 if ($return_found) {
-                    return $result->fields['Type']; // doesn't match, so return what it "is", if requested
+                    return $record['Type']; // doesn't match, so return what it "is", if requested
                 }
             }
-            $result->MoveNext();
         }
         return false;
     }

--- a/includes/functions/functions_gvcoupons.php
+++ b/includes/functions/functions_gvcoupons.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * functions_gvcoupons.php
- * Functions related to processing Gift Vouchers/Certificates and coupons
+ * Functions related to processing Gift Vouchers/Certificates
  *
  * @copyright Copyright 2003-2023 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
@@ -10,7 +10,7 @@
  */
 
 /**
- * Update the Customers GV account balance using the amount of the GV specified
+ * Update the Customer's GV account balance using the amount of the GV specified
  *
  * @param int $customer_id
  * @param int $gv_id
@@ -67,191 +67,41 @@ function zen_user_has_gv_account(int $customer_id)
 }
 
 /**
- * Create a Coupon Code. Returns blank if cannot generate a unique code using the passed criteria.
- * @param string $salt - this is an optional string to help seed the random code with greater entropy
- * @param int $length - this is the desired length of the generated code
- * @param string $prefix - include a prefix string if you want to force the generated code to start with a specific string
- * @return string (new coupon code) (will be blank if the function failed)
+ * @deprecated v2.0.0; use Coupon::generateRandomCouponCode() instead.
  */
 function zen_create_coupon_code(string $salt = "secret", $length = SECURITY_CODE_LENGTH, string $prefix = '')
 {
-    global $db;
-    $length = (int)$length;
-    static $max_db_length;
-    if (!isset($max_db_length)) $max_db_length = zen_field_length(TABLE_COUPONS, 'coupon_code');  // schema is normally max 32 chars for this field
-    if ($length > $max_db_length) $length = $max_db_length;
-    if (strlen($prefix) > $max_db_length) return ''; // if prefix is already too long for the db, we can't generate a new code
-    if (strlen($prefix) + (int)$length > $max_db_length) $length = $max_db_length - strlen($prefix);
-    if ($length < 4) return ''; // if the recalculated length (esp in respect to prefixes) is less than 4 (for very basic entropy) then abort
-    $ccid = md5(uniqid("", $salt));
-    $ccid .= md5(uniqid("", $salt));
-    $ccid .= md5(uniqid("", $salt));
-    $ccid .= md5(uniqid("", $salt));
-    srand((double)microtime() * 1000000); // seed the random number generator
-    $good_result = 0;
-    $id1 = '';
-    while ($good_result == 0) {
-        $random_start = @rand(0, (128 - $length));
-        $id1 = substr($ccid, $random_start, $length);
-        $sql = "SELECT coupon_code
-                FROM " . TABLE_COUPONS . "
-                WHERE coupon_code = :couponcode";
-        $sql = $db->bindVars($sql, ':couponcode', $prefix . $id1, 'string');
-        $result = $db->Execute($sql);
-        if ($result->RecordCount() < 1) $good_result = 1;
-    }
-    return ($good_result == 1) ? $prefix . $id1 : ''; // blank means couldn't generate a unique code (typically because the max length was encountered before being able to generate unique)
+    return Coupon::generateRandomCouponCode($salt, $length, $prefix);
 }
 
-
 /**
- * is coupon valid for specials and sales
- * @param int $product_id
- * @param int $coupon_id
- * @return bool
+ * @deprecated v2.0.0 use CouponValidation::is_coupon_valid_for_sales
  */
 function is_coupon_valid_for_sales($product_id, $coupon_id): bool
 {
-    global $db;
-    $sql = "SELECT coupon_id, coupon_is_valid_for_sales
-            FROM " . TABLE_COUPONS . "
-            WHERE coupon_id = " . (int)$coupon_id;
-
-    $result = $db->Execute($sql);
-
-    if ($result->EOF) {
-        return false;
-    }
-
-    // check whether coupon has been flagged for not valid with sales
-    if (!empty($result->fields['coupon_is_valid_for_sales'])) {
-        return true;
-    }
-
-    // check for any special on $product_id
-    $chk_product_on_sale = zen_get_products_special_price($product_id, true);
-    if (!$chk_product_on_sale) {
-        // check for any sale on $product_id
-        $chk_product_on_sale = zen_get_products_special_price($product_id, false);
-    }
-    if ($chk_product_on_sale) {
-        return false;
-    }
-    return true; // is on special or sale
+    return CouponValidation::is_coupon_valid_for_sales($product_id, $coupon_id);
 }
 
-
 /**
- * Check whether the product is valid for the specified coupon, according to model/category/product restrictions assigned to the coupon
- * @param int $product_id
- * @param int $coupon_id
- * @return bool
+ * @deprecated v2.0.0 use CouponValidation::is_product_valid
  */
 function is_product_valid($product_id, $coupon_id): bool
 {
-    global $db;
-
-    $product_id = (int)$product_id;
-
-    $coupons_query = "SELECT * FROM " . TABLE_COUPON_RESTRICT . "
-                      WHERE coupon_id = " . (int)$coupon_id . "
-                      ORDER BY coupon_restrict ASC";
-
-    $coupons = $db->Execute($coupons_query);
-
-    $product_query = "SELECT products_model FROM " . TABLE_PRODUCTS . "
-                      WHERE products_id = $product_id";
-
-    $product = $db->Execute($product_query);
-
-    if (preg_match('/^GIFT/', $product->fields['products_model'])) {
-        return false;
-    }
-
-    // modified to manage restrictions better - leave commented for now
-    if ($coupons->RecordCount() == 0) return true;
-    if ($coupons->RecordCount() == 1) {
-        // If product is restricted(deny) and is same as tested product deny
-        if (($coupons->fields['product_id'] != 0) && $coupons->fields['product_id'] == $product_id && $coupons->fields['coupon_restrict'] == 'Y') return false;
-        // If product is not restricted(allow) and is not same as tested product deny
-        if (($coupons->fields['product_id'] != 0) && $coupons->fields['product_id'] != $product_id && $coupons->fields['coupon_restrict'] == 'N') return false;
-        // if category is restricted(deny) and product in category deny
-        if (($coupons->fields['category_id'] != 0) && (zen_product_in_category($product_id, $coupons->fields['category_id'])) && ($coupons->fields['coupon_restrict'] == 'Y')) return false;
-        // if category is not restricted(allow) and product not in category deny
-        if (($coupons->fields['category_id'] != 0) && (!zen_product_in_category($product_id, $coupons->fields['category_id'])) && ($coupons->fields['coupon_restrict'] == 'N')) return false;
-        return true;
-    }
-    $allow_for_category = validate_for_category($product_id, $coupon_id);
-    $allow_for_product = validate_for_product($product_id, $coupon_id);
-//    echo '#'.$product_id . '#' . $allow_for_category;
-//    echo '#'.$product_id . '#' . $allow_for_product;
-    if ($allow_for_category == 'none') {
-        if ($allow_for_product === 'none') return true;
-        if ($allow_for_product === true) return true;
-        if ($allow_for_product === false) return false;
-    }
-    if ($allow_for_category === true) {
-        if ($allow_for_product === 'none') return true;
-        if ($allow_for_product === true) return true;
-        if ($allow_for_product === false) return false;
-    }
-    if ($allow_for_category === false) {
-        if ($allow_for_product === 'none') return false;
-        if ($allow_for_product === true) return true;
-        if ($allow_for_product === false) return false;
-    }
-    return false; //should never get here
+    return CouponValidation::is_product_valid($product_id, $coupon_id);
 }
 
 /**
- * Check whether the product is assigned to a category which is allowed for the coupon ID
- * @param int $product_id
- * @param int $coupon_id
- * @return bool|string
+ * @deprecated v2.0.0 use CouponValidation::validate_for_category
  */
 function validate_for_category(int $product_id, int $coupon_id)
 {
-    global $db;
-    $productCatPath = zen_get_product_path($product_id);
-    $catPathArray = array_reverse(explode('_', $productCatPath));
-    $sql = "SELECT count(*) AS total
-            FROM " . TABLE_COUPON_RESTRICT . "
-            WHERE category_id = -1
-            AND coupon_restrict = 'Y'
-            AND coupon_id = " . (int)$coupon_id . " LIMIT 1";
-    $checkQuery = $db->Execute($sql);
-    foreach ($catPathArray as $catPath) {
-        $sql = "SELECT * FROM " . TABLE_COUPON_RESTRICT . "
-                WHERE category_id = " . (int)$catPath . "
-                AND coupon_id = " . (int)$coupon_id;
-        $result = $db->Execute($sql);
-        if ($result->recordCount() > 0 && $result->fields['coupon_restrict'] == 'N') return true;
-        if ($result->recordCount() > 0 && $result->fields['coupon_restrict'] == 'Y') return false;
-    }
-    if ($checkQuery->fields['total'] > 0) {
-        return false;
-    }
-
-    return 'none';
+    return CouponValidation::validate_for_category($product_id, $coupon_id);
 }
 
 /**
- * Check whether coupon ID is valid for the specified product
- *
- * @param int $product_id
- * @param int $coupon_id
- * @return bool|string
+ * @deprecated v2.0.0 use CouponValidation::validate_for_product
  */
 function validate_for_product(int $product_id, int $coupon_id)
 {
-    global $db;
-    $sql = "SELECT * FROM " . TABLE_COUPON_RESTRICT . "
-            WHERE product_id = " . (int)$product_id . "
-            AND coupon_id = " . (int)$coupon_id . " LIMIT 1";
-    $result = $db->Execute($sql);
-    if ($result->RecordCount()) {
-        if ($result->fields['coupon_restrict'] == 'N') return true;
-        if ($result->fields['coupon_restrict'] == 'Y') return false;
-    }
-    return 'none';
+    return CouponValidation::validate_for_product($product_id, $coupon_id);
 }

--- a/includes/modules/create_account.php
+++ b/includes/modules/create_account.php
@@ -360,7 +360,7 @@ if (isset($_POST['action']) && ($_POST['action'] === 'process') && !isset($login
             } //endif coupon
 
             if (NEW_SIGNUP_GIFT_VOUCHER_AMOUNT > 0) {
-                $coupon_code = zen_create_coupon_code();
+                $coupon_code = Coupon::generateRandomCouponCode();
                 $insert_query = $db->Execute("INSERT INTO " . TABLE_COUPONS . " (coupon_code, coupon_type, coupon_amount, date_created) VALUES ('" . $coupon_code . "', 'G', '" . NEW_SIGNUP_GIFT_VOUCHER_AMOUNT . "', now())");
                 $insert_id = $db->Insert_ID();
                 $db->Execute("INSERT INTO " . TABLE_COUPON_EMAIL_TRACK . " (coupon_id, customer_id_sent, sent_firstname, emailed_to, date_sent) VALUES ('" . $insert_id . "', '0', 'Admin', '" . $email_address . "', now() )");

--- a/includes/modules/order_total/ot_coupon.php
+++ b/includes/modules/order_total/ot_coupon.php
@@ -519,7 +519,7 @@ class ot_coupon extends base
                     $products = $_SESSION['cart']->get_products();
                     $coupon_product_count = 0;
                     foreach ($products as $product) {
-                        if (is_product_valid($product['id'], $coupon_details['coupon_id'])) {
+                        if (CouponValidation::is_product_valid($product['id'], $coupon_details['coupon_id'])) {
                             $coupon_product_count += $_SESSION['cart']->get_quantity($product['id']);
                         }
                     }
@@ -648,7 +648,7 @@ class ot_coupon extends base
         $i = 0;
         foreach ($products as $product) {
             $i++;
-            $is_product_valid = (is_product_valid($product['id'], $coupon_id) && is_coupon_valid_for_sales($product['id'], $coupon_id));
+            $is_product_valid = (CouponValidation::is_product_valid($product['id'], $coupon_id) && CouponValidation::is_coupon_valid_for_sales($product['id'], $coupon_id));
 
             $this->notify('NOTIFY_OT_COUPON_PRODUCT_VALIDITY', ['is_product_valid' => $is_product_valid, 'i' => $i]);
 
@@ -826,7 +826,7 @@ class ot_coupon extends base
 
         $found_valid = false;
         foreach ($products as $product) {
-            if (is_product_valid($product['id'], $coupon_id) && is_coupon_valid_for_sales($product['id'], $coupon_id)) {
+            if (CouponValidation::is_product_valid($product['id'], $coupon_id) && CouponValidation::is_coupon_valid_for_sales($product['id'], $coupon_id)) {
                 $found_valid = true;
                 break;
             }

--- a/includes/modules/pages/gv_send/header_php.php
+++ b/includes/modules/pages/gv_send/header_php.php
@@ -97,7 +97,7 @@ if ($_GET['action'] == 'send') {
 
 if ($_GET['action'] == 'process') {
   if (!isset($_POST['back'])) { // customer didn't click the back button
-    $id1 = zen_create_coupon_code($account->fields['customers_email_address']);
+    $id1 = Coupon::generateRandomCouponCode($account->fields['customers_email_address']);
     // sanitize and remove non-numeric characters
     $_POST['amount'] = preg_replace('/[^0-9.,%]/', '', $_POST['amount']);
 

--- a/not_for_release/testFramework/Support/StubCouponValidation.php
+++ b/not_for_release/testFramework/Support/StubCouponValidation.php
@@ -1,0 +1,38 @@
+<?php
+
+//namespace Tests\Support;
+class CouponValidation
+{
+
+    /**
+     * Check whether the product is valid for the specified coupon, according to model/category/product restrictions assigned to the coupon
+     */
+    public static function is_product_valid(int $product_id, int $coupon_id): bool
+    {
+        return true;
+    }
+
+    /**
+     * Check whether the product is assigned to a category which is allowed for the coupon ID
+     */
+    public static function validate_for_category(int $product_id, int $coupon_id): bool|string
+    {
+        return 'none';
+    }
+
+    /**
+     * is coupon valid for specials and sales
+     */
+    public static function is_coupon_valid_for_sales(int $product_id, int $coupon_id): bool
+    {
+        return true;
+    }
+
+    /**
+     * Check whether coupon ID is valid for the specified product
+     */
+    public static function validate_for_product(int $product_id, int $coupon_id): bool|string
+    {
+        return 'none';
+    }
+}

--- a/not_for_release/testFramework/Unit/testsDiscountCoupon/DiscountCouponsTest.php
+++ b/not_for_release/testFramework/Unit/testsDiscountCoupon/DiscountCouponsTest.php
@@ -17,11 +17,11 @@ class DiscountCouponsTest extends zcDiscountCouponTest
     {
         parent::setUp();
         require_once (TESTCWD . 'Support/functionsDiscountCoupons.php');
+        require_once (TESTCWD . 'Support/StubCouponValidation.php');
         require_once DIR_FS_CATALOG . 'includes/modules/order_total/ot_coupon.php';
         require_once DIR_FS_CATALOG . 'includes/classes/shopping_cart.php';
         require_once DIR_FS_CATALOG . 'includes/classes/currencies.php';
         require_once DIR_FS_CATALOG . 'includes/classes/db/mysql/query_factory.php';
-        require_once DIR_FS_CATALOG . 'includes/classes/CouponValidation.php';
         $_SESSION['currency'] = 'USD';
         $_SESSION['cc_id'] = '1';
         define('MODULE_ORDER_TOTAL_COUPON_HEADER', '');

--- a/not_for_release/testFramework/Unit/testsDiscountCoupon/DiscountCouponsTest.php
+++ b/not_for_release/testFramework/Unit/testsDiscountCoupon/DiscountCouponsTest.php
@@ -21,6 +21,7 @@ class DiscountCouponsTest extends zcDiscountCouponTest
         require_once DIR_FS_CATALOG . 'includes/classes/shopping_cart.php';
         require_once DIR_FS_CATALOG . 'includes/classes/currencies.php';
         require_once DIR_FS_CATALOG . 'includes/classes/db/mysql/query_factory.php';
+        require_once DIR_FS_CATALOG . 'includes/classes/CouponValidation.php';
         $_SESSION['currency'] = 'USD';
         $_SESSION['cc_id'] = '1';
         define('MODULE_ORDER_TOTAL_COUPON_HEADER', '');


### PR DESCRIPTION
Pursuant to the comment by @proseLA in #5974 this extracts numerous blocks of background logic out of the top of `coupon_admin`, into `static` methods on 2 new classes: `Coupon` and `CouponValidation`.

I anticipate that perhaps the `CouponValidation` class could be the new home for many of the validation methods currently in `ot_coupon`. Indeed, it is `ot_coupon` that uses the methods that are now in that class.

In `functions_gvcoupons.php` are only a couple functions related to GV's, and a few backward-compatibility stubs for the functions that were moved into the new classes.