### PR TITLE
Correct paypaldp/paypalwpp 'retirement' update

### DIFF
--- a/includes/modules/payment/paypaldp.php
+++ b/includes/modules/payment/paypaldp.php
@@ -253,38 +253,31 @@ class paypaldp extends base {
     $this->codeTitle = MODULE_PAYMENT_PAYPALDP_TEXT_ADMIN_TITLE_WPP;
     $this->codeVersion = '1.5.8';
     $this->enableDirectPayment = true;
-
+    $this->enabled = (defined('MODULE_PAYMENT_PAYPALDP_STATUS') && (MODULE_PAYMENT_PAYPALDP_STATUS === 'True' || (IS_ADMIN_FLAG === true && MODULE_PAYMENT_PAYPALDP_STATUS === 'Retired')));
     // Set the title & description text based on the mode we're in
     if (IS_ADMIN_FLAG === true) {
       $this->description = sprintf(MODULE_PAYMENT_PAYPALDP_TEXT_ADMIN_DESCRIPTION, ' (rev' . $this->codeVersion . ')');
       $country = (defined('MODULE_PAYMENT_PAYPALDP_MERCHANT_COUNTRY')) ? MODULE_PAYMENT_PAYPALDP_MERCHANT_COUNTRY : STORE_COUNTRY;
       $this->title = $country == '223' || $country == 'USA' ? MODULE_PAYMENT_PAYPALDP_TEXT_ADMIN_TITLE_WPP : MODULE_PAYMENT_PAYPALDP_TEXT_ADMIN_TITLE_NONUSA;
       $this->title .= (defined('MODULE_PAYMENT_PAYPALDP_MERCHANT_COUNTRY') ? ' (' . MODULE_PAYMENT_PAYPALDP_MERCHANT_COUNTRY . ')' : '');
-     } else {
+      if ($this->enabled) {
+        if ( ((MODULE_PAYMENT_PAYPALDP_MERCHANT_COUNTRY == 'US' || MODULE_PAYMENT_PAYPALDP_MERCHANT_COUNTRY == 'Canada') && (MODULE_PAYMENT_PAYPALWPP_APISIGNATURE == '' || MODULE_PAYMENT_PAYPALWPP_APIUSERNAME == '' || MODULE_PAYMENT_PAYPALWPP_APIPASSWORD == ''))
+              || (!defined('MODULE_PAYMENT_PAYPALWPP_STATUS') || MODULE_PAYMENT_PAYPALWPP_STATUS != 'True')
+          ) $this->title .= '<span class="alert"><strong> NOT CONFIGURED YET</strong></span>';
+        if (MODULE_PAYMENT_PAYPALDP_SERVER =='sandbox') $this->title .= '<strong><span class="alert"> (sandbox active)</span></strong>';
+        if (MODULE_PAYMENT_PAYPALDP_DEBUGGING =='Log File' || MODULE_PAYMENT_PAYPALDP_DEBUGGING =='Log and Email') $this->title .= '<strong> (Debug)</strong>';
+        if (!function_exists('curl_init')) $this->title .= '<strong><span class="alert"> CURL NOT FOUND. Cannot Use.</span></strong>';
+      }
+    } else {
       $this->description = MODULE_PAYMENT_PAYPALDP_TEXT_DESCRIPTION;
       $this->title = MODULE_PAYMENT_PAYPALDP_TEXT_TITLE; //cc
     }
 
     $this->sort_order = defined('MODULE_PAYMENT_PAYPALDP_SORT_ORDER') ? MODULE_PAYMENT_PAYPALDP_SORT_ORDER : null;
-    if (null === $this->sort_order) {
-        return false;
-    }
+
+    if (null === $this->sort_order) return false;
 
     $this->enabled = (MODULE_PAYMENT_PAYPALDP_STATUS === 'True' || (IS_ADMIN_FLAG === true && MODULE_PAYMENT_PAYPALDP_STATUS === 'Retired'));
-    if ($this->enabled === true && IS_ADMIN_FLAG === true) {
-        if ((MODULE_PAYMENT_PAYPALDP_MERCHANT_COUNTRY === 'US' || MODULE_PAYMENT_PAYPALDP_MERCHANT_COUNTRY === 'Canada') && (MODULE_PAYMENT_PAYPALWPP_APISIGNATURE === '' || MODULE_PAYMENT_PAYPALWPP_APIUSERNAME === '' || MODULE_PAYMENT_PAYPALWPP_APIPASSWORD === '')) {
-            $this->title .= '<span class="alert"><strong> NOT CONFIGURED YET</strong></span>';
-        }
-        if (MODULE_PAYMENT_PAYPALDP_SERVER === 'sandbox') {
-            $this->title .= '<strong><span class="alert"> (sandbox active)</span></strong>';
-        }
-        if (MODULE_PAYMENT_PAYPALDP_DEBUGGING =='Log File' || MODULE_PAYMENT_PAYPALDP_DEBUGGING =='Log and Email') {
-            $this->title .= '<strong> (Debug)</strong>';
-        }
-        if (!function_exists('curl_init')) {
-            $this->title .= '<strong><span class="alert"> CURL NOT FOUND. Cannot Use.</span></strong>';
-        }
-    }
 
     if ((!defined('PAYPAL_OVERRIDE_CURL_WARNING') || (defined('PAYPAL_OVERRIDE_CURL_WARNING') && PAYPAL_OVERRIDE_CURL_WARNING != 'True')) && !function_exists('curl_init')) $this->enabled = false;
 

--- a/includes/modules/payment/paypaldp.php
+++ b/includes/modules/payment/paypaldp.php
@@ -260,24 +260,31 @@ class paypaldp extends base {
       $country = (defined('MODULE_PAYMENT_PAYPALDP_MERCHANT_COUNTRY')) ? MODULE_PAYMENT_PAYPALDP_MERCHANT_COUNTRY : STORE_COUNTRY;
       $this->title = $country == '223' || $country == 'USA' ? MODULE_PAYMENT_PAYPALDP_TEXT_ADMIN_TITLE_WPP : MODULE_PAYMENT_PAYPALDP_TEXT_ADMIN_TITLE_NONUSA;
       $this->title .= (defined('MODULE_PAYMENT_PAYPALDP_MERCHANT_COUNTRY') ? ' (' . MODULE_PAYMENT_PAYPALDP_MERCHANT_COUNTRY . ')' : '');
-      if ($this->enabled) {
-        if ( ((MODULE_PAYMENT_PAYPALDP_MERCHANT_COUNTRY == 'US' || MODULE_PAYMENT_PAYPALDP_MERCHANT_COUNTRY == 'Canada') && (MODULE_PAYMENT_PAYPALWPP_APISIGNATURE == '' || MODULE_PAYMENT_PAYPALWPP_APIUSERNAME == '' || MODULE_PAYMENT_PAYPALWPP_APIPASSWORD == ''))
-              || (!defined('MODULE_PAYMENT_PAYPALWPP_STATUS') || MODULE_PAYMENT_PAYPALWPP_STATUS != 'True')
-          ) $this->title .= '<span class="alert"><strong> NOT CONFIGURED YET</strong></span>';
-        if (MODULE_PAYMENT_PAYPALDP_SERVER =='sandbox') $this->title .= '<strong><span class="alert"> (sandbox active)</span></strong>';
-        if (MODULE_PAYMENT_PAYPALDP_DEBUGGING =='Log File' || MODULE_PAYMENT_PAYPALDP_DEBUGGING =='Log and Email') $this->title .= '<strong> (Debug)</strong>';
-        if (!function_exists('curl_init')) $this->title .= '<strong><span class="alert"> CURL NOT FOUND. Cannot Use.</span></strong>';
-      }
-    } else {
+     } else {
       $this->description = MODULE_PAYMENT_PAYPALDP_TEXT_DESCRIPTION;
       $this->title = MODULE_PAYMENT_PAYPALDP_TEXT_TITLE; //cc
     }
 
     $this->sort_order = defined('MODULE_PAYMENT_PAYPALDP_SORT_ORDER') ? MODULE_PAYMENT_PAYPALDP_SORT_ORDER : null;
-
-    if (null === $this->sort_order) return false;
+    if (null === $this->sort_order) {
+        return false;
+    }
 
     $this->enabled = (MODULE_PAYMENT_PAYPALDP_STATUS === 'True' || (IS_ADMIN_FLAG === true && MODULE_PAYMENT_PAYPALDP_STATUS === 'Retired'));
+    if ($this->enabled === true && IS_ADMIN_FLAG === true) {
+        if ((MODULE_PAYMENT_PAYPALDP_MERCHANT_COUNTRY === 'US' || MODULE_PAYMENT_PAYPALDP_MERCHANT_COUNTRY === 'Canada') && (MODULE_PAYMENT_PAYPALWPP_APISIGNATURE === '' || MODULE_PAYMENT_PAYPALWPP_APIUSERNAME === '' || MODULE_PAYMENT_PAYPALWPP_APIPASSWORD === '')) {
+            $this->title .= '<span class="alert"><strong> NOT CONFIGURED YET</strong></span>';
+        }
+        if (MODULE_PAYMENT_PAYPALDP_SERVER === 'sandbox') {
+            $this->title .= '<strong><span class="alert"> (sandbox active)</span></strong>';
+        }
+        if (MODULE_PAYMENT_PAYPALDP_DEBUGGING =='Log File' || MODULE_PAYMENT_PAYPALDP_DEBUGGING =='Log and Email') {
+            $this->title .= '<strong> (Debug)</strong>';
+        }
+        if (!function_exists('curl_init')) {
+            $this->title .= '<strong><span class="alert"> CURL NOT FOUND. Cannot Use.</span></strong>';
+        }
+    }
 
     if ((!defined('PAYPAL_OVERRIDE_CURL_WARNING') || (defined('PAYPAL_OVERRIDE_CURL_WARNING') && PAYPAL_OVERRIDE_CURL_WARNING != 'True')) && !function_exists('curl_init')) $this->enabled = false;
 

--- a/includes/modules/payment/paypaldp.php
+++ b/includes/modules/payment/paypaldp.php
@@ -277,8 +277,6 @@ class paypaldp extends base {
 
     if (null === $this->sort_order) return false;
 
-    $this->enabled = (MODULE_PAYMENT_PAYPALDP_STATUS === 'True' || (IS_ADMIN_FLAG === true && MODULE_PAYMENT_PAYPALDP_STATUS === 'Retired'));
-
     if ((!defined('PAYPAL_OVERRIDE_CURL_WARNING') || (defined('PAYPAL_OVERRIDE_CURL_WARNING') && PAYPAL_OVERRIDE_CURL_WARNING != 'True')) && !function_exists('curl_init')) $this->enabled = false;
 
     $this->enableDebugging = (MODULE_PAYMENT_PAYPALDP_DEBUGGING == 'Log File' || MODULE_PAYMENT_PAYPALDP_DEBUGGING =='Log and Email');

--- a/includes/modules/payment/paypalwpp.php
+++ b/includes/modules/payment/paypalwpp.php
@@ -151,53 +151,43 @@ class paypalwpp extends base {
     $this->code = 'paypalwpp';
     $this->codeTitle = MODULE_PAYMENT_PAYPALWPP_TEXT_ADMIN_TITLE_EC;
     $this->codeVersion = '1.5.8';
-
+    $this->enabled = (defined('MODULE_PAYMENT_PAYPALWPP_STATUS') && (MODULE_PAYMENT_PAYPALWPP_STATUS === 'True' || (IS_ADMIN_FLAG === true && MODULE_PAYMENT_PAYPALWPP_STATUS === 'Retired')));
     // Set the title & description text based on the mode we're in ... EC vs US/UK vs admin
     if (IS_ADMIN_FLAG === true) {
       $this->description = sprintf(MODULE_PAYMENT_PAYPALWPP_TEXT_ADMIN_DESCRIPTION, ' (rev' . $this->codeVersion . ')');
-      $this->title = MODULE_PAYMENT_PAYPALWPP_TEXT_ADMIN_TITLE_EC;
+      switch (MODULE_PAYMENT_PAYPALWPP_MODULE_MODE) {
+        case ('PayPal'):
+          $this->title = MODULE_PAYMENT_PAYPALWPP_TEXT_ADMIN_TITLE_EC;
+        break;
+        case ('Payflow-UK'):
+          $this->title = MODULE_PAYMENT_PAYPALWPP_TEXT_ADMIN_TITLE_PRO20;
+        break;
+        case ('Payflow-US'):
+          if (defined('MODULE_PAYMENT_PAYPALWPP_PAYFLOW_EC') && MODULE_PAYMENT_PAYPALWPP_PAYFLOW_EC == 'Yes') {
+            $this->title = MODULE_PAYMENT_PAYPALWPP_TEXT_ADMIN_TITLE_PF_EC;
+          } else {
+            $this->title = MODULE_PAYMENT_PAYPALWPP_TEXT_ADMIN_TITLE_PF_GATEWAY;
+          }
+        break;
+        default:
+          $this->title = MODULE_PAYMENT_PAYPALWPP_TEXT_ADMIN_TITLE_EC;
+      }
+
+      $this->sort_order = defined('MODULE_PAYMENT_PAYPALWPP_SORT_ORDER') ? MODULE_PAYMENT_PAYPALWPP_SORT_ORDER : null;
+
+      if (null === $this->sort_order) return false;
+
+      if ($this->enabled) {
+        if ( (MODULE_PAYMENT_PAYPALWPP_MODULE_MODE == 'PayPal' && (MODULE_PAYMENT_PAYPALWPP_APISIGNATURE == '' || MODULE_PAYMENT_PAYPALWPP_APIUSERNAME == '' || MODULE_PAYMENT_PAYPALWPP_APIPASSWORD == ''))
+          || (substr(MODULE_PAYMENT_PAYPALWPP_MODULE_MODE,0,7) == 'Payflow' && (MODULE_PAYMENT_PAYPALWPP_PFPARTNER == '' || MODULE_PAYMENT_PAYPALWPP_PFVENDOR == '' || MODULE_PAYMENT_PAYPALWPP_PFUSER == '' || MODULE_PAYMENT_PAYPALWPP_PFPASSWORD == ''))
+          ) $this->title .= '<span class="alert"><strong> NOT CONFIGURED YET</strong></span>';
+        if (MODULE_PAYMENT_PAYPALWPP_SERVER =='sandbox') $this->title .= '<strong><span class="alert"> (sandbox active)</span></strong>';
+        if (MODULE_PAYMENT_PAYPALWPP_DEBUGGING =='Log File' || MODULE_PAYMENT_PAYPALWPP_DEBUGGING =='Log and Email') $this->title .= '<strong> (Debug)</strong>';
+        if (!function_exists('curl_init')) $this->title .= '<strong><span class="alert"> CURL NOT FOUND. Cannot Use.</span></strong>';
+      }
     } else {
       $this->description = MODULE_PAYMENT_PAYPALWPP_TEXT_DESCRIPTION;
       $this->title = MODULE_PAYMENT_PAYPALWPP_EC_TEXT_TITLE; //pp
-    }
-
-    $this->sort_order = defined('MODULE_PAYMENT_PAYPALWPP_SORT_ORDER') ? MODULE_PAYMENT_PAYPALWPP_SORT_ORDER : null;
-    if (null === $this->sort_order) return false;
-
-    $this->enabled = (MODULE_PAYMENT_PAYPALWPP_STATUS === 'True' || (IS_ADMIN_FLAG === true && MODULE_PAYMENT_PAYPALWPP_STATUS === 'Retired'));
-
-    if ($this->enabled === true && IS_ADMIN_FLAG === true) {
-        switch (MODULE_PAYMENT_PAYPALWPP_MODULE_MODE) {
-            case ('PayPal'):
-                if (MODULE_PAYMENT_PAYPALWPP_APISIGNATURE === '' || MODULE_PAYMENT_PAYPALWPP_APIUSERNAME === '' || MODULE_PAYMENT_PAYPALWPP_APIPASSWORD === '') {
-                    $this->title .= '<span class="alert"><strong> NOT CONFIGURED YET</strong></span>';
-                }
-                break;
-            case ('Payflow-UK'):
-                $this->title = MODULE_PAYMENT_PAYPALWPP_TEXT_ADMIN_TITLE_PRO20;
-                break;
-            case ('Payflow-US'):
-                if (defined('MODULE_PAYMENT_PAYPALWPP_PAYFLOW_EC') && MODULE_PAYMENT_PAYPALWPP_PAYFLOW_EC == 'Yes') {
-                    $this->title = MODULE_PAYMENT_PAYPALWPP_TEXT_ADMIN_TITLE_PF_EC;
-                } else {
-                    $this->title = MODULE_PAYMENT_PAYPALWPP_TEXT_ADMIN_TITLE_PF_GATEWAY;
-                }
-                break;
-            default:
-                break;
-        }
-        if (strpos(MODULE_PAYMENT_PAYPALWPP_MODULE_MODE, 'Payflow') === 0 && (MODULE_PAYMENT_PAYPALWPP_PFPARTNER === '' || MODULE_PAYMENT_PAYPALWPP_PFVENDOR === '' || MODULE_PAYMENT_PAYPALWPP_PFUSER === '' || MODULE_PAYMENT_PAYPALWPP_PFPASSWORD === '')) {
-            $this->title .= '<span class="alert"><strong> NOT CONFIGURED YET</strong></span>';
-        }
-        if (MODULE_PAYMENT_PAYPALWPP_SERVER === 'sandbox') {
-            $this->title .= '<strong><span class="alert"> (sandbox active)</span></strong>';
-        }
-        if (MODULE_PAYMENT_PAYPALWPP_DEBUGGING =='Log File' || MODULE_PAYMENT_PAYPALWPP_DEBUGGING =='Log and Email') {
-            $this->title .= '<strong> (Debug)</strong>';
-        }
-        if (!function_exists('curl_init')) {
-            $this->title .= '<strong><span class="alert"> CURL NOT FOUND. Cannot Use.</span></strong>';
-        }
     }
 
     if ((!defined('PAYPAL_OVERRIDE_CURL_WARNING') || (defined('PAYPAL_OVERRIDE_CURL_WARNING') && PAYPAL_OVERRIDE_CURL_WARNING != 'True')) && !function_exists('curl_init')) $this->enabled = false;

--- a/includes/modules/payment/paypalwpp.php
+++ b/includes/modules/payment/paypalwpp.php
@@ -155,41 +155,49 @@ class paypalwpp extends base {
     // Set the title & description text based on the mode we're in ... EC vs US/UK vs admin
     if (IS_ADMIN_FLAG === true) {
       $this->description = sprintf(MODULE_PAYMENT_PAYPALWPP_TEXT_ADMIN_DESCRIPTION, ' (rev' . $this->codeVersion . ')');
-      switch (MODULE_PAYMENT_PAYPALWPP_MODULE_MODE) {
-        case ('PayPal'):
-          $this->title = MODULE_PAYMENT_PAYPALWPP_TEXT_ADMIN_TITLE_EC;
-        break;
-        case ('Payflow-UK'):
-          $this->title = MODULE_PAYMENT_PAYPALWPP_TEXT_ADMIN_TITLE_PRO20;
-        break;
-        case ('Payflow-US'):
-          if (defined('MODULE_PAYMENT_PAYPALWPP_PAYFLOW_EC') && MODULE_PAYMENT_PAYPALWPP_PAYFLOW_EC == 'Yes') {
-            $this->title = MODULE_PAYMENT_PAYPALWPP_TEXT_ADMIN_TITLE_PF_EC;
-          } else {
-            $this->title = MODULE_PAYMENT_PAYPALWPP_TEXT_ADMIN_TITLE_PF_GATEWAY;
-          }
-        break;
-        default:
-          $this->title = MODULE_PAYMENT_PAYPALWPP_TEXT_ADMIN_TITLE_EC;
-      }
-
-      $this->sort_order = defined('MODULE_PAYMENT_PAYPALWPP_SORT_ORDER') ? MODULE_PAYMENT_PAYPALWPP_SORT_ORDER : null;
-
-      if (null === $this->sort_order) return false;
-
-      $this->enabled = (MODULE_PAYMENT_PAYPALWPP_STATUS === 'True' || (IS_ADMIN_FLAG === true && MODULE_PAYMENT_PAYPALWPP_STATUS === 'Retired'));
-
-      if ($this->enabled) {
-        if ( (MODULE_PAYMENT_PAYPALWPP_MODULE_MODE == 'PayPal' && (MODULE_PAYMENT_PAYPALWPP_APISIGNATURE == '' || MODULE_PAYMENT_PAYPALWPP_APIUSERNAME == '' || MODULE_PAYMENT_PAYPALWPP_APIPASSWORD == ''))
-          || (substr(MODULE_PAYMENT_PAYPALWPP_MODULE_MODE,0,7) == 'Payflow' && (MODULE_PAYMENT_PAYPALWPP_PFPARTNER == '' || MODULE_PAYMENT_PAYPALWPP_PFVENDOR == '' || MODULE_PAYMENT_PAYPALWPP_PFUSER == '' || MODULE_PAYMENT_PAYPALWPP_PFPASSWORD == ''))
-          ) $this->title .= '<span class="alert"><strong> NOT CONFIGURED YET</strong></span>';
-        if (MODULE_PAYMENT_PAYPALWPP_SERVER =='sandbox') $this->title .= '<strong><span class="alert"> (sandbox active)</span></strong>';
-        if (MODULE_PAYMENT_PAYPALWPP_DEBUGGING =='Log File' || MODULE_PAYMENT_PAYPALWPP_DEBUGGING =='Log and Email') $this->title .= '<strong> (Debug)</strong>';
-        if (!function_exists('curl_init')) $this->title .= '<strong><span class="alert"> CURL NOT FOUND. Cannot Use.</span></strong>';
-      }
+      $this->title = MODULE_PAYMENT_PAYPALWPP_TEXT_ADMIN_TITLE_EC;
     } else {
       $this->description = MODULE_PAYMENT_PAYPALWPP_TEXT_DESCRIPTION;
       $this->title = MODULE_PAYMENT_PAYPALWPP_EC_TEXT_TITLE; //pp
+    }
+
+    $this->sort_order = defined('MODULE_PAYMENT_PAYPALWPP_SORT_ORDER') ? MODULE_PAYMENT_PAYPALWPP_SORT_ORDER : null;
+    if (null === $this->sort_order) return false;
+
+    $this->enabled = (MODULE_PAYMENT_PAYPALWPP_STATUS === 'True' || (IS_ADMIN_FLAG === true && MODULE_PAYMENT_PAYPALWPP_STATUS === 'Retired'));
+
+    if ($this->enabled === true && IS_ADMIN_FLAG === true) {
+        switch (MODULE_PAYMENT_PAYPALWPP_MODULE_MODE) {
+            case ('PayPal'):
+                if (MODULE_PAYMENT_PAYPALWPP_APISIGNATURE === '' || MODULE_PAYMENT_PAYPALWPP_APIUSERNAME === '' || MODULE_PAYMENT_PAYPALWPP_APIPASSWORD === '') {
+                    $this->title .= '<span class="alert"><strong> NOT CONFIGURED YET</strong></span>';
+                }
+                break;
+            case ('Payflow-UK'):
+                $this->title = MODULE_PAYMENT_PAYPALWPP_TEXT_ADMIN_TITLE_PRO20;
+                break;
+            case ('Payflow-US'):
+                if (defined('MODULE_PAYMENT_PAYPALWPP_PAYFLOW_EC') && MODULE_PAYMENT_PAYPALWPP_PAYFLOW_EC == 'Yes') {
+                    $this->title = MODULE_PAYMENT_PAYPALWPP_TEXT_ADMIN_TITLE_PF_EC;
+                } else {
+                    $this->title = MODULE_PAYMENT_PAYPALWPP_TEXT_ADMIN_TITLE_PF_GATEWAY;
+                }
+                break;
+            default:
+                break;
+        }
+        if (strpos(MODULE_PAYMENT_PAYPALWPP_MODULE_MODE, 'Payflow') === 0 && (MODULE_PAYMENT_PAYPALWPP_PFPARTNER === '' || MODULE_PAYMENT_PAYPALWPP_PFVENDOR === '' || MODULE_PAYMENT_PAYPALWPP_PFUSER === '' || MODULE_PAYMENT_PAYPALWPP_PFPASSWORD === '')) {
+            $this->title .= '<span class="alert"><strong> NOT CONFIGURED YET</strong></span>';
+        }
+        if (MODULE_PAYMENT_PAYPALWPP_SERVER === 'sandbox') {
+            $this->title .= '<strong><span class="alert"> (sandbox active)</span></strong>';
+        }
+        if (MODULE_PAYMENT_PAYPALWPP_DEBUGGING =='Log File' || MODULE_PAYMENT_PAYPALWPP_DEBUGGING =='Log and Email') {
+            $this->title .= '<strong> (Debug)</strong>';
+        }
+        if (!function_exists('curl_init')) {
+            $this->title .= '<strong><span class="alert"> CURL NOT FOUND. Cannot Use.</span></strong>';
+        }
     }
 
     if ((!defined('PAYPAL_OVERRIDE_CURL_WARNING') || (defined('PAYPAL_OVERRIDE_CURL_WARNING') && PAYPAL_OVERRIDE_CURL_WARNING != 'True')) && !function_exists('curl_init')) $this->enabled = false;


### PR DESCRIPTION
Fixes #6129.

- Note, contains some reformatting so that I could 'see' what was going on.
- Moves admin title/description changes after the payment module has been determined to be enabled.