### PR TITLE
Correct tpl_ajax_checkout_confirmation_default.php Warnings

### DIFF
--- a/includes/templates/responsive_classic/templates/tpl_ajax_checkout_confirmation_default.php
+++ b/includes/templates/responsive_classic/templates/tpl_ajax_checkout_confirmation_default.php
@@ -123,7 +123,7 @@
         <tr class="<?php echo $order->products[$i]['rowClass']; ?>">
           <td  class="cartQuantity"><?php echo $order->products[$i]['qty']; ?>&nbsp;x</td>
           <td class="cartProductDisplay"><?php echo $order->products[$i]['name']; ?>
-          <?php  echo $stock_check[$i]; ?>
+          <?php echo (!empty($stock_check[$i])) ? $stock_check[$i] : ''; ?>
 
 <?php // if there are attributes, loop thru them and display one per line
     if (isset($order->products[$i]['attributes']) && sizeof($order->products[$i]['attributes']) > 0 ) {

--- a/includes/templates/template_default/templates/tpl_ajax_checkout_confirmation_default.php
+++ b/includes/templates/template_default/templates/tpl_ajax_checkout_confirmation_default.php
@@ -130,7 +130,7 @@
         <tr class="<?php echo $order->products[$i]['rowClass']; ?>">
           <td  class="cartQuantity"><?php echo $order->products[$i]['qty']; ?>&nbsp;x</td>
           <td class="cartProductDisplay"><?php echo $order->products[$i]['name']; ?>
-          <?php  echo $stock_check[$i]; ?>
+          <?php echo (!empty($stock_check[$i])) ? $stock_check[$i] : ''; ?>
 
 <?php // if there are attributes, loop thru them and display one per line
     if (isset($order->products[$i]['attributes']) && sizeof($order->products[$i]['attributes']) > 0 ) {


### PR DESCRIPTION
As reported in [this](https://www.zen-cart.com/showthread.php?229896-PHP-Notice-ob_flush()-Failed-to-flush-buffer-zcAjaxPayment-php&p=1398629#post1398629) Zen Cart forum bug report.