### PR TITLE
Correct tax-removal in `ot_coupon` for excluded products

### DIFF
--- a/includes/modules/order_total/ot_coupon.php
+++ b/includes/modules/order_total/ot_coupon.php
@@ -659,10 +659,7 @@ class ot_coupon extends base
 
                 $orderTotal -= $product['final_price'] * $product['quantity'];
 
-                if ($this->include_tax == 'true') {
-                    $orderTotal -= $productsTaxAmount;
-                }
-                if (DISPLAY_PRICE_WITH_TAX == 'true') {
+                if ($this->include_tax === 'true' || DISPLAY_PRICE_WITH_TAX === 'true') {
                     $orderTotal -= $productsTaxAmount;
                 }
                 $orderTotalTax -= $productsTaxAmount;


### PR DESCRIPTION
Fixes #3612