### PR TITLE
Show contact-us button instead of continue, when no shipping available

### DIFF
--- a/includes/templates/template_default/templates/tpl_checkout_shipping_default.php
+++ b/includes/templates/template_default/templates/tpl_checkout_shipping_default.php
@@ -129,8 +129,25 @@
 <?php echo zen_draw_textarea_field('comments', '45', '3', (isset($comments) ? $comments : ''), 'aria-label="' . HEADING_ORDER_COMMENTS . '"'); ?>
 </fieldset>
 
-<div class="buttonRow forward"><?php echo zen_image_submit(BUTTON_IMAGE_CONTINUE_CHECKOUT, BUTTON_CONTINUE_ALT); ?></div>
-<div class="buttonRow back"><?php echo '<strong>' . TITLE_CONTINUE_CHECKOUT_PROCEDURE . '</strong>' . '<br>' . TEXT_CONTINUE_CHECKOUT_PROCEDURE; ?></div>
+<?php
+// this can be defined in site-specific-settings
+$show_contact_us_instead_of_continue = $show_contact_us_instead_of_continue ?? false;
+?>
+<?php if (empty($show_contact_us_instead_of_continue)) { ?>
+    <div class="buttonRow forward"><?php echo zen_image_submit(BUTTON_IMAGE_CONTINUE_CHECKOUT, BUTTON_CONTINUE_ALT); ?></div>
+    <div class="buttonRow back"><?php echo '<strong>' . TITLE_CONTINUE_CHECKOUT_PROCEDURE . '</strong>' . '<br>' . TEXT_CONTINUE_CHECKOUT_PROCEDURE; ?></div>
+<?php } else { ?>
+    <?php if (zen_count_shipping_modules() > 0) { ?>
+        <div class="buttonRow forward"><?php echo zen_image_submit(BUTTON_IMAGE_CONTINUE_CHECKOUT, BUTTON_CONTINUE_ALT); ?></div>
+    <?php } else { ?>
+        <div class="buttonRow forward"><a href="<?php echo zen_href_link(FILENAME_CONTACT_US, '', 'SSL'); ?>" id="linkContactUs"><?php echo zen_image_button(BUTTON_IMAGE_CONTACT_US , BUTTON_CONTACT_US_TEXT); ?></a></div>
+    <?php } ?>
+    <?php if (zen_count_shipping_modules() > 0) { ?>
+        <div class="buttonRow back"><?php echo '<strong>' . TITLE_CONTINUE_CHECKOUT_PROCEDURE . '</strong>' . '<br>' . TEXT_CONTINUE_CHECKOUT_PROCEDURE; ?></div>
+    <?php } else { ?>
+        <div class="buttonRow back"><?php echo '<strong>' . TITLE_NO_SHIPPING_AVAILABLE . '</strong>' . '<br>' . TEXT_NO_SHIPPING_AVAILABLE; ?></div>
+    <?php } ?>
+<?php } ?>
 
 </form>
 </div>


### PR DESCRIPTION
Optional flow can be changed in template or in site-specific-overrides.

Fixes #5988

![Screen Shot 2024-01-26 at 8 31 46 PM](https://github.com/zencart/zencart/assets/404472/ff176272-4ac4-4f8d-b3bf-cf195670ca64)
