### PR TITLE
Orders page - make customer lookup check by cID before email

### DIFF
--- a/admin/orders.php
+++ b/admin/orders.php
@@ -621,7 +621,15 @@ if (!empty($action) && $order_exists === true) {
               </tr>
               <tr>
                 <td class="noprint"><strong><?php echo ENTRY_CUSTOMER; ?></strong></td>
-                <td class="noprint"><?php echo '<a href="' . zen_href_link(FILENAME_CUSTOMERS, 'search=' . $order->customer['email_address'], 'SSL') . '">' . TEXT_CUSTOMER_LOOKUP . '</a>'; ?></td>
+                <td class="noprint">
+                  <?php 
+                  if ($order->customer['id'] == 0) { 
+                       echo '<a href="' . zen_href_link(FILENAME_CUSTOMERS, 'search=' . $order->customer['email_address'], 'SSL') . '">' . TEXT_CUSTOMER_LOOKUP . '</a>'; 
+                  } else {
+                       echo '<a href="' . zen_href_link(FILENAME_CUSTOMERS, 'cID=' . $order->customer['id'], 'SSL') . '">' . TEXT_CUSTOMER_LOOKUP . '</a>'; 
+                  }
+                  ?>
+                </td>
               </tr>
             </table>
           </div>


### PR DESCRIPTION
Current customer search is by email address.  This fails if the customer has changed their email address, but will work if the customer id associated with the order is non-zero and is used in a search. 