### PR TITLE
Use 2 session vars for admin cat/prod sort

### DIFF
--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -57,18 +57,22 @@ if (isset($current_category_id) && isset($_GET['pID'])) {
   }
 }
 
-if (!isset($_SESSION['categories_products_sort_order'])) {
-  $_SESSION['categories_products_sort_order'] = CATEGORIES_PRODUCTS_SORT_ORDER;
+if (!isset($_SESSION['categories_sort_order'])) {
+  $_SESSION['categories_sort_order'] = CATEGORIES_PRODUCTS_SORT_ORDER;
 }
-
-if (!isset($_GET['reset_categories_products_sort_order'])) {
-  $reset_categories_products_sort_order = $_SESSION['categories_products_sort_order'];
+if (!isset($_SESSION['products_sort_order'])) {
+  $_SESSION['products_sort_order'] = CATEGORIES_PRODUCTS_SORT_ORDER;
 }
 
 if (!empty($action)) {
   switch ($action) {
-    case 'set_categories_products_sort_order':
-      $_SESSION['categories_products_sort_order'] = $_GET['reset_categories_products_sort_order'];
+    case 'set_categories_sort_order':
+      $_SESSION['categories_sort_order'] = $_GET['reset_categories_products_sort_order'];
+      $action = '';
+      zen_redirect(zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING, 'cPath=' . $_GET['cPath'] . ((isset($_GET['pID']) && !empty($_GET['pID'])) ? '&pID=' . $_GET['pID'] : '') .  $search_parameter . ((isset($_GET['page']) && !empty($_GET['page'])) ? '&page=' . $_GET['page'] : '')));
+      break;
+    case 'set_products_sort_order':
+      $_SESSION['products_sort_order'] = $_GET['reset_categories_products_sort_order'];
       $action = '';
       zen_redirect(zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING, 'cPath=' . $_GET['cPath'] . ((isset($_GET['pID']) && !empty($_GET['pID'])) ? '&pID=' . $_GET['pID'] : '') .  $search_parameter . ((isset($_GET['page']) && !empty($_GET['page'])) ? '&page=' . $_GET['page'] : '')));
       break;
@@ -405,6 +409,8 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
                     ['id' => '4', 'text' => TEXT_SORT_CATEGORIES_STATUS],
                     ['id' => '5', 'text' => TEXT_SORT_CATEGORIES_STATUS_DESC]
                 ];
+                $reset_categories_products_sort_order = $_SESSION['categories_sort_order'];
+                $form_action = 'set_categories_sort_order';
             } else {
                 // toggle switch for product display sort order
                 $categories_products_sort_order_array = [
@@ -421,6 +427,8 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
                     ['id' => '10', 'text' => TEXT_SORT_PRODUCTS_ID],
                     ['id' => '11', 'text' => TEXT_SORT_PRODUCTS_WEIGHT]
                 ];
+                $reset_categories_products_sort_order = $_SESSION['products_sort_order'];
+                $form_action = 'set_products_sort_order';
             }
             echo zen_draw_form('set_categories_products_sort_order_form', FILENAME_CATEGORY_PRODUCT_LISTING, '', 'get', 'class="form-horizontal"');
             ?>
@@ -436,7 +444,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
               echo (isset($_GET['pID']) ? zen_draw_hidden_field('pID', $_GET['pID']) : '');
               echo (isset($_GET['page']) ? zen_draw_hidden_field('page', $_GET['page']) : '');
               echo (isset($_GET['search']) ? zen_draw_hidden_field('search', $_GET['search']) : '');
-              echo zen_draw_hidden_field('action', 'set_categories_products_sort_order');
+              echo zen_draw_hidden_field('action', $form_action);
               ?>
             </div>
             <?php
@@ -481,7 +489,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
       <div class="row">
         <div<?php echo (empty($action)) ? '' : ' class="col-xs-12 col-sm-12 col-md-9 col-lg-9 configurationColumnLeft"'; ?>>
           <?php
-          switch ($_SESSION['categories_products_sort_order']) {
+          switch ($_SESSION['categories_sort_order']) {
               case (0):
                   $order_by = " ORDER BY c.sort_order, cd.categories_name";
                   break;
@@ -527,7 +535,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
           $categories = $db->Execute($sql);
 
           $show_prod_labels = ($search_result || $categories->EOF);
-          
+
           $wholesale_pricing_enabled = (WHOLESALE_PRICING_CONFIG !== 'false');
           $wholesale_pricing_indicator = '<span class="text-danger">*</span>';
           $wholesale_pricing_heading = ($wholesale_pricing_enabled === true) ? '<br>' . $wholesale_pricing_indicator . '<small>' . TABLE_HEADING_HAS_WHOLESALE_PRICE . '</small>' : '';
@@ -785,7 +793,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
               <?php
             }
 
-            switch ($_SESSION['categories_products_sort_order']) {
+            switch ($_SESSION['products_sort_order']) {
                 case (0):
                     $order_by = " ORDER BY p.products_sort_order, pd.products_name";
                     break;


### PR DESCRIPTION
Fixes #5897 - Admin: Categories & Products Display Order intrinsically linked

This retains the single config setting, but splits into 2 session variables, so that the last-used cat sort is used on all cats, and last-used prod sort on all prods, in a given session.