### PR TITLE
Extend the 'fluid' layout mode from products to categories too

### DIFF
--- a/includes/modules/category_row.php
+++ b/includes/modules/category_row.php
@@ -14,40 +14,90 @@ if (!defined('IS_ADMIN_FLAG')) {
     die('Illegal Access');
 }
 
-$title = '';
 $num_categories = $categories->RecordCount();
+if (empty($num_categories)) {
+    return;
+}
 
-$row = 0;
-$col = 0;
+$rows = 0;
+$columns = 0;
 $list_box_contents = [];
-if ($num_categories > 0) {
-    if ($num_categories < MAX_DISPLAY_CATEGORIES_PER_ROW || MAX_DISPLAY_CATEGORIES_PER_ROW === 0) {
-        $col_width = floor(100/$num_categories);
-    } else {
-        $col_width = floor(100/MAX_DISPLAY_CATEGORIES_PER_ROW);
+$title = '';
+
+$columns_per_row = defined('MAX_DISPLAY_CATEGORIES_PER_ROW') ? (int)MAX_DISPLAY_CATEGORIES_PER_ROW : 0;
+if (empty($category_row_layout_style) || !in_array($category_row_layout_style, ['columns', 'fluid'])) {
+    $category_row_layout_style = $columns_per_row > 0 ? 'columns' : 'fluid';
+}
+
+// if in fixed-columns mode, calculate column width
+if ($category_row_layout_style === 'columns') {
+    $calc_value = $columns_per_row;
+    if ($num_categories < $columns_per_row || $columns_per_row === 0) {
+        $calc_value = $num_categories;
+    }
+    $col_width = floor(100 / $calc_value) - 0.5;
+}
+
+foreach ($categories as $next_category) {
+    $zco_notifier->notify('NOTIFY_CATEGORY_ROW_IMAGE', $next_category['categories_id'], $next_category['categories_image']);
+    if (empty($next_category['categories_image'])) {
+        $next_category['categories_image'] = 'pixel_trans.gif';
+    }
+    $cPath_new = zen_get_path($next_category['categories_id']);
+
+    // strip out 0_ from top level cats
+    $cPath_new = str_replace('=' . (int)TOPMOST_CATEGORY_PARENT_ID . '_', '=', $cPath_new);
+
+    //    $categories->fields['products_name'] = zen_get_products_name($categories->fields['products_id']);
+
+
+
+    // Set css classes for "row" wrapper, to allow for fluid grouping of cells based on viewport
+    // these defaults are inspired by Bootstrap4, but can be customized to suit your own framework
+    if ($category_row_layout_style === 'fluid') {
+        $grid_cards_classes = $grid_category_cards_classes ?? 'row row-clms-3';
+        if (!isset($grid_category_classes_matrix)) {
+            // this array is intentionally in reverse order, with largest index first
+            $grid_category_classes_matrix = [
+                '480' => 'row row-clms-1 row-clms-sm-2 row-clms-md-3 row-clms-lg-4 row-clms-xl-6',
+            ];
+        }
+
+        // determine classes to use based on number of grid-columns used by "center" column
+        if (isset($center_column_width)) {
+            foreach ($grid_category_classes_matrix as $width => $classes) {
+                if ($center_column_width >= $width) {
+                    $grid_cards_classes = $classes;
+                    break;
+                }
+            }
+        }
+        $list_box_contents[$rows]['params'] = 'class="' . $grid_cards_classes . ' text-center"';
     }
 
-    foreach ($categories as $next_category) {
-        $zco_notifier->notify('NOTIFY_CATEGORY_ROW_IMAGE', $next_category['categories_id'], $next_category['categories_image']); 
-        if (empty($next_category['categories_image'])) {
-            $next_category['categories_image'] = 'pixel_trans.gif';
-        }
-        $cPath_new = zen_get_path($next_category['categories_id']);
+    $style = '';
+    if ($category_row_layout_style === 'columns') {
+        $style = ' style="width:' . $col_width . '%;"';
+    }
+    $grid_category_card_params = $grid_category_card_params ?? 'categoryListBoxContents centeredContent back gridlayout';
+    $grid_category_wrap_classes = $grid_category_wrap_classes ?? '';
+    $list_box_contents[$rows][] = [
+        'params' => 'class="' . $grid_category_card_params . '"' . $style,
+        'text' =>
+            '<a href="' . zen_href_link(FILENAME_DEFAULT, $cPath_new) . '">' .
+            zen_image(DIR_WS_IMAGES . $next_category['categories_image'], $next_category['categories_name'], SUBCATEGORY_IMAGE_WIDTH, SUBCATEGORY_IMAGE_HEIGHT, 'loading="lazy"') .
+            '<br>' .
+            $next_category['categories_name'] .
+            '</a>',
+        'wrap_with_classes' => $grid_category_wrap_classes,
+        'card_type' => $category_row_layout_style,
+    ];
 
-        // strip out 0_ from top level cats
-        $cPath_new = str_replace('=0_', '=', $cPath_new);
-
-        //    $categories->fields['products_name'] = zen_get_products_name($categories->fields['products_id']);
-
-        $list_box_contents[$row][$col] = [
-            'params' => 'class="categoryListBoxContents"' . ' ' . 'style="width:' . $col_width . '%;"',
-            'text' => '<a href="' . zen_href_link(FILENAME_DEFAULT, $cPath_new) . '">' . zen_image(DIR_WS_IMAGES . $next_category['categories_image'], $next_category['categories_name'], SUBCATEGORY_IMAGE_WIDTH, SUBCATEGORY_IMAGE_HEIGHT, 'loading="lazy"') . '<br>' . $next_category['categories_name'] . '</a>'
-        ];
-
-        $col++;
-        if ($col >= MAX_DISPLAY_CATEGORIES_PER_ROW) {
-            $col = 0;
-            $row++;
+    if ($category_row_layout_style === 'columns') {
+        $columns++;
+        if ($columns >= $columns_per_row) {
+            $columns = 0;
+            $rows++;
         }
     }
 }

--- a/includes/modules/responsive_classic/product_listing.php
+++ b/includes/modules/responsive_classic/product_listing.php
@@ -21,12 +21,15 @@ $error_categories = false;
 
 $show_submit = zen_run_normal();
 
-$columns_per_row = defined('PRODUCT_LISTING_COLUMNS_PER_ROW') ? PRODUCT_LISTING_COLUMNS_PER_ROW : 1;
-$product_listing_layout_style = (int)$columns_per_row > 1 ? 'columns' : 'table';
-if (empty($columns_per_row)) $product_listing_layout_style = 'fluid';
-if ($columns_per_row === 'fluid') $product_listing_layout_style = 'fluid';
+$columns_per_row = defined('PRODUCT_LISTING_COLUMNS_PER_ROW') ? (int)PRODUCT_LISTING_COLUMNS_PER_ROW : 1;
+if (empty($product_listing_layout_style) || !in_array($product_listing_layout_style, ['columns', 'table', 'fluid'])) {
+    $product_listing_layout_style = $columns_per_row > 1 ? 'columns' : 'table';
+    if (empty($columns_per_row)) {
+        $product_listing_layout_style = 'fluid';
+    }
+}
 
-$max_results = (int)MAX_DISPLAY_PRODUCTS_LISTING;
+$max_results = (int)($product_listing_max_results ?? MAX_DISPLAY_PRODUCTS_LISTING);
 if ($product_listing_layout_style === 'columns' && $columns_per_row > 1) {
     $max_results = ($columns_per_row * (int)($max_results / $columns_per_row));
 }
@@ -174,31 +177,28 @@ if ($num_products_count > 0) {
 //            }
 //        }
 
-        // set css classes for "row" wrapper, to allow for fluid grouping of cells based on viewport
-        // these defaults are based on Bootstrap4, but can be customized to suit your own framework
+        // Set css classes for "row" wrapper, to allow for fluid grouping of cells based on viewport
+        // these defaults are inspired by Bootstrap4, but can be customized to suit your own framework
         if ($product_listing_layout_style === 'fluid') {
-            $grid_cards_classes = 'row-cols-1 row-cols-md-2 row-cols-lg-2 row-cols-xl-3';
-            if (!isset($grid_classes_matrix)) {
+            $grid_cards_classes = $grid_product_cards_classes ?? 'row row-clmns-3';
+            if (!isset($grid_product_classes_matrix)) {
                 // this array is intentionally in reverse order, with largest index first
-                $grid_classes_matrix = [
-                    '12' => 'row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 row-cols-xl-6',
-                    '10' => 'row-cols-1 row-cols-md-2 row-cols-lg-4 row-cols-xl-5',
-                    '9' => 'row-cols-1 row-cols-md-3 row-cols-lg-4 row-cols-xl-5',
-                    '8' => 'row-cols-1 row-cols-md-2 row-cols-lg-3 row-cols-xl-4',
-                    '6' => 'row-cols-1 row-cols-md-2 row-cols-lg-2 row-cols-xl-3',
+                $grid_product_classes_matrix = [
+                    // for responsive_classic the array index here is in 'pixels', because $center_column_width is in pixels. See tpl_main_page.php
+                    '480' => 'row row-clms-1 row-clms-sm-2 row-clms-md-3 row-clms-lg-4 row-clms-xl-6',
                 ];
             }
 
-            // determine classes to use based on number of grid-columns used by "center" column
+            // determine classes to use based on number of grid-columns used by "center" column. See tpl_main_page.php
             if (isset($center_column_width)) {
-                foreach ($grid_classes_matrix as $width => $classes) {
+                foreach ($grid_product_classes_matrix as $width => $classes) {
                     if ($center_column_width >= $width) {
                         $grid_cards_classes = $classes;
                         break;
                     }
                 }
             }
-            $list_box_contents[$rows]['params'] = 'class="row ' . $grid_cards_classes . ' text-center"';
+            $list_box_contents[$rows]['params'] = 'class="' . $grid_cards_classes . ' text-center"';
         }
 
         $product_contents = [];
@@ -365,8 +365,8 @@ if ($num_products_count > 0) {
                     $lc_text = '';
                     if (!empty($record['products_image']) || PRODUCTS_IMAGE_NO_IMAGE_STATUS > 0) {
                         $lc_text .= '<div class="list-image">';
-                        $lc_text .= '<a href="' . $href . '">';
-                        $lc_text .= zen_image(DIR_WS_IMAGES . $record['products_image'], $listing_product_name, IMAGE_PRODUCT_LISTING_WIDTH, IMAGE_PRODUCT_LISTING_HEIGHT, 'class="listingProductImage"');
+                        $lc_text .= '<a href="' . $href . '" title="' . zen_output_string_protected($listing_product_name) . '">';
+                        $lc_text .= zen_image(DIR_WS_IMAGES . $record['products_image'], $listing_product_name, IMAGE_PRODUCT_LISTING_WIDTH, IMAGE_PRODUCT_LISTING_HEIGHT, 'loading="lazy" class="listingProductImage"');
                         $lc_text .= '</a>';
                         $lc_text .= '</div>';
                     }
@@ -411,10 +411,12 @@ if ($num_products_count > 0) {
             if ($product_listing_layout_style === 'columns') {
                 $style = ' style="width:' . $col_width . '%;"';
             }
+            $grid_product_card_params = $grid_product_card_params ?? 'centerBoxContentsProducts centeredContent back gridlayout';
+            $grid_product_wrap_classes = $grid_product_wrap_classes ?? '';
             $list_box_contents[$rows][] = [
-                'params' => 'class="centerBoxContentsProducts centeredContent back gridlayout"' . $style,
+                'params' => 'class="' . $grid_product_card_params . '"' . $style,
                 'text' => $lc_text,
-                'wrap_with_classes' => '',
+                'wrap_with_classes' => $grid_product_wrap_classes,
                 'card_type' => $product_listing_layout_style,
                 'category' => $record['master_categories_id'],
                 'parent_category_name' => $record['parent_category_name'],
@@ -432,7 +434,6 @@ if ($num_products_count > 0) {
         }
     }
 } else {
-
     $list_box_contents = [];
     $list_box_contents[0][] = [
         'params' => 'class="productListing-data"',

--- a/includes/templates/responsive_classic/css/responsive_default.css
+++ b/includes/templates/responsive_classic/css/responsive_default.css
@@ -13,7 +13,7 @@
 
 @media (min-width:0px) and (max-width:480px){
 /*bof responsive*/
-.onerow-fluid {width:100% !important;} 
+.onerow-fluid {width:100% !important;}
 .onerow-fluid>[class*="col"] {float:none;display:block;width:auto;margin:0px;clear:both;}
 
 /*bof header*/
@@ -196,7 +196,7 @@ h1{text-align:center;}
 
 @media (min-width:481px) and (max-width:767px){
 /*bof responsive*/
-.onerow-fluid {width:100% !important;} 
+.onerow-fluid {width:100% !important;}
 .onerow-fluid>[class*="col"] { float:none;display:block;width:auto;margin:0px;clear:both;  }
 
 /*bof header*/
@@ -320,7 +320,7 @@ div#productListing tr.productListing-odd {clear:both;}
 .prod-list-wrap{height:auto;}
 .tabTable{display:table;}
 .productListing-odd, .productListing-even{display:table-row;height:100%;padding-top:20px;}
-.list-image{margin:20px 20px 10px auto; text-align:center;display:inline-block;height:100%;vertical-align:top;}
+.list-image{margin:20px 20px 10px auto; text-align:center;display:inline-block;height:auto;vertical-align:top;}
 .list-input{width:25%;margin-right:1.5em;}
 .list-more{margin-right:1.5em;}
 
@@ -410,4 +410,106 @@ ul.orderHistList li a{padding-left:0;}
 
 @media (min-width:1500px) {
 div#headerWrapper,div#navSuppWrapper {width:100% !important;margin:auto; clear:both;}
+}
+
+
+@media (min-width:0px) and (max-width:480px){
+    .row.row-clms-1 .gridlayout {width: 100%}
+    .row.row-clms-2 .gridlayout {width: 49%}
+    .row.row-clms-3 .gridlayout {width: 33%}
+    .row.row-clms-4 .gridlayout {width: 25%}
+    .row.row-clms-5 .gridlayout {width: 20%}
+    .row.row-clms-6 .gridlayout {width: 16.5%}
+}
+@media (min-width:481px) and (max-width:767px){
+    .row.row-clms-1 .gridlayout {width: 100%}
+    .row.row-clms-2 .gridlayout {width: 49%}
+    .row.row-clms-3 .gridlayout {width: 33%}
+    .row.row-clms-4 .gridlayout {width: 25%}
+    .row.row-clms-5 .gridlayout {width: 20%}
+    .row.row-clms-6 .gridlayout {width: 16.5%}
+    .row.row-clms-sm-1 .gridlayout {width: 100%}
+    .row.row-clms-sm-2 .gridlayout {width: 49%}
+    .row.row-clms-sm-3 .gridlayout {width: 33%}
+    .row.row-clms-sm-4 .gridlayout {width: 25%}
+    .row.row-clms-sm-5 .gridlayout {width: 20%}
+    .row.row-clms-sm-6 .gridlayout {width: 16.5%}
+}
+@media (min-width:768px) and (max-width:1500px) {
+    .row.row-clms-1 .gridlayout {width: 100%}
+    .row.row-clms-2 .gridlayout {width: 49%}
+    .row.row-clms-3 .gridlayout {width: 33%}
+    .row.row-clms-4 .gridlayout {width: 25%}
+    .row.row-clms-5 .gridlayout {width: 20%}
+    .row.row-clms-6 .gridlayout {width: 16.5%}
+    .row.row-clms-sm-1 .gridlayout {width: 100%}
+    .row.row-clms-sm-2 .gridlayout {width: 49%}
+    .row.row-clms-sm-3 .gridlayout {width: 33%}
+    .row.row-clms-sm-4 .gridlayout {width: 25%}
+    .row.row-clms-sm-5 .gridlayout {width: 20%}
+    .row.row-clms-sm-6 .gridlayout {width: 16.5%}
+    .row.row-clms-md-1 .gridlayout {width: 100%}
+    .row.row-clms-md-2 .gridlayout {width: 49%}
+    .row.row-clms-md-3 .gridlayout {width: 33%}
+    .row.row-clms-md-4 .gridlayout {width: 25%}
+    .row.row-clms-md-5 .gridlayout {width: 20%}
+    .row.row-clms-md-6 .gridlayout {width: 16.5%}
+}
+@media (min-width:1500px) and (max-width:1800px) {
+    .row.row-clms-1 .gridlayout {width: 100%}
+    .row.row-clms-2 .gridlayout {width: 49%}
+    .row.row-clms-3 .gridlayout {width: 33%}
+    .row.row-clms-4 .gridlayout {width: 25%}
+    .row.row-clms-5 .gridlayout {width: 20%}
+    .row.row-clms-6 .gridlayout {width: 16.5%}
+    .row.row-clms-sm-1 .gridlayout {width: 100%}
+    .row.row-clms-sm-2 .gridlayout {width: 49%}
+    .row.row-clms-sm-3 .gridlayout {width: 33%}
+    .row.row-clms-sm-4 .gridlayout {width: 25%}
+    .row.row-clms-sm-5 .gridlayout {width: 20%}
+    .row.row-clms-sm-6 .gridlayout {width: 16.5%}
+    .row.row-clms-md-1 .gridlayout {width: 100%}
+    .row.row-clms-md-2 .gridlayout {width: 49%}
+    .row.row-clms-md-3 .gridlayout {width: 33%}
+    .row.row-clms-md-4 .gridlayout {width: 25%}
+    .row.row-clms-md-5 .gridlayout {width: 20%}
+    .row.row-clms-md-6 .gridlayout {width: 16.5%}
+    .row.row-clms-lg-1 .gridlayout {width: 100%}
+    .row.row-clms-lg-2 .gridlayout {width: 49%}
+    .row.row-clms-lg-3 .gridlayout {width: 33%}
+    .row.row-clms-lg-4 .gridlayout {width: 25%}
+    .row.row-clms-lg-5 .gridlayout {width: 20%}
+    .row.row-clms-lg-6 .gridlayout {width: 16.5%}
+}
+@media (min-width:1800px) {
+    .row.row-clms-1 .gridlayout {width: 100%}
+    .row.row-clms-2 .gridlayout {width: 49%}
+    .row.row-clms-3 .gridlayout {width: 33%}
+    .row.row-clms-4 .gridlayout {width: 25%}
+    .row.row-clms-5 .gridlayout {width: 20%}
+    .row.row-clms-6 .gridlayout {width: 16.5%}
+    .row.row-clms-sm-1 .gridlayout {width: 100%}
+    .row.row-clms-sm-2 .gridlayout {width: 49%}
+    .row.row-clms-sm-3 .gridlayout {width: 33%}
+    .row.row-clms-sm-4 .gridlayout {width: 25%}
+    .row.row-clms-sm-5 .gridlayout {width: 20%}
+    .row.row-clms-sm-6 .gridlayout {width: 16.5%}
+    .row.row-clms-md-1 .gridlayout {width: 100%}
+    .row.row-clms-md-2 .gridlayout {width: 49%}
+    .row.row-clms-md-3 .gridlayout {width: 33%}
+    .row.row-clms-md-4 .gridlayout {width: 25%}
+    .row.row-clms-md-5 .gridlayout {width: 20%}
+    .row.row-clms-md-6 .gridlayout {width: 16.5%}
+    .row.row-clms-lg-1 .gridlayout {width: 100%}
+    .row.row-clms-lg-2 .gridlayout {width: 49%}
+    .row.row-clms-lg-3 .gridlayout {width: 33%}
+    .row.row-clms-lg-4 .gridlayout {width: 25%}
+    .row.row-clms-lg-5 .gridlayout {width: 20%}
+    .row.row-clms-lg-6 .gridlayout {width: 16.5%}
+    .row.row-clms-xl-1 .gridlayout {width: 100%}
+    .row.row-clms-xl-2 .gridlayout {width: 49%}
+    .row.row-clms-xl-3 .gridlayout {width: 33%}
+    .row.row-clms-xl-4 .gridlayout {width: 25%}
+    .row.row-clms-xl-5 .gridlayout {width: 20%}
+    .row.row-clms-xl-6 .gridlayout {width: 16.5%}
 }

--- a/includes/templates/responsive_classic/css/stylesheet.css
+++ b/includes/templates/responsive_classic/css/stylesheet.css
@@ -278,7 +278,7 @@ div#checkoutShippingContentChoose{margin-bottom:20px;}
 .categoryListBoxContents img{margin-bottom:10px;}
 .categoryListBoxContents a{font-size:1.2em;text-decoration:none;}
 .categoryListBoxContents a:hover{}
-.categoryListBoxContents{padding:20px 0;display:block;cursor:pointer;}
+.categoryListBoxContents{/*padding:20px 0;*/display:block;cursor:pointer;}
 .categoryListBoxContents:hover{}
 .categoryListBoxContents:hover a{}
 #indexProductListCatDescription, #categoryDescription{margin-left:5%;float:left;}
@@ -328,12 +328,14 @@ span.list-addtext{display:block;text-align:center;}
 #no-products{padding:20px;margin:20px 0;}
 
 /*product listing column-layout overrides*/
-.gridlayout.centerBoxContentsProducts { padding: 2em 0; }
+.gridlayout.centerBoxContentsProducts { padding: 2em 0;}
+.gridlayout.categoryListBoxContents { padding: 2em 0;}
 .gridlayout .list-image {float:none}
 .gridlayout .list-image {min-height: revert; min-width: revert}
 .gridlayout .list-image {margin-right: inherit;}
 .gridlayout .list-more {float: none;}
 #productListing .gridlayout .list-more {margin: auto; width: 30%}
+#indexCategories .gridlayout .list-more {margin: auto; width: 30%}
 .gridlayout .itemTitle {width:90%;margin:5px auto}
 .gridlayout .listingDescription {width:90%;margin:10px auto}
 .gridlayout .cart-add {float:none;}


### PR DESCRIPTION
Pre-settable variables include:
- `$grid_category_classes_matrix`
- `$grid_category_cards_classes`
- `$grid_category_card_params`
- `$grid_category_wrap_classes`
- `$category_row_layout_style`

and
- `$grid_product_classes_matrix`
- `$grid_product_cards_classes`
- `$grid_product_card_params`
- `$grid_product_wrap_classes`
- `$product_listing_layout_style`

Inspired from https://github.com/lat9/ZCA-Bootstrap-Template/issues/305
Also adds lazy-loading of product images, and closes #6246 