### PR TITLE
Add coupons.referrer edit UI and validation.

### DIFF
--- a/admin/coupon_admin.php
+++ b/admin/coupon_admin.php
@@ -722,12 +722,8 @@ switch ($_GET['action']) {
                 <td><?php echo COUPON_REFERRER; ?></td>
                 <td><?php
                 // Referrers inputs may be empty, sanitise here
-                $trimmed_referrers = array_map(function ($referrer) {
-                  return trim($referrer);
-                }, $_POST['coupon_referrer']);
-                $referrers = array_filter($trimmed_referrers, function ($referrer) {
-                  return !empty(trim($referrer));
-                });
+                $trimmed_referrers = array_map(fn ($referrer) => trim($referrer), $_POST['coupon_referrer'] ?? []);
+                $referrers = array_filter($trimmed_referrers, fn ($referrer) => !empty(trim($referrer)));
                 // Validate that none clash with existing coupons, excluding ourself
                 foreach ($referrers as $referrer) {
                   $already_assigned = CouponValidation::referrer_already_assigned($referrer, $_GET['cid']);
@@ -740,7 +736,7 @@ switch ($_GET['action']) {
                     break;
                   }
                 }
-                $referrers = join(',', $referrers);
+                $referrers = implode(',', $referrers);
                 echo $referrers ?: 'none'; ?></td>
               </tr>
               <tr>
@@ -973,6 +969,8 @@ switch ($_GET['action']) {
               foreach ($referrers as $idx => $referrer) {
                 $btn_cls = $idx === 0 ? 'btn-success' : 'btn-danger';
                 $btn_label = $idx === 0 ? 'fa-plus' : 'fa-times';
+
+              // NOTE: any changes to the following data-list-entry div/button HTML needs to be updated in the coupon_admin.js javascript as well:
               ?>
               <div class="col-sm-12" data-list-entry>
                 <div class="input-group"><?php echo zen_draw_input_field('coupon_referrer[]', $referrer, 'class="form-control"'); ?>

--- a/admin/coupon_admin.php
+++ b/admin/coupon_admin.php
@@ -39,6 +39,7 @@ if (isset($_GET['search']) && zen_not_null($_GET['search'])) {
         'cd.coupon_name',
         'cd.coupon_description',
         'c.coupon_code',
+        'c.referrer'
     ];
     $searchWords = zen_build_keyword_where_clause($keyword_search_fields, trim($keywords), true);
     $sql = "SELECT c.coupon_id, c.coupon_active
@@ -649,6 +650,7 @@ switch ($_GET['action']) {
             <?php
             break;
           case 'update_preview':
+            $invalid_message = null; // Control whether we allow submitting the new values
             echo zen_draw_form('coupon', FILENAME_COUPON_ADMIN, 'action=update_confirm&oldaction=' . $_GET['oldaction'] . '&cid=' . $_GET['cid'] . (isset($_GET['page']) ? '&page=' . $_GET['page'] : ''));
             ?>
             <table class="table">
@@ -718,7 +720,28 @@ switch ($_GET['action']) {
               </tr>
               <tr>
                 <td><?php echo COUPON_REFERRER; ?></td>
-                <td><?php echo $_POST['coupon_referrer'] ?: 'none'; ?></td>
+                <td><?php
+                // Referrers inputs may be empty, sanitise here
+                $trimmed_referrers = array_map(function ($referrer) {
+                  return trim($referrer);
+                }, $_POST['coupon_referrer']);
+                $referrers = array_filter($trimmed_referrers, function ($referrer) {
+                  return !empty(trim($referrer));
+                });
+                // Validate that none clash with existing coupons, excluding ourself
+                foreach ($referrers as $referrer) {
+                  $already_assigned = CouponValidation::referrer_already_assigned($referrer, $_GET['cid']);
+                  if (!empty($already_assigned)) {
+                    $invalid_message = sprintf(
+                      COUPON_REFERRER_EXISTS,
+                      $already_assigned['coupon_code'],
+                      $already_assigned['coupon_id'],
+                      $referrer);
+                    break;
+                  }
+                }
+                $referrers = join(',', $referrers);
+                echo $referrers ?: 'none'; ?></td>
               </tr>
               <tr>
                 <td><?php echo COUPON_STARTDATE; ?></td>
@@ -744,7 +767,7 @@ switch ($_GET['action']) {
               echo zen_draw_hidden_field('coupon_code', stripslashes($c_code));
               echo zen_draw_hidden_field('coupon_uses_coupon', $_POST['coupon_uses_coupon']);
               echo zen_draw_hidden_field('coupon_uses_user', $_POST['coupon_uses_user']);
-              echo zen_draw_hidden_field('coupon_referrer', $_POST['coupon_referrer']);
+              echo zen_draw_hidden_field('coupon_referrer', $referrers);
               echo zen_draw_hidden_field('coupon_products', (!empty($_POST['coupon_products']) ? $_POST['coupon_products'] : ''));
               echo zen_draw_hidden_field('coupon_categories', (!empty($_POST['coupon_categories']) ? $_POST['coupon_categories'] : ''));
               echo zen_draw_hidden_field('coupon_startdate', date('Y-m-d', mktime(0, 0, 0, $_POST['coupon_startdate_month'], $_POST['coupon_startdate_day'], $_POST['coupon_startdate_year'])));
@@ -755,8 +778,13 @@ switch ($_GET['action']) {
               echo zen_draw_hidden_field('coupon_is_valid_for_sales', (int)$_POST['coupon_is_valid_for_sales']);
               ?>
               <tr>
-                <td class="text-right">
-                  <button type="submit" class="btn btn-primary"><?php echo COUPON_BUTTON_CONFIRM; ?></button>&nbsp;<a href="<?php echo zen_href_link(FILENAME_COUPON_ADMIN, 'cid=' . $_GET['cid'] . (isset($_GET['status']) ? '&status=' . $_GET['status'] : '') . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '')); ?>" class="btn btn-default" role="button"><?php echo TEXT_CANCEL; ?></a>
+                <td class="text-right" colspan=2>
+                  <?php
+                  if (!empty($invalid_message)) {
+                    echo "<span class='errorText'>" . $invalid_message . '</span>';
+                  }
+                  ?>
+                  <button type="submit" class="btn btn-primary" <?php echo empty($invalid_message) ? '' : 'disabled' ?>><?php echo COUPON_BUTTON_CONFIRM; ?></button>&nbsp;<a href="<?php echo zen_href_link(FILENAME_COUPON_ADMIN, 'cid=' . $_GET['cid'] . (isset($_GET['status']) ? '&status=' . $_GET['status'] : '') . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '')); ?>" class="btn btn-default" role="button"><?php echo TEXT_CANCEL; ?></a>
                 </td>
                 <td></td>
               </tr>
@@ -937,13 +965,25 @@ switch ($_GET['action']) {
               </div>
             </div>
             <div class="form-group">
-              <?php echo zen_draw_label(COUPON_REFERRER, 'coupon_referrer', 'class="control-label col-sm-3"'); ?>
-              <div class="col-sm-9 col-md-6">
-                <div class="input-group"><?php echo zen_draw_input_field('coupon_referrer', (!empty($coupon_referrer) && $coupon_referrer >= 1 ? $coupon_referrer : ''), 'class="form-control" id="coupon_referrer"'); ?>
-                  <span class="input-group-addon">
-                    <i class="fa-solid fa-circle-info fa-lg" data-toggle="tooltip" title="<?php echo COUPON_REFERRER_HELP; ?>"></i>
-                  </span>
+              <?php echo zen_draw_label(COUPON_REFERRER . '&nbsp;<i class="fa-solid fa-circle-info fa-lg" data-toggle="tooltip" title="' . COUPON_REFERRER_HELP . '"></i>', 'coupon_referrer', 'class="control-label col-sm-3"'); ?>
+              <div class="input-group col-sm-9 col-md-6" data-list="referrers">
+              <?php
+              // Render an input box for each referrer value. These are collected on POST and recombined
+              $referrers = explode(',', $coupon_referrer);
+              foreach ($referrers as $idx => $referrer) {
+                $btn_cls = $idx === 0 ? 'btn-success' : 'btn-danger';
+                $btn_label = $idx === 0 ? 'fa-plus' : 'fa-times';
+              ?>
+              <div class="col-sm-12" data-list-entry>
+                <div class="input-group"><?php echo zen_draw_input_field('coupon_referrer[]', $referrer, 'class="form-control"'); ?>
+                <div class="input-group-btn">
+                  <button type="button" class="btn <?php echo $btn_cls ?>">
+                    <i class="fa-solid <?php echo $btn_label ?>"></i>
+                  </button>
                 </div>
+                </div>
+              </div>
+              <?php } ?>
               </div>
             </div>
             <?php

--- a/admin/includes/javascript/coupon_admin.js
+++ b/admin/includes/javascript/coupon_admin.js
@@ -1,0 +1,35 @@
+/* Handle adding and removing list elements */
+$( () => {
+    const parentNode = $('[data-list=referrers]');
+    setupListControls(parentNode);
+});
+
+/**
+ * Listen for bubbling click events on the Add/Remove buttons of a list of inputs.
+ * The first item is expected to have an Add button for adding new entries.
+ * All subsequent items have a Remove button that removes themself.
+ * The UI may be left with some blank inputs, so data must be sanitised in the backend
+ * when posted.
+ * @param {Node} parentNode The enclosing parent node, where we can add new elements.
+ */
+function setupListControls (parentNode) {
+    $(parentNode).on('click', '.btn-success', () => {
+        // NB This markup should match what's used in coupon_admin.php when building
+        // the UI from existing content.
+        $('<div class="col-sm-12" data-list-entry>' +
+            '<div class="input-group"><input type="text" name="coupon_referrer[]" class="form-control">' +
+            '<div class="input-group-btn">' +
+            '    <button type="button" class="btn btn-danger">' +
+            '    <i class="fa-solid fa-times"></i>' +
+            '    </button>' +
+            '</div>' +
+            '</div>' +
+            '</div>').appendTo(parentNode);
+    });
+    $(parentNode).on('click', '.btn-danger', (e) => {
+        // Find the enclosing element with a data-list-entry attribute and remove it.
+        const parents = $(e.currentTarget).parents('[data-list-entry]');
+        parents.remove();
+    });
+
+}

--- a/admin/includes/languages/english/lang.coupon_admin.php
+++ b/admin/includes/languages/english/lang.coupon_admin.php
@@ -58,6 +58,7 @@ $define = [
     'COUPON_USES_COUPON' => 'Uses per Coupon',
     'COUPON_USES_USER' => 'Uses per Customer',
     'COUPON_REFERRER' => 'Valid Referrers',
+    'COUPON_REFERRER_EXISTS' => 'Coupon \'%s\' (id %d) already exists with the referrer \'%s\'',
     'COUPON_PRODUCTS' => 'Valid Product List',
     'COUPON_CATEGORIES' => 'Valid Categories List',
     'DATE_CREATED' => 'Date Created',

--- a/includes/classes/CouponValidation.php
+++ b/includes/classes/CouponValidation.php
@@ -179,4 +179,30 @@ class CouponValidation
         }
         return 'none';
     }
+
+    /**
+     * Check if a referrer is already assigned to a coupon.
+     * Because only one coupon can be active at a time, we can only support
+     * a one-to-one relationship between coupons and referrers.
+     * e.g. referrer 'abc.com' may only be assigned to one coupon, not two or more.
+     *
+     * @param string $referrer The domain to check e.g. 'abc.com'
+     * @param int $exclude_coupon_id Optional coupon_id to exclude
+     * @return ?array
+     */
+    public static function referrer_already_assigned(string $referrer, ?int $exclude_coupon_id = null): ?array
+    {
+        global $db;
+        $sql = "SELECT coupon_id, coupon_code
+                FROM " . TABLE_COUPONS . "
+                WHERE referrer LIKE '%:referrer:%'";
+        $sql = $db->bindVars($sql, ':referrer:', $referrer, 'noquotestring');
+        if (!empty($exclude_coupon_id)) {
+            $sql .= " AND coupon_id <> $exclude_coupon_id";
+        }
+
+        $result = $db->Execute($sql);
+
+        return $result->RecordCount() !== 0 ? $result->fields : null;
+    }
 }


### PR DESCRIPTION
See conversation on Issue #6193 (which is closed, not sure how these PR's are supposed to work in this case).

Two improvements to the coupon-admin UI for the recently added `coupons.referrer` field:

- Search now includes `referrers` field.  Not perfect as it's just a substring search on the raw field, so if the field has `a.com,b.com` in it, you can search for "com,b" and it'll match, but this seems good enough for now.
- Edit UI now has a series of input boxes with +/- icons, and the update/preview handler pulls these values, validates that no other coupon has a specific referrer (displays error message and prevents save).

The actual values are still stored as a CSV list, so the catalog side does not need changing.

I wrote the +/- handling from scratch, adding new file `admin/includes/javascript/coupon_admin.js` with some jQuery code that's fairly abstract.  If it's useful elsewhere it could be re-employed, but I don't like the way the HTML hardcoded in there has to match the HTML used in `coupon_admin.php`.  Room for improvement, but good enough for now?