### PR TITLE
Compatibility for pages without admin_html_head

### DIFF
--- a/admin/includes/admin_html_head.php
+++ b/admin/includes/admin_html_head.php
@@ -6,8 +6,16 @@
  * @version $Id: Nick Fenwick 2023 Jul 10 Modified in v2.0.0-alpha1 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
-  die('Illegal Access');
+    die('Illegal Access');
 }
+
+// -----
+// Set a processing flag that indicates that this file has been loaded.  The
+// flag is used by /admin/includes/header.php to warn admins and developers
+// if the legacy stylesheet loading is currently in effect.  That legacy-loading
+// (and this section) will be removed in a subsequent release of Zen Cart.
+//
+$zen_admin_html_head_loaded = true;
 ?>
 <meta charset="<?php echo CHARSET; ?>">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/admin/includes/header.php
+++ b/admin/includes/header.php
@@ -58,6 +58,18 @@ if (empty($action)) {
     $hide_languages = true;
 } // hide when other language dropdown is used
 
+// -----
+// If the current page-load did not use the admin_html_head.php for the CSS files'
+// loading, let the admin know via message and log a PHP Deprecated issue ... once for
+// each page during an admin's session.
+//
+// Note: This section will be removed in a future version of Zen Cart!
+//
+if (!isset($zen_admin_html_head_loaded) && !isset($_SESSION['pages_needing_update'][$current_page])) {
+    $_SESSION['pages_needing_update'][$current_page] = true;
+    $messageStack->add(WARNING_PAGE_REQUIRES_UPDATE, 'warning');
+    trigger_error(WARNING_PAGE_REQUIRES_UPDATE, E_USER_DEPRECATED);
+}
 
 // display alerts/error messages, if any
 if ($messageStack->size > 0) {

--- a/admin/includes/languages/lang.english.php
+++ b/admin/includes/languages/lang.english.php
@@ -633,7 +633,7 @@ $define = [
     'WARNING_FILE_UPLOADS_DISABLED' => 'Warning: File uploads are disabled in the php.ini configuration file.',
     'WARNING_INSTALL_DIRECTORY_EXISTS' => 'SECURITY WARNING: Installation directory exists at: %s. Please remove this directory for security reasons.',
     'WARNING_NO_FILE_UPLOADED' => 'Warning: No file uploaded.',
-    'WARNING_PAGE_REQUIRES_UPDATE' => 'This page requires updates for the next Zen Cart version.  Please let your site developer or plugin author know!',
+    'WARNING_PAGE_REQUIRES_UPDATE' => 'This page requires updates for the next Zen Cart version.  Please refer your site developer or plugin author to <a href="https://docs.zen-cart.com/dev/plugins/admin_head_content/" rel="noopener noreferrer" target="_blank">this</a> documentation.',
     'WARNING_PRIMARY_SERVER_FAILED' => 'Warning: The primary exchange rate server (%s) failed for %s (%s) - trying the secondary exchange rate server.',
     'WARNING_REVIEW_ROGUE_ACTIVITY' => 'ALERT: Please review for possible XSS activity:',
     'WARNING_SESSION_AUTO_START' => 'Warning: session.auto_start is enabled - please disable this PHP feature in php.ini (restarting your webserver may be necessary to activate the change).',

--- a/admin/includes/languages/lang.english.php
+++ b/admin/includes/languages/lang.english.php
@@ -633,6 +633,7 @@ $define = [
     'WARNING_FILE_UPLOADS_DISABLED' => 'Warning: File uploads are disabled in the php.ini configuration file.',
     'WARNING_INSTALL_DIRECTORY_EXISTS' => 'SECURITY WARNING: Installation directory exists at: %s. Please remove this directory for security reasons.',
     'WARNING_NO_FILE_UPLOADED' => 'Warning: No file uploaded.',
+    'WARNING_PAGE_REQUIRES_UPDATE' => 'This page requires updates for the next Zen Cart version.  Please let your site developer or plugin author know!',
     'WARNING_PRIMARY_SERVER_FAILED' => 'Warning: The primary exchange rate server (%s) failed for %s (%s) - trying the secondary exchange rate server.',
     'WARNING_REVIEW_ROGUE_ACTIVITY' => 'ALERT: Please review for possible XSS activity:',
     'WARNING_SESSION_AUTO_START' => 'Warning: session.auto_start is enabled - please disable this PHP feature in php.ini (restarting your webserver may be necessary to activate the change).',

--- a/admin/includes/menu.css
+++ b/admin/includes/menu.css
@@ -1,0 +1,61 @@
+
+.headerBar {
+    background-color: #333;
+    color: #fff;
+}
+.headerBar select {
+    color: #333;
+    background-color: #fff;
+}
+
+.headerBarContent {
+    color: #ffffff;
+    font-weight: bold;
+    padding: 2px;
+}
+
+.headerBar .nav {
+    float: right;
+    margin-right: 5px;
+}
+
+.headerBar div ul li a {
+    padding: 3px;
+    margin-top: 3px;
+}
+
+.headerBar div ul li a:hover {
+    color: #333;
+}
+
+.upperMenu{
+    display: none;
+}
+
+@media (min-width: 979px) {
+    ul.nav li.dropdown:hover > ul.dropdown-menu {
+        display: block;
+    }
+    .upperMenu{
+        display: block;
+    }
+    .upperMenuItems{
+        display: none !important;
+    }
+}
+.navbar-default {
+    background-color: #d7d6cc;
+}
+.navbar-nav li>a.dropdown-toggle {
+    font-size: 1.2em;
+    color: #333;
+}
+@media (min-width: 768px) {
+    .navbar-nav>li>a {
+        padding-top: 5px;
+        padding-bottom: 5px;
+    }
+    .navbar {
+        min-height: 30px;
+    }
+}

--- a/admin/includes/menu.css
+++ b/admin/includes/menu.css
@@ -1,4 +1,7 @@
-
+/*
+ * Left here TEMPORARILY for legacy pages that do not use the new admin_html_head.php file; the
+ * file will be removed in Zen Cart 2.1.0!
+ */
 .headerBar {
     background-color: #333;
     color: #fff;

--- a/admin/includes/menu.js
+++ b/admin/includes/menu.js
@@ -1,0 +1,13 @@
+/* this is only for backward compatibility - will be removed in future version */
+function cssjsmenu() {
+  viewport = document.querySelector("meta[name=viewport]");
+  if (viewport != undefined) {
+    viewport.setAttribute('content', 'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=1');
+  } else {
+    var metaTag=document.createElement('meta');
+  metaTag.name = "viewport"
+    metaTag.content = "width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=1"
+    document.getElementsByTagName('head')[0].appendChild(metaTag);
+  }
+}
+function init() {}

--- a/admin/includes/menu.js
+++ b/admin/includes/menu.js
@@ -1,4 +1,7 @@
-/* this is only for backward compatibility - will be removed in future version */
+/*
+ * Left here TEMPORARILY for legacy pages that do not use the new admin_html_head.php file; the
+ * file will be removed in Zen Cart 2.1.0!
+ */
 function cssjsmenu() {
   viewport = document.querySelector("meta[name=viewport]");
   if (viewport != undefined) {

--- a/admin/includes/stylesheet.css
+++ b/admin/includes/stylesheet.css
@@ -1,0 +1,22 @@
+/**
+ * @copyright Copyright 2003-2022 Zen Cart Development Team
+ * @copyright Portions Copyright 2003 osCommerce
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: DrByte 2020 Jul 10 Modified in v1.5.8-alpha $
+ */
+
+/*
+ * Left here for legacy pages that do not use the new admin_html_head.php file
+ */
+/*@import url("https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css");*/
+@import url("css/bootstrap.min.css");
+/*@import url("https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css");*/
+@import url("fontawesome/css/fontawesome.min.css");
+@import url("fontawesome/css/solid.min.css");
+@import url("fontawesome/css/regular.min.css");
+@import url("fontawesome/css/v4-shims.min.css");
+@import url("https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css");
+/*@import url("css/jquery-ui.css");*/
+@import url("css/jAlert.css");
+@import url("menu.css");
+@import url("css/stylesheet.css");

--- a/admin/includes/stylesheet.css
+++ b/admin/includes/stylesheet.css
@@ -6,7 +6,8 @@
  */
 
 /*
- * Left here for legacy pages that do not use the new admin_html_head.php file
+ * Left here TEMPORARILY for legacy pages that do not use the new admin_html_head.php file; the
+ * file will be removed in Zen Cart 2.1.0!
  */
 /*@import url("https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css");*/
 @import url("css/bootstrap.min.css");


### PR DESCRIPTION
Fixes #6214.

For each admin-session, the first time a page is loaded that doesn't use admin_html_head.php to perform the base CSS load, a message is displayed

![image](https://github.com/zencart/zencart/assets/2685585/b71193ac-3d2d-4f3b-86b1-f8c1b507e53c)

... and a PHP Deprecated log is created.

```
[10-Feb-2024 14:32:17 UTC] Request URI: /zc200w/admin200/index.php?cmd=header_test, IP address: 127.0.0.1, Language id 1
#0 [internal function]: zen_debug_error_handler()
#1 C:\xampp\htdocs\zc200w\admin200\includes\header.php(71): trigger_error()
#2 C:\xampp\htdocs\zc200w\admin200\header_test.php(58): require('C:\\xampp\\htdocs...')
#3 C:\xampp\htdocs\zc200w\admin200\index.php(11): require('C:\\xampp\\htdocs...')
--> PHP Deprecated: This page requires updates for the next Zen Cart version. Please let your site developer or plugin author know! in C:\xampp\htdocs\zc200w\admin200\includes\header.php on line 71.
```