### PR TITLE
IntlDateFormatter - show timezone offset

### DIFF
--- a/admin/includes/header.php
+++ b/admin/includes/header.php
@@ -212,8 +212,9 @@ if (defined('MODULE_ORDER_TOTAL_GV_SHOW_QUEUE_IN_ADMIN') && MODULE_ORDER_TOTAL_G
     </div>
     <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6">
         <?php
-        echo((strtoupper(substr(PHP_OS, 0, 3)) == 'WIN') ? iconv('ISO-8859-1', 'UTF-8', $zcDate->output(ADMIN_NAV_DATE_TIME_FORMAT, time())) : $zcDate->output(ADMIN_NAV_DATE_TIME_FORMAT, time())); //windows does not "do" UTF-8...so a manual conversion is necessary
-        echo '&nbsp;' . date("O", time()) . ' GMT';  // time zone
+        /** @var zcDate $zcDate */
+        $date = $zcDate->output(ADMIN_NAV_DATE_TIME_FORMAT, time());
+        echo (function_exists('mb_convert_encoding')) ? mb_convert_encoding($date, 'UTF-8') : $date;
         echo '&nbsp;[' . $_SERVER['REMOTE_ADDR'] . ']'; // current admin user's IP address
         echo '<br>';
         echo gethostname();

--- a/admin/includes/languages/lang.english.php
+++ b/admin/includes/languages/lang.english.php
@@ -9,7 +9,7 @@
 @setlocale(LC_TIME, ['en_US', 'en_US.utf8', 'en', 'English_United States.1252']);
 
 $define = [
-    'ADMIN_NAV_DATE_TIME_FORMAT' => '%A %d %b %Y %X',
+    'ADMIN_NAV_DATE_TIME_FORMAT' => '%A %d %b %Y %X (%Z)',
     'ARIA_PAGINATION_' => '',
     'ARIA_PAGINATION_CURRENTLY_ON' => ', now on page %s',
     'ARIA_PAGINATION_CURRENT_PAGE' => 'Current Page',

--- a/includes/classes/zcDate.php
+++ b/includes/classes/zcDate.php
@@ -67,6 +67,8 @@ class zcDate extends base
             '%X' => 'H:i:s',
             '%y' => 'y',
             '%Y' => 'Y',
+            '%z' => 'ZZZZ',
+            '%Z' => 'ZZZZ',
         ];
         $this->strftime2date = [
             'from' => array_keys($strftime2date),
@@ -113,6 +115,8 @@ class zcDate extends base
                 '%X' => $time_short,
                 '%y' => 'yy',
                 '%Y' => 'y',
+                '%z' => 'ZZZZ',
+                '%Z' => 'ZZZZ',
             ];
             $this->strftime2intl = [
                 'from' => array_keys($strftime2intl),


### PR DESCRIPTION
`%Z` shows `ZZZZ` equivalent, which shows the timezone offset

Fixes #6229 


Refs: 
https://www.php.net/manual/en/function.strftime.php
https://www.php.net/manual/en/datetime.formats.php
https://unicode-org.github.io/icu/userguide/format_parse/datetime/#date-field-symbol-table