### PR TITLE
Add a space between "ID" and customer id so cust id can be copied more easily

### DIFF
--- a/admin/customers.php
+++ b/admin/customers.php
@@ -1924,7 +1924,7 @@ if ($action === 'edit' || $action === 'update') {
                 $heading[] = [
                     'text' =>
                         '<h4>' .
-                            TABLE_HEADING_ID . $cInfo->customers_id . ' ' .
+                            TABLE_HEADING_ID . ' ' . $cInfo->customers_id . ' ' .
                             $cInfo->customers_firstname . ' ' . $cInfo->customers_lastname .
                         '</h4>' .
                         '<br>' .


### PR DESCRIPTION
<img width="150" alt="id" src="https://github.com/zencart/zencart/assets/4391638/ab1b7894-4953-43d0-88a9-4e7983a8c133">

(Before this, "ID" and the numeric id were together.)