### PR TITLE
Auto-add unique-ish id attribute to admin textarea fields

### DIFF
--- a/admin/includes/functions/html_output.php
+++ b/admin/includes/functions/html_output.php
@@ -463,6 +463,10 @@ function zen_draw_input_field($name, $value = '~*~*#', $parameters = '', $requir
 
     if (!empty($parameters)) $field .= ' ' . $parameters;
 
+    if (!str_contains($parameters, 'id="')) {
+        $field .= ' id="' . zen_output_string(str_replace(['[', ']'], '-', $name)) . '"';
+    }
+
     $field .= '>';
 
     if ($text == '~*~*#' && (isset($GLOBALS[$name]) && is_string($GLOBALS[$name])) && ($reinsert_value == true) ) {


### PR DESCRIPTION
Needed for future updates to CKEditor

eg: `textarea` with `name=pages_html_text[1]` now also gets `id="pages_html_text-1-"`

(The `[` and `]` characters are replaced with `-` to prevent clashing with other CSS syntax.)