### PR TITLE
CKEditor 5

### DIFF
--- a/admin/includes/ckeditor.php
+++ b/admin/includes/ckeditor.php
@@ -1,51 +1,258 @@
 <?php
+
 /**
- * @copyright Copyright 2003-2023 Zen Cart Development Team
+ * CKEditor 5
+ *
+ * Custom config can be set up in /editors/ckeditor5/config.js
+ *
+ * @copyright Copyright 2003-2024 Zen Cart Development Team
  * @copyright Portions Copyright 2010 Kuroi Web Design
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Scott C Wilson 2022 Oct 16 Modified in v1.5.8a $
+ * @version $Id:  Modified 2024-07-01 $
+ *
+ * @var language $lng
+ *
+ * Ref: https://ckeditor.com/docs/ckeditor5/latest/getting-started/installation/quick-start.html#installing-ckeditor-5-from-cdn
+ * Ref: https://github.com/ckeditor/ckeditor5/releases
  */
 if (!defined('IS_ADMIN_FLAG')) {
-  die('Illegal Access');
+    die('Illegal Access');
 }
-// prepare list of languages supported by this website, so we can tell CKEditor
-$var = zen_get_languages();
-$jsLanguageLookupArray = "var lang = new Array;\n";
-foreach ($var as $key)
-{
-  $jsLanguageLookupArray .= "        lang[" . $key['id'] . "] = '" . $key['code'] . "';\n";
+
+// To "upgrade" to a newer version, set the number here. See https://github.com/ckeditor/ckeditor5/releases for latest.
+const CKEDITOR_VERSION = '42.0.0';
+
+
+// for compatibility with pre-ZC-v2.0.0 where class is PSR-autoloaded
+if (!isset($lng)) {
+    if (!class_exists('language')) {
+        include(DIR_FS_CATALOG . DIR_WS_CLASSES . 'language.php');
+    }
+    $lng = new language;
+}
+// Get an array of languages: [1=>'en', 2=>'fr', etc] to match up textarea ID suffix to know which language the editor should use for that field.
+if (method_exists($lng, 'get_language_list')) {
+    $langArray = $lng->get_language_list();
+} else {
+    // fallback for compatibility with pre-ZC-v2.0.0
+    $langArray = [];
+    foreach ($lng->catalog_languages as $lang) {
+        $langArray[$lang['id']] = $lang['code'];
+    }
 }
 ?>
-<script>window.jQuery || document.write('<script src="https://code.jquery.com/jquery-3.6.1.min.js" integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ=" crossorigin="anonymous"><\/script>');</script>
-<script>window.jQuery || document.write('<script src="includes/javascript/jquery.min.js"><\/script>');</script>
-<script src="https://cdn.ckeditor.com/4.22.1/standard-all/ckeditor.js" title="CKEditorCDN"></script>
 
-<script title="ckEditor-Initialize">
-    jQuery(document).ready(function() {
-        <?php echo $jsLanguageLookupArray; ?>
-        // Activate on every textarea field that has the editorHook class and does not have the noEditor class
-        jQuery('textarea.editorHook').each(function() {
-            if (!jQuery(this).hasClass('noEditor'))
-            {
-                // handle multi-language variants of fields
-                index = jQuery(this).attr('name').match(/\d+/);
-                if (index == null) index = <?php echo $_SESSION['languages_id'] ?>;
+<link title="CKEditorCSS" rel="stylesheet" href="https://cdn.ckeditor.com/ckeditor5/<?= CKEDITOR_VERSION ?>/ckeditor5.css">
+<style>
+    /* for Bootstrap compatibility to prevent interfering with tables */
+    .ck-content .table {
+        width: auto;
+    }
+</style>
+<script title="CKEditor5CDN" type="importmap">
+    {
+        "imports": {
+            "ckeditor5": "https://cdn.ckeditor.com/ckeditor5/<?= CKEDITOR_VERSION ?>/ckeditor5.js",
+            "ckeditor5/": "https://cdn.ckeditor.com/ckeditor5/<?= CKEDITOR_VERSION ?>/"
+        }
+    }
+</script>
+<script title="CKEditor-custom-config" src="<?= (function_exists('zen_catalog_base_link') ? zen_catalog_base_link() : '/') . DIR_WS_EDITORS . 'ckeditor5/config.js' ?>"></script>
+<script title="CKEditor-initialize" type="module">
+    const langArray = <?= json_encode($langArray) ?>;
+    const defaultLang = '<?= DEFAULT_LANGUAGE ?>';
+    const sessionLangId = '<?= $_SESSION['languages_id'] ?>';
+    const sessionLangCode = '<?= $_SESSION['languages_code'] ?>';
 
-                CKEDITOR.replace(jQuery(this).attr('name'),
-                    {
-                        customConfig: '<?php echo (function_exists('zen_catalog_base_link') ? zen_catalog_base_link() : '/') . DIR_WS_EDITORS . 'ckeditor/config.js'; ?>',
-                        language: lang[index]
-                    });
+    // Get list of textarea fields that have the editorHook class and do not have the noEditor class
+    const editorElements = document.querySelectorAll('.editorHook:not(.noEditor)');
+
+    import {
+        Alignment,
+        Autoformat,
+        AutoImage,
+        AutoLink,
+        BlockQuote,
+        Bold,
+        ClassicEditor,
+        Clipboard,
+        Code,
+        CodeBlock,
+        Essentials,
+        FindAndReplace,
+        Font,
+        GeneralHtmlSupport,
+        Heading,
+        HtmlEmbed,
+        Image,
+        ImageCaption,
+        ImageInsert,
+        ImageResize,
+        ImageStyle,
+        ImageToolbar,
+        Indent,
+        IndentBlock,
+        Italic,
+        LinkImage,
+        List,
+        MediaEmbed,
+        Paragraph,
+        PasteFromMarkdownExperimental,
+        PasteFromOffice,
+        RemoveFormat,
+        SelectAll,
+        ShowBlocks,
+        SourceEditing,
+        SpecialCharacters,
+        SpecialCharactersEssentials,
+        Strikethrough,
+        Style,
+        Subscript,
+        Superscript,
+        Table,
+        TableCellProperties,
+        TableColumnResize,
+        TableProperties,
+        TableToolbar,
+        TextPartLanguage,
+        Underline,
+        Undo
+    } from 'ckeditor5';
+
+    <?php
+    // import translations needed
+    foreach ($langArray as $langCode) {
+        echo "import " . $langCode . "Translation from 'ckeditor5/translations/" . $langCode . ".js';\n";
+    }
+    ?>
+    const uiLanguages = {
+        <?php
+    foreach ($langArray as $langCode) {
+        echo '"' . $langCode . '": ' . $langCode . 'Translation,';
+    }
+    ?>
+    };
+
+
+    const editorConfig = {
+        plugins: [
+            Essentials, Font, Bold, Italic, Underline, Strikethrough, Subscript, Superscript, Code,
+            Clipboard, PasteFromOffice, Autoformat, PasteFromMarkdownExperimental, FindAndReplace,
+            CodeBlock, Heading, Paragraph, Undo, BlockQuote, Indent, IndentBlock, List, SelectAll,
+            Alignment, GeneralHtmlSupport, HtmlEmbed, Style, SourceEditing, MediaEmbed, TextPartLanguage, ShowBlocks,
+            SpecialCharacters, SpecialCharactersEssentials, RemoveFormat,
+            Table, TableToolbar, TableProperties, TableCellProperties, TableColumnResize,
+            Image, AutoImage, ImageInsert, ImageToolbar, ImageCaption, ImageStyle, ImageResize, LinkImage
+        ],
+        toolbar: {
+            items: [
+                'undo', 'redo', 'findAndReplace',
+                '|', 'link', 'insertImage', 'mediaEmbed', 'insertTable',
+                '|', 'heading', 'fontsize', /* 'fontfamily', */ 'specialCharacters',
+                '|', 'showBlocks',
+                // 'sourceEditing' may or may not be desired. Do not use if admins might paste content from untrusted sources
+                'sourceEditing',
+                // using htmlEmbed poses a security risk: do not use if Admins might paste content from untrusted sources; A sanitizer should be configured if htmlEmbed is enabled.
+                // 'htmlEmbed',
+                '-', 'bold', 'italic', 'underline', 'strikethrough',
+                // 'superscript', 'subscript',
+                'code',
+                '|', 'removeFormat',
+                '|', 'numberedList', 'bulletedList', 'indent', 'outdent', 'blockQuote', 'alignment',
+                '|', 'fontColor', 'fontBackgroundColor',
+            ],
+            shouldNotGroupWhenFull: true
+        },
+
+        image: {
+            insert: {
+                integrations: ['url'/*, 'upload', 'assetManager'*/],
+
+                // If "type" setting is omitted, the editor defaults to 'block'.
+                type: 'auto'
+            },
+            // image toolbar layout:
+            toolbar: [
+                'imageStyle:block',
+                'imageStyle:side',
+                '|',
+                'toggleImageCaption',
+                'imageTextAlternative',
+                '|',
+                'linkImage',
+                '|',
+                'imageStyle:inline',
+                'imageStyle:block',
+                'imageStyle:wrapText',
+            ],
+        },
+
+        link: {
+            defaultProtocol: 'https://',
+            allowedProtocols: [ 'https?', 'tel', 'sms', 'mailto'],
+            decorators: {
+                openInNewTab: {
+                    mode: 'manual',
+                    label: 'Open in a new tab',
+                    attributes: {
+                        target: '_blank',
+                        rel: 'noopener noreferrer'
+                    }
+                }
             }
-        });
-    });
+        },
+
+        table: {
+            contentToolbar: [
+                'tableColumn', 'tableRow', 'mergeTableCells',
+                'tableProperties', 'tableCellProperties',
+            ],
+        },
+    };
+
+
+// console.log(editorElements);
+    // Loop through the target elements and activate the Editor on each.
+    for (const editorElement of editorElements) {
+
+        // Determine language to use for this element's content and the UI
+        const contentLangCode = langArray[editorElement.name.match(/\d+/) ?? sessionLangId];
+        const langConfig = {
+            language: {
+                // ui: sessionLangCode,
+                content: contentLangCode,
+            }
+        };
+
+        const translationsConfig = {
+            translations: [
+                uiLanguages[contentLangCode],
+                // uiLanguages[sessionLangCode],
+            ]
+        };
+
+        // In case the override/custom config.js doesn't load or is not present, fallback to empty object.
+        let customConfig = {};
+        if (typeof myCKEditorConfig !== 'undefined') {
+            customConfig = myCKEditorConfig;
+        }
+
+        // Combine configs: First use the master config above, then any custom overrides from /editors/ckeditor5/config.js, and then override language for specific fields
+        const currentEditorConfig = {...editorConfig, ...translationsConfig, ...customConfig, ...langConfig};
+//console.log(currentEditorConfig);
+
+        // Instantiate this editor instance, before looping to the next one on the page.
+        ClassicEditor
+            .create(editorElement, currentEditorConfig)
+            .then(editor => {
+                window.editor = editor;
+            })
+            .catch(error => {
+                // console.error(error.stack);
+                console.error(error);
+            });
+    }
 </script>
 
 <?php
-// Other options:
-// - Edit your /editors/ckeditor/config.js file to control the toolbar buttons, add additional plugins, control the UI color, etc
-//
-// Advanced:
-// https://ckeditor.com/docs/ckeditor4/latest/features/styles.html#the-stylesheet-parser-plugin
-// - set custom styles in the /editors/ckeditor/styles.js file
-// - import a template-specific stylesheet from catalog-side, using config.contentsCss setting, so dialogs "look like catalog-side" in admin editor
+// - Edit your /editors/ckeditor5/config.js file to control the toolbar buttons, add additional plugins, etc

--- a/admin/includes/css/stylesheet.css
+++ b/admin/includes/css/stylesheet.css
@@ -953,3 +953,9 @@ tbody>tr>td.align-bottom {
     margin-top: 3rem !important;
 }
 /**/
+
+/* CKEditor */
+.ck-editor__editable {
+    min-height: 250px;
+    max-height: 650px;
+}

--- a/editors/ckeditor5/config.js
+++ b/editors/ckeditor5/config.js
@@ -1,0 +1,108 @@
+let myCKEditorConfig = {
+    // For complete reference see:
+    // https://ckeditor.com/docs/ckeditor5/latest/api/module_core_editor_editorconfig-EditorConfig.html
+
+    // If you have a paid commercial license for premium features, enter the key here, and uncomment the line:
+    // licenseKey: '<YOUR_LICENSE_KEY>',
+
+
+    //// IMPORTANT NOTE: every section enabled here will replace the "entire" matching section from the master configuration
+    ////      ... therefore, if there is something you wish to adjust in a small way, copy that complete section from the
+    ////          master ckeditor.php editorConfig defaults and then make your alterations to that.
+
+
+    // https://ckeditor.com/docs/ckeditor5/latest/getting-started/setup/menubar.html
+    menuBar: {
+        isVisible: true
+    },
+
+    // Custom toolbar configurations can be added below.
+    //
+    // Beware: defining 'toolbar' will completely replace the already-configured toolbar, so you must define a complete toolbar set.
+    // toolbar: {
+    // },
+
+    // https://ckeditor.com/docs/ckeditor5/latest/features/font.html
+    // fontFamily: {
+    //     options: [
+    //         'default',
+    //         'Ubuntu, Arial, sans-serif',
+    //         'Ubuntu Mono, Courier New, Courier, monospace'
+    //     ],
+    // }
+    // ,
+
+    // Limit to certain font size choices, or expand available options
+    fontSize: {
+        options: [
+            8, 9, 10, 11, 12, 'default', 13, 14, 15, 16, 17, 18, 19, 20, 22, 24, 26, 28, 36, 48, 72,
+        ],
+
+        // Allow all font sizes including those that are unknown to CKEditor.
+        supportAllValues: true
+    },
+
+
+    // https://ckeditor.com/docs/ckeditor5/latest/features/html/general-html-support.html
+    // htmlSupport: {
+    //     allow: [ /* HTML features to allow. */ ],
+    //     disallow: [ /* HTML features to disallow. */ ]
+    // }
+
+    // findAndReplace: {
+    //     uiType: 'dropdown'
+    // },
+
+    // https://ckeditor.com/docs/ckeditor5/latest/features/style.html
+    // style: {
+    //     definitions: [
+            // Styles definitions.
+            // ...
+            // {
+            //     name: 'Article category',
+            //     element: 'h3',
+            //     classes: [ 'category' ]
+            // },
+            // {
+            //     name: 'Info box',
+            //     element: 'p',
+            //     classes: [ 'info-box' ]
+            // },
+        // ]
+    // },
+
+    // https://ckeditor.com/docs/ckeditor5/latest/features/link.html
+    // link: {
+    //     defaultProtocol: 'https://',
+    //     allowedProtocols: [ 'https?', 'tel', 'sms', 'mailto'],
+    //     decorators: {
+    //         openInNewTab: {
+    //             mode: 'manual',
+    //             label: 'Open in a new tab',
+    //             attributes: {
+    //                 target: '_blank',
+    //                 rel: 'noopener noreferrer'
+    //             }
+    //         }
+    //     }
+    // },
+
+    // https://ckeditor.com/docs/ckeditor5/latest/features/tables/tables-styling.html
+    // table: {
+    //     contentToolbar: [
+    //         'tableColumn', 'tableRow', 'mergeTableCells',
+    //         'tableProperties', 'tableCellProperties',
+    //     ],
+    //
+    //     tableProperties: {
+    //         // The configuration of the TableProperties plugin.
+    //         // ...
+    //     },
+    //
+    //     tableCellProperties: {
+    //         // The configuration of the TableCellProperties plugin.
+    //         // ...
+    //     }
+    // },
+
+}


### PR DESCRIPTION
Ref #6209

This uses CKEditor 5 "Classic Mode", which turns a textarea field into an in-browser editor field.

Minor differences from CKE4:
- right-click "context menu" is no longer a custom menu: it's just the browser's own context-menu.
- button-bar no longer offers cut/copy/paste: but normal keyboard shortcuts and right-click menu can be used.
- spell-check not offered without purchasing a commercial license

Tested on versions v210, v200, v158, v157, v156 to confirm that the CKE5 editor loads correctly using the code changes in this PR.

To backport to an older version, simply copy the files from this PR.
`/admin/includes/ckeditor.php` (whole file)
`/editors/ckeditor5/config.js` (whole file and directory)
and manually patch the stylesheet:
`/admin/includes/css/stylesheet.css` (just the last few lines related to .ck-editor__editable must be copied into the old file) (Note on v156 the stylesheet is in the `/admin/includes` dir, not in the `/admin/includes/css` subdir)

<img width="781" alt="Screen Shot 2024-07-01 at 10 58 55 PM" src="https://github.com/zencart/zencart/assets/404472/69ba5777-068f-448b-8283-985b51228f3c">
