### PR TITLE
zcDate->output() - allow calendar override

### DIFF
--- a/includes/classes/zcDate.php
+++ b/includes/classes/zcDate.php
@@ -142,10 +142,11 @@ class zcDate extends base
     /**
      * @param string $format  output method should start with a strftime-format string
      * @param int    $timestamp
+     * @param string|null $calendar_locale Optional calendar-related locale. eg: 'ja_JP@calendar=japanese'
      *
      * @return false|string
      */
-    public function output(string $format, int $timestamp = 0)
+    public function output(string $format, int $timestamp = 0, ?string $calendar_locale = null)
     {
         if ($timestamp === 0) {
             $timestamp = time();
@@ -175,13 +176,18 @@ class zcDate extends base
                 $this->initializeConversionArrays();
             }
 
+            $calendar = IntlDateFormatter::GREGORIAN;
+            if (!empty($calendar_locale)) {
+                $calendar = IntlCalendar::createInstance(null, $calendar_locale);
+            }
+
             $converted_format = $this->convertFormat($format, $this->strftime2intl);
             $this->dateObject = datefmt_create(
                 $this->locale,
                 IntlDateFormatter::FULL,
                 IntlDateFormatter::FULL,
                 date_default_timezone_get(),
-                IntlDateFormatter::GREGORIAN,
+                $calendar,
                 $converted_format
             );
             $output = $this->dateObject->format($timestamp);


### PR DESCRIPTION
Ref: https://github.com/zencart/zencart/pull/6239#issuecomment-1962285093
Ref: #6229 

@piloujp 

If someone wants to override the calendar used with `$zcDate->output()`, they can pass the desired calendar-related locale.
