### PR TITLE
Gather *all* fields from the address-book table

### DIFF
--- a/includes/classes/Customer.php
+++ b/includes/classes/Customer.php
@@ -559,7 +559,7 @@ class Customer extends base
         }
 
         $sql =
-            "SELECT address_book_id,
+            "SELECT ab.*,
                     entry_firstname AS firstname, entry_lastname AS lastname,
                     entry_company AS company, entry_street_address AS street_address,
                     entry_suburb AS suburb, entry_city AS city, entry_postcode AS postcode,


### PR DESCRIPTION
In the restructuring of customer information to the `Customer` class, plugin additions to the `address_book` table have been lost.

Gather *all* fields from the `address_book` table in the `getFormattedAddressBookList` method to resurrect those fields.  See this VAT4EU issue for some of the fall-out: https://github.com/lat9/vat4eu/issues/23.

That way, all those fields will be present in each `addresses` array's `address` element for that (and other) plugins to us.