### PR TITLE
Remove double namespace from MeasurementUnits class

### DIFF
--- a/includes/classes/MeasurementUnits.php
+++ b/includes/classes/MeasurementUnits.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Zencart;
-
 use TypeError;
 
 class MeasurementUnits

--- a/includes/psr4Autoload.php
+++ b/includes/psr4Autoload.php
@@ -4,7 +4,7 @@
  * @license https://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: DrByte 2024 Feb 22 Modified in v2.0.0-beta1 $
  */
-
+/** @var \Aura\Autoload\Loader $psr4Autoloader */
 $psr4Autoloader->addPrefix('Zencart\QueryBuilder', DIR_FS_CATALOG . DIR_WS_CLASSES);
 $psr4Autoloader->addPrefix('Zencart\Traits', DIR_FS_CATALOG . DIR_WS_CLASSES . 'traits');
 $psr4Autoloader->addPrefix('Zencart\FileSystem', DIR_FS_CATALOG . DIR_WS_CLASSES );
@@ -14,7 +14,7 @@ $psr4Autoloader->addPrefix('Zencart\LanguageLoader', DIR_FS_CATALOG . DIR_WS_CLA
 $psr4Autoloader->addPrefix('Zencart\ResourceLoaders', DIR_FS_CATALOG . DIR_WS_CLASSES . 'ResourceLoaders');
 $psr4Autoloader->addPrefix('Zencart\PageLoader', DIR_FS_CATALOG . DIR_WS_CLASSES . 'ResourceLoaders');
 $psr4Autoloader->addPrefix('Zencart\Events', DIR_FS_CATALOG . DIR_WS_CLASSES );
-$psr4Autoloader->addPrefix('Zencart\MeasurementUnits', DIR_FS_CATALOG . DIR_WS_CLASSES );
+$psr4Autoloader->setClassFile('MeasurementUnits', DIR_FS_CATALOG . DIR_WS_CLASSES . 'MeasurementUnits.php' );
 $psr4Autoloader->addPrefix('Zencart\PluginSupport', DIR_FS_CATALOG . DIR_WS_CLASSES . 'PluginSupport');
 $psr4Autoloader->addPrefix('Zencart\ViewBuilders', DIR_FS_CATALOG . DIR_WS_CLASSES . 'ViewBuilders');
 $psr4Autoloader->addPrefix('Zencart\Exceptions', DIR_FS_CATALOG . DIR_WS_CLASSES . 'Exceptions');


### PR DESCRIPTION
Moving it from `\Zencart\Zencart\MeasurementUnits` to just `MeasurementUnits` seems to make it more intuitive.

This has not been officially released yet, so this is probably the best time to do it.