### PR TITLE
Allow optional parameter to be null

### DIFF
--- a/includes/classes/MeasurementUnits.php
+++ b/includes/classes/MeasurementUnits.php
@@ -7,7 +7,7 @@ class MeasurementUnits
     /**
      * Convert weight from one unit to another
      */
-    public static function convertWeight(float|int $incoming, string $from_unit, string $to_unit, ?int $precision): float|int
+    public static function convertWeight(float|int $incoming, string $from_unit, string $to_unit, ?int $precision = null): float|int
     {
         if (!in_array($from_unit, ['lbs', 'kgs', 'oz', 'g'])) {
             throw new TypeError('Invalid weight unit for $from_unit: ' . $from_unit);
@@ -49,7 +49,7 @@ class MeasurementUnits
     /**
      * Convert lengths from one unit to another
      */
-    public static function convertLength(float|int $incoming, string $from_unit, string $to_unit, ?int $precision): float
+    public static function convertLength(float|int $incoming, string $from_unit, string $to_unit, ?int $precision = null): float
     {
         if (!in_array($from_unit, ['in', 'cm'])) {
             throw new TypeError('Invalid length unit for $from_unit: ' . $from_unit);


### PR DESCRIPTION
Intent was to be able to drop the last `null` from this:
`MeasurementUnits::convertWeight(10, 'lbs', 'oz', null)`
like:
`MeasurementUnits::convertWeight(10, 'lbs', 'oz')`