### PR TITLE
Add $tplSetting object for accessing Template Settings

### DIFF
--- a/includes/classes/Settings.php
+++ b/includes/classes/Settings.php
@@ -1,0 +1,194 @@
+<?php
+
+/**
+ * @copyright Copyright 2003-2024 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id:  New in v2.0.0 $
+ */
+
+abstract class Settings implements ArrayAccess, Countable
+{
+    /**
+     * If $this->settings[$key] not found, look for a defined($key) constant.
+     */
+    protected bool $includeConstants = false;
+
+    /**
+     * Stores all the "set" settings
+     */
+    protected array $settings = [];
+
+    /**
+     * Tracks requested type-casting instructions
+     */
+    protected array $types = [];
+
+    public function __construct(array $settings = [])
+    {
+        $this->setFromArray($settings);
+    }
+
+    /**
+     * Set multiple settings via an array.
+     * The array can be entries of $key=>$value and/or $key=>['value'=>$value, 'type'=>$type]
+     * If $overwrite is false then existing $keys will be ignored.
+     *
+     * @param array|null $settings_array
+     * @param bool $overwrite
+     * @return void
+     */
+    public function setFromArray(?array $settings_array = null, bool $overwrite = false): void
+    {
+        if (empty($settings_array)) {
+            return;
+        }
+
+        foreach ($settings_array as $key => $value) {
+            // caveat: offsetExists() also checks for constants if the flag is enabled; bypass by calling setType() instead.
+            if (!$overwrite && $this->offsetExists($key)) {
+                continue;
+            }
+
+            $this->offsetSet($key, $value);
+        }
+    }
+
+    /**
+     * Specify a PHP data type to be cast to when accessing a setting as a class property
+     *
+     */
+    public function setType(string $key, ?string $type = null): void
+    {
+        if (!in_array($type, ['string', 'boolean', 'bool', 'int', 'integer', 'double', 'real', 'float', 'array', null], true)) {
+            throw new TypeError('Invalid type specified: ' . $type);
+        }
+
+        if ($this->offsetExists($key)) {
+            $this->types[$key] = $type;
+        }
+    }
+
+    /**
+     * Cast a value to a desired type
+     */
+    protected function returnCastValue(mixed $value, ?string $cast_to): mixed
+    {
+        if ($cast_to === null) {
+            return $value;
+        }
+
+        // Handle boolean strings if boolean requested
+        if (is_string($value) && str_starts_with($cast_to, 'bool') && in_array($value, ['true', 'TRUE', 'false', 'FALSE',])) {
+            return match ($value) {
+                'true', 'TRUE' => true,
+                'false', 'FALSE' => false,
+            };
+        }
+
+        return match ($cast_to) {
+            'string' => (string)$value,
+            'boolean', 'bool' => (bool)$value,
+            'int', 'integer' => (int)$value,
+            'double', 'real', 'float' => (float)$value,
+            'array' => (is_array($value)) ? $value : [$value],
+            default => $value,
+        };
+    }
+
+    protected function globalConstantExists(string $constant_name): bool
+    {
+        return defined($constant_name);
+    }
+
+    protected function getGlobalConstant(string $constant_name): mixed
+    {
+        return defined($constant_name) ? constant($constant_name) : null;
+    }
+
+    public function __isset($key)
+    {
+        return $this->offsetExists($key);
+    }
+
+    /**
+     * @implements ArrayAccess
+     */
+    public function offsetExists(mixed $offset): bool
+    {
+        if ($this->includeConstants) {
+            return isset($this->settings[$offset]) || $this->globalConstantExists($offset);
+        }
+
+        return isset($this->settings[$offset]);
+    }
+
+    public function __set($setting, $value)
+    {
+        $this->offsetSet($setting, $value);
+    }
+
+    /**
+     * @implements ArrayAccess
+     */
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        if (is_null($offset)) {
+            throw new TypeError('Key must not be null.');
+        }
+
+        if (isset($value['value'], $value['type'])) {
+            $this->settings[$offset] = $value['value'];
+            $this->types[$offset] = $value['type'];
+        } elseif (isset($value['value'])) {
+            $this->settings[$offset] = $value['value'];
+        } elseif (isset($value['type'])) {
+            $this->types[$offset] = $value['type'];
+        } else {
+            $this->settings[$offset] = $value;
+        }
+    }
+
+    public function __unset(string $key)
+    {
+        $this->offsetUnset($key);
+    }
+
+    /**
+     * @implements ArrayAccess
+     */
+    public function offsetUnset(mixed $offset): void
+    {
+        if ($this->offsetExists($offset)) {
+            unset($this->settings[$offset], $this->types[$offset]);
+        }
+    }
+
+    public function __get(string $key)
+    {
+        if (!$this->offsetExists($key)) {
+            return null;
+        }
+
+        if ($this->includeConstants) {
+            return $this->returnCastValue($this->settings[$key] ?? $this->getGlobalConstant($key), $this->types[$key] ?? null);
+        }
+
+        return $this->returnCastValue($this->settings[$key], $this->types[$key] ?? null);
+    }
+
+    /**
+     * @implements ArrayAccess
+     */
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->offsetExists($offset) ? $this->__get($offset) : null;
+    }
+
+    /**
+     * @implements Countable
+     */
+    public function count(): int
+    {
+        return count($this->settings);
+    }
+}

--- a/includes/classes/TemplateSettings.php
+++ b/includes/classes/TemplateSettings.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @copyright Copyright 2003-2024 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id:  New in v2.0.0 $
+ */
+
+class TemplateSettings extends Settings
+{
+    protected bool $includeConstants = true;
+
+    public function __construct(array $settings = [])
+    {
+        parent::__construct();
+
+        /**
+         * If no $settings were passed to the constructor,
+         * look for the global $tpl_settings array and import it.
+         */
+        if (empty($settings) && !empty($GLOBALS['tpl_settings'])) {
+            $this->setFromArray($GLOBALS['tpl_settings']);
+        }
+    }
+}

--- a/includes/functions/functions_general_shared.php
+++ b/includes/functions/functions_general_shared.php
@@ -61,85 +61,19 @@ function fmod_round($x, $y)
 }
 
 /**
- * Template settings access helper function.
- * This will first look to the global $tpl_settings array for the setting key (the name of the constant being overridden)
- * Lookup order:
- * - $tpl_settings array key
- * - global CONSTANT
- * - global $var by same name, if requested
- *
- * All returned values will be passed through zen_cast() to allow casting to desired type, if specified.
- *
- * If nothing is found, the supplied default will be returned. Else null.
- */
-function tpl(string $setting, string $cast_to = null, $default = null, bool $check_globals = false): mixed
-{
-    // Check whether the $tpl_settings array contains the $setting
-    // It could be populated from the template_settings.php file or the template_settings JSON field in the db
-    global $tpl_settings;
-    if (isset($tpl_settings[$setting])) {
-        return zen_cast($tpl_settings[$setting], $cast_to);
-    }
-
-    // Fallback to a globally-defined constant, if it exists
-    if (defined($setting)) {
-        return zen_cast(constant($setting), $cast_to);
-    }
-
-    // Else fall back to a global variable
-    if ($check_globals) {
-        // first exact case as supplied
-        if (isset($GLOBALS[$setting])) {
-            return zen_cast($GLOBALS[$setting], $cast_to);
-        }
-        // next check all lower-case
-        $setting = strtolower($setting); // $setting is not used again below, so convert directly
-        if (isset($GLOBALS[$setting])) {
-            return zen_cast($GLOBALS[$setting], $cast_to);
-        }
-    }
-
-    // Else return the provided default, if any
-    if ($default !== null) {
-        return zen_cast($default, $cast_to);
-    }
-
-    return null;
-}
-
-/**
- * Cast an input to a desired type; Frequently used by the tpl() template-settings helper function.
+ * Cast an input to a desired type.
  * (Note: does not operate recursively on arrays)
  */
 function zen_cast($input, ?string $cast_to): mixed
 {
-    // null case is listed first because it's likely to be the most common when called from the tpl() function
-    // null treats it as a passthrough, doing no casting.
-    if ($cast_to === null) {
-        return $input;
-    }
-
-    switch ($cast_to) {
-        case 'string':
-            return (string)$input;
-        case 'boolean':
-        case 'bool':
-            return (bool)$input;
-        case 'int':
-        case 'integer':
-            return (int)$input;
-        case 'double':
-        case 'float':
-            return (float)$input;
-        case 'array':
-            if (is_array($input)) {
-                return $input;
-            }
-            return [$input];
-        case 'passthru':
-        default:
-            return $input;
-    }
+    return match ($cast_to) {
+        'string' => (string)$input,
+        'boolean', 'bool' => (bool)$input,
+        'int', 'integer' => (int)$input,
+        'double', 'float' => (float)$input,
+        'array' => (is_array($input)) ? $input : [$input],
+        default => $input,
+    };
 }
 
 /**

--- a/includes/psr4Autoload.php
+++ b/includes/psr4Autoload.php
@@ -23,3 +23,5 @@ $psr4Autoloader->addPrefix('Zencart\Request', DIR_FS_CATALOG . DIR_WS_CLASSES);
 if (defined('DIR_FS_ADMIN')) {
     $psr4Autoloader->addPrefix('Zencart\Paginator', DIR_FS_ADMIN . DIR_WS_CLASSES);
 }
+$psr4Autoloader->setClassFile('Settings', DIR_FS_CATALOG . DIR_WS_CLASSES . 'Settings.php' );
+$psr4Autoloader->setClassFile('TemplateSettings', DIR_FS_CATALOG . DIR_WS_CLASSES . 'TemplateSettings.php' );

--- a/includes/templates/responsive_classic/template_settings.php
+++ b/includes/templates/responsive_classic/template_settings.php
@@ -5,20 +5,21 @@
  * You may define here any variables or settings that are specific to this template.
  * And then in your template, you can reference these variables as needed, independent of other templates.
  *
- * Any settings that you add to the $tpl_settings[] array can be retrieved via the tpl() helper function,
+ * Any settings that you add to the $tpl_settings[] array can be retrieved via the $tplSetting object,
  * which also lets you lookup global constants defined in the Admin as a fallback in case that setting
  * isn't in the $tpl_settings array.
  *
  * NOTE: Wherever a template hard-codes a CONSTANT that's defined globally in the Admin, that will be used
  * directly whether or not there is an override set in this file.
- * To override any global setting you'll need to update your template to use the tpl() helper function instead.
+ * To override any global setting you'll need to update your template to use the $tplSetting object instead.
  *
- * eg: SHOW_BANNERS_GROUP_SET1 could be replaced in your template with tpl('SHOW_BANNERS_GROUP_SET1'), and
- * then first the settings below will be consulted, and if it's defined here it will be used, else it will
- * fallback to whatever the global setting is from the admin.
+ * eg: SHOW_BANNERS_GROUP_SET1 could be replaced in your template with $tplSetting->SHOW_BANNERS_GROUP_SET1
+ * and then first the settings below will be consulted, and if it's defined here it will be used, else it
+ * will fallback to whatever the global setting is from the admin.
  *
- * NOTE: The ADMIN area of your site will NOT be aware of any of these override settings as defined below.
+ * NOTE: The ADMIN config area of your site will NOT be aware of any of these override settings as defined below.
  *
+ * @var $tplSetting TemplateSettings
  */
 /** TPL_SETTINGS ARRAY */
 $tpl_settings['TEMPLATE_NAME'] = 'Responsive Classic';

--- a/includes/templates/template_default/template_settings.php
+++ b/includes/templates/template_default/template_settings.php
@@ -5,20 +5,21 @@
  * You may define here any variables or settings that are specific to this template.
  * And then in your template, you can reference these variables as needed, independent of other templates.
  *
- * Any settings that you add to the $tpl_settings[] array can be retrieved via the tpl() helper function,
+ * Any settings that you add to the $tpl_settings[] array can be retrieved via the $tplSetting object,
  * which also lets you lookup global constants defined in the Admin as a fallback in case that setting
  * isn't in the $tpl_settings array.
  *
  * NOTE: Wherever a template hard-codes a CONSTANT that's defined globally in the Admin, that will be used
  * directly whether or not there is an override set in this file.
- * To override any global setting you'll need to update your template to use the tpl() helper function instead.
+ * To override any global setting you'll need to update your template to use the $tplSetting object instead.
  *
- * eg: SHOW_BANNERS_GROUP_SET1 could be replaced in your template with tpl('SHOW_BANNERS_GROUP_SET1'), and
- * then first the settings below will be consulted, and if it's defined here it will be used, else it will
- * fallback to whatever the global setting is from the admin.
+ * eg: SHOW_BANNERS_GROUP_SET1 could be replaced in your template with $tplSetting->SHOW_BANNERS_GROUP_SET1
+ * and then first the settings below will be consulted, and if it's defined here it will be used, else it
+ * will fallback to whatever the global setting is from the admin.
  *
- * NOTE: The ADMIN area of your site will NOT be aware of any of these override settings as defined below.
+ * NOTE: The ADMIN config area of your site will NOT be aware of any of these override settings as defined below.
  *
+ * @var $tplSetting TemplateSettings
  */
 /** TPL_SETTINGS ARRAY */
 $tpl_settings['TEMPLATE_NAME'] = 'Template Default';


### PR DESCRIPTION
(This essentially makes the `tpl()` function unnecessary, so it is deleted here.)

The global var `$tplSetting` added here (can choose a different name before merge) is a (class) object that (initially) loads all its properties from the global `$tpl_settings[]` array found in `template_settings.php`. 
(Other "soft settings" global vars in that file are unrelated, and can happily be there without conflict.)

Example:
(These are hypothetical, illustrative only; I'm not suggesting that these actual settings would commonly be used.) `template_settings.php` contains:
```
$tpl_settings['SET_COLUMN_LEFT_LAYOUT'] = '2';
$tpl_settings['SET_COLUMN_RIGHT_LAYOUT'] = [
    'value' => '2',
    'type' => 'int',
    ];
$tpl_settings['BS4_AJAX_SEARCH_ENABLE'] = [
    'value' => 'true',
    'type' => 'string',
    ];
$tpl_settings['header_bg_color'] = '#F0F0F0';
```

In `tpl_main_page.php` it could be used thus:
`$tplSetting->SET_COLUMN_LEFT_LAYOUT` (returns string value '2' , straight passthru) 
`$tplSetting->SET_COLUMN_RIGHT_LAYOUT` (returns integer value 2, due to 'type' cast) 
`$tplSetting->BS4_AJAX_SEARCH_ENABLE` (returns string 'true') 
`$tplSetting->header_bg_color` (returns string '#F0F0F0')

Additionally, one could subsequently override a setting by setting it to a new value: 
`$tplSetting->header_bg_color = '#C3C3C3';`
and/or optionally casting it to a new Type:
`$tplSetting->setType('header_bg_color', 'array');`  (why you'd want an array for this, I dunno, again, example only) So now referencing it reports the changes:
`echo $tplSetting->header_bg_color`  (returns: `[0 => "#C3C3C3"]` )

For a db constant that has no entry in `$tpl_settings` array or in the `$tplSetting` object: 
`echo $tplSetting->ACCOUNT_STATE_DRAW_INITIAL_DROPDOWN;` gives string `'false'` because it's stored as string in configuration table. 
but call this first:
`$tplSetting->setType('ACCOUNT_STATE_DRAW_INITIAL_DROPDOWN', 'bool');` 
and now 
`echo $tplSetting->ACCOUNT_STATE_DRAW_INITIAL_DROPDOWN;` gives boolean `false`