### PR TITLE
Remove E_STRICT

### DIFF
--- a/ipn_main_handler.php
+++ b/ipn_main_handler.php
@@ -134,7 +134,7 @@ Processing...
     @ini_set('log_errors', 1);
     @ini_set('display_errors', 0); // do not output errors to screen/browser/client (only to log file)
     @ini_set('error_log', DIR_FS_CATALOG . $debug_logfile_path);
-    error_reporting(version_compare(PHP_VERSION, 5.3, '>=') ? E_ALL & ~E_DEPRECATED & ~E_NOTICE : (version_compare(PHP_VERSION, 5.4, '>=') ? E_ALL & ~E_DEPRECATED & ~E_NOTICE & ~E_STRICT : E_ALL & ~E_NOTICE));
+    error_reporting(E_ALL & ~E_DEPRECATED & ~E_NOTICE);
   }
 
   ipn_debug_email('Breakpoint: Flag Status:' . "\nisECtransaction = " . (int)$isECtransaction . "\nisDPtransaction = " . (int)$isDPtransaction);


### PR DESCRIPTION
It was retired in PHP 7.0
And is proposed to throw deprecations starting in PHP 8.4