### PR TITLE
Move session handling to OOP format for PHP 8.4 compatibility

### DIFF
--- a/includes/classes/SessionHandler.php
+++ b/includes/classes/SessionHandler.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Zen Cart Database Session Handler
+ *
+ * @copyright Copyright 2003-2024 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id:  New in v2.0.0 $
+ */
+
+namespace Zencart;
+
+class SessionHandler implements \SessionHandlerInterface
+{
+
+    /**
+     * @inheritDoc
+     */
+    public function close(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function destroy(string $id): bool
+    {
+        global $db;
+        $sql = "DELETE FROM " . TABLE_SESSIONS . " WHERE sesskey = '" . zen_db_input($id) . "'";
+        $db->Execute($sql);
+
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function gc(int $max_lifetime): int|false
+    {
+        global $db;
+        $sql = "DELETE FROM " . TABLE_SESSIONS . " WHERE expiry < " . time();
+        $db->Execute($sql);
+
+        return $db->affectedRows() ?? false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function open(string $path, string $name): bool
+    {
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function read(string $id): string|false
+    {
+        global $db;
+        $qid = "SELECT value
+                FROM " . TABLE_SESSIONS . "
+                WHERE sesskey = '" . zen_db_input($id) . "'
+                AND expiry > '" . time() . "'";
+
+        $value = $db->Execute($qid);
+
+        if (!empty($value->fields['value'])) {
+            $value->fields['value'] = base64_decode($value->fields['value']);
+            return $value->fields['value'];
+        }
+
+        return '';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function write(string $id, string $data): bool
+    {
+        global $db;
+        if (!is_object($db)) {
+            return false;
+        }
+        $data = base64_encode($data);
+
+        global $SESS_LIFE;
+        $expiry = time() + $SESS_LIFE;
+
+        $sql = "INSERT INTO " . TABLE_SESSIONS . " (sesskey, expiry, `value`)
+                VALUES (:zkey, :zexpiry, :zvalue)
+                ON DUPLICATE KEY UPDATE `value`=:zvalue, expiry=:zexpiry";
+
+        $sql = $db->bindVars($sql, ':zkey', $id, 'string');
+        $sql = $db->bindVars($sql, ':zexpiry', $expiry, 'integer');
+        $sql = $db->bindVars($sql, ':zvalue', $data, 'string');
+        $result = $db->Execute($sql);
+
+        return !empty($result->resource);
+    }
+}

--- a/includes/psr4Autoload.php
+++ b/includes/psr4Autoload.php
@@ -5,6 +5,7 @@
  * @version $Id: DrByte 2024 Feb 22 Modified in v2.0.0-beta1 $
  */
 /** @var \Aura\Autoload\Loader $psr4Autoloader */
+$psr4Autoloader->setClassFile('Zencart\SessionHandler', DIR_FS_CATALOG . DIR_WS_CLASSES . 'SessionHandler.php' );
 $psr4Autoloader->addPrefix('Zencart\QueryBuilder', DIR_FS_CATALOG . DIR_WS_CLASSES);
 $psr4Autoloader->addPrefix('Zencart\Traits', DIR_FS_CATALOG . DIR_WS_CLASSES . 'traits');
 $psr4Autoloader->addPrefix('Zencart\FileSystem', DIR_FS_CATALOG . DIR_WS_CLASSES );


### PR DESCRIPTION
Currently in PHP 8.4.0-dev the call to `session_set_save_handler()` only accepts 2 parameters, not the multiple procedural-style parameters that have historically been used. Throws deprecation notifications.

`PHP Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated`

This PR reworks the code to implement the [SessionHandlerInterface](https://www.php.net/manual/en/class.sessionhandlerinterface.php) which was introduced in PHP 5.4.0