### PR TITLE
Add INNER JOIN parser support

### DIFF
--- a/admin/sqlpatch.php
+++ b/admin/sqlpatch.php
@@ -251,6 +251,9 @@ function executeSql($lines, $database, $table_prefix = '') {
         case (substr($line_upper, 0, 7) == 'SELECT ' && substr_count($line_upper, 'FROM ') > 0):
           $line = str_ireplace('FROM ', 'FROM ' . $table_prefix, $line);
           break;
+        case (substr($line_upper, 0, 10) == 'INNER JOIN '):
+          $line = 'INNER JOIN ' . $table_prefix . ltrim(substr($line, 12));
+          break;
         case (substr($line_upper, 0, 10) == 'LEFT JOIN '):
           $line = 'LEFT JOIN ' . $table_prefix . ltrim(substr($line, 10));
           break;
@@ -873,4 +876,4 @@ if (!empty($action)) {
     </body>
   </html>
   <?php require(DIR_WS_INCLUDES . 'application_bottom.php');
-  
+

--- a/zc_install/includes/classes/class.zcDatabaseInstaller.php
+++ b/zc_install/includes/classes/class.zcDatabaseInstaller.php
@@ -580,6 +580,17 @@ class zcDatabaseInstaller
         }
     }
 
+    public function parserInnerJoin(): void
+    {
+        if (!$this->tableExists($this->lineSplit[2])) {
+            $result = sprintf(REASON_TABLE_NOT_FOUND, $this->lineSplit[2]) . ' CHECK PREFIXES!';
+            $this->writeUpgradeExceptions($this->line, $result, $this->fileName);
+            error_log($result . "\n" . $this->line . "\n---------------\n\n");
+        } else {
+            $this->line = 'INNER JOIN ' . $this->dbPrefix . substr($this->line, 12);
+        }
+    }
+
     public function parserLeftJoin(): void
     {
         if (!$this->tableExists($this->lineSplit[2])) {


### PR DESCRIPTION
Some `v200` SQL "upgrade" queries rely on INNER JOIN syntax, instead of just LEFT JOIN which is already supported.