### PR TITLE
Removed old bug correction for year 1969

### DIFF
--- a/includes/functions/functions_dates.php
+++ b/includes/functions/functions_dates.php
@@ -86,7 +86,6 @@ function zen_date_short($raw_date)
     $second = (int)substr($raw_date, 17, 2);
 
     return date(DATE_FORMAT, mktime($hour, $minute, $second, $month, $day, $year));
-
 }
 
 

--- a/includes/functions/functions_dates.php
+++ b/includes/functions/functions_dates.php
@@ -85,12 +85,7 @@ function zen_date_short($raw_date)
     $minute = (int)substr($raw_date, 14, 2);
     $second = (int)substr($raw_date, 17, 2);
 
-// error on 1969 only allows for leap year
-    if ($year != 1969 && @date('Y', mktime($hour, $minute, $second, $month, $day, $year)) == $year) {
-        return date(DATE_FORMAT, mktime($hour, $minute, $second, $month, $day, $year));
-    } else {
-        return preg_replace('/2037$/', $year, date(DATE_FORMAT, mktime($hour, $minute, $second, $month, $day, 2037)));
-    }
+    return date(DATE_FORMAT, mktime($hour, $minute, $second, $month, $day, $year));
 
 }
 


### PR DESCRIPTION
Fixes #6293
Removing code in zen_date_short function for an old bug that does not exist anymore and actually provoking a new bug in certain condition. See issue #6293.