### PR TITLE
Don't offer GV payment if order only has GV's

### DIFF
--- a/includes/modules/order_total/ot_gv.php
+++ b/includes/modules/order_total/ot_gv.php
@@ -279,11 +279,14 @@ class ot_gv {
                 break;
             }
         }
+        if ($only_gvs_in_order === true) {
+            return [];
+        }
 
         $selection = [];
         $gv_query = $db->Execute("SELECT coupon_id FROM " . TABLE_COUPONS . " WHERE coupon_type = 'G' AND coupon_active = 'Y' LIMIT 1");
         // checks to see if any GVs are in the system and active or if the current customer has any GV balance
-        if ($only_gvs_in_order === false && (!$gv_query->EOF || $this->use_credit_amount())) {
+        if (!$gv_query->EOF || $this->use_credit_amount()) {
             $selection = [
                 'id' => $this->code,
                 'module' => $this->title,


### PR DESCRIPTION
If an order has only Gift Certificates/Vouchers, don't offer Gift Vouchers as a possible payment for the order.

Processing currently displays on the `checkout_payment` page, but quietly disallows the GV payment if the order contains only GV products.