### PR TITLE
message in estimator when no shipping available

### DIFF
--- a/includes/languages/lang.english.php
+++ b/includes/languages/lang.english.php
@@ -463,6 +463,7 @@ $define = [
     'TEXT_NO_NEW_PRODUCTS' => 'More new products will be added soon. Please check back later.',
     'TEXT_NO_PROD_RESTRICTIONS' => 'This coupon is valid for all products.',
     'TEXT_NO_PROD_SALES' => 'This coupon is not valid for products on sale.',
+    'TEXT_NO_SHIPPING_AVAILABLE_ESTIMATOR' => 'Sorry, we have no online options for shipping this order to the address shown.  Please contact us for alternate arrangements!',
     'TEXT_NO_REVIEWS' => 'There are currently no product reviews.',
     'TEXT_NUMBER_SYMBOL' => '# ',
     'TEXT_OF_5_STARS' => '',

--- a/includes/templates/template_default/templates/tpl_modules_shipping_estimator.php
+++ b/includes/templates/template_default/templates/tpl_modules_shipping_estimator.php
@@ -166,7 +166,14 @@
       }
 ?>
 </table>
-<?php
+<?php 
+      if (empty($quotes)) { 
+?>
+      <div id="noShippingAvailable" class="alert important">
+         <?php echo TEXT_NO_SHIPPING_AVAILABLE_ESTIMATOR; ?>
+      </div>
+<?php 
+      } 
    }
   }
 echo '</form>'; ?>


### PR DESCRIPTION
If all shipping methods have zones set and the selected address (or entered data) is outside the zones, the estimator simply shows a blank below available methods.

<img width="600" alt="ship_before" src="https://github.com/zencart/zencart/assets/4391638/08912377-4109-4f08-9666-74bf02d9ef7f">

This change adds the warning message from the checkout page. 

<img width="600" alt="ship_after" src="https://github.com/zencart/zencart/assets/4391638/b6b4b428-1d20-45bb-9b0f-11fd88b290cf">


