### PR TITLE
Email failures: Don't log if message rejected for spam

### DIFF
--- a/includes/functions/functions_email.php
+++ b/includes/functions/functions_email.php
@@ -506,7 +506,10 @@
             if ($ErrorInfo !== '') {
                 $mail_langs = $mail->getTranslations();
                 if (strpos($ErrorInfo, $mail_langs['recipients_failed']) === false) {
-                    trigger_error('Email Error: ' . $ErrorInfo);
+                   // Don't log SMTP rejected spam; log others
+                   if (!str_contains($ErrorInfo, 'spam content')) {
+                       trigger_error('Email Error: ' . $ErrorInfo);
+                   }
                 } else {
                     $log_prefix = (IS_ADMIN_FLAG === true) ? '/myDEBUG-bounced-email-adm-' : '/myDEBUG-bounced-email-';
                     $log_date = new DateTime();


### PR DESCRIPTION
Seeing more and more of these: 

```
[13-Mar-2024 21:40:32 UTC] PHP Notice:  Email Error: SMTP Error: data not accepted.SMTP server error: DATA END command failed Detail: Mail contain spam content BCCCF140117^M
 SMTP code: 550 Additional SMTP info: 5.7.1
 in /home/account/domains/client.com/public_html/includes/functions/functions_email.php on line 426
```

There's no value to dropping a log; this is just idiots pasting in junk to the contact_us page. 

I suspect the message above was written by a non-native speaker of English and will eventually be corrected to say "Mail contain**s** spam content" so I'm just grepping for the last two words. 