### PR TITLE
change parameter of notifier in admin customers

### DIFF
--- a/admin/customers.php
+++ b/admin/customers.php
@@ -1700,7 +1700,7 @@ if ($action === 'edit' || $action === 'update') {
         $additional_columns = [];
         $zco_notifier->notify(
             'NOTIFY_ADMIN_CUSTOMERS_LISTING_ELEMENT',
-            $customer,
+            $result,
             $additional_columns
         );
         if (is_array($additional_columns) && count($additional_columns) !== 0) {

--- a/admin/customers.php
+++ b/admin/customers.php
@@ -1701,7 +1701,8 @@ if ($action === 'edit' || $action === 'update') {
         $zco_notifier->notify(
             'NOTIFY_ADMIN_CUSTOMERS_LISTING_ELEMENT',
             $result,
-            $additional_columns
+            $additional_columns,
+            $customer
         );
         if (is_array($additional_columns) && count($additional_columns) !== 0) {
             if (count($additional_columns) !== $additional_heading_count) {


### PR DESCRIPTION
this problem looks to be in v158 as well.  

in v157, we had the following:
https://github.com/zencart/zencart/blob/40c161c8f5c0d58ac9e39d2dec479780d522e47e/admin/customers.php#L1236-L1237

currently we have:
https://github.com/zencart/zencart/blob/0430d9573f21170459aadbb4585f6122a3f98d90/admin/customers.php#L1627-L1630

now, above this, there is this notifier:
https://github.com/zencart/zencart/blob/0430d9573f21170459aadbb4585f6122a3f98d90/admin/customers.php#L1580-L1585

now the var `$new_fields` is only used in the `$customers_query_raw` which is now ONLY used to get the customers_id and then use the Customer object.  so those new fields are now lost.  and certainly not available for use in the `NOTIFY_ADMIN_CUSTOMERS_LISTING_ELEMENT` notifier.

now, i suppose one could very easily get around this situation by pulling all of the data needed using the 2nd (`NOTIFY_ADMIN_CUSTOMERS_LISTING_ELEMENT`) notifier, but if that is what we want to do, my recommendation would be to remove the `$new_fields` parameter, because i can not see those fields being available for use in the code.

else, we can change the parameter in the notifier to `$result` as done in this PR and be back to the behavior seem in v157. 