### PR TITLE
Display "Single Column Settings" for responsive classic

### DIFF
--- a/includes/templates/responsive_classic/template_info.php
+++ b/includes/templates/responsive_classic/template_info.php
@@ -17,7 +17,6 @@ $template_description = 'This HTML5 template is mobile friendly and uses contemp
 $template_screenshot = 'scr_responsive_classic.jpg';
 
 // -----
-// Normally, this template does not use "Single Column Settings" in the admin's "Layout Controller",
-// but if a site has set the value, the template honors that setting.
+// Enable the admin's "Layout Controller" to also display the single-column layout settings.
 //
-$uses_single_column_layout_settings = (isset($uses_single_column_layout_settings)) ? $uses_single_column_layout_settings : false;
+$uses_single_column_layout_settings = true;


### PR DESCRIPTION
Force the "Layout Boxes Controller" to show the settings for "Single Column" mode for the `responsive_classic` template.