### PR TITLE
Centralize PCI configuration settings

### DIFF
--- a/admin/includes/functions/admin_access.php
+++ b/admin/includes/functions/admin_access.php
@@ -6,10 +6,10 @@
  * @version $Id: Scott C Wilson 2022 Nov 24 Modified in v1.5.8a $
  */
 
-if (!defined('ADMIN_PASSWORD_MIN_LENGTH')) define('ADMIN_PASSWORD_MIN_LENGTH', 7);
-
 // The admin login slamming threshold is the minimum number of failed logins before an email is sent to the storeowner reporting ongoing failed logins
 zen_define_default('ADMIN_LOGIN_SLAMMING_THRESHOLD', 3);
+// Do you want warning/courtesy emails to be sent after several login failures have occurred (determined by the threshold above)?
+zen_define_default('ADMIN_SWITCH_SEND_LOGIN_FAILURE_EMAILS', 'Yes');
 
 /**
  * Checks whether the currently logged on user has permission to access
@@ -400,7 +400,7 @@ function zen_validate_user_login(string $admin_name, string $admin_pass): array
             zen_mail($result['admin_name'], $result['admin_email'], TEXT_EMAIL_SUBJECT_LOGIN_FAILURES, sprintf(TEXT_EMAIL_MULTIPLE_LOGIN_FAILURES, $_SERVER['REMOTE_ADDR']), STORE_NAME, EMAIL_FROM, $html_msg, 'no_archive');
         }
         if ($expired_token < 10000) {
-            if ($_SESSION['login_attempt'] > 6 || (!empty($result) && $result['failed_logins'] > 6)) {
+            if ($_SESSION['login_attempt'] > (int)ADMIN_LOGIN_LOCKOUT_LIMIT || (!empty($result) && $result['failed_logins'] > (int)ADMIN_LOGIN_LOCKOUT_LIMIT)) {
                 $sql = "UPDATE " . TABLE_ADMIN . " SET lockout_expires = " . (time() + ADMIN_LOGIN_LOCKOUT_TIMER) . " WHERE admin_name = :adminname: ";
                 $sql = $db->bindVars($sql, ':adminname:', $admin_name, 'stringIgnoreNull');
                 $db->Execute($sql);

--- a/admin/includes/init_includes/init_general_funcs.php
+++ b/admin/includes/init_includes/init_general_funcs.php
@@ -13,6 +13,7 @@ if (!defined('IS_ADMIN_FLAG')) {
 define('BOX_WIDTH', 125); // how wide the boxes should be in pixels (default: 125)
 
 
+require 'includes/init_includes/init_pci_settings.php';
 
 require DIR_FS_CATALOG . DIR_WS_FUNCTIONS . 'database.php';
 

--- a/admin/includes/init_includes/init_pci_settings.php
+++ b/admin/includes/init_includes/init_pci_settings.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * PCI Settings
+ *
+ * PCI DSS standards require certain limits be enforced
+ *
+ * PCI rules apply if your store handles payment-processing of any kind.
+ *
+ * When payments are handled by 3rd-party providers,
+ * and when Admins have no access to customer card data or tokens,
+ * then one might be able to assert that their PCI requirements are less onerous.
+ * ... BUT ...
+ * BEFORE CHANGING ANY OF THESE VALUES, BE SURE TO CHECK WITH YOUR MERCHANT-ACCOUNT (PAYMENT) PROVIDERS.
+ *
+ * Additional PA-DSS settings can be controlled via Admin Configuration: My Store
+ *
+ * PCI 3 rules expire March 31, 2024 (and some merchants may have until March 2025 to switch to PCI 4)
+ * PCI 4 rules begin March 31, 2024, and will be required by all merchants by March 31, 2025.
+ *
+ *
+ * DEV NOTE: This file does not comply with the internal "overrides" capability. All edits must be made to this file directly.
+ */
+
+// Lockout threshold: number of (admin) failed-login attempts allowed before lockout is triggered
+// PCI3 had at lockout threshold of 6; PCI4 allows 10
+zen_define_default('ADMIN_LOGIN_LOCKOUT_LIMIT', 10);
+
+// Lockout duration: 30 minutes (30 * 60 seconds)
+zen_define_default('ADMIN_LOGIN_LOCKOUT_TIMER', (30 * 60));
+
+// Password length, for Admin users
+// PCI3 rules specify min length 7; PCI4 requires 12 (or at least 8 if 12 isn't possible) after 2025/03/31
+zen_define_default('ADMIN_PASSWORD_MIN_LENGTH', 8);
+
+// Password Rotation Cycle: 90 days
+zen_define_default('ADMIN_PASSWORD_EXPIRES_INTERVAL', strtotime('- 90 day'));
+

--- a/admin/login.php
+++ b/admin/login.php
@@ -7,11 +7,6 @@
  */
 require 'includes/application_top.php';
 
-define('ADMIN_SWITCH_SEND_LOGIN_FAILURE_EMAILS', 'Yes'); // Can be set to 'No' if you don't want warning/courtesy emails to be sent after several login failures have occurred
-// PCI-DSS / PA-DSS requirements for lockouts and intervals:
-define('ADMIN_LOGIN_LOCKOUT_TIMER', (30 * 60));
-define('ADMIN_PASSWORD_EXPIRES_INTERVAL', strtotime('- 90 day'));
-
 //////////
 $admin_name = $admin_pass = $message = "";
 $errors = array();


### PR DESCRIPTION
Move PCI-related configuration settings to a single file.

This lets a storeowner configure the values in a central place when standards change.