### PR TITLE
Correct ot_loworderfee PHP Deprecated log

### DIFF
--- a/includes/modules/order_total/ot_loworderfee.php
+++ b/includes/modules/order_total/ot_loworderfee.php
@@ -35,6 +35,11 @@ class ot_loworderfee
      */
     public $title;
     /**
+     * $enabled determines whether this module shows or not... during checkout.
+     * @var boolean
+     */
+    public $enabled;
+    /**
      * $output is an array of the display elements used on checkout pages
      * @var array
      */


### PR DESCRIPTION
Seeing logs like
```
[24-Mar-2024 15:48:37 America/New_York] Request URI: /zc200w/index.php?main_page=checkout_payment, IP address: 127.0.0.1, Language id 1
#0 C:\xampp\htdocs\zc200w\includes\modules\order_total\ot_loworderfee.php(48): zen_debug_error_handler()
#1 C:\xampp\htdocs\zc200w\includes\classes\order_total.php(56): ot_loworderfee->__construct()
#2 C:\xampp\htdocs\zc200w\includes\modules\pages\checkout_payment\header_php.php(99): order_total->__construct()
#3 C:\xampp\htdocs\zc200w\index.php(35): require('C:\\xampp\\htdocs...')
--> PHP Deprecated: Creation of dynamic property ot_loworderfee::$enabled is deprecated in C:\xampp\htdocs\zc200w\includes\modules\order_total\ot_loworderfee.php on line 48.
```