### PR TITLE
Product class

### DIFF
--- a/includes/classes/Product.php
+++ b/includes/classes/Product.php
@@ -1,0 +1,311 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright 2003-2024 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: DrByte  New in 2.1.0 $
+ *
+ * @var language $lng
+ * @var queryFactory $db
+ */
+
+use Zencart\Traits\NotifierManager;
+
+class Product
+{
+    use NotifierManager;
+
+    protected array $data;
+    protected array $languages;
+
+    /** @deprecated use ->get('property') or ->getData()  */
+    public array $fields;
+
+    /** @deprecated use !exists()  */
+    public bool $EOF = true;
+
+    public function __construct(protected ?int $product_id = null)
+    {
+        $this->initLanguages();
+
+        if ($this->product_id !== null) {
+            $this->data = $this->loadProductDetails($this->product_id);
+
+            // set some backward compatibility properties
+            $this->fields = $this->data;
+            $this->EOF = empty($this->data);
+        }
+    }
+
+    public function forLanguage(?int $language_id): self
+    {
+        $this->data = $this->getDataForLanguage($language_id);
+        $this->fields = $this->data;
+
+        return $this;
+    }
+
+    public function withDefaultLanguage(): self
+    {
+        $this->data = $this->getDataForLanguage();
+        $this->fields = $this->data;
+
+        return $this;
+    }
+
+    public function getData(): ?array
+    {
+        return $this->data;
+    }
+
+    public function get(string $name)
+    {
+        return $this->data[$name] ?? $this->data['lang'][$this->languages[(int)$_SESSION['languages_id']]] ?? null;
+    }
+
+    /**
+     * Same as getData(), but for specific language only
+     */
+    public function getDataForLanguage(?int $language_id = null): ?array
+    {
+        if (empty($language_id)) {
+            $language_id = (int)$_SESSION['languages_id'];
+        }
+        $data = $this->data;
+
+        // strip all languages except specified one, and merge into parent array instead of sub-array
+        foreach($data['lang'][$this->languages[$language_id]] as $key => $value) {
+            $data[$key] = $value;
+        }
+        unset($data['lang']);
+
+        return $data;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->product_id;
+    }
+
+    public function exists(): bool
+    {
+        return !empty($this->product_id);
+    }
+    public function isValid(): bool
+    {
+        return !empty($this->data);
+    }
+
+    public function isLinked(): bool
+    {
+        return ($this->data['linked_categories_count'] ?? 0) > 0;
+    }
+
+    public function isVirtual(): bool
+    {
+        return ($this->data['products_virtual'] ?? 0) === '1';
+    }
+
+    public function isAlwaysFreeShipping(): bool
+    {
+        return ($this->data['product_is_always_free_shipping'] ?? '') === '1';
+    }
+
+    public function status(): int
+    {
+        return (int)($this->data['products_status'] ?? 0);
+    }
+
+    public function isGiftVoucher(): bool
+    {
+        return str_starts_with($this->data['products_model'] ?? '', 'GIFT');
+    }
+
+    public function allowsAddToCart(): bool
+    {
+        if (empty($this->data)) {
+            return false;
+        }
+
+        $allow_add_to_cart = ($this->data['allow_add_to_cart'] ?? 'N') !== 'N';
+
+        if ($allow_add_to_cart && $this->isGiftVoucher()) {
+            // if GV feature disabled, can't allow GV's to be added to cart
+            if (!defined('MODULE_ORDER_TOTAL_GV_STATUS') || MODULE_ORDER_TOTAL_GV_STATUS !== 'true') {
+                $allow_add_to_cart = false;
+            }
+        }
+
+        $this->notify('NOTIFY_GET_PRODUCT_ALLOW_ADD_TO_CART', $this->product_id, $allow_add_to_cart, $this->data);
+
+        // test for boolean and for 'Y', since observer might try to return 'Y'
+        return in_array($allow_add_to_cart, [true, 'Y'], true);
+    }
+
+    public function getProductQuantity(): int|float
+    {
+        $quantity = $this->data['products_quantity'] ?? '0';
+        $this->notify('NOTIFY_GET_PRODUCT_QUANTITY', $this->product_id, $quantity);
+        return zen_str_to_numeric((string)$quantity);
+    }
+
+    public function getTypeHandler(): string
+    {
+        return ($this->data['type_handler'] ?? 'product');
+    }
+
+    public function getInfoPage(): string
+    {
+        return $this->getTypeHandler() . '_info';
+    }
+
+    public function hasPriceQuantityDiscounts(): bool
+    {
+        if (empty($this->data)) {
+            return false;
+        }
+
+        global $db;
+        $sql = "SELECT products_id FROM " . TABLE_PRODUCTS_DISCOUNT_QUANTITY . " WHERE products_id=" . (int)$this->product_id;
+        $results = $db->Execute($sql, 1);
+        return !$results->EOF;
+    }
+
+    public function hasPriceSpecials()
+    {
+        if (empty($this->data)) {
+            return false;
+        }
+
+        global $db;
+        $sql = "SELECT products_id FROM " . TABLE_SPECIALS . " WHERE products_id=" . (int)$this->product_id;
+        $results = $db->Execute($sql, 1);
+        return !$results->EOF;
+    }
+
+    public function priceIsByAttribute(): bool
+    {
+        return ($this->data['products_priced_by_attribute'] ?? '0') === '1';
+    }
+
+    public function priceIsFree(): bool
+    {
+        return ($this->data['product_is_free'] ?? '0') === '1';
+    }
+
+    public function priceIsCall(): bool
+    {
+        return ($this->data['product_is_call'] ?? '0') === '1';
+    }
+
+    public function __get(string $name)
+    {
+        return $this->get($name);
+    }
+
+    protected function loadProductDetails(int $product_id, ?int $language_id = null): array
+    {
+        global $db;
+
+        $sql = "SELECT p.*, pt.allow_add_to_cart, pt.type_handler, m.manufacturers_name, m.manufacturers_image
+                FROM " . TABLE_PRODUCTS . " p
+                LEFT JOIN " . TABLE_PRODUCT_TYPES . " pt ON (p.products_type = pt.type_id)
+                LEFT JOIN " . TABLE_MANUFACTURERS . " m USING (manufacturers_id)
+                WHERE p.products_id = " . (int)$product_id;
+        $product = $db->Execute($sql, 1, true, 900);
+
+        if ($product->EOF) {
+            return [];
+        }
+
+        $data = $product->fields;
+        $data['id'] = $data['products_id'];
+        $data['product_id'] = $data['products_id'];
+        $data['info_page'] = $data['type_handler'] . '_info';
+        //$data['parent_category_id'] = $data['master_categories_id'];
+
+        /**
+         * Add $data['lang'][code] = [products_name, products_description, etc] for each language
+         */
+        $sql = "SELECT pd.*
+                FROM " . TABLE_PRODUCTS_DESCRIPTION . " pd
+                WHERE pd.products_id = " . (int)$product_id . "
+                ORDER BY language_id";
+        $pd = $db->Execute($sql, null, true, 900);
+        foreach ($pd as $result) {
+            unset($result['products_id']);
+            $data['lang'][$this->languages[$result['language_id']]] = $result;
+        }
+
+        // count linked categories
+        $sql = "SELECT categories_id FROM " . TABLE_PRODUCTS_TO_CATEGORIES . " ptc WHERE products_id=" . (int)$product_id;
+        $results = $db->Execute($sql, null, true, 900);
+        $data['linked_categories_count'] = $results->RecordCount();
+        $data['linked_categories'] = [];
+        foreach($results as $result) {
+            $data['linked_categories'][] = $result['categories_id'];
+        }
+
+        // get cPath
+        $categories = [];
+        zen_get_parent_categories($categories, $data['master_categories_id']);
+        $categories = array_reverse($categories);
+        $categories[] = $data['master_categories_id'];
+        $data['cPath'] = implode('_', $categories);
+
+
+        //Allow an observer to modify details
+        $this->notify('NOTIFY_GET_PRODUCT_OBJECT_DETAILS', $product_id, $data);
+
+        return $data;
+    }
+
+    protected function initLanguages(): void
+    {
+        global $lng;
+
+        if ($lng === null) {
+            $lng = new language();
+        }
+
+        $this->languages = $lng->get_language_list();  // [1 => 'en', 2 => 'fr']
+    }
+}
+
+
+/* This class essentially deprecates the following functions (note Notifier hook differences):
+zen_get_product_details (er, well, it's now a helper to access this class)
+zen_get_products_category_id
+zen_products_id_valid
+zen_get_products_name
+zen_get_products_model
+zen_get_products_status
+zen_get_product_is_linked
+zen_get_products_stock (*)
+zen_get_products_manufacturers_name
+zen_get_products_manufacturers_image
+zen_get_products_manufacturers_id
+zen_get_products_url
+zen_get_products_description
+zen_get_info_page
+zen_get_products_type
+zen_get_products_image (er, well, must call zen_image yourself)
+zen_get_products_virtual
+zen_get_products_allow_add_to_cart
+zen_get_product_is_always_free_shipping
+zen_products_lookup
+zen_get_parent_category_id
+zen_has_product_discounts
+zen_has_product_specials
+zen_get_product_path
+zen_get_products_price_is_free
+zen_get_products_price_is_call
+zen_get_products_price_is_priced_by_attributes
+zen_get_products_quantity_order_min
+zen_get_products_quantity_order_units
+zen_get_products_quantity_order_max
+zen_get_products_qty_box_status
+zen_get_products_quantity_mixed
+
+*/

--- a/includes/modules/also_purchased_products.php
+++ b/includes/modules/also_purchased_products.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * also_purchased_products.php
  *
@@ -8,44 +9,49 @@
  * @version $Id: DrByte 2020 Dec 25 Modified in v1.5.8-alpha $
  */
 if (!defined('IS_ADMIN_FLAG')) {
-  die('Illegal Access');
+    die('Illegal Access');
 }
 if (isset($_GET['products_id']) && SHOW_PRODUCT_INFO_COLUMNS_ALSO_PURCHASED_PRODUCTS > 0 && MIN_DISPLAY_ALSO_PURCHASED > 0) {
+    $also_purchased_products = $db->ExecuteRandomMulti(sprintf(SQL_ALSO_PURCHASED, (int)$_GET['products_id'], (int)$_GET['products_id']), (int)MAX_DISPLAY_ALSO_PURCHASED);
 
-  $also_purchased_products = $db->ExecuteRandomMulti(sprintf(SQL_ALSO_PURCHASED, (int)$_GET['products_id'], (int)$_GET['products_id']), (int)MAX_DISPLAY_ALSO_PURCHASED);
+    $num_products_ordered = $also_purchased_products->RecordCount();
 
-  $num_products_ordered = $also_purchased_products->RecordCount();
+    $row = 0;
+    $col = 0;
+    $list_box_contents = [];
+    $title = '';
 
-  $row = 0;
-  $col = 0;
-  $list_box_contents = [];
-  $title = '';
+    // show only when 1 or more and equal to or greater than minimum set in admin
+    if ($num_products_ordered >= MIN_DISPLAY_ALSO_PURCHASED && $num_products_ordered > 0) {
+        if ($num_products_ordered < SHOW_PRODUCT_INFO_COLUMNS_ALSO_PURCHASED_PRODUCTS) {
+            $col_width = floor(100 / $num_products_ordered);
+        } else {
+            $col_width = floor(100 / SHOW_PRODUCT_INFO_COLUMNS_ALSO_PURCHASED_PRODUCTS);
+        }
 
-  // show only when 1 or more and equal to or greater than minimum set in admin
-  if ($num_products_ordered >= MIN_DISPLAY_ALSO_PURCHASED && $num_products_ordered > 0) {
-    if ($num_products_ordered < SHOW_PRODUCT_INFO_COLUMNS_ALSO_PURCHASED_PRODUCTS) {
-      $col_width = floor(100/$num_products_ordered);
-    } else {
-      $col_width = floor(100/SHOW_PRODUCT_INFO_COLUMNS_ALSO_PURCHASED_PRODUCTS);
+        while (!$also_purchased_products->EOF) {
+            $product_info = new Product($also_purchased_products->fields['products_id']);
+            $data = array_merge($also_purchased_products->fields, $product_info->getDataForLanguage());
+
+            $list_box_contents[$row][$col] = [
+                'params' => 'class="centerBoxContentsAlsoPurch"' . ' ' . 'style="width:' . $col_width . '%;"',
+                'text' => ((empty($data['products_image']) && (int)PRODUCTS_IMAGE_NO_IMAGE_STATUS === 0) ? ''
+                        : '<a href="' . zen_href_link(zen_get_info_page($data['products_id']), 'products_id=' . $data['products_id']) . '">'
+                        . zen_image(DIR_WS_IMAGES . $data['products_image'], $data['products_name'], SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT)
+                        . '</a><br>')
+                    . '<a href="' . zen_href_link(zen_get_info_page($data['products_id']), 'products_id=' . $data['products_id']) . '">' . $data['products_name'] . '</a>',
+            ];
+
+            $col++;
+            if ($col > (SHOW_PRODUCT_INFO_COLUMNS_ALSO_PURCHASED_PRODUCTS - 1)) {
+                $col = 0;
+                $row++;
+            }
+            $also_purchased_products->MoveNextRandom();
+        }
     }
-
-    while (!$also_purchased_products->EOF) {
-      $also_purchased_products->fields['products_name'] = zen_get_products_name($also_purchased_products->fields['products_id']);
-      $list_box_contents[$row][$col] = [
-          'params' => 'class="centerBoxContentsAlsoPurch"' . ' ' . 'style="width:' . $col_width . '%;"',
-          'text' => ((empty($also_purchased_products->fields['products_image']) && (int)PRODUCTS_IMAGE_NO_IMAGE_STATUS === 0) ? '' : '<a href="' . zen_href_link(zen_get_info_page($also_purchased_products->fields['products_id']), 'products_id=' . $also_purchased_products->fields['products_id']) . '">' . zen_image(DIR_WS_IMAGES . $also_purchased_products->fields['products_image'], $also_purchased_products->fields['products_name'], SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT) . '</a><br>') . '<a href="' . zen_href_link(zen_get_info_page($also_purchased_products->fields['products_id']), 'products_id=' . $also_purchased_products->fields['products_id']) . '">' . $also_purchased_products->fields['products_name'] . '</a>'
-      ];
-
-      $col ++;
-      if ($col > (SHOW_PRODUCT_INFO_COLUMNS_ALSO_PURCHASED_PRODUCTS - 1)) {
-        $col = 0;
-        $row ++;
-      }
-      $also_purchased_products->MoveNextRandom();
+    if ($also_purchased_products->RecordCount() > 0 && $also_purchased_products->RecordCount() >= MIN_DISPLAY_ALSO_PURCHASED) {
+        $title = '<h2 class="centerBoxHeading">' . TEXT_ALSO_PURCHASED_PRODUCTS . '</h2>';
+        $zc_show_also_purchased = true;
     }
-  }
-  if ($also_purchased_products->RecordCount() > 0 && $also_purchased_products->RecordCount() >= MIN_DISPLAY_ALSO_PURCHASED) {
-    $title = '<h2 class="centerBoxHeading">' . TEXT_ALSO_PURCHASED_PRODUCTS . '</h2>';
-    $zc_show_also_purchased = true;
-  }
 }

--- a/includes/modules/featured_products.php
+++ b/includes/modules/featured_products.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * featured_products module - prepares content for display
  *
@@ -8,84 +9,99 @@
  * @version $Id: brittainmark 2022 Oct 24 Modified in v1.5.8a $
  */
 if (!defined('IS_ADMIN_FLAG')) {
-  die('Illegal Access');
+    die('Illegal Access');
 }
 
 // initialize vars
-$categories_products_id_list = array();
+$categories_products_id_list = [];
 $list_of_products = '';
-$featured_products_query = '';
+$sql = '';
 $display_limit = '';
 
-if ( (($manufacturers_id > 0 && empty($_GET['filter_id'])) || !empty($_GET['music_genre_id']) || !empty($_GET['record_company_id'])) || empty($new_products_category_id) ) {
-  $featured_products_query = "SELECT p.products_id, p.products_image, pd.products_name, p.master_categories_id
-                              FROM " . TABLE_PRODUCTS . " p
-                              LEFT JOIN " . TABLE_FEATURED . " f ON p.products_id = f.products_id
-                              LEFT JOIN " . TABLE_PRODUCTS_DESCRIPTION . " pd ON p.products_id = pd.products_id
-                              AND pd.language_id = " . (int)$_SESSION['languages_id'] . "
-                              WHERE p.products_status = 1
-                              AND f.status = 1";
+if ((($manufacturers_id > 0 && empty($_GET['filter_id'])) || !empty($_GET['music_genre_id']) || !empty($_GET['record_company_id'])) || empty($new_products_category_id)) {
+    $sql = "SELECT p.products_id, p.products_image, pd.products_name, p.master_categories_id
+            FROM " . TABLE_PRODUCTS . " p
+            LEFT JOIN " . TABLE_FEATURED . " f ON p.products_id = f.products_id
+            LEFT JOIN " . TABLE_PRODUCTS_DESCRIPTION . " pd ON p.products_id = pd.products_id
+            AND pd.language_id = " . (int)$_SESSION['languages_id'] . "
+            WHERE p.products_status = 1
+            AND f.status = 1";
 } else {
-  // get all products and cPaths in this subcat tree
-  $productsInCategory = zen_get_categories_products_list( (($manufacturers_id > 0 && !empty($_GET['filter_id'])) ? zen_get_generated_category_path_rev($_GET['filter_id']) : $cPath), false, true, 0, $display_limit);
+    // get all products and cPaths in this subcat tree
+    $productsInCategory = zen_get_categories_products_list((($manufacturers_id > 0 && !empty($_GET['filter_id'])) ? zen_get_generated_category_path_rev($_GET['filter_id']) : $cPath), false, true, 0, $display_limit);
 
-  if (is_array($productsInCategory) && sizeof($productsInCategory) > 0) {
-    // build products-list string to insert into SQL query
-    foreach($productsInCategory as $key => $value) {
-      $list_of_products .= $key . ', ';
+    if (is_array($productsInCategory) && count($productsInCategory) > 0) {
+        // build products-list string to insert into SQL query
+        foreach ($productsInCategory as $key => $value) {
+            $list_of_products .= $key . ', ';
+        }
+        $list_of_products = substr($list_of_products, 0, -2); // remove trailing comma
+        $sql = "SELECT p.products_id, p.products_image, pd.products_name, p.master_categories_id
+                FROM " . TABLE_PRODUCTS . " p
+                LEFT JOIN " . TABLE_FEATURED . " f ON p.products_id = f.products_id
+                LEFT JOIN " . TABLE_PRODUCTS_DESCRIPTION . " pd ON p.products_id = pd.products_id
+                  AND pd.language_id = " . (int)$_SESSION['languages_id'] . "
+                WHERE p.products_status = 1
+                AND f.status = 1
+                AND p.products_id IN (" . $list_of_products . ")";
     }
-    $list_of_products = substr($list_of_products, 0, -2); // remove trailing comma
-    $featured_products_query = "SELECT p.products_id, p.products_image, pd.products_name, p.master_categories_id
-                                FROM " . TABLE_PRODUCTS . " p
-                                LEFT JOIN " . TABLE_FEATURED . " f ON p.products_id = f.products_id
-                                LEFT JOIN " . TABLE_PRODUCTS_DESCRIPTION . " pd ON p.products_id = pd.products_id
-                                  AND pd.language_id = " . (int)$_SESSION['languages_id'] . "
-                                WHERE p.products_status = 1
-                                AND f.status = 1
-                                AND p.products_id IN (" . $list_of_products . ")";
-  }
 }
-if ($featured_products_query != '') $featured_products = $db->ExecuteRandomMulti($featured_products_query, MAX_DISPLAY_SEARCH_RESULTS_FEATURED);
+if ($sql !== '') {
+    $featured_products = $db->ExecuteRandomMulti($sql, MAX_DISPLAY_SEARCH_RESULTS_FEATURED);
+}
 
 $row = 0;
 $col = 0;
-$list_box_contents = array();
+$list_box_contents = [];
 $title = '';
 
-$num_products_count = ($featured_products_query == '') ? 0 : $featured_products->RecordCount();
+$num_products_count = ($sql === '') ? 0 : $featured_products->RecordCount();
 
 // show only when 1 or more
 if ($num_products_count > 0) {
-  if ($num_products_count < SHOW_PRODUCT_INFO_COLUMNS_FEATURED_PRODUCTS || SHOW_PRODUCT_INFO_COLUMNS_FEATURED_PRODUCTS == 0) {
-    $col_width = floor(100/$num_products_count);
-  } else {
-    $col_width = floor(100/SHOW_PRODUCT_INFO_COLUMNS_FEATURED_PRODUCTS);
-  }
-  while (!$featured_products->EOF) {
-    $products_price = zen_get_products_display_price($featured_products->fields['products_id']);
-    if (!isset($productsInCategory[$featured_products->fields['products_id']])) $productsInCategory[$featured_products->fields['products_id']] = zen_get_generated_category_path_rev($featured_products->fields['master_categories_id']);
-
-    $zco_notifier->notify('NOTIFY_MODULES_FEATURED_PRODUCTS_B4_LIST_BOX', array(), $featured_products->fields, $products_price);
-
-    $list_box_contents[$row][$col] = array('params' =>'class="centerBoxContentsFeatured centeredContent back"' . ' ' . 'style="width:' . $col_width . '%;"',
-    'text' => (($featured_products->fields['products_image'] == '' and PRODUCTS_IMAGE_NO_IMAGE_STATUS == 0) ? '' : '<a href="' . zen_href_link(zen_get_info_page($featured_products->fields['products_id']), 'cPath=' . $productsInCategory[$featured_products->fields['products_id']] . '&products_id=' . $featured_products->fields['products_id']) . '">' . zen_image(DIR_WS_IMAGES . $featured_products->fields['products_image'], $featured_products->fields['products_name'], IMAGE_FEATURED_PRODUCTS_LISTING_WIDTH, IMAGE_FEATURED_PRODUCTS_LISTING_HEIGHT) . '</a><br>') . '<a href="' . zen_href_link(zen_get_info_page($featured_products->fields['products_id']), 'cPath=' . $productsInCategory[$featured_products->fields['products_id']] . '&products_id=' . $featured_products->fields['products_id']) . '">' . $featured_products->fields['products_name'] . '</a><br>' . $products_price);
-
-    $col ++;
-    if ($col > (SHOW_PRODUCT_INFO_COLUMNS_FEATURED_PRODUCTS - 1)) {
-      $col = 0;
-      $row ++;
-    }
-    $featured_products->MoveNextRandom();
-  }
-
-  if ($featured_products->RecordCount() > 0) {
-    if (!empty($current_category_id)) {
-      $category_title = zen_get_category_name((int)$current_category_id);
-      $title = '<h2 class="centerBoxHeading">' . TABLE_HEADING_FEATURED_PRODUCTS . ($category_title != '' ? ' - ' . $category_title : '') . '</h2>';
+    if ($num_products_count < SHOW_PRODUCT_INFO_COLUMNS_FEATURED_PRODUCTS || SHOW_PRODUCT_INFO_COLUMNS_FEATURED_PRODUCTS == 0) {
+        $col_width = floor(100 / $num_products_count);
     } else {
-      $title = '<h2 class="centerBoxHeading">' . TABLE_HEADING_FEATURED_PRODUCTS . '</h2>';
+        $col_width = floor(100 / SHOW_PRODUCT_INFO_COLUMNS_FEATURED_PRODUCTS);
     }
-    $zc_show_featured = true;
-  }
+    while (!$featured_products->EOF) {
+        $product_info = new Product($featured_products->fields['products_id']);
+        $data = $product_info->getDataForLanguage();
+
+        $products_price = zen_get_products_display_price($data['products_id']);
+        if (!isset($productsInCategory[$data['products_id']])) {
+            $productsInCategory[$data['products_id']] = zen_get_generated_category_path_rev($data['master_categories_id']);
+        }
+
+        $zco_notifier->notify('NOTIFY_MODULES_FEATURED_PRODUCTS_B4_LIST_BOX', [], $data, $products_price);
+
+        $list_box_contents[$row][$col] = [
+            'params' => 'class="centerBoxContentsFeatured centeredContent back"' . ' ' . 'style="width:' . $col_width . '%;"',
+            'text' => (($data['products_image'] === '' and PRODUCTS_IMAGE_NO_IMAGE_STATUS == 0) ? ''
+                    : '<a href="'
+                        . zen_href_link(zen_get_info_page($data['products_id']), 'cPath=' . $productsInCategory[$data['products_id']] . '&products_id=' . $data['products_id']) . '">'
+                        . zen_image(DIR_WS_IMAGES . $data['products_image'], $data['products_name'], IMAGE_FEATURED_PRODUCTS_LISTING_WIDTH, IMAGE_FEATURED_PRODUCTS_LISTING_HEIGHT)
+                    . '</a><br>')
+                . '<a href="' . zen_href_link(zen_get_info_page($data['products_id']), 'cPath=' . $productsInCategory[$data['products_id']] . '&products_id=' . $data['products_id']) . '">' . $data['products_name']
+                . '</a><br>' . $products_price,
+        ];
+
+        $col++;
+        if ($col > (SHOW_PRODUCT_INFO_COLUMNS_FEATURED_PRODUCTS - 1)) {
+            $col = 0;
+            $row++;
+        }
+        $featured_products->MoveNextRandom();
+    }
+
+    if ($featured_products->RecordCount() > 0) {
+        if (!empty($current_category_id)) {
+            $category_title = zen_get_category_name((int)$current_category_id);
+            $title = '<h2 class="centerBoxHeading">' . TABLE_HEADING_FEATURED_PRODUCTS . ($category_title !== '' ? ' - ' . $category_title : '') . '</h2>';
+        } else {
+            $title = '<h2 class="centerBoxHeading">' . TABLE_HEADING_FEATURED_PRODUCTS . '</h2>';
+        }
+        $zc_show_featured = true;
+    }
 }
 

--- a/includes/modules/new_products.php
+++ b/includes/modules/new_products.php
@@ -70,7 +70,7 @@ if ($num_products_count > 0) {
 
         $products_price = zen_get_products_display_price($new_products_id);
         $new_products_link = zen_href_link(zen_get_info_page($new_products_id), 'cPath=' . $productsInCategory[$new_products_id] . '&products_id=' . $new_products_id);
-        $new_products_name = $new_products->fields['products_name'];
+        $new_products_name = zen_get_products_name($new_products->fields['products_id']);
 
         if ($new_products->fields['products_image'] === '' && PRODUCTS_IMAGE_NO_IMAGE_STATUS === '0') {
             $new_products_image = '';
@@ -98,7 +98,7 @@ if ($num_products_count > 0) {
 
     if (!empty($current_category_id)) {
         $category_title = zen_get_category_name((int)$current_category_id);
-        $title = '<h2 class="centerBoxHeading">' . sprintf(TABLE_HEADING_NEW_PRODUCTS, $zcDate->output('%B')) . ($category_title != '' ? ' - ' . $category_title : '' ) . '</h2>';
+        $title = '<h2 class="centerBoxHeading">' . sprintf(TABLE_HEADING_NEW_PRODUCTS, $zcDate->output('%B')) . ($category_title !== '' ? ' - ' . $category_title : '' ) . '</h2>';
     } else {
         $title = '<h2 class="centerBoxHeading">' . sprintf(TABLE_HEADING_NEW_PRODUCTS, $zcDate->output('%B')) . '</h2>';
     }

--- a/includes/modules/pages/document_general_info/header_php.php
+++ b/includes/modules/pages/document_general_info/header_php.php
@@ -13,9 +13,9 @@ $zco_notifier->notify('NOTIFY_HEADER_START_DOCUMENT_GENERAL_INFO');
 
 require(DIR_WS_MODULES . zen_get_module_directory('require_languages.php'));
 
-$product_info = zen_get_product_details($products_id_current = (!empty($_GET['products_id']) ? (int)$_GET['products_id'] : 0));
-if (!empty($product_info->fields['type_handler']) && $current_page !== $product_info->fields['type_handler'] . '_info') {
-    zen_redirect(zen_href_link($product_info->fields['type_handler'] . '_info', zen_get_all_get_params()));
+$product_info = new Product($products_id_current = (!empty($_GET['products_id']) ? (int)$_GET['products_id'] : 0));
+if ($current_page !== $product_info->get('info_page')) {
+    zen_redirect(zen_href_link($product_info->get('info_page'), zen_get_all_get_params()));
 }
 
 zen_product_set_header_response($products_id_current, $product_info);

--- a/includes/modules/pages/document_general_info/main_template_vars.php
+++ b/includes/modules/pages/document_general_info/main_template_vars.php
@@ -14,11 +14,13 @@
   // This should be first line of the script:
   $zco_notifier->notify('NOTIFY_MAIN_TEMPLATE_VARS_START_DOCUMENT_GENERAL_INFO');
 
-  if (!isset($product_info->EOF, $product_info->fields['products_id'], $product_info->fields['products_status']) || (int)$product_info->fields['products_id'] !== (int)$_GET['products_id']) {
-    $product_info = zen_get_product_details($_GET['products_id']);
+  $product_info = $product_info ?? new Product($_GET['products_id']);
+
+  if (!isset($product_info->fields['products_id'], $product_info->fields['products_status']) || (int)$product_info->fields['products_id'] !== (int)$_GET['products_id']) {
+      $product_info = new Product($_GET['products_id']);
   }
 
-  $product_not_found = $product_info->EOF;
+  $product_not_found = !$product_info->exists();
 
   if (!defined('DISABLED_PRODUCTS_TRIGGER_HTTP200') || DISABLED_PRODUCTS_TRIGGER_HTTP200 !== 'true') {
       if (!$product_not_found && $product_info->fields['products_status'] != 1) {
@@ -38,7 +40,7 @@
 
     $products_price = $currencies->display_price($product_info->fields['products_price'], zen_get_tax_rate($product_info->fields['products_tax_class_id']));
 
-    $manufacturers_name= zen_get_products_manufacturers_name((int)$_GET['products_id']);
+    $manufacturers_name = $product_info->fields['manufacturers_name'];
 
     if ($new_price = zen_get_products_special_price($product_info->fields['products_id'])) {
       $specials_price = $currencies->display_price($new_price, zen_get_tax_rate($product_info->fields['products_tax_class_id']));
@@ -61,17 +63,17 @@
 
     $reviews = $db->Execute($reviews_query);
 
-  $products_name = $product_info->fields['products_name'];
+  $products_name = $product_info->fields['lang'][$_SESSION['languages_code']]['products_name'];
   $products_model = $product_info->fields['products_model'];
   // if no common markup tags in description, add line breaks for readability:
-  $products_description = (!preg_match('/(<br|<p|<div|<dd|<li|<span)/i', $product_info->fields['products_description']) ? nl2br($product_info->fields['products_description']) : $product_info->fields['products_description']);
+  $products_description = (!preg_match('/(<br|<p|<div|<dd|<li|<span)/i', $product_info->fields['lang'][$_SESSION['languages_code']]['products_description']) ? nl2br($product_info->fields['lang'][$_SESSION['languages_code']]['products_description']) : $product_info->fields['lang'][$_SESSION['languages_code']]['products_description']);
 
   $products_image = (($product_not_found || $product_info->fields['products_image'] == '') && PRODUCTS_IMAGE_NO_IMAGE_STATUS == '1') ? PRODUCTS_IMAGE_NO_IMAGE : '';
   if ($product_info->fields['products_image'] != '' || PRODUCTS_IMAGE_NO_IMAGE_STATUS != '1') {
     $products_image = $product_info->fields['products_image'];
   }
 
-  $products_url = $product_info->fields['products_url'];
+  $products_url = $product_info->fields['lang'][$_SESSION['languages_code']]['products_url'];
   $products_date_available = $product_info->fields['products_date_available'];
   $products_date_added = $product_info->fields['products_date_added'];
   $products_manufacturer = $manufacturers_name;

--- a/includes/modules/pages/document_product_info/header_php.php
+++ b/includes/modules/pages/document_product_info/header_php.php
@@ -13,9 +13,9 @@ $zco_notifier->notify('NOTIFY_HEADER_START_DOCUMENT_PRODUCT_INFO');
 
 require(DIR_WS_MODULES . zen_get_module_directory('require_languages.php'));
 
-$product_info = zen_get_product_details($products_id_current = (!empty($_GET['products_id']) ? (int)$_GET['products_id'] : 0));
-if (!empty($product_info->fields['type_handler']) && $current_page !== $product_info->fields['type_handler'] . '_info') {
-    zen_redirect(zen_href_link($product_info->fields['type_handler'] . '_info', zen_get_all_get_params()));
+$product_info = new Product($products_id_current = (!empty($_GET['products_id']) ? (int)$_GET['products_id'] : 0));
+if ($current_page !== $product_info->get('info_page')) {
+    zen_redirect(zen_href_link($product_info->get('info_page'), zen_get_all_get_params()));
 }
 
 zen_product_set_header_response($products_id_current, $product_info);

--- a/includes/modules/pages/document_product_info/main_template_vars.php
+++ b/includes/modules/pages/document_product_info/main_template_vars.php
@@ -14,11 +14,13 @@
   // This should be first line of the script:
   $zco_notifier->notify('NOTIFY_MAIN_TEMPLATE_VARS_START_DOCUMENT_PRODUCT_INFO');
 
-  if (!isset($product_info->EOF, $product_info->fields['products_id'], $product_info->fields['products_status']) || (int)$product_info->fields['products_id'] !== (int)$_GET['products_id']) {
-    $product_info = zen_get_product_details($_GET['products_id']);
+  $product_info = $product_info ?? new Product($_GET['products_id']);
+
+  if (!isset($product_info->fields['products_id'], $product_info->fields['products_status']) || (int)$product_info->fields['products_id'] !== (int)$_GET['products_id']) {
+      $product_info = new Product($_GET['products_id']);
   }
 
-  $product_not_found = $product_info->EOF;
+  $product_not_found = !$product_info->exists();
 
   if (!defined('DISABLED_PRODUCTS_TRIGGER_HTTP200') || DISABLED_PRODUCTS_TRIGGER_HTTP200 !== 'true') {
       if (!$product_not_found && $product_info->fields['products_status'] != 1) {
@@ -38,7 +40,7 @@
 
     $products_price = $currencies->display_price($product_info->fields['products_price'], zen_get_tax_rate($product_info->fields['products_tax_class_id']));
 
-    $manufacturers_name= zen_get_products_manufacturers_name((int)$_GET['products_id']);
+    $manufacturers_name = $product_info->fields['manufacturers_name'];
 
     if ($new_price = zen_get_products_special_price($product_info->fields['products_id'])) {
       $specials_price = $currencies->display_price($new_price, zen_get_tax_rate($product_info->fields['products_tax_class_id']));
@@ -61,17 +63,17 @@
 
     $reviews = $db->Execute($reviews_query);
 
-  $products_name = $product_info->fields['products_name'];
+  $products_name = $product_info->fields['lang'][$_SESSION['languages_code']]['products_name'];
   $products_model = $product_info->fields['products_model'];
   // if no common markup tags in description, add line breaks for readability:
-  $products_description = (!preg_match('/(<br|<p|<div|<dd|<li|<span)/i', $product_info->fields['products_description']) ? nl2br($product_info->fields['products_description']) : $product_info->fields['products_description']);
+  $products_description = (!preg_match('/(<br|<p|<div|<dd|<li|<span)/i', $product_info->fields['lang'][$_SESSION['languages_code']]['products_description']) ? nl2br($product_info->fields['lang'][$_SESSION['languages_code']]['products_description']) : $product_info->fields['lang'][$_SESSION['languages_code']]['products_description']);
 
   $products_image = (($product_not_found || $product_info->fields['products_image'] == '') && PRODUCTS_IMAGE_NO_IMAGE_STATUS == '1') ? PRODUCTS_IMAGE_NO_IMAGE : '';
   if ($product_info->fields['products_image'] != '' || PRODUCTS_IMAGE_NO_IMAGE_STATUS != '1') {
     $products_image = $product_info->fields['products_image'];
   }
 
-  $products_url = $product_info->fields['products_url'];
+  $products_url = $product_info->fields['lang'][$_SESSION['languages_code']]['products_url'];
   $products_date_available = $product_info->fields['products_date_available'];
   $products_date_added = $product_info->fields['products_date_added'];
   $products_manufacturer = $manufacturers_name;

--- a/includes/modules/pages/product_free_shipping_info/header_php.php
+++ b/includes/modules/pages/product_free_shipping_info/header_php.php
@@ -13,9 +13,9 @@ $zco_notifier->notify('NOTIFY_HEADER_START_PRODUCT_FREE_SHIPPING_INFO');
 
 require(DIR_WS_MODULES . zen_get_module_directory('require_languages.php'));
 
-$product_info = zen_get_product_details($products_id_current = (!empty($_GET['products_id']) ? (int)$_GET['products_id'] : 0));
-if (!empty($product_info->fields['type_handler']) && $current_page !== $product_info->fields['type_handler'] . '_info') {
-    zen_redirect(zen_href_link($product_info->fields['type_handler'] . '_info', zen_get_all_get_params()));
+$product_info = new Product($products_id_current = (!empty($_GET['products_id']) ? (int)$_GET['products_id'] : 0));
+if ($current_page !== $product_info->get('info_page')) {
+    zen_redirect(zen_href_link($product_info->get('info_page'), zen_get_all_get_params()));
 }
 
 zen_product_set_header_response($products_id_current, $product_info);

--- a/includes/modules/pages/product_free_shipping_info/main_template_vars.php
+++ b/includes/modules/pages/product_free_shipping_info/main_template_vars.php
@@ -14,11 +14,13 @@
   // This should be first line of the script:
   $zco_notifier->notify('NOTIFY_MAIN_TEMPLATE_VARS_START_PRODUCT_FREE_SHIPPING_INFO');
 
-  if (!isset($product_info->EOF, $product_info->fields['products_id'], $product_info->fields['products_status']) || (int)$product_info->fields['products_id'] !== (int)$_GET['products_id']) {
-    $product_info = zen_get_product_details($_GET['products_id']);
+  $product_info = $product_info ?? new Product($_GET['products_id']);
+
+  if (!isset($product_info->fields['products_id'], $product_info->fields['products_status']) || (int)$product_info->fields['products_id'] !== (int)$_GET['products_id']) {
+      $product_info = new Product($_GET['products_id']);
   }
 
-  $product_not_found = $product_info->EOF;
+  $product_not_found = !$product_info->exists();
 
   if (!defined('DISABLED_PRODUCTS_TRIGGER_HTTP200') || DISABLED_PRODUCTS_TRIGGER_HTTP200 !== 'true') {
       if (!$product_not_found && $product_info->fields['products_status'] != 1) {
@@ -38,7 +40,7 @@
 
     $products_price = $currencies->display_price($product_info->fields['products_price'], zen_get_tax_rate($product_info->fields['products_tax_class_id']));
 
-    $manufacturers_name= zen_get_products_manufacturers_name((int)$_GET['products_id']);
+    $manufacturers_name = $product_info->fields['manufacturers_name'];
 
     if ($new_price = zen_get_products_special_price($product_info->fields['products_id'])) {
       $specials_price = $currencies->display_price($new_price, zen_get_tax_rate($product_info->fields['products_tax_class_id']));
@@ -61,17 +63,17 @@
 
     $reviews = $db->Execute($reviews_query);
 
-  $products_name = $product_info->fields['products_name'];
+  $products_name = $product_info->fields['lang'][$_SESSION['languages_code']]['products_name'];
   $products_model = $product_info->fields['products_model'];
   // if no common markup tags in description, add line breaks for readability:
-  $products_description = (!preg_match('/(<br|<p|<div|<dd|<li|<span)/i', $product_info->fields['products_description']) ? nl2br($product_info->fields['products_description']) : $product_info->fields['products_description']);
+  $products_description = (!preg_match('/(<br|<p|<div|<dd|<li|<span)/i', $product_info->fields['lang'][$_SESSION['languages_code']]['products_description']) ? nl2br($product_info->fields['lang'][$_SESSION['languages_code']]['products_description']) : $product_info->fields['lang'][$_SESSION['languages_code']]['products_description']);
 
   $products_image = (($product_not_found || $product_info->fields['products_image'] == '') && PRODUCTS_IMAGE_NO_IMAGE_STATUS == '1') ? PRODUCTS_IMAGE_NO_IMAGE : '';
   if ($product_info->fields['products_image'] != '' || PRODUCTS_IMAGE_NO_IMAGE_STATUS != '1') {
     $products_image = $product_info->fields['products_image'];
   }
 
-  $products_url = $product_info->fields['products_url'];
+  $products_url = $product_info->fields['lang'][$_SESSION['languages_code']]['products_url'];
   $products_date_available = $product_info->fields['products_date_available'];
   $products_date_added = $product_info->fields['products_date_added'];
   $products_manufacturer = $manufacturers_name;

--- a/includes/modules/pages/product_info/header_php.php
+++ b/includes/modules/pages/product_info/header_php.php
@@ -13,9 +13,9 @@ $zco_notifier->notify('NOTIFY_HEADER_START_PRODUCT_INFO');
 
 require(DIR_WS_MODULES . zen_get_module_directory('require_languages.php'));
 
-$product_info = zen_get_product_details($products_id_current = (!empty($_GET['products_id']) ? (int)$_GET['products_id'] : 0));
-if (!empty($product_info->fields['type_handler']) && $current_page !== $product_info->fields['type_handler'] . '_info') {
-    zen_redirect(zen_href_link($product_info->fields['type_handler'] . '_info', zen_get_all_get_params()));
+$product_info = new Product($products_id_current = (!empty($_GET['products_id']) ? (int)$_GET['products_id'] : 0));
+if ($current_page !== $product_info->get('info_page')) {
+    zen_redirect(zen_href_link($product_info->get('info_page'), zen_get_all_get_params()));
 }
 
 zen_product_set_header_response($products_id_current, $product_info);

--- a/includes/modules/pages/product_info/main_template_vars.php
+++ b/includes/modules/pages/product_info/main_template_vars.php
@@ -14,11 +14,13 @@
 // This should be first line of the script:
     $zco_notifier->notify('NOTIFY_MAIN_TEMPLATE_VARS_START_PRODUCT_INFO');
 
-    if (!isset($product_info->EOF, $product_info->fields['products_id'], $product_info->fields['products_status']) || (int)$product_info->fields['products_id'] !== (int)$_GET['products_id']) {
-        $product_info = zen_get_product_details($_GET['products_id']);
+    $product_info = $product_info ?? new Product($_GET['products_id']);
+
+    if (!isset($product_info->fields['products_id'], $product_info->fields['products_status']) || (int)$product_info->fields['products_id'] !== (int)$_GET['products_id']) {
+        $product_info = new Product($_GET['products_id']);
     }
 
-    $product_not_found = $product_info->EOF;
+    $product_not_found = !$product_info->exists();
 
     if (!defined('DISABLED_PRODUCTS_TRIGGER_HTTP200') || DISABLED_PRODUCTS_TRIGGER_HTTP200 !== 'true') {
         if (!$product_not_found && $product_info->fields['products_status'] != 1) {
@@ -38,7 +40,7 @@
 
         $products_price = $currencies->display_price($product_info->fields['products_price'], zen_get_tax_rate($product_info->fields['products_tax_class_id']));
 
-        $manufacturers_name = zen_get_products_manufacturers_name((int)$_GET['products_id']);
+        $manufacturers_name = $product_info->fields['manufacturers_name'];
 
         if ($new_price = zen_get_products_special_price($product_info->fields['products_id'])) {
             $specials_price = $currencies->display_price($new_price, zen_get_tax_rate($product_info->fields['products_tax_class_id']));
@@ -53,25 +55,25 @@
         $review_status = " AND r.status = 1";
 
         $reviews_query = "SELECT count(*) AS count FROM " . TABLE_REVIEWS . " r, "
-          . TABLE_REVIEWS_DESCRIPTION . " rd
+                                                          . TABLE_REVIEWS_DESCRIPTION . " rd
                        WHERE r.products_id = " . (int)$_GET['products_id'] . "
                        AND r.reviews_id = rd.reviews_id
                        AND rd.languages_id = " . (int)$_SESSION['languages_id'] .
-          $review_status;
+                       $review_status;
 
         $reviews = $db->Execute($reviews_query);
 
-        $products_name = $product_info->fields['products_name'];
+        $products_name = $product_info->fields['lang'][$_SESSION['languages_code']]['products_name'];
         $products_model = $product_info->fields['products_model'];
         // if no common markup tags in description, add line breaks for readability:
-        $products_description = (!preg_match('/(<br|<p|<div|<dd|<li|<span)/i', $product_info->fields['products_description']) ? nl2br($product_info->fields['products_description']) : $product_info->fields['products_description']);
+        $products_description = (!preg_match('/(<br|<p|<div|<dd|<li|<span)/i', $product_info->fields['lang'][$_SESSION['languages_code']]['products_description']) ? nl2br($product_info->fields['lang'][$_SESSION['languages_code']]['products_description']) : $product_info->fields['lang'][$_SESSION['languages_code']]['products_description']);
 
         $products_image = (($product_not_found || $product_info->fields['products_image'] == '') && PRODUCTS_IMAGE_NO_IMAGE_STATUS == '1') ? PRODUCTS_IMAGE_NO_IMAGE : '';
         if ($product_info->fields['products_image'] != '' || PRODUCTS_IMAGE_NO_IMAGE_STATUS != '1') {
             $products_image = $product_info->fields['products_image'];
         }
 
-        $products_url = $product_info->fields['products_url'];
+        $products_url = $product_info->fields['lang'][$_SESSION['languages_code']]['products_url'];
         $products_date_available = $product_info->fields['products_date_available'];
         $products_date_added = $product_info->fields['products_date_added'];
         $products_manufacturer = $manufacturers_name;

--- a/includes/modules/pages/product_music_info/header_php.php
+++ b/includes/modules/pages/product_music_info/header_php.php
@@ -13,9 +13,9 @@ $zco_notifier->notify('NOTIFY_HEADER_START_PRODUCT_MUSIC_INFO');
 
 require(DIR_WS_MODULES . zen_get_module_directory('require_languages.php'));
 
-$product_info = zen_get_product_details($products_id_current = (!empty($_GET['products_id']) ? (int)$_GET['products_id'] : 0));
-if (!empty($product_info->fields['type_handler']) && $current_page !== $product_info->fields['type_handler'] . '_info') {
-    zen_redirect(zen_href_link($product_info->fields['type_handler'] . '_info', zen_get_all_get_params()));
+$product_info = new Product($products_id_current = (!empty($_GET['products_id']) ? (int)$_GET['products_id'] : 0));
+if ($current_page !== $product_info->get('info_page')) {
+    zen_redirect(zen_href_link($product_info->get('info_page'), zen_get_all_get_params()));
 }
 
 zen_product_set_header_response($products_id_current, $product_info);

--- a/includes/modules/pages/product_music_info/main_template_vars.php
+++ b/includes/modules/pages/product_music_info/main_template_vars.php
@@ -14,11 +14,13 @@
   // This should be first line of the script:
   $zco_notifier->notify('NOTIFY_MAIN_TEMPLATE_VARS_START_PRODUCT_MUSIC_INFO');
 
-  if (!isset($product_info->EOF, $product_info->fields['products_id'], $product_info->fields['products_status']) || (int)$product_info->fields['products_id'] !== (int)$_GET['products_id']) {
-    $product_info = zen_get_product_details($_GET['products_id']);
+  $product_info = $product_info ?? new Product($_GET['products_id']);
+
+  if (!isset($product_info->fields['products_id'], $product_info->fields['products_status']) || (int)$product_info->fields['products_id'] !== (int)$_GET['products_id']) {
+      $product_info = new Product($_GET['products_id']);
   }
 
-  $product_not_found = $product_info->EOF;
+  $product_not_found = !$product_info->exists();
 
   if (!defined('DISABLED_PRODUCTS_TRIGGER_HTTP200') || DISABLED_PRODUCTS_TRIGGER_HTTP200 !== 'true') {
       if (!$product_not_found && $product_info->fields['products_status'] != 1) {
@@ -38,7 +40,7 @@
 
     $products_price = $currencies->display_price($product_info->fields['products_price'], zen_get_tax_rate($product_info->fields['products_tax_class_id']));
 
-    $manufacturers_name = zen_get_products_manufacturers_name((int)$_GET['products_id']);
+    $manufacturers_name = $product_info->fields['manufacturers_name'];
 
     if ($new_price = zen_get_products_special_price($product_info->fields['products_id'])) {
       $specials_price = $currencies->display_price($new_price, zen_get_tax_rate($product_info->fields['products_tax_class_id']));
@@ -61,17 +63,17 @@
 
     $reviews = $db->Execute($reviews_query);
 
-  $products_name = $product_info->fields['products_name'];
+  $products_name = $product_info->fields['lang'][$_SESSION['languages_code']]['products_name'];
   $products_model = $product_info->fields['products_model'];
   // if no common markup tags in description, add line breaks for readability:
-  $products_description = (!preg_match('/(<br|<p|<div|<dd|<li|<span)/i', $product_info->fields['products_description']) ? nl2br($product_info->fields['products_description']) : $product_info->fields['products_description']);
+  $products_description = (!preg_match('/(<br|<p|<div|<dd|<li|<span)/i', $product_info->fields['lang'][$_SESSION['languages_code']]['products_description']) ? nl2br($product_info->fields['lang'][$_SESSION['languages_code']]['products_description']) : $product_info->fields['lang'][$_SESSION['languages_code']]['products_description']);
 
   $products_image = (($product_not_found || $product_info->fields['products_image'] == '') && PRODUCTS_IMAGE_NO_IMAGE_STATUS == '1') ? PRODUCTS_IMAGE_NO_IMAGE : '';
   if ($product_info->fields['products_image'] != '' || PRODUCTS_IMAGE_NO_IMAGE_STATUS != '1') {
     $products_image = $product_info->fields['products_image'];
   }
 
-  $products_url = $product_info->fields['products_url'];
+  $products_url = $product_info->fields['lang'][$_SESSION['languages_code']]['products_url'];
   $products_date_available = $product_info->fields['products_date_available'];
   $products_date_added = $product_info->fields['products_date_added'];
   $products_manufacturer = $manufacturers_name;

--- a/includes/modules/product_listing.php
+++ b/includes/modules/product_listing.php
@@ -129,17 +129,16 @@ if ($num_products_count > 0) {
     // Retrieve all records into an array to allow for sorting and insertion of additional data if needed
     $records = [];
     foreach ($listing as $record) {
+        $product_info = (new Product($record['products_id']))->getDataForLanguage((int)$_SESSION['languages_id']) ?? [];
         $category_id = !empty($record['categories_id']) ? $record['categories_id'] : $record['master_categories_id'];
         $parent_category_name = trim(zen_get_categories_parent_name($category_id));
         $category_name = trim(zen_get_category_name($category_id, (int)$_SESSION['languages_id']));
-        $product_details = zen_get_product_details($record['products_id']);
+
         $records[] = array_merge($record,
             [
                 'parent_category_name' => (!empty($parent_category_name)) ? $parent_category_name : $category_name,
                 'category_name' => $category_name,
-//                'master_categories_id' => $record['master_categories_id'],
-//                'products_sort_order' => $record['products_sort_order'],
-            ], $product_details->fields ?? []);
+            ], $product_info);
     }
 
     if (!empty($_GET['keyword'])) $skip_sort = true;
@@ -219,7 +218,7 @@ if ($num_products_count > 0) {
             $listing_product_name = zen_get_products_name((int)$record['products_id']);
             $listing_description = '';
             if ((int)PRODUCT_LIST_DESCRIPTION > 0) {
-                $listing_description = zen_trunc_string(zen_clean_html(stripslashes(zen_get_products_description($record['products_id'], $_SESSION['languages_id']))), PRODUCT_LIST_DESCRIPTION);
+                $listing_description = zen_trunc_string(zen_clean_html(stripslashes($record['products_description'])), PRODUCT_LIST_DESCRIPTION);
             }
             $listing_model = $record['products_model'] ?? '';
             $listing_mfg_name = $record['manufacturers_name'] ?? '';

--- a/includes/modules/responsive_classic/product_listing.php
+++ b/includes/modules/responsive_classic/product_listing.php
@@ -129,17 +129,16 @@ if ($num_products_count > 0) {
     // Retrieve all records into an array to allow for sorting and insertion of additional data if needed
     $records = [];
     foreach ($listing as $record) {
+        $product_info = (new Product($record['products_id']))->getDataForLanguage((int)$_SESSION['languages_id']) ?? [];
         $category_id = !empty($record['categories_id']) ? $record['categories_id'] : $record['master_categories_id'];
         $parent_category_name = trim(zen_get_categories_parent_name($category_id));
         $category_name = trim(zen_get_category_name($category_id, (int)$_SESSION['languages_id']));
+
         $records[] = array_merge($record,
             [
                 'parent_category_name' => (!empty($parent_category_name)) ? $parent_category_name : $category_name,
                 'category_name' => $category_name,
-//                'products_name' => $record['products_name'],
-//                'master_categories_id' => $record['master_categories_id'],
-//                'products_sort_order' => $record['products_sort_order'],
-            ]);
+            ], $product_info);
     }
 
     if (!empty($_GET['keyword'])) $skip_sort = true;
@@ -215,7 +214,7 @@ if ($num_products_count > 0) {
             $listing_product_name = $record['products_name'] ?? '';
             $listing_description = '';
             if ((int)PRODUCT_LIST_DESCRIPTION > 0) {
-                $listing_description = zen_trunc_string(zen_clean_html(stripslashes(zen_get_products_description($record['products_id'], $_SESSION['languages_id']))), PRODUCT_LIST_DESCRIPTION);
+                $listing_description = zen_trunc_string(zen_clean_html(stripslashes($record['products_description'])), PRODUCT_LIST_DESCRIPTION);
                 $lc_text .= '<div class="listingDescription">' . $listing_description . '</div>';
             }
             $listing_model = $record['products_model'] ?? '';

--- a/includes/modules/sideboxes/best_sellers.php
+++ b/includes/modules/sideboxes/best_sellers.php
@@ -38,6 +38,8 @@ $best_sellers = $db->Execute($best_sellers_query);
 if ($best_sellers->RecordCount() >= MIN_DISPLAY_BESTSELLERS) {
     $bestsellers_list = [];
     foreach ($best_sellers as $bestseller) {
+        $product_info = (new Product($bestseller['products_id']))->withDefaultLanguage();
+        $bestseller = array_merge($bestseller, $product_info->getData());
         $best_products_id = $bestseller['products_id'];
         $bestsellers_list[] = [
             'id' => $best_products_id,

--- a/includes/modules/specials_index.php
+++ b/includes/modules/specials_index.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * specials_index module
  *
@@ -8,17 +9,17 @@
  * @version $Id: lat9 2022 May 05 Modified in v1.5.8-alpha $
  */
 if (!defined('IS_ADMIN_FLAG')) {
-  die('Illegal Access');
+    die('Illegal Access');
 }
 
 // initialize vars
-$categories_products_id_list = array();
+$categories_products_id_list = [];
 $list_of_products = '';
 $specials_index_query = '';
 $display_limit = '';
 
-if ( (($manufacturers_id > 0 && empty($_GET['filter_id'])) || !empty($_GET['music_genre_id']) || !empty($_GET['record_company_id'])) || empty($new_products_category_id) ) {
-  $specials_index_query = "SELECT p.products_id, p.products_image, pd.products_name, p.master_categories_id
+if ((($manufacturers_id > 0 && empty($_GET['filter_id'])) || !empty($_GET['music_genre_id']) || !empty($_GET['record_company_id'])) || empty($new_products_category_id)) {
+    $specials_index_query = "SELECT p.products_id, p.products_image, pd.products_name, p.master_categories_id
                            FROM (" . TABLE_PRODUCTS . " p
                            LEFT JOIN " . TABLE_SPECIALS . " s ON p.products_id = s.products_id
                            LEFT JOIN " . TABLE_PRODUCTS_DESCRIPTION . " pd ON p.products_id = pd.products_id )
@@ -27,16 +28,16 @@ if ( (($manufacturers_id > 0 && empty($_GET['filter_id'])) || !empty($_GET['musi
                            AND p.products_status = 1 AND s.status = 1
                            AND pd.language_id = " . (int)$_SESSION['languages_id'];
 } else {
-  // get all products and cPaths in this subcat tree
-  $productsInCategory = zen_get_categories_products_list( (($manufacturers_id > 0 && !empty($_GET['filter_id'])) ? zen_get_generated_category_path_rev($_GET['filter_id']) : $cPath), false, true, 0, $display_limit);
+    // get all products and cPaths in this subcat tree
+    $productsInCategory = zen_get_categories_products_list((($manufacturers_id > 0 && !empty($_GET['filter_id'])) ? zen_get_generated_category_path_rev($_GET['filter_id']) : $cPath), false, true, 0, $display_limit);
 
-  if (is_array($productsInCategory) && sizeof($productsInCategory) > 0) {
-    // build products-list string to insert into SQL query
-    foreach($productsInCategory as $key => $value) {
-      $list_of_products .= $key . ', ';
-    }
-    $list_of_products = substr($list_of_products, 0, -2); // remove trailing comma
-    $specials_index_query = "SELECT DISTINCT p.products_id, p.products_image, pd.products_name, p.master_categories_id
+    if (is_array($productsInCategory) && sizeof($productsInCategory) > 0) {
+        // build products-list string to insert into SQL query
+        foreach ($productsInCategory as $key => $value) {
+            $list_of_products .= $key . ', ';
+        }
+        $list_of_products = substr($list_of_products, 0, -2); // remove trailing comma
+        $specials_index_query = "SELECT DISTINCT p.products_id, p.products_image, pd.products_name, p.master_categories_id
                              FROM (" . TABLE_PRODUCTS . " p
                              LEFT JOIN " . TABLE_SPECIALS . " s ON p.products_id = s.products_id
                              LEFT JOIN " . TABLE_PRODUCTS_DESCRIPTION . " pd ON p.products_id = pd.products_id )
@@ -45,46 +46,64 @@ if ( (($manufacturers_id > 0 && empty($_GET['filter_id'])) || !empty($_GET['musi
                              AND p.products_status = 1 AND s.status = 1
                              AND pd.language_id = " . (int)$_SESSION['languages_id'] . "
                              AND p.products_id in (" . $list_of_products . ")";
-  }
+    }
 }
-if ($specials_index_query != '') $specials_index = $db->ExecuteRandomMulti($specials_index_query, MAX_DISPLAY_SPECIAL_PRODUCTS_INDEX);
+if ($specials_index_query !== '') {
+    $specials_index = $db->ExecuteRandomMulti($specials_index_query, MAX_DISPLAY_SPECIAL_PRODUCTS_INDEX);
+}
 
 $row = 0;
 $col = 0;
-$list_box_contents = array();
+$list_box_contents = [];
 $title = '';
 
-$num_products_count = ($specials_index_query == '') ? 0 : $specials_index->RecordCount();
+$num_products_count = ($specials_index_query === '') ? 0 : $specials_index->RecordCount();
 
 // show only when 1 or more
 if ($num_products_count > 0) {
-  if ($num_products_count < SHOW_PRODUCT_INFO_COLUMNS_SPECIALS_PRODUCTS || SHOW_PRODUCT_INFO_COLUMNS_SPECIALS_PRODUCTS == 0 ) {
-    $col_width = floor(100/$num_products_count);
-  } else {
-    $col_width = floor(100/SHOW_PRODUCT_INFO_COLUMNS_SPECIALS_PRODUCTS);
-  }
-
-  $list_box_contents = array();
-  while (!$specials_index->EOF) {
-    $products_price = zen_get_products_display_price($specials_index->fields['products_id']);
-    if (!isset($productsInCategory[$specials_index->fields['products_id']])) $productsInCategory[$specials_index->fields['products_id']] = zen_get_generated_category_path_rev($specials_index->fields['master_categories_id']);
-
-    $zco_notifier->notify('NOTIFY_MODULES_SPECIALS_INDEX_B4_LIST_BOX', array(), $specials_index->fields, $products_price);
-
-    $specials_index->fields['products_name'] = zen_get_products_name($specials_index->fields['products_id']);
-    $list_box_contents[$row][$col] = array('params' => 'class="centerBoxContentsSpecials centeredContent back"' . ' ' . 'style="width:' . $col_width . '%;"',
-    'text' => (($specials_index->fields['products_image'] == '' and PRODUCTS_IMAGE_NO_IMAGE_STATUS == 0) ? '' : '<a href="' . zen_href_link(zen_get_info_page($specials_index->fields['products_id']), 'cPath=' . $productsInCategory[$specials_index->fields['products_id']] . '&products_id=' . (int)$specials_index->fields['products_id']) . '">' . zen_image(DIR_WS_IMAGES . $specials_index->fields['products_image'], $specials_index->fields['products_name'], SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT) . '</a><br>') . '<a href="' . zen_href_link(zen_get_info_page($specials_index->fields['products_id']), 'cPath=' . $productsInCategory[$specials_index->fields['products_id']] . '&products_id=' . $specials_index->fields['products_id']) . '">' . $specials_index->fields['products_name'] . '</a><br>' . $products_price);
-
-    $col ++;
-    if ($col > (SHOW_PRODUCT_INFO_COLUMNS_SPECIALS_PRODUCTS - 1)) {
-      $col = 0;
-      $row ++;
+    if ($num_products_count < SHOW_PRODUCT_INFO_COLUMNS_SPECIALS_PRODUCTS || SHOW_PRODUCT_INFO_COLUMNS_SPECIALS_PRODUCTS == 0) {
+        $col_width = floor(100 / $num_products_count);
+    } else {
+        $col_width = floor(100 / SHOW_PRODUCT_INFO_COLUMNS_SPECIALS_PRODUCTS);
     }
-    $specials_index->MoveNextRandom();
-  }
 
-  if ($specials_index->RecordCount() > 0) {
-    $title = '<h2 class="centerBoxHeading">' . sprintf(TABLE_HEADING_SPECIALS_INDEX, $zcDate->output('%B')) . '</h2>';
-    $zc_show_specials = true;
-  }
+    $list_box_contents = [];
+    while (!$specials_index->EOF) {
+        $product_info = new Product($specials_index->fields['products_id']);
+        $data = array_merge($specials_index->fields, $product_info->getDataForLanguage());
+
+        $products_price = zen_get_products_display_price($data['products_id']);
+        if (!isset($productsInCategory[$data['products_id']])) {
+            $productsInCategory[$data['products_id']] = zen_get_generated_category_path_rev($data['master_categories_id']);
+        }
+
+        $zco_notifier->notify('NOTIFY_MODULES_SPECIALS_INDEX_B4_LIST_BOX', [], $data, $products_price);
+
+        $data['products_name'] = zen_get_products_name($data['products_id']);
+        $list_box_contents[$row][$col] = [
+            'params' => 'class="centerBoxContentsSpecials centeredContent back"' . ' ' . 'style="width:' . $col_width . '%;"',
+            'text' => (($data['products_image'] === '' && PRODUCTS_IMAGE_NO_IMAGE_STATUS == 0)
+                    ? ''
+                    : '<a href="' . zen_href_link(
+                        zen_get_info_page($data['products_id']),
+                        'cPath=' . $productsInCategory[$data['products_id']] . '&products_id=' . (int)$data['products_id']
+                    ) . '">'
+                    . zen_image(DIR_WS_IMAGES . $data['products_image'], $data['products_name'], SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT)
+                    . '</a><br>')
+                . '<a href="' . zen_href_link(zen_get_info_page($data['products_id']), 'cPath=' . $productsInCategory[$data['products_id']] . '&products_id=' . $data['products_id']) . '">' . $data['products_name']
+                . '</a><br>' . $products_price,
+        ];
+
+        $col++;
+        if ($col > (SHOW_PRODUCT_INFO_COLUMNS_SPECIALS_PRODUCTS - 1)) {
+            $col = 0;
+            $row++;
+        }
+        $specials_index->MoveNextRandom();
+    }
+
+    if ($specials_index->RecordCount() > 0) {
+        $title = '<h2 class="centerBoxHeading">' . sprintf(TABLE_HEADING_SPECIALS_INDEX, $zcDate->output('%B')) . '</h2>';
+        $zc_show_specials = true;
+    }
 }

--- a/includes/modules/upcoming_products.php
+++ b/includes/modules/upcoming_products.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * upcoming_products module
  *
@@ -9,54 +10,58 @@
  * @version $Id: Drbyte Fri Mar 2 22:34:03 2018 -0500 Modified in v1.5.6 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
-  die('Illegal Access');
+    die('Illegal Access');
 }
 
 // initialize vars
-$categories_products_id_list = array();
+$categories_products_id_list = [];
 $list_of_products = '';
-$expected_query = '';
+$sql = '';
 
 $display_limit = zen_get_upcoming_date_range();
 
 $limit_clause = "  ORDER BY " . (EXPECTED_PRODUCTS_FIELD == 'date_expected' ? 'date_expected' : 'products_name') . " " . (EXPECTED_PRODUCTS_SORT == 'asc' ? 'ASC' : 'DESC') . "
                    LIMIT " . (int)MAX_DISPLAY_UPCOMING_PRODUCTS;
 
-if ( (($manufacturers_id > 0 && empty($_GET['filter_id'])) || !empty($_GET['music_genre_id']) || !empty($_GET['record_company_id'])) || empty($new_products_category_id) ) {
-  $expected_query = "SELECT p.products_id, pd.products_name, products_date_available AS date_expected, p.master_categories_id
-                     FROM " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_DESCRIPTION . " pd
-                     WHERE p.products_id = pd.products_id
-                     AND p.products_status = 1
-                     AND pd.language_id = " . (int)$_SESSION['languages_id'] .
-                     $display_limit .
-                     $limit_clause;
+if ((($manufacturers_id > 0 && empty($_GET['filter_id'])) || !empty($_GET['music_genre_id']) || !empty($_GET['record_company_id'])) || empty($new_products_category_id)) {
+    $sql = "SELECT p.products_id, pd.products_name, products_date_available AS date_expected, p.master_categories_id
+            FROM " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_DESCRIPTION . " pd
+            WHERE p.products_id = pd.products_id
+            AND p.products_status = 1
+            AND pd.language_id = " . (int)$_SESSION['languages_id'] .
+            $display_limit .
+            $limit_clause;
 } else {
-  // get all products and cPaths in this subcat tree
-  $productsInCategory = zen_get_categories_products_list( (($manufacturers_id > 0 && !empty($_GET['filter_id'])) ? zen_get_generated_category_path_rev($_GET['filter_id']) : $cPath), false, true, 0, $display_limit);
+    // get all products and cPaths in this subcat tree
+    $productsInCategory = zen_get_categories_products_list((($manufacturers_id > 0 && !empty($_GET['filter_id'])) ? zen_get_generated_category_path_rev($_GET['filter_id']) : $cPath), false, true, 0, $display_limit);
 
-  if (is_array($productsInCategory) && sizeof($productsInCategory) > 0) {
-    // build products-list string to insert into SQL query
-    foreach($productsInCategory as $key => $value) {
-      $list_of_products .= $key . ', ';
+    if (is_array($productsInCategory) && count($productsInCategory) > 0) {
+        // build products-list string to insert into SQL query
+        foreach ($productsInCategory as $key => $value) {
+            $list_of_products .= $key . ', ';
+        }
+        $list_of_products = substr($list_of_products, 0, -2); // remove trailing comma
+
+        $sql = "SELECT p.products_id, pd.products_name, products_date_available AS date_expected, p.master_categories_id
+                FROM " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_DESCRIPTION . " pd
+                WHERE p.products_id = pd.products_id
+                AND p.products_id IN (" . $list_of_products . ")
+                AND p.products_status = 1
+                AND pd.language_id = " . (int)$_SESSION['languages_id'] .
+                $display_limit .
+                $limit_clause;
     }
-    $list_of_products = substr($list_of_products, 0, -2); // remove trailing comma
-
-    $expected_query = "SELECT p.products_id, pd.products_name, products_date_available AS date_expected, p.master_categories_id
-                       FROM " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_DESCRIPTION . " pd
-                       WHERE p.products_id = pd.products_id
-                       AND p.products_id IN (" . $list_of_products . ")
-                       AND p.products_status = 1
-                       AND pd.language_id = " . (int)$_SESSION['languages_id'] .
-                       $display_limit .
-                       $limit_clause;
-  }
 }
 
-if ($expected_query != '') $expected = $db->Execute($expected_query);
-if ($expected_query != '' && $expected->RecordCount() > 0) {
-  foreach ($expected as $expect) {
-    if (!isset($productsInCategory[$expect['products_id']])) $productsInCategory[$expect['products_id']] = zen_get_generated_category_path_rev($expect['master_categories_id']);
-    $expectedItems[] = $expect;
-  }
-  require($template->get_template_dir('tpl_modules_upcoming_products.php', DIR_WS_TEMPLATE, $current_page_base,'templates'). '/' . 'tpl_modules_upcoming_products.php');
+if ($sql !== '') {
+    $expected = $db->Execute($sql);
+}
+if ($sql !== '' && $expected->RecordCount() > 0) {
+    foreach ($expected as $expect) {
+        if (!isset($productsInCategory[$expect['products_id']])) {
+            $productsInCategory[$expect['products_id']] = zen_get_generated_category_path_rev($expect['master_categories_id']);
+        }
+        $expectedItems[] = array_merge($expect, (new Product($expect['products_id']))->getDataForLanguage());
+    }
+    require $template->get_template_dir('tpl_modules_upcoming_products.php', DIR_WS_TEMPLATE, $current_page_base, 'templates') . '/' . 'tpl_modules_upcoming_products.php';
 }

--- a/includes/psr4Autoload.php
+++ b/includes/psr4Autoload.php
@@ -25,6 +25,7 @@ if (defined('DIR_FS_ADMIN')) {
     $psr4Autoloader->addPrefix('Zencart\Paginator', DIR_FS_ADMIN . DIR_WS_CLASSES);
 }
 $psr4Autoloader->setClassFile('language', DIR_FS_CATALOG . DIR_WS_CLASSES . 'language.php' );
+$psr4Autoloader->setClassFile('Product', DIR_FS_CATALOG . DIR_WS_CLASSES . 'Product.php' );
 $psr4Autoloader->setClassFile('Settings', DIR_FS_CATALOG . DIR_WS_CLASSES . 'Settings.php' );
 $psr4Autoloader->setClassFile('TemplateSettings', DIR_FS_CATALOG . DIR_WS_CLASSES . 'TemplateSettings.php' );
 $psr4Autoloader->setClassFile('ZenShipping', DIR_FS_CATALOG . DIR_WS_CLASSES . 'ZenShipping.php');

--- a/includes/templates/responsive_classic/sideboxes/tpl_reviews_random.php
+++ b/includes/templates/responsive_classic/sideboxes/tpl_reviews_random.php
@@ -7,12 +7,16 @@
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: DrByte 2020 Dec 25 Modified in v1.5.8-alpha $
  */
-  $content = "";
-  $review_box_counter = 0;
-  while (!$random_review_sidebox_product->EOF) {
+$content = "";
+$review_box_counter = 0;
+while (!$random_review_sidebox_product->EOF) {
     $review_box_counter++;
     $content .= '<div class="' . str_replace('_', '-', $box_id . 'Content') . ' sideBoxContent centeredContent">';
-    $content .= '<a href="' . zen_href_link(FILENAME_PRODUCT_REVIEWS_INFO, 'products_id=' . $random_review_sidebox_product->fields['products_id'] . '&reviews_id=' . $random_review_sidebox_product->fields['reviews_id']) . '">' . zen_image(DIR_WS_IMAGES . $random_review_sidebox_product->fields['products_image'], $random_review_sidebox_product->fields['products_name'], SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT) . '<br>' . nl2br(zen_trunc_string(zen_output_string_protected(stripslashes($random_review_sidebox_product->fields['reviews_text'])), 60)) . '</a><br><br>' . zen_image(DIR_WS_TEMPLATE_IMAGES . 'stars_' . $random_review_sidebox_product->fields['reviews_rating'] . '.png' , sprintf(BOX_REVIEWS_TEXT_OF_5_STARS, $random_review_sidebox_product->fields['reviews_rating']));
+    $content .= '<a href="' . zen_href_link(FILENAME_PRODUCT_REVIEWS_INFO, 'products_id=' . $random_review_sidebox_product->fields['products_id'] . '&reviews_id=' . $random_review_sidebox_product->fields['reviews_id']) . '">'
+        . zen_image(DIR_WS_IMAGES . $random_review_sidebox_product->fields['products_image'], zen_get_products_name($random_review_sidebox_product->fields['products_id']), SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT)
+        . '<br>' . nl2br(zen_trunc_string(zen_output_string_protected(stripslashes($random_review_sidebox_product->fields['reviews_text'])), 60))
+        . '</a><br><br>'
+        . zen_image(DIR_WS_TEMPLATE_IMAGES . 'stars_' . $random_review_sidebox_product->fields['reviews_rating'] . '.png', sprintf(BOX_REVIEWS_TEXT_OF_5_STARS, $random_review_sidebox_product->fields['reviews_rating']));
     $content .= '</div>';
     $random_review_sidebox_product->MoveNextRandom();
-  }
+}

--- a/includes/templates/template_default/sideboxes/tpl_featured.php
+++ b/includes/templates/template_default/sideboxes/tpl_featured.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Side Box Template
  *
@@ -7,17 +8,19 @@
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: DrByte 2020 Dec 25 Modified in v1.5.8-alpha $
  */
-  $content = "";
-  $content .= '<div class="sideBoxContent centeredContent">';
-  $featured_box_counter = 0;
-  while (!$random_featured_product->EOF) {
+$content = "";
+$content .= '<div class="sideBoxContent centeredContent">';
+$featured_box_counter = 0;
+while (!$random_featured_product->EOF) {
+    $data = (new Product($random_featured_product->fields['products_id']))->withDefaultLanguage()->getData();
     $featured_box_counter++;
-    $featured_box_price = zen_get_products_display_price($random_featured_product->fields['products_id']);
+    $featured_box_price = zen_get_products_display_price($data['products_id']);
     $content .= "\n" . '  <div class="sideBoxContentItem">';
-    $content .=  '<a href="' . zen_href_link(zen_get_info_page($random_featured_product->fields["products_id"]), 'cPath=' . zen_get_generated_category_path_rev($random_featured_product->fields["master_categories_id"]) . '&products_id=' . $random_featured_product->fields["products_id"]) . '">' . zen_image(DIR_WS_IMAGES . $random_featured_product->fields['products_image'], $random_featured_product->fields['products_name'], SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT);
-    $content .= '<br>' . $random_featured_product->fields['products_name'] . '</a>';
+    $content .= '<a href="' . zen_href_link(zen_get_info_page($data['products_id']), 'cPath=' . zen_get_generated_category_path_rev($data["master_categories_id"]) . '&products_id=' . $data["products_id"]) . '">'
+        . zen_image(DIR_WS_IMAGES . $data['products_image'], $data['products_name'], SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT);
+    $content .= '<br>' . $data['products_name'] . '</a>';
     $content .= '<div>' . $featured_box_price . '</div>';
     $content .= '</div>';
     $random_featured_product->MoveNextRandom();
-  }
-  $content .= '</div>' . "\n";
+}
+$content .= '</div>' . "\n";

--- a/includes/templates/template_default/sideboxes/tpl_reviews_random.php
+++ b/includes/templates/template_default/sideboxes/tpl_reviews_random.php
@@ -7,12 +7,16 @@
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: DrByte 2020 Dec 25 Modified in v1.5.8-alpha $
  */
-  $content = "";
-  $review_box_counter = 0;
-  while (!$random_review_sidebox_product->EOF) {
+$content = "";
+$review_box_counter = 0;
+while (!$random_review_sidebox_product->EOF) {
     $review_box_counter++;
     $content .= '<div class="' . str_replace('_', '-', $box_id . 'Content') . ' sideBoxContent centeredContent">';
-    $content .= '<a href="' . zen_href_link(FILENAME_PRODUCT_REVIEWS_INFO, 'products_id=' . $random_review_sidebox_product->fields['products_id'] . '&reviews_id=' . $random_review_sidebox_product->fields['reviews_id']) . '">' . zen_image(DIR_WS_IMAGES . $random_review_sidebox_product->fields['products_image'], $random_review_sidebox_product->fields['products_name'], SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT) . '<br>' . nl2br(zen_trunc_string(zen_output_string_protected(stripslashes($random_review_sidebox_product->fields['reviews_text'])), 60)) . '</a><br><br>' . zen_image(DIR_WS_TEMPLATE_IMAGES . 'stars_' . $random_review_sidebox_product->fields['reviews_rating'] . '.gif' , sprintf(BOX_REVIEWS_TEXT_OF_5_STARS, $random_review_sidebox_product->fields['reviews_rating']));
+    $content .= '<a href="' . zen_href_link(FILENAME_PRODUCT_REVIEWS_INFO, 'products_id=' . $random_review_sidebox_product->fields['products_id'] . '&reviews_id=' . $random_review_sidebox_product->fields['reviews_id']) . '">'
+        . zen_image(DIR_WS_IMAGES . $random_review_sidebox_product->fields['products_image'], zen_get_products_name($random_review_sidebox_product->fields['products_id']), SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT)
+        . '<br>' . nl2br(zen_trunc_string(zen_output_string_protected(stripslashes($random_review_sidebox_product->fields['reviews_text'])), 60))
+        . '</a><br><br>'
+        . zen_image(DIR_WS_TEMPLATE_IMAGES . 'stars_' . $random_review_sidebox_product->fields['reviews_rating'] . '.gif', sprintf(BOX_REVIEWS_TEXT_OF_5_STARS, $random_review_sidebox_product->fields['reviews_rating']));
     $content .= '</div>';
     $random_review_sidebox_product->MoveNextRandom();
-  }
+}

--- a/includes/templates/template_default/sideboxes/tpl_specials.php
+++ b/includes/templates/template_default/sideboxes/tpl_specials.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Side Box Template
  *
@@ -7,17 +8,19 @@
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: DrByte 2020 Dec 25 Modified in v1.5.8-alpha $
  */
-  $content = "";
-  $content .= '<div class="sideBoxContent centeredContent">';
-  $specials_box_counter = 0;
-  while (!$random_specials_sidebox_product->EOF) {
+$content = "";
+$content .= '<div class="sideBoxContent centeredContent">';
+$specials_box_counter = 0;
+while (!$random_specials_sidebox_product->EOF) {
+    $data = array_merge($random_specials_sidebox_product->fields, (new Product($random_specials_sidebox_product->fields['products_id']))->withDefaultLanguage()->getData());
     $specials_box_counter++;
-    $specials_box_price = zen_get_products_display_price($random_specials_sidebox_product->fields['products_id']);
+    $specials_box_price = zen_get_products_display_price($data['products_id']);
     $content .= "\n" . '  <div class="sideBoxContentItem">';
-    $content .= '<a href="' . zen_href_link(zen_get_info_page($random_specials_sidebox_product->fields["products_id"]), 'cPath=' . zen_get_generated_category_path_rev($random_specials_sidebox_product->fields["master_categories_id"]) . '&products_id=' . $random_specials_sidebox_product->fields["products_id"]) . '">' . zen_image(DIR_WS_IMAGES . $random_specials_sidebox_product->fields['products_image'], $random_specials_sidebox_product->fields['products_name'], SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT);
-    $content .= '<br>' . $random_specials_sidebox_product->fields['products_name'] . '</a>';
+    $content .= '<a href="' . zen_href_link(zen_get_info_page($data["products_id"]), 'cPath=' . zen_get_generated_category_path_rev($data["master_categories_id"]) . '&products_id=' . $data["products_id"]) . '">'
+        . zen_image(DIR_WS_IMAGES . $data['products_image'], $data['products_name'], SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT);
+    $content .= '<br>' . $data['products_name'] . '</a>';
     $content .= '<div>' . $specials_box_price . '</div>';
     $content .= '</div>';
     $random_specials_sidebox_product->MoveNextRandom();
-  }
-  $content .= '</div>' . "\n";
+}
+$content .= '</div>' . "\n";

--- a/includes/templates/template_default/sideboxes/tpl_whats_new.php
+++ b/includes/templates/template_default/sideboxes/tpl_whats_new.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Side Box Template
  *
@@ -7,17 +8,20 @@
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: DrByte 2020 Dec 25 Modified in v1.5.8-alpha $
  */
-  $content = "";
-  $content .= '<div class="sideBoxContent centeredContent">';
-  $whats_new_box_counter = 0;
-  while (!$random_whats_new_sidebox_product->EOF) {
+$content = "";
+$content .= '<div class="sideBoxContent centeredContent">';
+$whats_new_box_counter = 0;
+while (!$random_whats_new_sidebox_product->EOF) {
+    $data = (new Product($random_whats_new_sidebox_product->fields['products_id']))->withDefaultLanguage()->getData();
+
     $whats_new_box_counter++;
-    $whats_new_price = zen_get_products_display_price($random_whats_new_sidebox_product->fields['products_id']);
+    $whats_new_price = zen_get_products_display_price($data['products_id']);
     $content .= "\n" . '  <div class="sideBoxContentItem">';
-    $content .= '<a href="' . zen_href_link(zen_get_info_page($random_whats_new_sidebox_product->fields['products_id']), 'cPath=' . zen_get_generated_category_path_rev($random_whats_new_sidebox_product->fields['master_categories_id']) . '&products_id=' . $random_whats_new_sidebox_product->fields['products_id']) . '">' . zen_image(DIR_WS_IMAGES . $random_whats_new_sidebox_product->fields['products_image'], $random_whats_new_sidebox_product->fields['products_name'], SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT);
-    $content .= '<br>' . $random_whats_new_sidebox_product->fields['products_name'] . '</a>';
+    $content .= '<a href="' . zen_href_link(zen_get_info_page($data['products_id']), 'cPath=' . zen_get_generated_category_path_rev($data['master_categories_id']) . '&products_id=' . $data['products_id']) . '">'
+        . zen_image(DIR_WS_IMAGES . $data['products_image'], $data['products_name'], SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT);
+    $content .= '<br>' . $data['products_name'] . '</a>';
     $content .= '<div>' . $whats_new_price . '</div>';
     $content .= '</div>';
     $random_whats_new_sidebox_product->MoveNextRandom();
-  }
-  $content .= '</div>' . "\n";
+}
+$content .= '</div>' . "\n";


### PR DESCRIPTION
Centralizes all basic product-related querying and overriding. (Not including attributes or pricing.)

Closes #6367

The easiest override/notifier hook is now `NOTIFY_GET_PRODUCT_OBJECT_DETAILS`