### PR TITLE
Zone/State error in form when not using state pull down menu

### DIFF
--- a/includes/modules/pages/address_book_process/header_php.php
+++ b/includes/modules/pages/address_book_process/header_php.php
@@ -115,7 +115,7 @@ if (isset($_POST['action']) && (($_POST['action'] == 'process') || ($_POST['acti
                      FROM " . TABLE_ZONES . "
                      WHERE zone_country_id = :zoneCountryID
                      AND " .
-                     ((trim($state) != '' && $zone_id == 0) ? "(upper(zone_name) like ':zoneState%' OR upper(zone_code) like '%:zoneState%') OR " : "") .
+                     ((trim($state) != '' && (int)$zone_id === 0) ? "(upper(zone_name) like ':zoneState%' OR upper(zone_code) like '%:zoneState%') OR " : "") .
                     "zone_id = :zoneID
                      ORDER BY zone_code ASC, zone_name";
 


### PR DESCRIPTION
This file was forgotten when pr #5711 and later #6020 were done.
PR #5711 fixed issue #5707 but revealed another bug which was later fixed by pr #6020.
This commit fixes #5711 that was still there... in the same way it was (partially) fixed in #6020.