### PR TITLE
Lost penny management

### DIFF
--- a/includes/modules/order_total/ot_cod_fee.php
+++ b/includes/modules/order_total/ot_cod_fee.php
@@ -122,7 +122,7 @@
               $cod_cost += zen_calculate_tax($cod_cost, $tax);
             }
           }
-          $order->info['option_modules']['cod_fee'] = $cod_cost;
+          $order->info['option_modules'][$this->code] = $cod_cost;
 
           $this->output[] = array('title' => $this->title . ':',
                                   'text' => $currencies->format($cod_cost, true,  $order->info['currency'], $order->info['currency_value']),

--- a/includes/modules/order_total/ot_cod_fee.php
+++ b/includes/modules/order_total/ot_cod_fee.php
@@ -122,7 +122,7 @@
               $cod_cost += zen_calculate_tax($cod_cost, $tax);
             }
           }
-		  $order->info['option_modules']['cod_fee'] = $cod_cost;
+          $order->info['option_modules']['cod_fee'] = $cod_cost;
 
           $this->output[] = array('title' => $this->title . ':',
                                   'text' => $currencies->format($cod_cost, true,  $order->info['currency'], $order->info['currency_value']),

--- a/includes/modules/order_total/ot_cod_fee.php
+++ b/includes/modules/order_total/ot_cod_fee.php
@@ -118,7 +118,7 @@
             $order->info['tax'] += zen_calculate_tax($cod_cost, $tax);
             $order->info['tax_groups'][$tax_description] += zen_calculate_tax($cod_cost, $tax);
             $order->info['total'] += zen_calculate_tax($cod_cost, $tax);
-            if (DISPLAY_PRICE_WITH_TAX == 'true') {
+            if (DISPLAY_PRICE_WITH_TAX === 'true') {
               $cod_cost += zen_calculate_tax($cod_cost, $tax);
             }
           }

--- a/includes/modules/order_total/ot_cod_fee.php
+++ b/includes/modules/order_total/ot_cod_fee.php
@@ -122,6 +122,7 @@
               $cod_cost += zen_calculate_tax($cod_cost, $tax);
             }
           }
+		  $order->info['option_modules']['cod_fee'] = $cod_cost;
 
           $this->output[] = array('title' => $this->title . ':',
                                   'text' => $currencies->format($cod_cost, true,  $order->info['currency'], $order->info['currency_value']),

--- a/includes/modules/order_total/ot_coupon.php
+++ b/includes/modules/order_total/ot_coupon.php
@@ -46,7 +46,7 @@ class ot_coupon extends base
      * $deduction amount of deduction calculated/afforded while being applied to an order
      * @var float|null
      */
-    public $deduction;
+    protected $deduction;
     /**
      * $description is a soft name for this order total method
      * @var string
@@ -162,7 +162,7 @@ class ot_coupon extends base
             }
 
             $order->info['total'] -= $od_amount['total'];
-            $order->info['option_modules']['coupon_amount'] = - $od_amount['total'];
+            $order->info['option_modules'][$this->code] = - $od_amount['total'];
 
             if (DISPLAY_PRICE_WITH_TAX != 'true') {
                 $order->info['total'] -= $tax;

--- a/includes/modules/order_total/ot_coupon.php
+++ b/includes/modules/order_total/ot_coupon.php
@@ -46,7 +46,7 @@ class ot_coupon extends base
      * $deduction amount of deduction calculated/afforded while being applied to an order
      * @var float|null
      */
-    protected $deduction;
+    public $deduction;
     /**
      * $description is a soft name for this order total method
      * @var string
@@ -680,11 +680,15 @@ class ot_coupon extends base
                 $orderTotalTax -= $order->info['shipping_tax'] ?? 0;
             }
         }
+        if (DISPLAY_PRICE_WITH_TAX !== 'true') {
+            $orderTotal -= $orderTotalTax;
+        }
+
         // change what total is used for Discount Coupon Minimum
         $orderTotalFull = $order->info['total'] ?? 0;
-        if (isset($_SESSION['shipping_tax_amount']) && $_SESSION['shipping_tax_amount'] != 0) {
-            $orderTotalFull -= DISPLAY_PRICE_WITH_TAX == 'true' ? $order->info['shipping_cost'] - $order->info['shipping_tax'] : ($order->info['shipping_cost'] ?? 0);
-        }
+        //echo 'Current $orderTotalFull: ' . $orderTotalFull . ' shipping_cost: ' . $order->info['shipping_cost'] . '<br>';
+        $orderTotalFull -= $order->info['shipping_cost'] ?? 0;
+        //echo 'Current $orderTotalFull less shipping: ' . $orderTotalFull . '<br>';
         $orderTotalFull -= $orderTotalTax;
         //echo 'Current $orderTotalFull less taxes: ' . $orderTotalFull . '<br>';
         // left for total order amount ($orderTotalDetails['totalFull']) vs qualified order amount ($order_total['orderTotal']) - to include both in array

--- a/includes/modules/order_total/ot_coupon.php
+++ b/includes/modules/order_total/ot_coupon.php
@@ -152,24 +152,29 @@ class ot_coupon extends base
             foreach ($order->info['tax_groups'] as $key => $value) {
                 if (isset($od_amount['tax_groups'][$key])) {
                     $order->info['tax_groups'][$key] -= $od_amount['tax_groups'][$key];
-                    $order->info['tax_groups'][$key] = zen_round($order->info['tax_groups'][$key], $currencies->get_decimal_places($_SESSION['currency']));
                     $tax += $od_amount['tax_groups'][$key];
                 }
             }
             // free shipping for free shipping 'S' or percentage off and free shipping 'E' or amount off and free shipping 'O'
-            if (in_array($od_amount['type'], ['S', 'E', 'O'])) {
-                $order->info['shipping_cost'] = 0;
+            if (in_array($od_amount['type'], ['S', 'E', 'O']) && $this->include_shipping === 'false' && $this->calculate_tax === 'Credit Note') {
+				$od_amount['total'] += $order->info['shipping_cost'];
             }
 
-            $order->info['total'] -= $od_amount['total'];
-            $order->info['coupon_amount'] = $od_amount['total'];
+			$order->info['total'] -= $od_amount['total'];
+            $order->info['option_modules']['coupon_amount'] = - $od_amount['total'];
 
             if (DISPLAY_PRICE_WITH_TAX != 'true') {
                 $order->info['total'] -= $tax;
             }
             $order->info['tax'] -= $tax;
 
-            if ($order->info['total'] < 0) $order->info['total'] = 0;
+            if ($order->info['total'] < 0) {
+				$order->info['total'] = 0;
+				$order->info['tax'] = 0;
+				foreach ($order->info['tax_groups'] as $key => $value) {
+						$order->info['tax_groups'][$key] = 0;
+				}
+			}
 
             $this->output[] = [
                 'title' => $this->title . ': ' . $this->coupon_code . ' :',
@@ -498,15 +503,11 @@ class ot_coupon extends base
 
         $orderAmountToCompareAgainstCouponMinimum = (string)$orderTotalDetails['orderTotal'];
 
-        $orderAmountTotal = (string)$orderTotalDetails['orderTotal'];  // coupon is applied against value of only qualifying/restricted products in cart
+        $orderAmountTotal = $orderTotalDetails['orderTotal'];
+		// coupon is applied against value of only qualifying/restricted products in cart
         if ($coupon_details['coupon_calc_base'] == 1) {
             $orderAmountToCompareAgainstCouponMinimum = (string)$orderTotalDetails['totalFull']; // coupon minimum comparison includes sale items that may not be included in deduction
         }
-
-
-//echo 'ot_coupon coupon_total: ' . $coupon_details['coupon_calc_base'] . '<br>$orderTotalDetails[orderTotal]: ' . $orderTotalDetails['orderTotal'] . '<br>$orderTotalDetails[totalFull]: ' . $orderTotalDetails['totalFull'] . '<br>$orderAmountTotal: ' . $orderAmountTotal . '<br><br>$coupon_details[coupon_minimum_order]: ' . $coupon_details['coupon_minimum_order'] . '<br>$orderAmountToCompareAgainstCouponMinimum: ' . $orderAmountToCompareAgainstCouponMinimum . '<br>';
-
-        // @TODO - adjust all Totals to use $orderAmountTotal but strong review for what total applies where for Percentage, Amount, etc.
 
         if ($orderTotalDetails['orderTotal'] > 0) {
 
@@ -527,6 +528,7 @@ class ot_coupon extends base
                 }
 
                 // Determine return values for discount amounts based on coupon type
+				// A ratio is used to calculate new taxes. This ratio is like an average deduction factor for all tax classes apllied to total order.
                 $coupon_includes_free_shipping = false;
                 $od_amount['type'] = $coupon_details['coupon_type'];
 
@@ -541,39 +543,72 @@ class ot_coupon extends base
                         return $od_amount;
                         break;
                     case 'P': // percentage
-//                        $od_amount['total'] = zen_round($orderTotalDetails['orderTotal']*($coupon_details['coupon_amount']/100), $currencyDecimalPlaces);
-                        $od_amount['total'] = zen_round($orderAmountTotal * ($coupon_details['coupon_amount'] / 100), $currencyDecimalPlaces);
-//                        $ratio = $od_amount['total']/$orderTotalDetails['orderTotal'];
-                        $ratio = $od_amount['total'] / $orderAmountTotal;
+					    if ($this->calculate_tax == 'Credit Note') { // Calculate deduction from gross price
+                            $od_amount['total'] = (DISPLAY_PRICE_WITH_TAX == 'true' ? $orderAmountTotal - $orderTotalDetails['orderTax'] : $orderAmountTotal) * $coupon_details['coupon_amount'] / 100;
+                            $od_amount['total'] = DISPLAY_PRICE_WITH_TAX == 'true' ?  $od_amount['total'] * (1 + (zen_get_tax_rate($this->tax_class) / 100)) : $od_amount['total'];
+						} else { // calculate deduction from net price
+                            $od_amount['total'] = (DISPLAY_PRICE_WITH_TAX == 'true' ? $orderAmountTotal : $orderAmountTotal + $orderTotalDetails['orderTax']) * $coupon_details['coupon_amount'] / 100;
+                            $od_amount['total'] = DISPLAY_PRICE_WITH_TAX == 'true' ?  $od_amount['total'] : $od_amount['total'] / (1 + ($orderTotalDetails['orderTax'] / $orderTotalDetails['orderTotal']));
+						}
+                        $ratio = $coupon_details['coupon_amount'] / 100;
                         break;
                     case 'E': // percentage & Free Shipping
-//                        $od_amount['total'] = zen_round($orderTotalDetails['orderTotal']*($coupon_details['coupon_amount']/100), $currencyDecimalPlaces);
-                        $od_amount['total'] = zen_round($orderAmountTotal * ($coupon_details['coupon_amount'] / 100), $currencyDecimalPlaces);
+					    if ($this->calculate_tax == 'Credit Note') {
+                            $od_amount['total'] = (DISPLAY_PRICE_WITH_TAX == 'true' ? $orderAmountTotal - $orderTotalDetails['orderTax'] : $orderAmountTotal) * $coupon_details['coupon_amount'] / 100;
+                            $od_amount['total'] = DISPLAY_PRICE_WITH_TAX == 'true' ?  $od_amount['total'] * (1 + (zen_get_tax_rate($this->tax_class) / 100)) : $od_amount['total'];
+						} else {
+                            $od_amount['total'] = (DISPLAY_PRICE_WITH_TAX == 'true' ? $orderAmountTotal : $orderAmountTotal + $orderTotalDetails['orderTax']) * $coupon_details['coupon_amount'] / 100;
+                            $od_amount['total'] = DISPLAY_PRICE_WITH_TAX == 'true' ?  $od_amount['total'] : $od_amount['total'] / (1 + ($orderTotalDetails['orderTax'] / $orderTotalDetails['orderTotal']));
+						}
+                        if (isset($_SESSION['shipping_tax_description']) && $_SESSION['shipping_tax_description'] != '') {
+                            $od_amount['tax_groups'][$_SESSION['shipping_tax_description']] = $orderTotalDetails['shippingTax'];
+                        }
                         // add in Free Shipping
                         $coupon_includes_free_shipping = true;
-                        $od_amount['tax'] = ($this->calculate_tax == 'Standard') ? $orderTotalDetails['shippingTax'] : 0;
-                        $ratio = $od_amount['total'] / $orderAmountTotal;
-                        if (isset($_SESSION['shipping_tax_description']) && $_SESSION['shipping_tax_description'] != '') {
-                            $od_amount['tax_groups'][$_SESSION['shipping_tax_description']] = $od_amount['tax'];
-                        }
+                        $ratio = $coupon_details['coupon_amount'] / 100;
                         break;
                     case 'F': // Fixed amount Off
-//                        $od_amount['total'] = zen_round($coupon_details['coupon_amount'] * ($orderTotalDetails['orderTotal']>0), $currencyDecimalPlaces);
-                        $od_amount['total'] = zen_round(($coupon_details['coupon_amount'] > $orderTotalDetails['orderTotal'] ? $orderTotalDetails['orderTotal'] : $coupon_details['coupon_amount']) * ($orderTotalDetails['orderTotal'] > 0) * $coupon_product_count, $currencyDecimalPlaces);
-//                        $ratio = $od_amount['total']/$orderTotalDetails['orderTotal'];
-                        $ratio = $od_amount['total'] / $orderAmountTotal;
+					    if ($this->calculate_tax == 'Credit Note') {
+							if (DISPLAY_PRICE_WITH_TAX != 'true') {
+                                $od_amount['total'] = ($coupon_details['coupon_amount'] > $orderTotalDetails['orderTotal'] ? $orderTotalDetails['orderTotal'] : $coupon_details['coupon_amount']) * ($orderTotalDetails['orderTotal'] > 0) * $coupon_product_count;
+							} else {								
+                                $od_amount['total'] = ($coupon_details['coupon_amount'] > ($orderTotalDetails['orderTotal'] - $orderTotalDetails['orderTax']) ? ($orderTotalDetails['orderTotal'] - $orderTotalDetails['orderTax']) : $coupon_details['coupon_amount']) * ($orderTotalDetails['orderTotal'] > 0) * $coupon_product_count;
+							}
+                            $od_amount['total'] = DISPLAY_PRICE_WITH_TAX == 'false' ?  $od_amount['total'] : $od_amount['total'] * (1 + (zen_get_tax_rate($this->tax_class) / 100));
+                            $ratio = DISPLAY_PRICE_WITH_TAX == 'true' ? $od_amount['total'] / ($orderAmountTotal - $orderTotalDetails['orderTax']) : $od_amount['total'] / $orderAmountTotal;
+						} else {
+							if (DISPLAY_PRICE_WITH_TAX == 'true') {
+                                $od_amount['total'] = ($coupon_details['coupon_amount'] > $orderTotalDetails['orderTotal'] ? $orderTotalDetails['orderTotal'] : $coupon_details['coupon_amount']) * ($orderTotalDetails['orderTotal'] > 0) * $coupon_product_count;
+							} else {								
+                                $od_amount['total'] = ($coupon_details['coupon_amount'] > ($orderTotalDetails['orderTotal'] + $orderTotalDetails['orderTax']) ? ($orderTotalDetails['orderTotal'] + $orderTotalDetails['orderTax']) : $coupon_details['coupon_amount']) * ($orderTotalDetails['orderTotal'] > 0) * $coupon_product_count;
+							}
+                            $od_amount['total'] = DISPLAY_PRICE_WITH_TAX == 'true' ?  $od_amount['total'] : $od_amount['total'] / (1 + ($orderTotalDetails['orderTax'] / $orderTotalDetails['orderTotal']));
+                            $ratio = $od_amount['total'] / $orderAmountTotal;
+						}
                         break;
                     case 'O': // Both Fixed amount off & Free Shipping
-//                        $od_amount['total'] = zen_round($coupon_details['coupon_amount'] * ($orderTotalDetails['orderTotal']>0), $currencyDecimalPlaces);
-                        $od_amount['total'] = zen_round(($coupon_details['coupon_amount'] > $orderTotalDetails['orderTotal'] ? $orderTotalDetails['orderTotal'] : $coupon_details['coupon_amount']) * ($orderTotalDetails['orderTotal'] > 0) * $coupon_product_count, $currencyDecimalPlaces);
-                        //$od_amount['total'] = zen_round($coupon_details['coupon_amount'] * ($orderAmountTotal>0), $currencyDecimalPlaces);
+					    if ($this->calculate_tax == 'Credit Note') {
+							if (DISPLAY_PRICE_WITH_TAX != 'true') {
+                                $od_amount['total'] = ($coupon_details['coupon_amount'] > $orderTotalDetails['orderTotal'] ? $orderTotalDetails['orderTotal'] : $coupon_details['coupon_amount']) * ($orderTotalDetails['orderTotal'] > 0) * $coupon_product_count;
+							} else {								
+                                $od_amount['total'] = ($coupon_details['coupon_amount'] > ($orderTotalDetails['orderTotal'] - $orderTotalDetails['orderTax']) ? ($orderTotalDetails['orderTotal'] - $orderTotalDetails['orderTax']) : $coupon_details['coupon_amount']) * ($orderTotalDetails['orderTotal'] > 0) * $coupon_product_count;
+							}
+                            $od_amount['total'] = DISPLAY_PRICE_WITH_TAX == 'false' ?  $od_amount['total'] : $od_amount['total'] * (1 + (zen_get_tax_rate($this->tax_class) / 100));
+                            $ratio = DISPLAY_PRICE_WITH_TAX == 'true' ? $od_amount['total'] / ($orderAmountTotal - $orderTotalDetails['orderTax']) : $od_amount['total'] / $orderAmountTotal;
+						} else {
+							if (DISPLAY_PRICE_WITH_TAX == 'true') {
+                                $od_amount['total'] = ($coupon_details['coupon_amount'] > $orderTotalDetails['orderTotal'] ? $orderTotalDetails['orderTotal'] : $coupon_details['coupon_amount']) * ($orderTotalDetails['orderTotal'] > 0) * $coupon_product_count;
+							} else {							
+                                $od_amount['total'] = ($coupon_details['coupon_amount'] > ($orderTotalDetails['orderTotal'] + $orderTotalDetails['orderTax']) ? ($orderTotalDetails['orderTotal'] + $orderTotalDetails['orderTax']) : $coupon_details['coupon_amount']) * ($orderTotalDetails['orderTotal'] > 0) * $coupon_product_count;
+							}
+                            $od_amount['total'] = DISPLAY_PRICE_WITH_TAX == 'true' ?  $od_amount['total'] : $od_amount['total'] / (1 + ($orderTotalDetails['orderTax'] / $orderTotalDetails['orderTotal']));
+                            $ratio = $od_amount['total'] / $orderAmountTotal;
+						}
+                        if (isset($_SESSION['shipping_tax_description']) && $_SESSION['shipping_tax_description'] != '') {
+                            $od_amount['tax_groups'][$_SESSION['shipping_tax_description']] = $orderTotalDetails['shippingTax'];
+                        }
                         // add in Free Shipping
                         $coupon_includes_free_shipping = true;
-                        $od_amount['tax'] = ($this->calculate_tax == 'Standard') ? $orderTotalDetails['shippingTax'] : 0;
-                        $ratio = $od_amount['total'] / $orderAmountTotal;
-                        if (isset($_SESSION['shipping_tax_description']) && $_SESSION['shipping_tax_description'] != '') {
-                            $od_amount['tax_groups'][$_SESSION['shipping_tax_description']] = $od_amount['tax'];
-                        }
                         break;
                     case 'G': // GV / Gift Certificate
                     default:
@@ -591,18 +626,34 @@ class ot_coupon extends base
                                     $this_tax -= $orderTotalDetails['shippingTax'];
                                 }
                             }
-                            $od_amount['tax_groups'][$key] = zen_round($this_tax * $ratio, $currencyDecimalPlaces);
+							$od_amount['tax_groups'][$key] = isset($od_amount['tax_groups'][$key]) ? $od_amount['tax_groups'][$key] + $this_tax * $ratio : $this_tax * $ratio;
                             $od_amount['tax'] += $od_amount['tax_groups'][$key];
-                        }
-                        if (DISPLAY_PRICE_WITH_TAX == 'true' && $coupon_details['coupon_type'] == 'F') {
-                            $od_amount['total'] += $od_amount['tax'];
                         }
                         break;
                     case 'Credit Note':
-                        $tax_rate = zen_get_tax_rate($this->tax_class);
-                        $od_amount['tax'] = zen_calculate_tax($od_amount['total'], $tax_rate);
-                        $tax_description = zen_get_tax_description($this->tax_class);
-                        $od_amount['tax_groups'][$tax_description] = $od_amount['tax'];
+						if ($this->tax_class == true) {
+                            $tax_rate = zen_get_tax_rate($this->tax_class);
+                            $od_amount['tax'] += (DISPLAY_PRICE_WITH_TAX == 'true' ? $od_amount['total'] - ($od_amount['total'] / (1 + $tax_rate / 100)) : zen_calculate_tax($od_amount['total'], $tax_rate));
+							if ($od_amount['tax'] > ($orderTotalDetails['orderTax'] + $orderTotalDetails['shippingTax'])) {
+							    $od_amount['tax'] = $orderTotalDetails['orderTax'] + $orderTotalDetails['shippingTax'];
+								$od_amount['total'] = DISPLAY_PRICE_WITH_TAX == 'true' ? $od_amount['tax'] + ($od_amount['tax'] / ($tax_rate / 100)) : $od_amount['tax'] / ($tax_rate / 100);
+							}
+                            $tax_description = zen_get_tax_description($this->tax_class);
+                            isset($od_amount['tax_groups'][$tax_description]) ? $od_amount['tax_groups'][$tax_description] += $od_amount['tax'] : $od_amount['tax_groups'][$tax_description] = $od_amount['tax'];
+						} else {
+							if ($od_amount['total'] >= $orderTotalDetails['orderTotal']) $ratio = 1;
+							foreach ($orderTotalDetails['orderTaxGroups'] as $key => $value) {
+								$this_tax = $orderTotalDetails['orderTaxGroups'][$key];
+								if ($this->include_shipping != 'true') {
+									if (isset($_SESSION['shipping_tax_description']) && $_SESSION['shipping_tax_description'] == $key) {
+										$this_tax -= $orderTotalDetails['shippingTax'];
+									}
+								}
+								$od_amount['tax_groups'][$key] = isset($od_amount['tax_groups'][$key]) ? $od_amount['tax_groups'][$key] + $this_tax * $ratio : $this_tax * $ratio;
+								$od_amount['tax'] += $od_amount['tax_groups'][$key];
+							}
+							$od_amount['total'] += DISPLAY_PRICE_WITH_TAX == 'true' ? $od_amount['tax'] : 0;
+						}
                         break;
                     case 'None':
                     default:
@@ -611,8 +662,12 @@ class ot_coupon extends base
 
                 // adjust for free-shipping
                 if ($coupon_includes_free_shipping) {
-                    $od_amount['total'] += $orderTotalDetails['shipping'];
+					$od_amount['total'] += $orderTotalDetails['shipping'];
                 }
+				if ($od_amount['total'] > $orderTotalDetails['orderTotal']) {
+				    $od_amount['total'] = $orderTotalDetails['orderTotal'];
+					$od_amount['tax'] = $orderTotalDetails['orderTax'];
+				}
             }
         }
 
@@ -623,10 +678,6 @@ class ot_coupon extends base
         //
         $this->notify('NOTIFY_OT_COUPON_CALCS_FINISHED', ['coupon' => $coupon_details, 'order_totals' => $orderTotalDetails, 'od_amount' => $od_amount], $coupon_details);
 
-//    print_r($order->info);
-//    print_r($orderTotalDetails);echo "<br><br>";
-//    echo 'RATIo = '. $ratio;
-//    print_r($od_amount);
         return $od_amount;
     }
 
@@ -673,6 +724,9 @@ class ot_coupon extends base
             }
         }
 
+        if (DISPLAY_PRICE_WITH_TAX != 'true') {
+            $orderTotal -= $orderTotalTax;
+        }
         // shipping/tax
         if ($this->include_shipping !== 'true') {
             $orderTotal -= $order->info['shipping_cost'] ?? 0;
@@ -680,17 +734,12 @@ class ot_coupon extends base
                 $orderTotalTax -= $order->info['shipping_tax'] ?? 0;
             }
         }
-        if (DISPLAY_PRICE_WITH_TAX !== 'true') {
-            $orderTotal -= $orderTotalTax;
-        }
-
         // change what total is used for Discount Coupon Minimum
         $orderTotalFull = $order->info['total'] ?? 0;
-        //echo 'Current $orderTotalFull: ' . $orderTotalFull . ' shipping_cost: ' . $order->info['shipping_cost'] . '<br>';
-        $orderTotalFull -= $order->info['shipping_cost'] ?? 0;
-        //echo 'Current $orderTotalFull less shipping: ' . $orderTotalFull . '<br>';
+        if (isset($_SESSION['shipping_tax_amount']) && $_SESSION['shipping_tax_amount'] != 0) {
+            $orderTotalFull -= DISPLAY_PRICE_WITH_TAX == 'true' ? $order->info['shipping_cost'] - $order->info['shipping_tax'] : ($order->info['shipping_cost'] ?? 0);
+        }
         $orderTotalFull -= $orderTotalTax;
-        //echo 'Current $orderTotalFull less taxes: ' . $orderTotalFull . '<br>';
         // left for total order amount ($orderTotalDetails['totalFull']) vs qualified order amount ($order_total['orderTotal']) - to include both in array
         // add total order amount ($orderTotalFull) to array for $order_total['totalFull'] vs $order_total['orderTotal']
         return [
@@ -920,8 +969,6 @@ class ot_coupon extends base
         if ($coupon_details['coupon_calc_base'] == 1) {
             $orderAmountToCompareAgainstCouponMinimum = (string)$orderTotalDetails['totalFull']; // coupon minimum comparison includes sale items that may not be included in deduction
         }
-
-//echo 'Product: ' . $orderTotalDetails['orderTotal'] . ' Order: ' . $orderTotalDetails['totalFull'] . ' $orderAmountTotal: ' . $orderAmountTotal . '<br>';
 
 // ALTERNATE POTENTIAL RULES
 // for total order amount vs qualified order amount just switch the commented lines

--- a/includes/modules/order_total/ot_coupon.php
+++ b/includes/modules/order_total/ot_coupon.php
@@ -594,7 +594,7 @@ class ot_coupon extends base
                             $od_amount['tax_groups'][$key] = zen_round($this_tax * $ratio, $currencyDecimalPlaces);
                             $od_amount['tax'] += $od_amount['tax_groups'][$key];
                         }
-                        if (DISPLAY_PRICE_WITH_TAX == 'true' && $coupon_details['coupon_type'] == 'F') {
+                        if (DISPLAY_PRICE_WITH_TAX === 'true' && $coupon_details['coupon_type'] == 'F') {
                             $od_amount['total'] += $od_amount['tax'];
                         }
                         break;

--- a/includes/modules/order_total/ot_group_pricing.php
+++ b/includes/modules/order_total/ot_group_pricing.php
@@ -99,13 +99,17 @@ class ot_group_pricing {
           $tax += $od_amount['tax_groups'][$key];
         }
       }
-      $order->info['total'] = $order->info['total'] - $od_amount['total'];
       if (DISPLAY_PRICE_WITH_TAX == 'true') {
-        $od_amount['total'] += $tax;
-      }
+          $od_amount['total'] += $tax;
+		  $order->info['total'] -= $od_amount['total'];
+      } else {
+          $order->info['total'] -= $od_amount['total'] + $tax;
+	  }
+	  $order->info['option_modules']['group_discount_amount'] = - $od_amount['total'];
       if ($this->calculate_tax == "Standard") $order->info['total'] -= $tax;
       if ($order->info['total'] < 0) $order->info['total'] = 0;
       $order->info['tax'] = $order->info['tax'] - $tax;
+
       $this->output[] = array('title' => $this->title . ':',
       'text' => '-' . $currencies->format($od_amount['total'], true, $order->info['currency'], $order->info['currency_value']),
       'value' => $od_amount['total']);

--- a/includes/modules/order_total/ot_group_pricing.php
+++ b/includes/modules/order_total/ot_group_pricing.php
@@ -99,7 +99,7 @@ class ot_group_pricing {
           $tax += $od_amount['tax_groups'][$key];
         }
       }
-      $order->info['total'] -= $od_amount['total'];
+      $order->info['total'] = $order->info['total'] - $od_amount['total'];
       if (DISPLAY_PRICE_WITH_TAX == 'true') {
         $od_amount['total'] += $tax;
       }
@@ -107,7 +107,6 @@ class ot_group_pricing {
       if ($this->calculate_tax == "Standard") $order->info['total'] -= $tax;
       if ($order->info['total'] < 0) $order->info['total'] = 0;
       $order->info['tax'] = $order->info['tax'] - $tax;
-
       $this->output[] = array('title' => $this->title . ':',
       'text' => '-' . $currencies->format($od_amount['total'], true, $order->info['currency'], $order->info['currency_value']),
       'value' => $od_amount['total']);
@@ -146,11 +145,16 @@ class ot_group_pricing {
         return $od_amount;
     }
     $orderTotal = $this->get_order_total();
+    $orderTotalTax = $orderTotal['tax'];
+    $taxGroups = $orderTotal['taxGroups'];
     $group_query = $db->Execute("select customers_group_pricing from " . TABLE_CUSTOMERS . " where customers_id = '" . (int)$_SESSION['customer_id'] . "'");
     if ($group_query->fields['customers_group_pricing'] != '0') {
       $group_discount = $db->Execute("select group_name, group_percentage from " . TABLE_GROUP_PRICING . "
                                       where group_id = '" . (int)$group_query->fields['customers_group_pricing'] . "'");
-      $od_amount['total'] = ($orderTotal['total'] - $_SESSION['cart']->gv_only()) * $group_discount->fields['group_percentage'] / 100;
+      $gift_vouchers = $_SESSION['cart']->gv_only();
+      $discount = ($orderTotal['total'] - $gift_vouchers) * $group_discount->fields['group_percentage'] / 100;
+//      echo "discout = $discount<br>";
+      $od_amount['total'] = round($discount, 2);
       $ratio = $od_amount['total']/$order_total;
       /**
        * when calculating the ratio add some insignificant values to stop divide by zero errors
@@ -167,11 +171,12 @@ class ot_group_pricing {
           if ($od_amount['total'] >= $order_total) {
             $ratio = 1;
           }
+          $adjustedTax = $orderTotalTax * $ratio;
           if ($order->info['tax'] == 0) return $od_amount;
-          $ratio = ($orderTotal['tax'] != 0 ) ? $ratio : 0;
+          $ratioTax = ($orderTotalTax != 0 ) ? $adjustedTax/$orderTotalTax : 0;
           $tax_deduct = 0;
-          foreach ($orderTotal['taxGroups'] as $key=>$value) {
-            $od_amount['tax_groups'][$key] = $value * $ratio;
+          foreach ($taxGroups as $key=>$value) {
+            $od_amount['tax_groups'][$key] = $value * $ratioTax;
             $tax_deduct += $od_amount['tax_groups'][$key];
           }
           $od_amount['tax'] = $tax_deduct;

--- a/includes/modules/order_total/ot_group_pricing.php
+++ b/includes/modules/order_total/ot_group_pricing.php
@@ -99,12 +99,10 @@ class ot_group_pricing {
           $tax += $od_amount['tax_groups'][$key];
         }
       }
+      $order->info['total'] -= $od_amount['total'];
       if (DISPLAY_PRICE_WITH_TAX == 'true') {
-          $od_amount['total'] += $tax;
-		  $order->info['total'] -= $od_amount['total'] - $tax;
-      } else {
-          $order->info['total'] -= $od_amount['total'];
-	  }
+        $od_amount['total'] += $tax;
+      }
 	  $order->info['option_modules']['group_discount_amount'] = - $od_amount['total'];
       if ($this->calculate_tax == "Standard") $order->info['total'] -= $tax;
       if ($order->info['total'] < 0) $order->info['total'] = 0;
@@ -148,16 +146,11 @@ class ot_group_pricing {
         return $od_amount;
     }
     $orderTotal = $this->get_order_total();
-    $orderTotalTax = $orderTotal['tax'];
-    $taxGroups = $orderTotal['taxGroups'];
     $group_query = $db->Execute("select customers_group_pricing from " . TABLE_CUSTOMERS . " where customers_id = '" . (int)$_SESSION['customer_id'] . "'");
     if ($group_query->fields['customers_group_pricing'] != '0') {
       $group_discount = $db->Execute("select group_name, group_percentage from " . TABLE_GROUP_PRICING . "
                                       where group_id = '" . (int)$group_query->fields['customers_group_pricing'] . "'");
-      $gift_vouchers = $_SESSION['cart']->gv_only();
-      $discount = ($orderTotal['total'] - $gift_vouchers) * $group_discount->fields['group_percentage'] / 100;
-//      echo "discout = $discount<br>";
-      $od_amount['total'] = round($discount, 2);
+      $od_amount['total'] = ($orderTotal['total'] - $_SESSION['cart']->gv_only()) * $group_discount->fields['group_percentage'] / 100;
       $ratio = $od_amount['total']/$order_total;
       /**
        * when calculating the ratio add some insignificant values to stop divide by zero errors
@@ -174,12 +167,11 @@ class ot_group_pricing {
           if ($od_amount['total'] >= $order_total) {
             $ratio = 1;
           }
-          $adjustedTax = $orderTotalTax * $ratio;
           if ($order->info['tax'] == 0) return $od_amount;
-          $ratioTax = ($orderTotalTax != 0 ) ? $adjustedTax/$orderTotalTax : 0;
+          $ratio = ($orderTotal['tax'] != 0 ) ? $ratio : 0;
           $tax_deduct = 0;
-          foreach ($taxGroups as $key=>$value) {
-            $od_amount['tax_groups'][$key] = $value * $ratioTax;
+          foreach ($orderTotal['taxGroups'] as $key=>$value) {
+            $od_amount['tax_groups'][$key] = $value * $ratio;
             $tax_deduct += $od_amount['tax_groups'][$key];
           }
           $od_amount['tax'] = $tax_deduct;

--- a/includes/modules/order_total/ot_group_pricing.php
+++ b/includes/modules/order_total/ot_group_pricing.php
@@ -101,9 +101,9 @@ class ot_group_pricing {
       }
       if (DISPLAY_PRICE_WITH_TAX == 'true') {
           $od_amount['total'] += $tax;
-		  $order->info['total'] -= $od_amount['total'];
+		  $order->info['total'] -= $od_amount['total'] - $tax;
       } else {
-          $order->info['total'] -= $od_amount['total'] + $tax;
+          $order->info['total'] -= $od_amount['total'];
 	  }
 	  $order->info['option_modules']['group_discount_amount'] = - $od_amount['total'];
       if ($this->calculate_tax == "Standard") $order->info['total'] -= $tax;

--- a/includes/modules/order_total/ot_group_pricing.php
+++ b/includes/modules/order_total/ot_group_pricing.php
@@ -34,7 +34,7 @@ class ot_group_pricing {
      * $deduction amount of deduction calculated/afforded while being applied to an order
      * @var float|null
      */
-    public $deduction;
+    protected $deduction;
     /**
      * $description is a soft name for this order total method
      * @var string 
@@ -103,7 +103,7 @@ class ot_group_pricing {
       if (DISPLAY_PRICE_WITH_TAX === 'true') {
         $od_amount['total'] += $tax;
       }
-      $order->info['option_modules']['group_discount_amount'] = - $od_amount['total'];
+      $order->info['option_modules'][$this->code] = - $od_amount['total'];
       if ($this->calculate_tax == "Standard") $order->info['total'] -= $tax;
       if ($order->info['total'] < 0) $order->info['total'] = 0;
       $order->info['tax'] = $order->info['tax'] - $tax;

--- a/includes/modules/order_total/ot_group_pricing.php
+++ b/includes/modules/order_total/ot_group_pricing.php
@@ -100,7 +100,7 @@ class ot_group_pricing {
         }
       }
       $order->info['total'] = $order->info['total'] - $od_amount['total'];
-      if (DISPLAY_PRICE_WITH_TAX == 'true') {
+      if (DISPLAY_PRICE_WITH_TAX === 'true') {
         $od_amount['total'] += $tax;
       }
       $order->info['option_modules']['group_discount_amount'] = - $od_amount['total'];
@@ -119,7 +119,7 @@ class ot_group_pricing {
     $order_total = $order->info['total'];
     if ($this->include_shipping != 'true') $order_total -= $order->info['shipping_cost'];
     if ($this->include_tax != 'true') $order_total -= $order->info['tax'];
-    if (DISPLAY_PRICE_WITH_TAX == 'true' && $this->include_shipping != 'true')
+    if (DISPLAY_PRICE_WITH_TAX === 'true' && $this->include_shipping != 'true')
     {
       $order_total += $order->info['shipping_tax'];
     }
@@ -199,7 +199,7 @@ class ot_group_pricing {
     global $order;
     $od_amount = $this->calculate_deductions($order_total);
     $order->info['total'] = $order->info['total'] - $od_amount['total'];
-    return $od_amount['total'] + (DISPLAY_PRICE_WITH_TAX == 'true' ? 0 : $od_amount['tax']);
+    return $od_amount['total'] + (DISPLAY_PRICE_WITH_TAX === 'true' ? 0 : $od_amount['tax']);
   }
 
   function credit_selection() {

--- a/includes/modules/order_total/ot_group_pricing.php
+++ b/includes/modules/order_total/ot_group_pricing.php
@@ -103,7 +103,7 @@ class ot_group_pricing {
       if (DISPLAY_PRICE_WITH_TAX == 'true') {
         $od_amount['total'] += $tax;
       }
-	  $order->info['option_modules']['group_discount_amount'] = - $od_amount['total'];
+      $order->info['option_modules']['group_discount_amount'] = - $od_amount['total'];
       if ($this->calculate_tax == "Standard") $order->info['total'] -= $tax;
       if ($order->info['total'] < 0) $order->info['total'] = 0;
       $order->info['tax'] = $order->info['tax'] - $tax;

--- a/includes/modules/order_total/ot_gv.php
+++ b/includes/modules/order_total/ot_gv.php
@@ -150,7 +150,7 @@ class ot_gv {
         }
         $order->info['total'] = $order->info['total'] - $od_amount['total'];
         if ($this->calculate_tax == "Standard") $order->info['total'] -= $tax;
-		$order->info['option_modules']['gv_amount'] = - $od_amount['total'];
+        $order->info['option_modules']['gv_amount'] = - $od_amount['total'];
         if ($order->info['total'] < 0) $order->info['total'] = 0;
         $order->info['tax'] = $order->info['tax'] - $od_amount['tax'];
         // prepare order-total output for display and storing to invoice

--- a/includes/modules/order_total/ot_gv.php
+++ b/includes/modules/order_total/ot_gv.php
@@ -150,7 +150,7 @@ class ot_gv {
         }
         $order->info['total'] = $order->info['total'] - $od_amount['total'];
         if ($this->calculate_tax == "Standard") $order->info['total'] -= $tax;
-        $order->info['option_modules']['gv_amount'] = - $od_amount['total'];
+        $order->info['option_modules'][$this->code] = - $od_amount['total'];
         if ($order->info['total'] < 0) $order->info['total'] = 0;
         $order->info['tax'] = $order->info['tax'] - $od_amount['tax'];
         // prepare order-total output for display and storing to invoice

--- a/includes/modules/order_total/ot_gv.php
+++ b/includes/modules/order_total/ot_gv.php
@@ -148,10 +148,16 @@ class ot_gv {
             $tax += $od_amount['tax_groups'][$key];
           }
         }
-        $order->info['total'] = $order->info['total'] - $od_amount['total'];
-        if ($this->calculate_tax == "Standard") $order->info['total'] -= $tax;
-        if ($order->info['total'] < 0) $order->info['total'] = 0;
-        $order->info['tax'] = $order->info['tax'] - $od_amount['tax'];
+		$order->info['total'] = DISPLAY_PRICE_WITH_TAX == 'true' ? $order->info['total'] - $od_amount['total'] : $order->info['total'] - $od_amount['total'] - $od_amount['tax'];
+		$order->info['tax'] -= $tax;
+		$order->info['option_modules']['gv_amount'] = - $od_amount['total'];
+        if ($order->info['total'] < 0) {
+			$order->info['total'] = 0;
+			$order->info['tax'] = 0;
+			foreach ($order->info['tax_groups'] as $key => $value) {
+				$order->info['tax_groups'][$key] = 0;
+			}
+		}
         // prepare order-total output for display and storing to invoice
         $this->output[] = array('title' => $this->title . ':',
                                 'text' => '-' . $currencies->format($od_amount['total']),
@@ -425,7 +431,11 @@ class ot_gv {
       if ($od_amount['total'] >= $order_total) {
         $ratio = 1;
       } else {
-        $ratio = ($od_amount['total'] / ($order_total - $order->info['tax']));
+		if ($order->info['shipping_tax'] == 0) {
+			$ratio = $od_amount['total'] / ($order_total - $order->info['shipping_cost']);
+		} else {
+            $ratio = $od_amount['total'] / $order_total;
+		}
       }
       $tax_deduct = 0;
       foreach ($order->info['tax_groups'] as $key=>$value) {
@@ -433,10 +443,11 @@ class ot_gv {
         $tax_deduct += $od_amount['tax_groups'][$key];
       }
       $od_amount['tax'] = $tax_deduct;
+	  $od_amount['total'] = DISPLAY_PRICE_WITH_TAX == 'true' ? $od_amount['total'] : $od_amount['total'] - $od_amount['tax'];
       break;
       case 'Credit Note':
-        $od_amount['total'] = $deduction;
         $tax_rate = zen_get_tax_rate($this->tax_class);
+        $od_amount['total'] = DISPLAY_PRICE_WITH_TAX == 'true' ? zen_add_tax($deduction, $tax_rate) : $deduction;
         $od_amount['tax'] = zen_calculate_tax($deduction, $tax_rate);
         $tax_description = zen_get_tax_description($this->tax_class);
         $od_amount['tax_groups'][$tax_description] = $od_amount['tax'];
@@ -464,10 +475,9 @@ class ot_gv {
     global $order;
     $order_total = $order->info['total'];
     // if we are not supposed to include tax in credit calculations, subtract it out
-    if ($this->include_tax != 'true') $order_total -= $order->info['tax'];
+    if ($this->include_tax != 'true' && $this->calculate_tax == "None") $order_total -= $order->info['tax'];
     // if we are not supposed to include shipping amount in credit calcs, subtract it out
     if ($this->include_shipping != 'true') $order_total -= $order->info['shipping_cost'];
-    $order_total = $order->info['total'];
 
     // check gv_amount in cart and do not allow GVs to pay for GVs
     $chk_gv_amount = 0;

--- a/includes/modules/order_total/ot_gv.php
+++ b/includes/modules/order_total/ot_gv.php
@@ -148,16 +148,11 @@ class ot_gv {
             $tax += $od_amount['tax_groups'][$key];
           }
         }
-		$order->info['total'] = DISPLAY_PRICE_WITH_TAX == 'true' ? $order->info['total'] - $od_amount['total'] : $order->info['total'] - $od_amount['total'] - $od_amount['tax'];
-		$order->info['tax'] -= $tax;
+        $order->info['total'] = $order->info['total'] - $od_amount['total'];
+        if ($this->calculate_tax == "Standard") $order->info['total'] -= $tax;
 		$order->info['option_modules']['gv_amount'] = - $od_amount['total'];
-        if ($order->info['total'] < 0) {
-			$order->info['total'] = 0;
-			$order->info['tax'] = 0;
-			foreach ($order->info['tax_groups'] as $key => $value) {
-				$order->info['tax_groups'][$key] = 0;
-			}
-		}
+        if ($order->info['total'] < 0) $order->info['total'] = 0;
+        $order->info['tax'] = $order->info['tax'] - $od_amount['tax'];
         // prepare order-total output for display and storing to invoice
         $this->output[] = array('title' => $this->title . ':',
                                 'text' => '-' . $currencies->format($od_amount['total']),
@@ -431,11 +426,7 @@ class ot_gv {
       if ($od_amount['total'] >= $order_total) {
         $ratio = 1;
       } else {
-		if ($order->info['shipping_tax'] == 0) {
-			$ratio = $od_amount['total'] / ($order_total - $order->info['shipping_cost']);
-		} else {
-            $ratio = $od_amount['total'] / $order_total;
-		}
+        $ratio = ($od_amount['total'] / ($order_total - $order->info['tax']));
       }
       $tax_deduct = 0;
       foreach ($order->info['tax_groups'] as $key=>$value) {
@@ -443,11 +434,10 @@ class ot_gv {
         $tax_deduct += $od_amount['tax_groups'][$key];
       }
       $od_amount['tax'] = $tax_deduct;
-	  $od_amount['total'] = DISPLAY_PRICE_WITH_TAX == 'true' ? $od_amount['total'] : $od_amount['total'] - $od_amount['tax'];
       break;
       case 'Credit Note':
+        $od_amount['total'] = $deduction;
         $tax_rate = zen_get_tax_rate($this->tax_class);
-        $od_amount['total'] = DISPLAY_PRICE_WITH_TAX == 'true' ? zen_add_tax($deduction, $tax_rate) : $deduction;
         $od_amount['tax'] = zen_calculate_tax($deduction, $tax_rate);
         $tax_description = zen_get_tax_description($this->tax_class);
         $od_amount['tax_groups'][$tax_description] = $od_amount['tax'];
@@ -475,9 +465,10 @@ class ot_gv {
     global $order;
     $order_total = $order->info['total'];
     // if we are not supposed to include tax in credit calculations, subtract it out
-    if ($this->include_tax != 'true' && $this->calculate_tax == "None") $order_total -= $order->info['tax'];
+    if ($this->include_tax != 'true') $order_total -= $order->info['tax'];
     // if we are not supposed to include shipping amount in credit calcs, subtract it out
     if ($this->include_shipping != 'true') $order_total -= $order->info['shipping_cost'];
+    $order_total = $order->info['total'];
 
     // check gv_amount in cart and do not allow GVs to pay for GVs
     $chk_gv_amount = 0;

--- a/includes/modules/order_total/ot_loworderfee.php
+++ b/includes/modules/order_total/ot_loworderfee.php
@@ -125,7 +125,7 @@ class ot_loworderfee
                 if (DISPLAY_PRICE_WITH_TAX === 'true') {
                     $low_order_fee += zen_calculate_tax($low_order_fee, $tax);
                 }
-                $order->info['option_modules']['lord_fee'] = $low_order_fee;
+                $order->info['option_modules'][$this->code] = $low_order_fee;
 
                 $this->output[] = [
                     'title' => $this->title . ':',

--- a/includes/modules/order_total/ot_loworderfee.php
+++ b/includes/modules/order_total/ot_loworderfee.php
@@ -125,7 +125,7 @@ class ot_loworderfee
                 if (DISPLAY_PRICE_WITH_TAX === 'true') {
                     $low_order_fee += zen_calculate_tax($low_order_fee, $tax);
                 }
-				$order->info['option_modules']['lord_fee'] = $low_order_fee;
+                $order->info['option_modules']['lord_fee'] = $low_order_fee;
 
                 $this->output[] = [
                     'title' => $this->title . ':',

--- a/includes/modules/order_total/ot_loworderfee.php
+++ b/includes/modules/order_total/ot_loworderfee.php
@@ -80,7 +80,6 @@ class ot_loworderfee
                 break;
         }
 
-//        if ( ($pass == true) && ( ($order->info['total'] - $order->info['shipping_cost']) < MODULE_ORDER_TOTAL_LOWORDERFEE_ORDER_UNDER) ) {
         if ($pass == true && $order->info['subtotal'] < MODULE_ORDER_TOTAL_LOWORDERFEE_ORDER_UNDER) {
             $charge_it = 'true';
             $cart_content_type = $_SESSION['cart']->get_content_type();

--- a/includes/modules/order_total/ot_loworderfee.php
+++ b/includes/modules/order_total/ot_loworderfee.php
@@ -126,6 +126,7 @@ class ot_loworderfee
                 if (DISPLAY_PRICE_WITH_TAX === 'true') {
                     $low_order_fee += zen_calculate_tax($low_order_fee, $tax);
                 }
+				$order->info['option_modules']['lord_fee'] = $low_order_fee;
 
                 $this->output[] = [
                     'title' => $this->title . ':',

--- a/includes/modules/order_total/ot_subtotal.php
+++ b/includes/modules/order_total/ot_subtotal.php
@@ -59,7 +59,7 @@
     }
 
     function check() {
-	  global $db;
+      global $db;
       if (!isset($this->_check)) {
         $check_query = $db->Execute("select configuration_value from " . TABLE_CONFIGURATION . " where configuration_key = 'MODULE_ORDER_TOTAL_SUBTOTAL_STATUS'");
         $this->_check = $check_query->RecordCount();
@@ -73,13 +73,13 @@
     }
 
     function install() {
-	  global $db;
+      global $db;
       $db->Execute("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('This module is installed', 'MODULE_ORDER_TOTAL_SUBTOTAL_STATUS', 'true', '', '6', '1','zen_cfg_select_option(array(\'true\'), ', now())");
       $db->Execute("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Sort Order', 'MODULE_ORDER_TOTAL_SUBTOTAL_SORT_ORDER', '100', 'Sort order of display.', '6', '2', now())");
     }
 
     function remove() {
-	  global $db;
+      global $db;
       $db->Execute("delete from " . TABLE_CONFIGURATION . " where configuration_key in ('" . implode("', '", $this->keys()) . "')");
     }
   }

--- a/includes/modules/order_total/ot_total.php
+++ b/includes/modules/order_total/ot_total.php
@@ -52,17 +52,17 @@
 
     function process() {
       global $order, $currencies;
-	  // bof lost penny compensation
-	  $modules_total = $currencies->value($order->info['subtotal']) + $currencies->value($order->info['shipping_cost']);
+      // bof lost penny compensation
+      $modules_total = $currencies->value($order->info['subtotal']) + $currencies->value($order->info['shipping_cost']);
       if (!empty($order->info['option_modules'])) {
-		  foreach ($order->info['option_modules'] as $key => $value) {
-			  $modules_total += (isset($order->info['option_modules'][$key]) && $order->info['option_modules'][$key] !=0) ? $currencies->value($order->info['option_modules'][$key]) : 0;
-		  }
-	  }
-	  $modules_total += DISPLAY_PRICE_WITH_TAX != 'true' ? $currencies->value($order->info['tax']) : 0;
-	  $lost_penny = substr(strval(zen_round(abs($modules_total - $currencies->value($order->info['total'])), $currencies->get_decimal_places($_SESSION['currency']))), -1);
-	  $order->info['total'] = ($lost_penny == '1' && $order->info['total'] > 0) ? $currencies->value($modules_total, true, DEFAULT_CURRENCY) : $order->info['total'];
-	  // eof lost penny compensation
+          foreach ($order->info['option_modules'] as $key => $value) {
+              $modules_total += (isset($order->info['option_modules'][$key]) && $order->info['option_modules'][$key] !=0) ? $currencies->value($order->info['option_modules'][$key]) : 0;
+          }
+      }
+      $modules_total += DISPLAY_PRICE_WITH_TAX != 'true' ? $currencies->value($order->info['tax']) : 0;
+      $lost_penny = substr(strval(zen_round(abs($modules_total - $currencies->value($order->info['total'])), $currencies->get_decimal_places($_SESSION['currency']))), -1);
+      $order->info['total'] = ($lost_penny == '1' && $order->info['total'] > 0) ? $currencies->value($modules_total, true, DEFAULT_CURRENCY) : $order->info['total'];
+      // eof lost penny compensation
       $this->output[] = array('title' => $this->title . ':',
                               'text' => $currencies->format($order->info['total'], true, $order->info['currency'], $order->info['currency_value']),
                               'value' => $order->info['total']);

--- a/includes/modules/order_total/ot_total.php
+++ b/includes/modules/order_total/ot_total.php
@@ -59,7 +59,7 @@
               $modules_total += (isset($order->info['option_modules'][$key]) && $order->info['option_modules'][$key] !=0) ? $currencies->value($order->info['option_modules'][$key]) : 0;
           }
       }
-      $modules_total += DISPLAY_PRICE_WITH_TAX != 'true' ? $currencies->value($order->info['tax']) : 0;
+      $modules_total += DISPLAY_PRICE_WITH_TAX !== 'true' ? $currencies->value($order->info['tax']) : 0;
       $lost_penny = substr(strval(zen_round(abs($modules_total - $currencies->value($order->info['total'])), $currencies->get_decimal_places($_SESSION['currency']))), -1);
       $order->info['total'] = ($lost_penny == '1' && $order->info['total'] > 0) ? $currencies->value($modules_total, true, DEFAULT_CURRENCY) : $order->info['total'];
       // eof lost penny compensation

--- a/includes/modules/order_total/ot_total.php
+++ b/includes/modules/order_total/ot_total.php
@@ -53,13 +53,13 @@
     function process() {
       global $order, $currencies;
 	  // bof lost penny compensation
-	  $lost_penny_total = $currencies->value($order->info['subtotal']) + $currencies->value($order->info['shipping_cost']);
+	  $modules_total = $currencies->value($order->info['subtotal']) + $currencies->value($order->info['shipping_cost']);
 	  foreach ($order->info['option_modules'] as $key => $value) {
-	      $lost_penny_total += (isset($order->info['option_modules'][$key]) && $order->info['option_modules'][$key] !=0) ? $currencies->value($order->info['option_modules'][$key]) : 0;
+	      $modules_total += (isset($order->info['option_modules'][$key]) && $order->info['option_modules'][$key] !=0) ? $currencies->value($order->info['option_modules'][$key]) : 0;
 	  }
-	  $lost_penny_total += DISPLAY_PRICE_WITH_TAX != 'true' ? $currencies->value($order->info['tax']) : 0;
-	  $lost_penny = substr(strval(zen_round(abs($lost_penny_total - $currencies->value($order->info['total'])), $currencies->get_decimal_places($_SESSION['currency']))), -1);
-	  $order->info['total'] = ($lost_penny == '1' && $order->info['total'] > 0) ? $currencies->value($lost_penny_total, true, DEFAULT_CURRENCY) : $order->info['total'];
+	  $modules_total += DISPLAY_PRICE_WITH_TAX != 'true' ? $currencies->value($order->info['tax']) : 0;
+	  $lost_penny = substr(strval(zen_round(abs($modules_total - $currencies->value($order->info['total'])), $currencies->get_decimal_places($_SESSION['currency']))), -1);
+	  $order->info['total'] = ($lost_penny == '1' && $order->info['total'] > 0) ? $currencies->value($modules_total, true, DEFAULT_CURRENCY) : $order->info['total'];
 	  // eof lost penny compensation
       $this->output[] = array('title' => $this->title . ':',
                               'text' => $currencies->format($order->info['total'], true, $order->info['currency'], $order->info['currency_value']),

--- a/includes/modules/order_total/ot_total.php
+++ b/includes/modules/order_total/ot_total.php
@@ -61,7 +61,7 @@
       }
       $modules_total += DISPLAY_PRICE_WITH_TAX !== 'true' ? $currencies->value($order->info['tax']) : 0;
       $lost_penny = substr(strval(zen_round(abs($modules_total - $currencies->value($order->info['total'])), $currencies->get_decimal_places($_SESSION['currency']))), -1);
-      $order->info['total'] = ($lost_penny == '1' && $order->info['total'] > 0) ? $currencies->value($modules_total, true, DEFAULT_CURRENCY) : $order->info['total'];
+      $order->info['total'] = ($lost_penny === '1' && $order->info['total'] > 0) ? $currencies->value($modules_total, true, DEFAULT_CURRENCY) : $order->info['total'];
       // eof lost penny compensation
       $this->output[] = array('title' => $this->title . ':',
                               'text' => $currencies->format($order->info['total'], true, $order->info['currency'], $order->info['currency_value']),

--- a/includes/modules/order_total/ot_total.php
+++ b/includes/modules/order_total/ot_total.php
@@ -54,7 +54,9 @@
       global $order, $currencies;
 	  // bof lost penny compensation
 	  $lost_penny_total = $currencies->value($order->info['subtotal']) + $currencies->value($order->info['shipping_cost']);
-	  $lost_penny_total -= (isset($order->info['coupon_amount']) && $order->info['coupon_amount'] !=0) ? $currencies->value($order->info['coupon_amount']) : 0;
+	  foreach ($order->info['option_modules'] as $key => $value) {
+	      $lost_penny_total += (isset($order->info['option_modules'][$key]) && $order->info['option_modules'][$key] !=0) ? $currencies->value($order->info['option_modules'][$key]) : 0;
+	  }
 	  $lost_penny_total += DISPLAY_PRICE_WITH_TAX != 'true' ? $currencies->value($order->info['tax']) : 0;
 	  $lost_penny = substr(strval(zen_round(abs($lost_penny_total - $currencies->value($order->info['total'])), $currencies->get_decimal_places($_SESSION['currency']))), -1);
 	  $order->info['total'] = ($lost_penny == '1' && $order->info['total'] > 0) ? $currencies->value($lost_penny_total, true, DEFAULT_CURRENCY) : $order->info['total'];

--- a/includes/modules/order_total/ot_total.php
+++ b/includes/modules/order_total/ot_total.php
@@ -5,7 +5,7 @@
  * @copyright Copyright 2003-2023 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Scott C Wilson 2022 Oct 16 Modified in v1.5.8a $
+ * @version $Id: piloujp 2024 Apr 10 Modified in v2.0.0 $
  */
   class ot_total {
 
@@ -54,8 +54,10 @@
       global $order, $currencies;
 	  // bof lost penny compensation
 	  $modules_total = $currencies->value($order->info['subtotal']) + $currencies->value($order->info['shipping_cost']);
-	  foreach ($order->info['option_modules'] as $key => $value) {
-	      $modules_total += (isset($order->info['option_modules'][$key]) && $order->info['option_modules'][$key] !=0) ? $currencies->value($order->info['option_modules'][$key]) : 0;
+      if (!empty($order->info['option_modules'])) {
+		  foreach ($order->info['option_modules'] as $key => $value) {
+			  $modules_total += (isset($order->info['option_modules'][$key]) && $order->info['option_modules'][$key] !=0) ? $currencies->value($order->info['option_modules'][$key]) : 0;
+		  }
 	  }
 	  $modules_total += DISPLAY_PRICE_WITH_TAX != 'true' ? $currencies->value($order->info['tax']) : 0;
 	  $lost_penny = substr(strval(zen_round(abs($modules_total - $currencies->value($order->info['total'])), $currencies->get_decimal_places($_SESSION['currency']))), -1);

--- a/includes/modules/order_total/ot_total.php
+++ b/includes/modules/order_total/ot_total.php
@@ -52,8 +52,16 @@
 
     function process() {
       global $order, $currencies;
+	  // bof lost penny compensation
+	  $decimale = $currencies->get_decimal_places($_SESSION['currency']);
+	  $lost_penny_total = $currencies->value($order->info['subtotal']) + $currencies->value($order->info['shipping_cost']);
+	  $lost_penny_total -= (isset($order->info['coupon_amount']) && $order->info['coupon_amount'] !=0) ? $currencies->value($order->info['coupon_amount']) : 0;
+	  $lost_penny_total += DISPLAY_PRICE_WITH_TAX != 'true' ? $currencies->value($order->info['tax']) : 0;
+	  $lost_penny = substr(strval(zen_round(abs($lost_penny_total - $currencies->value($order->info['total'])), $decimale)), -1);
+	  $display_order_total = ($lost_penny == '1' && $order->info['total'] > 0) ? $currencies->value($lost_penny_total, true, DEFAULT_CURRENCY) : $order->info['total'];
+	  // eof lost penny compensation
       $this->output[] = array('title' => $this->title . ':',
-                              'text' => $currencies->format($order->info['total'], true, $order->info['currency'], $order->info['currency_value']),
+                              'text' => $currencies->format($display_order_total, true, $order->info['currency'], $order->info['currency_value']),
                               'value' => $order->info['total']);
     }
 

--- a/includes/modules/order_total/ot_total.php
+++ b/includes/modules/order_total/ot_total.php
@@ -53,15 +53,14 @@
     function process() {
       global $order, $currencies;
 	  // bof lost penny compensation
-	  $decimale = $currencies->get_decimal_places($_SESSION['currency']);
 	  $lost_penny_total = $currencies->value($order->info['subtotal']) + $currencies->value($order->info['shipping_cost']);
 	  $lost_penny_total -= (isset($order->info['coupon_amount']) && $order->info['coupon_amount'] !=0) ? $currencies->value($order->info['coupon_amount']) : 0;
 	  $lost_penny_total += DISPLAY_PRICE_WITH_TAX != 'true' ? $currencies->value($order->info['tax']) : 0;
-	  $lost_penny = substr(strval(zen_round(abs($lost_penny_total - $currencies->value($order->info['total'])), $decimale)), -1);
-	  $display_order_total = ($lost_penny == '1' && $order->info['total'] > 0) ? $currencies->value($lost_penny_total, true, DEFAULT_CURRENCY) : $order->info['total'];
+	  $lost_penny = substr(strval(zen_round(abs($lost_penny_total - $currencies->value($order->info['total'])), $currencies->get_decimal_places($_SESSION['currency']))), -1);
+	  $order->info['total'] = ($lost_penny == '1' && $order->info['total'] > 0) ? $currencies->value($lost_penny_total, true, DEFAULT_CURRENCY) : $order->info['total'];
 	  // eof lost penny compensation
       $this->output[] = array('title' => $this->title . ':',
-                              'text' => $currencies->format($display_order_total, true, $order->info['currency'], $order->info['currency_value']),
+                              'text' => $currencies->format($order->info['total'], true, $order->info['currency'], $order->info['currency_value']),
                               'value' => $order->info['total']);
     }
 

--- a/not_for_release/testFramework/FeatureStore/TaxCalculationsSEK/TestBasicTaxCalculationsNoShippingTax/BasicTaxShippingBillingNoShippingSEKTest.php
+++ b/not_for_release/testFramework/FeatureStore/TaxCalculationsSEK/TestBasicTaxCalculationsNoShippingTax/BasicTaxShippingBillingNoShippingSEKTest.php
@@ -47,13 +47,13 @@ class BasicTaxShippingBillingNoShippingSEKTest extends zcFeatureTestCaseStore
         $this->assertStringContainsString('12,2483', (string)$response->getContent() );
         $this->assertStringContainsString('0,4375', (string)$response->getContent() );
         $this->assertStringContainsString('0,8574', (string)$response->getContent() );
-        $this->assertStringContainsString('SEK13,5431SEK', (string)$response->getContent() );
+        $this->assertStringContainsString('SEK13,5432SEK', (string)$response->getContent() );
         $response = $this->browser->getResponse();
         $this->assertStringContainsString('Order Confirmation', (string)$response->getContent() );
         $this->assertStringContainsString('12,2483', (string)$response->getContent() );
         $this->assertStringContainsString('0,4375', (string)$response->getContent() );
         $this->assertStringContainsString('0,8574', (string)$response->getContent() );
-        $this->assertStringContainsString('SEK13,5431SEK', (string)$response->getContent() );
+        $this->assertStringContainsString('SEK13,5432SEK', (string)$response->getContent() );
         $this->browser->submitForm('btn_submit_x', [
         ]);
         $response = $this->browser->getResponse();

--- a/not_for_release/testFramework/FeatureStore/TaxCalculationsSEK/TestStoreTaxCalculationsNoShippingTax/BasicTaxStoreNoShippingSEKTest.php
+++ b/not_for_release/testFramework/FeatureStore/TaxCalculationsSEK/TestStoreTaxCalculationsNoShippingTax/BasicTaxStoreNoShippingSEKTest.php
@@ -46,13 +46,13 @@ class BasicTaxStoreNoShippingSEKTest extends zcFeatureTestCaseStore
         $this->assertStringContainsString('12,2483', (string)$response->getContent() );
         $this->assertStringContainsString('0,4375', (string)$response->getContent() );
         $this->assertStringContainsString('0,8574', (string)$response->getContent() );
-        $this->assertStringContainsString('SEK13,5431SEK', (string)$response->getContent() );
+        $this->assertStringContainsString('SEK13,5432SEK', (string)$response->getContent() );
         $response = $this->browser->getResponse();
         $this->assertStringContainsString('Order Confirmation', (string)$response->getContent() );
         $this->assertStringContainsString('12,2483', (string)$response->getContent() );
         $this->assertStringContainsString('0,4375', (string)$response->getContent() );
         $this->assertStringContainsString('0,8574', (string)$response->getContent() );
-        $this->assertStringContainsString('SEK13,5431SEK', (string)$response->getContent() );
+        $this->assertStringContainsString('SEK13,5432SEK', (string)$response->getContent() );
         $this->browser->submitForm('btn_submit_x', [
         ]);
         $response = $this->browser->getResponse();


### PR DESCRIPTION
In case of a penny difference between invoice total and sum of numbers on the same invoice, this modification will adjust the total to equal the sum of other numbers.
The one penny difference is still visible between invoice with prices including tax and invoice with prices without tax, but one by one, they are coherent, all numbers add correctly.

See forum thread '[The Lost Penny of ZC](https://www.zen-cart.com/showthread.php?230029-The-Lost-Penny-of-ZC)'.