### PR TITLE
Ensure variable is set in checkout shipping

### DIFF
--- a/includes/modules/pages/checkout_shipping/header_php.php
+++ b/includes/modules/pages/checkout_shipping/header_php.php
@@ -188,7 +188,7 @@ if (isset($_SESSION['cart']->cartID)) {
   if (isset($_SESSION['shipping']['id'])) {
     $checklist = [];
     foreach ($quotes as $key=>$val) {
-      if (is_array($val['methods'])) {
+      if (isset($val['methods']) && is_array($val['methods'])) {
         foreach($val['methods'] as $key2=>$method) {
           $checklist[] = $val['id'] . '_' . $method['id'];
         }


### PR DESCRIPTION
```
[11-Apr-2024 19:55:40 UTC] Request URI: /client/index.php?main_page=checkout_shipping, IP address: ::1, Language id 1
#0 /Users/scott/sites/client/includes/modules/pages/checkout_shipping/header_php.php(191): zen_debug_error_handler()
#1 /Users/scott/sites/client/index.php(35): require('/Users/scott/si...')
--> PHP Warning: Undefined array key "methods" in /Users/scott/sites/client/includes/modules/pages/checkout_shipping/header_php.php on line 191.

```
