### PR TITLE
Fix for forgotten password email

### DIFF
--- a/includes/functions/functions_email.php
+++ b/includes/functions/functions_email.php
@@ -604,6 +604,9 @@
         if (is_array($content)) {
             $block = $content;
         } else {
+            if ($content === '' || $content === 'none') {
+               return '';
+            }
             $block['EMAIL_MESSAGE_HTML'] = $content;
         }
 


### PR DESCRIPTION
Forgotten password doesn't pass in an array because no HTML email is sent.  So this log happens:

```
--> PHP Warning: Undefined array key "EMAIL_TO_ADDRESS" in /home/client/public_html/store/includes/functions/functions_email.php on line 626.
```

This PR fixes.