### PR TITLE
Correct new products query in 2.0.0

### DIFF
--- a/includes/functions/functions_products.php
+++ b/includes/functions/functions_products.php
@@ -179,10 +179,10 @@ function zen_get_new_date_range($time_limit = false)
 
     $zc_new_date = date('Ymd', $date_range);
     switch (true) {
-        case (SHOW_NEW_PRODUCTS_LIMIT === '0'):
+        case (SHOW_NEW_PRODUCTS_LIMIT === 0):
             $new_range = '';
             break;
-        case (SHOW_NEW_PRODUCTS_LIMIT === '1'):
+        case (SHOW_NEW_PRODUCTS_LIMIT === 1):
             $zc_new_date = date('Ym', time()) . '01';
             $new_range = ' AND p.products_date_added >= ' . $zc_new_date;
             break;


### PR DESCRIPTION
SHOW_NEW_PRODUCTS_LIMIT is an int, not a string #6399

Fixes #6398.

Removal of old `zen_get_products_new_timelimit` to be done as a follow on PR.