### PR TITLE
Handle case of uptime command not available

### DIFF
--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -343,7 +343,7 @@ function zen_get_system_information($privacy = false)
         $output = '';
         if (DISPLAY_SERVER_UPTIME == 'true') {
             @exec('uptime 2>&1', $output, $errnum);
-            if ($errnum == 0) {
+            if ($errnum == 0 && isset($output[0])) {
                 $uptime = $output[0];
             }
         }


### PR DESCRIPTION
As reported here: https://www.zen-cart.com/showthread.php?230071-RE-PHP-Warning-Undefined-array-key-0
