### PR TITLE
PayPal check - wrong variable used

### DIFF
--- a/includes/modules/payment/paypaldp.php
+++ b/includes/modules/payment/paypaldp.php
@@ -372,7 +372,7 @@ class paypaldp extends base {
       require_once DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/paypal_currency_check.php';
       if (paypalUSDCheck($order->info['total']) === false) {
         $this->enabled = false;
-        $this->zcLog('update_status', 'Module disabled because purchase price (' . $order_amount . ') exceeds PayPal-imposed maximum limit of 10,000 USD.');
+        $this->zcLog('update_status', 'Module disabled because purchase price (' . $order->info['total'] . ') exceeds PayPal-imposed maximum limit of 10,000 USD.');
       }
       if ($order->info['total'] == 0) {
         $this->enabled = false;


### PR DESCRIPTION
--> PHP Warning: Undefined variable $order_amount in /home/client/public_html/store/includes/modules/payment/paypaldp.php on line 375.