### PR TITLE
Remove redundant code from `init_templates.php`

### DIFF
--- a/includes/init_includes/init_templates.php
+++ b/includes/init_includes/init_templates.php
@@ -40,9 +40,10 @@ if (zen_is_whitelisted_admin_ip()) {
     if (isset($_GET['t']) && $_GET['t'] === 'off') {
         unset($_SESSION['tpl_override']);
     }
-    if (isset($_SESSION['tpl_override'])) $template_dir = $_SESSION['tpl_override'];
+    if (isset($_SESSION['tpl_override'])) {
+        $template_dir = $_SESSION['tpl_override'];
+    }
 }
-
 
 /**
  * Now that we've established which template to use, initialize all its components
@@ -51,24 +52,26 @@ if (zen_is_whitelisted_admin_ip()) {
 /**
  * The actual template directory to use
  */
-  define('DIR_WS_TEMPLATE', DIR_WS_TEMPLATES . $template_dir . '/');
+define('DIR_WS_TEMPLATE', DIR_WS_TEMPLATES . $template_dir . '/');
+
 /**
  * The actual template images directory to use
  */
-  define('DIR_WS_TEMPLATE_IMAGES', DIR_WS_TEMPLATE . 'images/');
+define('DIR_WS_TEMPLATE_IMAGES', DIR_WS_TEMPLATE . 'images/');
+
 /**
  * The actual template icons directory to use
  */
-  define('DIR_WS_TEMPLATE_ICONS', DIR_WS_TEMPLATE_IMAGES . 'icons/');
-
+define('DIR_WS_TEMPLATE_ICONS', DIR_WS_TEMPLATE_IMAGES . 'icons/');
 
 if (empty($tpl_settings) || !is_array($tpl_settings)) {
     $tpl_settings = [];
 }
+
 /**
  * Instantiate TemplateSettings object, before loading template's template_settings.php file.
  */
-$tplSetting = new TemplateSettings($tpl_settings ?? null);
+$tplSetting = new TemplateSettings($tpl_settings);
 
 /**
  * Load template-specific configuration settings, if they exist.
@@ -76,10 +79,12 @@ $tplSetting = new TemplateSettings($tpl_settings ?? null);
 if (file_exists(DIR_WS_TEMPLATE . 'template_settings.php')) {
     require_once DIR_WS_TEMPLATE . 'template_settings.php';
 }
+
 // check again in case overrides went wrong
 if (empty($tpl_settings) || !is_array($tpl_settings)) {
     $tpl_settings = [];
 }
+
 /**
  * Load any template override settings from db
  */
@@ -102,11 +107,7 @@ $languageLoader->finalizeLanguageDefines();
 /**
  * Process any overrides from the $tpl_settings array, inserting them into the $tplSetting class object
  */
-if (!isset($tplSetting)) {
-    $tplSetting = new TemplateSettings($tpl_settings ?? null);
-} else {
-    $tplSetting->setFromArray($tpl_settings ?? null);
-}
+$tplSetting->setFromArray($tpl_settings);
 
 /**
  * send the content charset "now" so that all content is impacted by it


### PR DESCRIPTION
- Includes some reformatting
- Line 71/74; no need to `null-coalesce`, $tpl_settings has been set.
- Previous lines 105-109 unneeded; $tplSetting previously set at line 71/74.
- New line 110; no need to `null-coalesce`, $tpl_settings has been set.