### PR TITLE
Test optimization: shorten strings for assertion

### DIFF
--- a/not_for_release/testFramework/FeatureStore/GVCoupons/GiftVoucherRedeemTest.php
+++ b/not_for_release/testFramework/FeatureStore/GVCoupons/GiftVoucherRedeemTest.php
@@ -13,7 +13,7 @@ class GiftVoucherRedeemTest extends zcFeatureTestCaseStore
      * @test
      * scenario GV 1
      */
-    public function testGvRedeemGuestNoGVNum()
+    public function testGvRedeemGuestNoGVNum(): void
     {
         $this->browser->request('GET', HTTP_SERVER  . '/index.php?main_page=gv_redeem');
         $response = $this->browser->getResponse();
@@ -27,9 +27,9 @@ class GiftVoucherRedeemTest extends zcFeatureTestCaseStore
      * @test
      * scenario GV 2
      */
-    public function testGvRedeemFixedCustomer()
+    public function testGvRedeemFixedCustomer(): void
     {
-        $this->runCustomSeeder('CouponTableSeeder');
+        self::runCustomSeeder('CouponTableSeeder');
         $profile = $this->createCustomerAccountOrLogin('florida-basic1');
         $this->browser->request('GET', HTTP_SERVER  . '/index.php?main_page=gv_redeem&gv_no=VALID10');
         $response = $this->browser->getResponse();
@@ -43,7 +43,7 @@ class GiftVoucherRedeemTest extends zcFeatureTestCaseStore
      * @test
      * scenario GV 3
      */
-    function testPurchaseWithGiftVoucher()
+    public function testPurchaseWithGiftVoucher(): void
     {
         $profile = $this->createCustomerAccountOrLogin('florida-basic1');
         $this->updateGVBalance($profile);
@@ -60,7 +60,7 @@ class GiftVoucherRedeemTest extends zcFeatureTestCaseStore
      * @test
      * scenario GV 4
      */
-    function testPurchaseCreditCoversFails()
+    public function testPurchaseCreditCoversFails(): void
     {
         $profile = $this->createCustomerAccountOrLogin('florida-basic1');
         $this->updateGVBalance($profile);
@@ -69,15 +69,16 @@ class GiftVoucherRedeemTest extends zcFeatureTestCaseStore
         $this->browser->request('GET', HTTP_SERVER  . '/index.php?main_page=checkout_shipping');
         $this->browser->submitForm('Continue', []);
         $this->browser->submitForm('Continue', ['cot_gv' => 45.28, 'payment' => '']);
-        $response = $this->browser->getResponse();
-        $this->assertStringContainsString('Please select a payment method for your order', (string)$response->getContent() );
+        $response = (string)$this->browser->getResponse()->getContent();
+        // TODO: It's possible this might be "found" merely because it's part of a JS error string in the HTML, not because it's properly rendered by the test actions...
+        $this->assertStringContainsString('Please select a payment method for your order', $response);
     }
 
     /**
      * @test
      * scenario GV 5
      */
-    function testPurchaseCreditCoversFailsShippingTax()
+    public function testPurchaseCreditCoversFailsShippingTax(): void
     {
         $this->switchFlatShippingTax('on');
         $profile = $this->createCustomerAccountOrLogin('florida-basic1');
@@ -87,8 +88,9 @@ class GiftVoucherRedeemTest extends zcFeatureTestCaseStore
         $this->browser->request('GET', HTTP_SERVER  . '/index.php?main_page=checkout_shipping');
         $this->browser->submitForm('Continue', []);
         $this->browser->submitForm('Continue', ['cot_gv' => 45.28, 'payment' => '']);
-        $response = $this->browser->getResponse();
-        $this->assertStringContainsString('Please select a payment method for your order', (string)$response->getContent() );
+        $response = (string)$this->browser->getResponse()->getContent();
+        $lookup_section = self::locateElementInPageSource('id="orderTotals"', $response, 4000);
+        $this->assertStringContainsString('Please select a payment method for your order', $lookup_section);
         $this->switchFlatShippingTax('off');
     }
 
@@ -96,7 +98,7 @@ class GiftVoucherRedeemTest extends zcFeatureTestCaseStore
      * @test
      * scenario GV 6
      */
-    function testPurchaseWithGiftVoucherSEK()
+    public function testPurchaseWithGiftVoucherSEK(): void
     {
         $this->setConfiguration('DEFAULT_CURRENCY', 'SEK');
         $profile = $this->createCustomerAccountOrLogin('florida-basic1');
@@ -106,8 +108,9 @@ class GiftVoucherRedeemTest extends zcFeatureTestCaseStore
         $this->browser->request('GET', HTTP_SERVER  . '/index.php?main_page=checkout_shipping');
         $this->browser->submitForm('Continue', []);
         $this->browser->submitForm('Continue', ['cot_gv' => '1,5', 'payment' => '']);
-        $response = $this->browser->getResponse();
-        $this->assertStringContainsString('SEK6,4259', (string)$response->getContent() );
+        $response = (string)$this->browser->getResponse()->getContent();
+        $lookup_section = self::locateElementInPageSource('id="checkoutOrderTotals"', $response);
+        $this->assertStringContainsString('SEK6,4259', $lookup_section);
         $this->setConfiguration('DEFAULT_CURRENCY', 'USD');
     }
 
@@ -115,7 +118,7 @@ class GiftVoucherRedeemTest extends zcFeatureTestCaseStore
      * @test
      * scenario GV 7
      */
-    function testSendGiftVoucherSEK()
+    public function testSendGiftVoucherSEK(): void
     {
         $this->setConfiguration('DEFAULT_CURRENCY', 'SEK');
         $profile = $this->createCustomerAccountOrLogin('florida-basic1');

--- a/not_for_release/testFramework/FeatureStore/LowOrderFees/LowOrderFeeTest.php
+++ b/not_for_release/testFramework/FeatureStore/LowOrderFees/LowOrderFeeTest.php
@@ -10,7 +10,7 @@ class LowOrderFeeTest extends zcFeatureTestCaseStore
      * @test
      * scenario LOF 1
      */
-    public function it_tests_a_simple_loworderfee()
+    public function it_tests_a_simple_loworderfee(): void
     {
         $this->switchLowOrderFee('on');
         $this->createCustomerAccountOrLogin('florida-basic1');
@@ -21,12 +21,13 @@ class LowOrderFeeTest extends zcFeatureTestCaseStore
         $response = $this->browser->getResponse();
         $this->assertStringContainsString('39.99', (string)$response->getContent() );
         $this->browser->submitForm('Continue', []);
-        $response = $this->browser->getResponse();
-        $this->assertStringContainsString('39.99', (string)$response->getContent() ); //sub-total
-        $this->assertStringContainsString('2.50', (string)$response->getContent() ); // shipping
-        $this->assertStringContainsString('2.80', (string)$response->getContent() ); // tax
-        $this->assertStringContainsString('5.00', (string)$response->getContent() );// low order fee
-        $this->assertStringContainsString('50.29', (string)$response->getContent() ); // total
+        $response = (string)$this->browser->getResponse()->getContent();
+        $lookup_section = self::locateElementInPageSource('id="orderTotals"', $response);
+        $this->assertStringContainsString('39.99', $lookup_section); //sub-total
+        $this->assertStringContainsString('2.50', $lookup_section); // shipping
+        $this->assertStringContainsString('2.80', $lookup_section); // tax
+        $this->assertStringContainsString('5.00', $lookup_section);// low order fee
+        $this->assertStringContainsString('50.29', $lookup_section); // total
         $this->switchLowOrderFee('off');
     }
 
@@ -34,7 +35,7 @@ class LowOrderFeeTest extends zcFeatureTestCaseStore
      * @test
      * scenario LOF 2
      */
-    public function it_test_a_loworderfee_with_almost_full_GV()
+    public function it_test_a_loworderfee_with_almost_full_GV(): void
     {
         $this->switchLowOrderFee('on');
         $profile = ProfileManager::getProfile('florida-basic1');
@@ -44,12 +45,13 @@ class LowOrderFeeTest extends zcFeatureTestCaseStore
         $this->browser->request('GET', HTTP_SERVER  . '/index.php?main_page=product_info&cPath=1_9&products_id=3&action=buy_now');
         $this->browser->request('GET', HTTP_SERVER  . '/index.php?main_page=checkout_shipping');
         $this->browser->submitForm('Continue', []);
-        $response = $this->browser->getResponse();
-        $this->assertStringContainsString('39.99', (string)$response->getContent() ); //sub-total
-        $this->assertStringContainsString('2.50', (string)$response->getContent() ); // shipping
-        $this->assertStringContainsString('2.80', (string)$response->getContent() ); // tax
-        $this->assertStringContainsString('5.00', (string)$response->getContent() );// low order fee
-        $this->assertStringContainsString('50.29', (string)$response->getContent() ); // total
+        $response = (string)$this->browser->getResponse()->getContent();
+        $lookup_section = self::locateElementInPageSource('id="orderTotals"', $response);
+        $this->assertStringContainsString('39.99', $lookup_section); //sub-total
+        $this->assertStringContainsString('2.50', $lookup_section); // shipping
+        $this->assertStringContainsString('2.80', $lookup_section); // tax
+        $this->assertStringContainsString('5.00', $lookup_section);// low order fee
+        $this->assertStringContainsString('50.29', $lookup_section); // total
         $this->browser->submitForm('Continue', ['cot_gv' => '45.28', 'payment' => '']);
         $response = $this->browser->getResponse();
         $this->assertStringContainsString('Please select a payment method for your order', (string)$response->getContent() );
@@ -59,7 +61,7 @@ class LowOrderFeeTest extends zcFeatureTestCaseStore
      * @test
      * scenario LOF 3
      */
-    public function it_tests_lowOrderFee_with_full_GV()
+    public function it_tests_lowOrderFee_with_full_GV(): void
     {
         $this->switchLowOrderFee('on');
         $profile = ProfileManager::getProfile('florida-basic1');
@@ -70,12 +72,13 @@ class LowOrderFeeTest extends zcFeatureTestCaseStore
         $this->browser->request('GET', HTTP_SERVER  . '/index.php?main_page=checkout_shipping');
         $this->browser->request('GET', HTTP_SERVER  . '/index.php?main_page=checkout_shipping');
         $this->browser->submitForm('Continue', []);
-        $response = $this->browser->getResponse();
-        $this->assertStringContainsString('39.99', (string)$response->getContent() ); //sub-total
-        $this->assertStringContainsString('2.50', (string)$response->getContent() ); // shipping
-        $this->assertStringContainsString('2.80', (string)$response->getContent() ); // tax
-        $this->assertStringContainsString('5.00', (string)$response->getContent() );// low order fee
-        $this->assertStringContainsString('50.29', (string)$response->getContent() ); // total
+        $response = (string)$this->browser->getResponse()->getContent();
+        $lookup_section = self::locateElementInPageSource('id="orderTotals"', $response);
+        $this->assertStringContainsString('39.99', $lookup_section); //sub-total
+        $this->assertStringContainsString('2.50', $lookup_section); // shipping
+        $this->assertStringContainsString('2.80', $lookup_section); // tax
+        $this->assertStringContainsString('5.00', $lookup_section);// low order fee
+        $this->assertStringContainsString('50.29', $lookup_section); // total
         $this->browser->submitForm('Continue', ['cot_gv' => '45.29', 'payment' => '']);
         $response = $this->browser->getResponse();
         $this->assertStringContainsString('Please select a payment method for your order', (string)$response->getContent() );
@@ -85,7 +88,7 @@ class LowOrderFeeTest extends zcFeatureTestCaseStore
      * @test
      * scenario LOF 4
      */
-    public function it_tests_loworderfee_with_almost_full_GV_and_shippingTax()
+    public function it_tests_loworderfee_with_almost_full_GV_and_shippingTax(): void
     {
         $this->switchLowOrderFee('on');
         $this->switchItemShippingTax('on');
@@ -96,12 +99,13 @@ class LowOrderFeeTest extends zcFeatureTestCaseStore
         $this->browser->request('GET', HTTP_SERVER  . '/index.php?main_page=product_info&cPath=1_9&products_id=3&action=buy_now');
         $this->browser->request('GET', HTTP_SERVER  . '/index.php?main_page=checkout_shipping');
         $this->browser->submitForm('Continue', []);
-        $response = $this->browser->getResponse();
-        $this->assertStringContainsString('39.99', (string)$response->getContent() ); //sub-total
-        $this->assertStringContainsString('2.50', (string)$response->getContent() ); // shipping
-        $this->assertStringContainsString('3.05', (string)$response->getContent() ); // tax
-        $this->assertStringContainsString('5.00', (string)$response->getContent() );// low order fee
-        $this->assertStringContainsString('50.54', (string)$response->getContent() ); // total
+        $response = (string)$this->browser->getResponse()->getContent();
+        $lookup_section = self::locateElementInPageSource('id="orderTotals"', $response);
+        $this->assertStringContainsString('39.99', $lookup_section); //sub-total
+        $this->assertStringContainsString('2.50', $lookup_section); // shipping
+        $this->assertStringContainsString('3.05', $lookup_section); // tax
+        $this->assertStringContainsString('5.00', $lookup_section);// low order fee
+        $this->assertStringContainsString('50.54', $lookup_section); // total
         $this->browser->submitForm('Continue', ['cot_gv' => '45.76', 'payment' => '']);
         $response = $this->browser->getResponse();
         $this->assertStringContainsString('Please select a payment method for your order', (string)$response->getContent() );
@@ -113,7 +117,7 @@ class LowOrderFeeTest extends zcFeatureTestCaseStore
      * @test
      * scenario LOF 5
      */
-    public function it_tests_loworderfee_with_full_GV_and_shipping_tax()
+    public function it_tests_loworderfee_with_full_GV_and_shipping_tax(): void
     {
         $this->switchLowOrderFee('on');
         $this->switchItemShippingTax('on');
@@ -124,20 +128,22 @@ class LowOrderFeeTest extends zcFeatureTestCaseStore
         $this->browser->request('GET', HTTP_SERVER  . '/index.php?main_page=product_info&cPath=1_9&products_id=3&action=buy_now');
         $this->browser->request('GET', HTTP_SERVER  . '/index.php?main_page=checkout_shipping');
         $this->browser->submitForm('Continue', []);
-        $response = $this->browser->getResponse();
-        $this->assertStringContainsString('39.99', (string)$response->getContent() ); //sub-total
-        $this->assertStringContainsString('2.50', (string)$response->getContent() ); // shipping
-        $this->assertStringContainsString('3.05', (string)$response->getContent() ); // tax
-        $this->assertStringContainsString('5.00', (string)$response->getContent() );// low order fee
-        $this->assertStringContainsString('50.54', (string)$response->getContent() ); // total
+        $response = (string)$this->browser->getResponse()->getContent();
+        $lookup_section = self::locateElementInPageSource('id="orderTotals"', $response);
+        $this->assertStringContainsString('39.99', $lookup_section); //sub-total
+        $this->assertStringContainsString('2.50', $lookup_section); // shipping
+        $this->assertStringContainsString('3.05', $lookup_section); // tax
+        $this->assertStringContainsString('5.00', $lookup_section);// low order fee
+        $this->assertStringContainsString('50.54', $lookup_section); // total
         $this->browser->submitForm('Continue', ['cot_gv' => '50.54', 'payment' => '']);
-        $response = $this->browser->getResponse();
-        $this->assertStringContainsString('39.99', (string)$response->getContent() ); //sub-total
-        $this->assertStringContainsString('2.50', (string)$response->getContent() ); // shipping item
-        $this->assertStringContainsString('3.05', (string)$response->getContent() ); // Tax
-        $this->assertStringContainsString('5.00', (string)$response->getContent() ); // low order fee
-        $this->assertStringContainsString('-$50.54', (string)$response->getContent() ); // gv used
-        $this->assertStringContainsString('0.00', (string)$response->getContent() ); // balance
+        $response = (string)$this->browser->getResponse()->getContent();
+        $lookup_section = self::locateElementInPageSource('id="orderTotals"', $response);
+        $this->assertStringContainsString('39.99', $lookup_section); //sub-total
+        $this->assertStringContainsString('2.50', $lookup_section); // shipping item
+        $this->assertStringContainsString('3.05', $lookup_section); // Tax
+        $this->assertStringContainsString('5.00', $lookup_section); // low order fee
+        $this->assertStringContainsString('-$50.54', $lookup_section); // gv used
+        $this->assertStringContainsString('0.00', $lookup_section); // balance
         $this->switchLowOrderFee('off');
         $this->switchItemShippingTax('off');
     }
@@ -146,7 +152,7 @@ class LowOrderFeeTest extends zcFeatureTestCaseStore
      * @test
      * scenario LOF 6
      */
-    public function it_tests_loworderfee_with_full_GV_shipping_tax_inclusive()
+    public function it_tests_loworderfee_with_full_GV_shipping_tax_inclusive(): void
     {
         $this->switchToTaxInclusive();
         $this->switchLowOrderFee('on');
@@ -159,13 +165,14 @@ class LowOrderFeeTest extends zcFeatureTestCaseStore
         $this->browser->request('GET', HTTP_SERVER  . '/index.php?main_page=checkout_shipping');
         $this->browser->submitForm('Continue', []);
         $this->browser->submitForm('Continue', ['cot_gv' => '50.54', 'payment' => '']);
-        $response = $this->browser->getResponse();
-        $this->assertStringContainsString('42.79', (string)$response->getContent() );
-        $this->assertStringContainsString('2.75', (string)$response->getContent() );
-        $this->assertStringContainsString('3.05', (string)$response->getContent() );
-        $this->assertStringContainsString('5.00', (string)$response->getContent() );
-        $this->assertStringContainsString('-$50.54', (string)$response->getContent() );
-        $this->assertStringContainsString('0.00', (string)$response->getContent() );
+        $response = (string)$this->browser->getResponse()->getContent();
+        $lookup_section = self::locateElementInPageSource('id="orderTotals"', $response);
+        $this->assertStringContainsString('42.79', $lookup_section);
+        $this->assertStringContainsString('2.75', $lookup_section);
+        $this->assertStringContainsString('3.05', $lookup_section);
+        $this->assertStringContainsString('5.00', $lookup_section);
+        $this->assertStringContainsString('-$50.54', $lookup_section);
+        $this->assertStringContainsString('0.00', $lookup_section);
         $this->switchLowOrderFee('off');
         $this->switchItemShippingTax('off');
         $this->switchToTaxNonInclusive();
@@ -175,7 +182,7 @@ class LowOrderFeeTest extends zcFeatureTestCaseStore
      * @test
      * scenario LOF 7
      */
-    public function it_tests_loworderfee_with_group_discount()
+    public function it_tests_loworderfee_with_group_discount(): void
     {
         $this->switchLowOrderFee('on');
         $profile = ProfileManager::getProfile('florida-basic1');
@@ -187,13 +194,14 @@ class LowOrderFeeTest extends zcFeatureTestCaseStore
         $this->browser->request('GET', HTTP_SERVER  . '/index.php?main_page=checkout_shipping');
         $this->browser->submitForm('Continue', []);
         $this->browser->submitForm('Continue', ['payment' => '']);
-        $response = $this->browser->getResponse();
-        $this->assertStringContainsString('39.99', (string)$response->getContent() );
-        $this->assertStringContainsString('2.50', (string)$response->getContent() );
-        $this->assertStringContainsString('-$4.00', (string)$response->getContent() );
-        $this->assertStringContainsString('2.52', (string)$response->getContent() );
-        $this->assertStringContainsString('5.00', (string)$response->getContent() );
-        $this->assertStringContainsString('46.01', (string)$response->getContent() );
+        $response = (string)$this->browser->getResponse()->getContent();
+        $lookup_section = self::locateElementInPageSource('id="orderTotals"', $response);
+        $this->assertStringContainsString('39.99', $lookup_section);
+        $this->assertStringContainsString('2.50', $lookup_section);
+        $this->assertStringContainsString('-$4.00', $lookup_section);
+        $this->assertStringContainsString('2.52', $lookup_section);
+        $this->assertStringContainsString('5.00', $lookup_section);
+        $this->assertStringContainsString('46.01', $lookup_section);
         $this->setCustomerGroupDiscount($profile['email_address'], 0);
         $this->switchLowOrderFee('off');
     }
@@ -202,7 +210,7 @@ class LowOrderFeeTest extends zcFeatureTestCaseStore
      * @test
      * scenario LOF 8
      */
-    public function it_tests_loworderfee_with_group_discount_and_insufficient_GV()
+    public function it_tests_loworderfee_with_group_discount_and_insufficient_GV(): void
     {
         $this->switchLowOrderFee('on');
         $profile = ProfileManager::getProfile('florida-basic1');
@@ -213,13 +221,14 @@ class LowOrderFeeTest extends zcFeatureTestCaseStore
         $this->browser->request('GET', HTTP_SERVER  . '/index.php?main_page=product_info&cPath=1_9&products_id=3&action=buy_now');
         $this->browser->request('GET', HTTP_SERVER  . '/index.php?main_page=checkout_shipping');
         $this->browser->submitForm('Continue', []);
-        $response = $this->browser->getResponse();
-        $this->assertStringContainsString('39.99', (string)$response->getContent() );
-        $this->assertStringContainsString('2.50', (string)$response->getContent() );
-        $this->assertStringContainsString('-$4.00', (string)$response->getContent() );
-        $this->assertStringContainsString('2.52', (string)$response->getContent() );
-        $this->assertStringContainsString('5.00', (string)$response->getContent() );
-        $this->assertStringContainsString('46.01', (string)$response->getContent() );
+        $response = (string)$this->browser->getResponse()->getContent();
+        $lookup_section = self::locateElementInPageSource('id="orderTotals"', $response);
+        $this->assertStringContainsString('39.99', $lookup_section);
+        $this->assertStringContainsString('2.50', $lookup_section);
+        $this->assertStringContainsString('-$4.00', $lookup_section);
+        $this->assertStringContainsString('2.52', $lookup_section);
+        $this->assertStringContainsString('5.00', $lookup_section);
+        $this->assertStringContainsString('46.01', $lookup_section);
         $this->browser->submitForm('Continue', ['cot_gv' => 39.99, 'payment' => '']);
         $response = $this->browser->getResponse();
         $this->assertStringContainsString('Please select a payment method for your order', (string)$response->getContent() );
@@ -231,7 +240,7 @@ class LowOrderFeeTest extends zcFeatureTestCaseStore
      * @test
      * scenario LOF 9
      */
-    public function it_tests_loworderfee_with_group_discount_and_full_GV()
+    public function it_tests_loworderfee_with_group_discount_and_full_GV(): void
     {
         $this->switchLowOrderFee('on');
         $profile = ProfileManager::getProfile('florida-basic1');
@@ -245,13 +254,14 @@ class LowOrderFeeTest extends zcFeatureTestCaseStore
         $response = $this->browser->getResponse();
         $this->assertStringContainsString('39.99', (string)$response->getContent() );
         $this->browser->submitForm('Continue', ['cot_gv' => 46.01, 'payment' => '']);
-        $response = $this->browser->getResponse();
-        $this->assertStringContainsString('39.99', (string)$response->getContent() );
-        $this->assertStringContainsString('2.50', (string)$response->getContent() );
-        $this->assertStringContainsString('-$4.00', (string)$response->getContent() );
-        $this->assertStringContainsString('2.52', (string)$response->getContent() );
-        $this->assertStringContainsString('5.00', (string)$response->getContent() );
-        $this->assertStringContainsString('-$46.01', (string)$response->getContent() );
+        $response = (string)$this->browser->getResponse()->getContent();
+        $lookup_section = self::locateElementInPageSource('id="orderTotals"', $response);
+        $this->assertStringContainsString('39.99', $lookup_section);
+        $this->assertStringContainsString('2.50', $lookup_section);
+        $this->assertStringContainsString('-$4.00', $lookup_section);
+        $this->assertStringContainsString('2.52', $lookup_section);
+        $this->assertStringContainsString('5.00', $lookup_section);
+        $this->assertStringContainsString('-$46.01', $lookup_section);
         $this->setCustomerGroupDiscount($profile['email_address'], 0);
         $this->switchLowOrderFee('off');
     }

--- a/not_for_release/testFramework/Support/Traits/GeneralConcerns.php
+++ b/not_for_release/testFramework/Support/Traits/GeneralConcerns.php
@@ -49,6 +49,13 @@ trait GeneralConcerns
         $this->browser = new HttpBrowser(HttpClient::create());
     }
 
+    public static function locateElementInPageSource(string $element_lookup_text, string $page_source, int $length = 1500): string
+    {
+        $position = strpos($page_source, $element_lookup_text);
+        // if not found, return whole $page_source; but if found, only return a portion of the page
+        return ($position === false) ? $page_source : substr($page_source, $position, $length);
+    }
+
     /**
      * @param $page
      * @return mixed


### PR DESCRIPTION
When the test fails, it's easier to debug by looking through a shorter segment than through the entire page's HTML.