### PR TITLE
No means to insert additional "Information" sidebox links

### DIFF
--- a/includes/modules/sideboxes/information.php
+++ b/includes/modules/sideboxes/information.php
@@ -72,6 +72,8 @@ if (SHOW_NEWSLETTER_UNSUBSCRIBE_LINK == 'true') {
     $information[] = '<a href="' . zen_href_link(FILENAME_UNSUBSCRIBE) . '">' . BOX_INFORMATION_UNSUBSCRIBE . '</a>';
 }
 
+$zco_notifier->notify('NOTIFY_INFORMATION_SIDEBOX_ADDITIONS', [], $information);
+
 require($template->get_template_dir('tpl_information.php', DIR_WS_TEMPLATE, $current_page_base, 'sideboxes') . '/tpl_information.php');
 
 $title = BOX_HEADING_INFORMATION;


### PR DESCRIPTION
Many plugins, like [Printable Price List]( https://www.zen-cart.com/downloads.php?do=file&id=173) have only one template override to add an additional link to the information sidebox.

This PR adds a notification to enable that addition.