### PR TITLE
Add explicit null allowed for function type definitions.

### DIFF
--- a/includes/classes/Customer.php
+++ b/includes/classes/Customer.php
@@ -84,7 +84,7 @@ class Customer extends base
         return $wholesale_info['wholesale_tier'];
     }
 
-    public function getData(string $element = null)
+    public function getData(?string $element = null)
     {
         if (empty($element)) {
             return $this->data;
@@ -120,7 +120,7 @@ class Customer extends base
      * @param int|null $idToCheck
      * @return bool
      */
-    public function isSameAsLoggedIn(int $idToCheck = null)
+    public function isSameAsLoggedIn(?int $idToCheck = null)
     {
         if (empty($idToCheck)) {
             $idToCheck = $this->customer_id;
@@ -237,7 +237,7 @@ class Customer extends base
         return (bool)$in_guest_checkout;
     }
 
-    public function customerExistsInDatabase(int $customer_id = null): bool
+    public function customerExistsInDatabase(?int $customer_id = null): bool
     {
         global $db;
 
@@ -515,7 +515,7 @@ class Customer extends base
         return false;
     }
 
-    public function getAddressBookEntries(int $customer_id = null): object
+    public function getAddressBookEntries(?int $customer_id = null): object
     {
         global $db;
 
@@ -535,7 +535,7 @@ class Customer extends base
         return $db->Execute($sql);
     }
 
-    public function getNumberOfAddressBookEntries(int $customer_id = null): int
+    public function getNumberOfAddressBookEntries(?int $customer_id = null): int
     {
         if (empty($customer_id)) {
             $customer_id = $this->customer_id;
@@ -547,7 +547,7 @@ class Customer extends base
         return count($this->getAddressBookEntries());
     }
 
-    public function getFormattedAddressBookList(int $customer_id = null): array
+    public function getFormattedAddressBookList(?int $customer_id = null): array
     {
         global $db;
 

--- a/includes/functions/functions_customers.php
+++ b/includes/functions/functions_customers.php
@@ -31,7 +31,7 @@ function zen_customer_greeting(): string
  * @param bool $check_session unused legacy param
  * @return int
  */
-function zen_count_customer_orders(int $customer_id = null, $check_session = true): int
+function zen_count_customer_orders(?int $customer_id = null, $check_session = true): int
 {
     $customer = new Customer($customer_id);
 
@@ -54,7 +54,7 @@ function zen_get_customers_address_primary(int $customer_id): int
  * @param int|null $customer_id
  * @return array
  */
-function zen_get_customer_address_book_entries(int $customer_id = null): array
+function zen_get_customer_address_book_entries(?int $customer_id = null): array
 {
     $customer = new Customer($customer_id);
 
@@ -74,7 +74,7 @@ function zen_get_customers_address_book($customer_id) {
  * @return int
  * @deprecated use Customer::getFormattedAddressBookList or zen_get_customer_address_book_entries()
  */
-function zen_count_customer_address_book_entries(int $customer_id = null, $check_session = true): int
+function zen_count_customer_address_book_entries(?int $customer_id = null, $check_session = true): int
 {
     return count(zen_get_customer_address_book_entries($customer_id));
 }

--- a/includes/functions/functions_strings.php
+++ b/includes/functions/functions_strings.php
@@ -440,7 +440,7 @@ function zen_str_to_numeric($string) {
  * @param string|null $fallback Value to return if failures occur
  * @return string
  */
-function zen_get_translated_config_setting(string $config_key, string $lang_define_prefix = null, string $fallback = null): string
+function zen_get_translated_config_setting(string $config_key, ?string $lang_define_prefix = null, ?string $fallback = null): string
 {
     // Get current configuration_value for the specified key.
     // It would already be defined as a constant at this point, so if not defined, then it's invalid, so we'll return the fallback.

--- a/includes/functions/php_polyfills.php
+++ b/includes/functions/php_polyfills.php
@@ -86,7 +86,7 @@ if (!function_exists('json_validate')) {
 }
 
 if (!function_exists('mb_str_pad') && function_exists('mb_substr')) {
-    function mb_str_pad(string $string, int $length, string $pad_string = ' ', int $pad_type = \STR_PAD_RIGHT, string $encoding = null): string
+    function mb_str_pad(string $string, int $length, string $pad_string = ' ', int $pad_type = \STR_PAD_RIGHT, ?string $encoding = null): string
     {
         if (!\in_array($pad_type, [\STR_PAD_RIGHT, \STR_PAD_LEFT, \STR_PAD_BOTH], true)) {
             throw new \ValueError('mb_str_pad(): Argument #4 ($pad_type) must be STR_PAD_LEFT, STR_PAD_RIGHT, or STR_PAD_BOTH');


### PR DESCRIPTION
Prevent depreciation warning in PHP8.4