### PR TITLE
Correcting misplaced `</div>` tags ...

### DIFF
--- a/includes/templates/responsive_classic/templates/tpl_document_general_info_display.php
+++ b/includes/templates/responsive_classic/templates/tpl_document_general_info_display.php
@@ -63,10 +63,10 @@ require($template->get_template_dir('/tpl_products_next_previous.php',DIR_WS_TEM
  */
   require($template->get_template_dir('/tpl_modules_additional_images.php',DIR_WS_TEMPLATE, $current_page_base,'templates'). '/tpl_modules_additional_images.php'); ?>
 <!--eof Additional Product Images -->
-</div>
 <?php
   }
 ?>
+</div>
 <div id="pinfo-right">
 <!--bof Product details list  -->
 <?php if ( (($flag_show_product_info_model == 1 and $products_model != '') or ($flag_show_product_info_weight == 1 and $products_weight !=0) or ($flag_show_product_info_quantity == 1) or ($flag_show_product_info_manufacturer == 1 and !empty($manufacturers_name))) ) { ?>

--- a/includes/templates/responsive_classic/templates/tpl_document_product_info_display.php
+++ b/includes/templates/responsive_classic/templates/tpl_document_product_info_display.php
@@ -64,10 +64,10 @@ require($template->get_template_dir('/tpl_products_next_previous.php',DIR_WS_TEM
  */
   require($template->get_template_dir('/tpl_modules_additional_images.php',DIR_WS_TEMPLATE, $current_page_base,'templates'). '/tpl_modules_additional_images.php'); ?>
 <!--eof Additional Product Images -->
-</div>
 <?php
   }
 ?>
+</div>
 <div id="pinfo-right">
 <!--bof Product details list  -->
 <?php if ( (($flag_show_product_info_model == 1 and $products_model != '') or ($flag_show_product_info_weight == 1 and $products_weight !=0) or ($flag_show_product_info_quantity == 1) or ($flag_show_product_info_manufacturer == 1 and !empty($manufacturers_name))) ) { ?>

--- a/includes/templates/responsive_classic/templates/tpl_product_free_shipping_info_display.php
+++ b/includes/templates/responsive_classic/templates/tpl_product_free_shipping_info_display.php
@@ -63,10 +63,10 @@ require($template->get_template_dir('/tpl_products_next_previous.php',DIR_WS_TEM
  */
   require($template->get_template_dir('/tpl_modules_additional_images.php',DIR_WS_TEMPLATE, $current_page_base,'templates'). '/tpl_modules_additional_images.php'); ?>
 <!--eof Additional Product Images -->
-</div>
 <?php
   }
 ?>
+</div>
 <div id="pinfo-right">
 <!--bof Product details list  -->
 <?php if ( (($flag_show_product_info_model == 1 and $products_model != '') or ($flag_show_product_info_weight == 1 and $products_weight !=0) or ($flag_show_product_info_quantity == 1) or ($flag_show_product_info_manufacturer == 1 and !empty($manufacturers_name))) ) { ?>

--- a/includes/templates/responsive_classic/templates/tpl_product_info_display.php
+++ b/includes/templates/responsive_classic/templates/tpl_product_info_display.php
@@ -65,10 +65,10 @@ require($template->get_template_dir('/tpl_products_next_previous.php',DIR_WS_TEM
  */
   require($template->get_template_dir('/tpl_modules_additional_images.php',DIR_WS_TEMPLATE, $current_page_base,'templates'). '/tpl_modules_additional_images.php'); ?>
 <!--eof Additional Product Images -->
-</div>
 <?php
   }
 ?>
+</div>
 <div id="pinfo-right" class="group grids">
 <!--bof Product Price block -->
 <!--bof Product details list  -->

--- a/includes/templates/responsive_classic/templates/tpl_product_music_info_display.php
+++ b/includes/templates/responsive_classic/templates/tpl_product_music_info_display.php
@@ -63,10 +63,10 @@ require($template->get_template_dir('/tpl_products_next_previous.php',DIR_WS_TEM
  */
   require($template->get_template_dir('/tpl_modules_additional_images.php',DIR_WS_TEMPLATE, $current_page_base,'templates'). '/tpl_modules_additional_images.php'); ?>
 <!--eof Additional Product Images -->
-</div>
 <?php
   }
 ?>
+</div>
 <div id="pinfo-right">
 <!--bof Media Manager -->
 <div id="mediaManager" class="productMusic group"><?php


### PR DESCRIPTION
... in various product-information templates for `responsive_classic`.  As reported in [this](https://www.zen-cart.com/showthread.php?230133-Misplaced-lt-div-gt-tag-in-tpl_product_info_display-php) Zen Cart forum thread.