### PR TITLE
Include errorinfo in email_archive.

### DIFF
--- a/includes/functions/functions_email.php
+++ b/includes/functions/functions_email.php
@@ -551,19 +551,21 @@
         $email_html = (EMAIL_USE_HTML == 'true') ? zen_db_prepare_input_html_safe($email_html) : zen_db_prepare_input('HTML disabled in admin');
         $email_text = zen_db_prepare_input($email_text);
         $module = zen_db_prepare_input($module);
-        $error_msgs = zen_db_prepare_input($error_msgs);
+        $error_msgs = empty($error_msgs) ? 'NULL' : zen_db_prepare_input($error_msgs);
 
-        $db->Execute("INSERT INTO " . TABLE_EMAIL_ARCHIVE . "
-                  (email_to_name, email_to_address, email_from_name, email_from_address, email_subject, email_html, email_text, date_sent, module)
-                  VALUES ('" . zen_db_input($to_name) . "',
-                          '" . zen_db_input($to_email_address) . "',
-                          '" . zen_db_input($from_email_name) . "',
-                          '" . zen_db_input($from_email_address) . "',
-                          '" . zen_db_input($email_subject) . "',
-                          '" . zen_db_input($email_html) . "',
-                          '" . zen_db_input($email_text) . "',
-                          now() ,
-                          '" . zen_db_input($module) . "')");
+        $db->perform(TABLE_EMAIL_ARCHIVE, [
+            [ 'fieldName' => 'email_to_name', 'value' => $to_name, 'type' => 'string' ],
+            [ 'fieldName' => 'email_to_address', 'value' => $to_email_address, 'type' => 'string' ],
+            [ 'fieldName' => 'email_from_name', 'value' => $from_email_name, 'type' => 'string' ],
+            [ 'fieldName' => 'email_from_address', 'value' => $from_email_address, 'type' => 'string' ],
+            [ 'fieldName' => 'email_subject', 'value' => $email_subject, 'type' => 'string' ],
+            [ 'fieldName' => 'email_html', 'value' => $email_html, 'type' => 'string' ],
+            [ 'fieldName' => 'email_text', 'value' => $email_text, 'type' => 'string' ],
+            [ 'fieldName' => 'date_sent', 'value' => 'now()', 'type' => 'passthru' ],
+            [ 'fieldName' => 'module', 'value' => $module, 'type' => 'string' ],
+            [ 'fieldName' => 'errorinfo', 'value' => $error_msgs, 'type' => 'string' ],
+        ]);
+
         return $db;
     }
 

--- a/zc_install/sql/install/mysql_zencart.sql
+++ b/zc_install/sql/install/mysql_zencart.sql
@@ -752,6 +752,7 @@ CREATE TABLE email_archive (
   email_text text NOT NULL,
   date_sent datetime NOT NULL default '0001-01-01 00:00:00',
   module varchar(64) NOT NULL default '',
+  errorinfo TEXT DEFAULT NULL,
   PRIMARY KEY  (archive_id),
   KEY idx_email_to_address_zen (email_to_address),
   KEY idx_module_zen (module)

--- a/zc_install/sql/updates/mysql_upgrade_zencart_210.sql
+++ b/zc_install/sql/updates/mysql_upgrade_zencart_210.sql
@@ -34,7 +34,9 @@
 TRUNCATE TABLE whos_online;
 TRUNCATE TABLE db_cache;
 
-
+#PROGRESS_FEEDBACK:!TEXT=Adding error logging to email archive ...
+# Add column to store any errorinfo returned from phpmailer.
+ALTER TABLE ADD ALTER TABLE email_archive ADD COLUMN (errorinfo TEXT NULL);
 
 
 

--- a/zc_install/sql/updates/mysql_upgrade_zencart_210.sql
+++ b/zc_install/sql/updates/mysql_upgrade_zencart_210.sql
@@ -36,7 +36,7 @@ TRUNCATE TABLE db_cache;
 
 #PROGRESS_FEEDBACK:!TEXT=Adding error logging to email archive ...
 # Add column to store any errorinfo returned from phpmailer.
-ALTER TABLE ADD ALTER TABLE email_archive ADD COLUMN (errorinfo TEXT NULL);
+ALTER TABLE email_archive ADD COLUMN errorinfo TEXT DEFAULT NULL;
 
 
 


### PR DESCRIPTION
Fixes #6449 

*PLEASE REVIEW* the database upgrade script, I've had a half hearted stab at it.  I still don't know how this install/upgrade process works and I'm surprised to see the latest file has version `210` in it.  My changes here probably need rewriting and including in the install script too.

I've tested this change on my local zencart, running the `ALTER TABLE` manually.  It inserts NULL errorinfo if no errorinfo was provided (empty string), otherwise the errorinfo stirng.

Also rewrote the email_archive insert to use `$db->perform` just because I feel it looks neater.  Happy to stand corrected.