### PR TITLE
Enable zc_plugins to provide AJAX content

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -44,8 +44,6 @@ function ajaxAbort($status = 400, $msg = null)
 }
 // --- support functions ------------------
 
-
-
 if (!isset($_GET['act']) || !isset($_GET['method'])) {
     ajaxAbort();
 }
@@ -53,14 +51,18 @@ if (!isset($_GET['act']) || !isset($_GET['method'])) {
 $language_page_directory = DIR_WS_LANGUAGES . $_SESSION['language'] . '/';
 
 $className = 'zc' . ucfirst($_GET['act']);
-$classFile = $className . '.php';
-$basePath  = DIR_FS_CATALOG . DIR_WS_CLASSES;
-
-if (!file_exists(realpath($basePath . 'ajax/' . basename($classFile)))) {
-    ajaxAbort();
+$classFile = basename($className . '.php');
+$classPath = DIR_WS_CLASSES . 'ajax/';
+$basePath  = DIR_FS_CATALOG;
+if (file_exists(realpath($basePath . $classPath . $classFile))) {
+    require realpath($basePath . $classPath . $classFile);
+} else {
+    $fs->loadFilesFromPluginsDirectory($installedPlugins, 'catalog/' . $classPath, '~^' . $classFile . '$~');
+    if (!class_exists($className)) {
+        ajaxAbort();
+    }
 }
 
-require realpath($basePath . 'ajax/' . basename($classFile));
 $class = new $className();
 if (!method_exists($class, $_GET['method'])) {
     ajaxAbort(400, 'class method error');


### PR DESCRIPTION
Currently, only files present in `/includes/classes/ajax` are loaded to handle AJAX requests.