### PR TITLE
PageLoader should use FileSystem for file exists

### DIFF
--- a/includes/classes/ResourceLoaders/PageLoader.php
+++ b/includes/classes/ResourceLoaders/PageLoader.php
@@ -97,7 +97,7 @@ class PageLoader
     {
         foreach ($this->installedPlugins as $plugin) {
             $checkDir = 'zc_plugins/' . $plugin['unique_key'] . '/' . $plugin['version'] . '/catalog/includes/templates/default/' . $templateDir . '/';
-            if (file_exists($checkDir . $templateCode )) {
+            if ($this->fileSystem->fileExistsInDirectory($checkDir, preg_replace('/\//', '', $templateCode))) {
                 return $checkDir;
             }
         }


### PR DESCRIPTION
In trying to get the Bootstrap template to accept a _specific_ file from a zc_plugin's directory, I found that using
```php
    $user_styles = $template->get_template_dir('site_specific_styles.php', DIR_WS_TEMPLATE, $current_page_base, 'css') . '/site_specific_styles.php';
    if (file_exists($user_styles)) {
        require $user_styles; 
    }
```
didn't find the plugin's file `/catalog/templates/default/css/site_specific_styles.php` even though the file was present.  It turns out that `FileSystem->fileExistsInDirectory` uses a _greedy_ regex pattern when making its determination:
```php
        $filePattern = '/' . str_replace("/", "\/", $filePattern) . '$/';
```
... thus matching `/includes/templates/bootstrap/css/dist-site_specific_styles.php`.

Changing the Bootstrap code to use
```php
    $user_styles = $template->get_template_dir('^site_specific_styles.php', DIR_WS_TEMPLATE, $current_page_base, 'css') . '/site_specific_styles.php';
    if (file_exists($user_styles)) {
        require $user_styles; 
    }
```
... note the `^` in front of the name, so the generated regex is `/^site_specific_styles.php$/` and the FileSystem is now indicating that the 'found' path is zc_plugin's `/catalog/templates/default/css/` directory.  Unfortunately, the PageLoader class is currently using `file_exists` to determine whether to load the file and since the file name starts with `^`, it's not found.  Sigh.

This PR updates the PageLoader class to use the FileSystem's `fileExistsInDirectory` to correctly locate a _specific_ file.