### PR TITLE
Make allowance for null products model

### DIFF
--- a/admin/products_price_manager.php
+++ b/admin/products_price_manager.php
@@ -817,6 +817,10 @@ if (!empty($action)) {
                   <div class="col-sm-9 col-md-6 text-center">
                     <?php
 // Specials cannot be added to Gift Vouchers when false
+                    // prevent log on null 
+                    if (empty($pInfo->products_model)) { 
+                        $pInfo->products_model = ''; 
+                    }
                     if ((substr($pInfo->products_model, 0, 4) != 'GIFT') || (substr($pInfo->products_model, 0, 4) == 'GIFT' && (defined('MODULE_ORDER_TOTAL_GV_SPECIAL') && MODULE_ORDER_TOTAL_GV_SPECIAL == 'true'))) {
                       ?>
                       <a href="<?php echo zen_href_link(FILENAME_SPECIALS, 'add_products_id=' . $_GET['products_filter'] . '&action=new' . (isset($sInfo->specials_id) ? '&sID=' . $sInfo->specials_id : '') . '&go_back=ON' . '&current_category_id=' . $current_category_id); ?>" class="btn btn-info" role="button"><i class="fa-solid fa-plus"></i> <?php echo IMAGE_INSTALL_SPECIAL; ?></a>

--- a/admin/specials.php
+++ b/admin/specials.php
@@ -227,7 +227,7 @@ if (!empty($action)) {
         if ($check_product->RecordCount() < 1) {// check for valid PID
           $skip_special = true;
           $messageStack->add_session(sprintf(WARNING_SPECIALS_PRE_ADD_PID_NO_EXIST, (int)$_POST['pre_add_products_id']), 'caution');
-        } elseif ((!defined('MODULE_ORDER_TOTAL_GV_SPECIAL') || MODULE_ORDER_TOTAL_GV_SPECIAL === 'false') && (substr($check_product->fields['products_model'], 0, 4) === 'GIFT')) { // check for PID as a gift voucher
+        } elseif ((!defined('MODULE_ORDER_TOTAL_GV_SPECIAL') || MODULE_ORDER_TOTAL_GV_SPECIAL === 'false') && (substr($check_product->fields['products_model'] ?? '', 0, 4) === 'GIFT')) { // check for PID as a gift voucher
           $skip_special = true;
           $messageStack->add_session(sprintf(WARNING_SPECIALS_PRE_ADD_PID_GIFT, (int)$_POST['pre_add_products_id']), 'caution');
         }

--- a/includes/classes/CouponValidation.php
+++ b/includes/classes/CouponValidation.php
@@ -29,7 +29,7 @@ class CouponValidation
 
         $product = $db->Execute($product_query);
 
-        if (str_starts_with($product->fields['products_model'], 'GIFT')) {
+        if (str_starts_with($product->fields['products_model'] ?? '', 'GIFT')) {
             return false;
         }
 

--- a/includes/classes/shopping_cart.php
+++ b/includes/classes/shopping_cart.php
@@ -692,7 +692,7 @@ class shoppingCart extends base
             $products_raw_price = zen_get_retail_or_wholesale_price($product['products_price'], $product['products_price_w']);
             $products_price = $products_raw_price;
 
-            $is_free_shipping = $product['product_is_always_free_shipping'] === '1' || $product['products_virtual'] === '1' || str_starts_with($product['products_model'], 'GIFT');
+            $is_free_shipping = $product['product_is_always_free_shipping'] === '1' || $product['products_virtual'] === '1' || str_starts_with($product['products_model'] ?? '', 'GIFT');
 
             // adjusted count for free shipping
             if ($product['product_is_always_free_shipping'] !== '1' && $product['products_virtual'] !== '1') {
@@ -1492,7 +1492,7 @@ class shoppingCart extends base
                 $free_ship_check = zen_get_product_details($prid);
                 $free_ship_check = $free_ship_check->fields;
 
-                if (str_starts_with($free_ship_check['products_model'], 'GIFT')) {
+                if (str_starts_with($free_ship_check['products_model'] ?? '', 'GIFT')) {
 // @TODO - fix GIFT price in cart special/attribute
                     $gift_special = zen_get_products_special_price($prid, true);
                     $gift_pba = zen_get_products_price_is_priced_by_attributes($prid);

--- a/includes/functions/functions_prices.php
+++ b/includes/functions/functions_prices.php
@@ -29,7 +29,7 @@ function zen_get_products_special_price($product_id, $specials_price_only = fals
         $special_price = false;
     }
 
-    if (strpos($product->fields['products_model'], 'GIFT') === 0) {    //Never apply a salededuction to Ian Wilson's Giftvouchers
+    if (strpos(($product->fields['products_model'] ?? ''), 'GIFT') === 0) {    //Never apply a salededuction to Ian Wilson's Giftvouchers
         if (!empty($special_price)) {
             return $special_price;
         }

--- a/includes/functions/functions_products.php
+++ b/includes/functions/functions_products.php
@@ -689,7 +689,7 @@ function zen_get_products_allow_add_to_cart($product_id)
     $allow_add_to_cart = !$product_query_results->EOF && $product_query_results->fields['allow_add_to_cart'] !== 'N';
 
     // If product is encoded as GV but GV feature is turned off, disallow add-to-cart
-    if ($allow_add_to_cart === true && strpos($product_query_results->fields['products_model'], 'GIFT') === 0) {
+    if ($allow_add_to_cart === true && strpos(($product_query_results->fields['products_model'] ?? ''), 'GIFT') === 0) {
         if (!defined('MODULE_ORDER_TOTAL_GV_STATUS') || MODULE_ORDER_TOTAL_GV_STATUS !== 'true') {
             $allow_add_to_cart = false;
         }

--- a/includes/modules/order_total/ot_gv.php
+++ b/includes/modules/order_total/ot_gv.php
@@ -274,7 +274,7 @@ class ot_gv {
         //
         $only_gvs_in_order = true;
         foreach ($order->products as $next_product) {
-            if (str_starts_with($next_product['model'], 'GIFT') === false) {
+            if (str_starts_with($next_product['model'] ?? '', 'GIFT') === false) {
                 $only_gvs_in_order = false;
                 break;
             }


### PR DESCRIPTION
Products model is a nullable field.

--> PHP Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /Users/scott/sites/client/includes/functions/functions_prices.php on line 32.