### PR TITLE
Allow Notifier deprecations to be registered

### DIFF
--- a/includes/classes/traits/ObserverManager.php
+++ b/includes/classes/traits/ObserverManager.php
@@ -11,31 +11,45 @@ use Zencart\Events\EventDto;
 
 trait ObserverManager
 {
+    private static array $deprecatedNotifications = [
+        'NOTIFY_GET_PRODUCT_DETAILS' => 'NOTIFY_GET_PRODUCT_OBJECT_DETAILS',
+    ];
+
     /**
-     * method used to an attach an observer to the notifier object
+     * Attach an observer to the notifier object
+     * ("Subscribe" in pub/sub terminology, or "listener" in "event listener" terminology)
      *
      * NB. We have to get a little sneaky here to stop session based classes adding events ad infinitum
      * To do this we first concatenate the class name with the event id, as a class is only ever going to attach to an
      * event id once, this provides a unique key. To ensure there are no naming problems with the array key, we md5 the
      * unique name to provide a unique hashed key.
      *
-     * @param object Reference to the observer class
-     * @param array An array of eventId's to observe
+     * @param object $observer Reference to the observer class
+     * @param array $eventIDArray Array of eventId's to observe
      */
-    function attach(&$observer, $eventIDArray)
+    public function attach(&$observer, array $eventIDArray): void
     {
         foreach ($eventIDArray as $eventID) {
+
+            // handle deprecations
+            if (array_key_exists($eventID, self::$deprecatedNotifications)) {
+                trigger_error("Use of deprecated notification '$eventID'.  Consider using '" . self::$deprecatedNotifications[$eventID] . "' instead.", E_USER_WARNING);
+                continue;
+            }
+
+            // handle attach
             $nameHash = md5(get_class($observer) . $eventID);
-            EventDto::getInstance()->setObserver($nameHash, array('obs' => &$observer, 'eventID' => $eventID));
+            EventDto::getInstance()->setObserver($nameHash, ['obs' => &$observer, 'eventID' => $eventID]);
         }
     }
 
     /**
-     * method used to detach an observer from the notifier object
-     * @param object
-     * @param array
+     * Detach an observer from the notifier object
+     *
+     * @param object $observer
+     * @param array $eventIDArray
      */
-    function detach($observer, $eventIDArray)
+    public function detach($observer, array $eventIDArray): void
     {
         foreach ($eventIDArray as $eventID) {
             $nameHash = md5(get_class($observer) . $eventID);
@@ -43,4 +57,12 @@ trait ObserverManager
         }
     }
 
+    public function registerDeprecatedEvent(string $oldEventId, string $newEventId): void
+    {
+        if (array_key_exists($oldEventId, self::$deprecatedNotifications)) {
+            return;
+        }
+
+        self::$deprecatedNotifications[$oldEventId] = $newEventId;
+    }
 }


### PR DESCRIPTION
Adds the following methods to Notifier and Observer base traits:
`registerDeprecatedEvent($old, $new)`
`registerObserverAlias($old, $new)`
