### PR TITLE
`zc_plugin`: Enable installer language default

### DIFF
--- a/includes/classes/PluginSupport/BasePluginInstaller.php
+++ b/includes/classes/PluginSupport/BasePluginInstaller.php
@@ -94,13 +94,22 @@ class BasePluginInstaller
         $this->dbConn->execute($sql);
     }
 
-
     protected function loadInstallerLanguageFile($file)
     {
         $lng = $_SESSION['language'];
         $filename = $this->pluginDir . '/Installer/languages/' . $lng . '/' . $file;
         if (file_exists($filename)) {
-            require_once($filename);
+            require_once $filename;
+            return;
+        }
+
+        if ($lng === 'english') {
+            return;
+        }
+
+        $filename = $this->pluginDir . '/Installer/languages/english/' . $file;
+        if (file_exists($filename)) {
+            require_once $filename;
         }
     }
 


### PR DESCRIPTION
If a site's current language is other than 'english' (the default) when a zc_plugin is installed and the plugin fails its install with an error message, no message will be displayed if the plugin doesn't supply a non-english message.

This change corrects that condition.