### PR TITLE
Correct storefront auto-load of zc_plugin classes

### DIFF
--- a/includes/classes/InitSystem.php
+++ b/includes/classes/InitSystem.php
@@ -86,8 +86,8 @@ class InitSystem
         if (isset($entry['classPath'])) {
             $filePath = $entry['classPath'];
         }
-        if ($entry['loaderType'] == 'plugin') {
-            $filePath = $this->findPluginDirectory($filePath, $entry['pluginInfo']['unique_key']);
+        if ($entry['loaderType'] === 'plugin') {
+            $filePath = $this->findPluginDirectory($entry['classPath'] ?? DIR_WS_CLASSES, $entry['pluginInfo']['unique_key']);
         }
         $this->debugList[] = 'processing class - ' . $filePath  . $entry['loadFile'];
         $result = 'FAILED';


### PR DESCRIPTION
Currently, the `initSystem` fails to load those files
```
[153] => ##################################################################
    [154] => Action Point - 78
    [155] => Auto Type Method - processAutoTypeClass
    [156] => processing class - C:/xampp/htdocs/zc200w/zc_plugins/POSM/v5.0.0/catalog/C:/xampp/htdocs/zc200w/includes/classes/observers/class.products_options_stock_observer.php
    [157] => loading class - C:/xampp/htdocs/zc200w/zc_plugins/POSM/v5.0.0/catalog/C:/xampp/htdocs/zc200w/includes/classes/observers/class.products_options_stock_observer.php - FAILED
```