### PR TITLE
Non-language `get` fails when element is `NULL`

### DIFF
--- a/includes/classes/Product.php
+++ b/includes/classes/Product.php
@@ -61,7 +61,7 @@ class Product
 
     public function get(string $name)
     {
-        return $this->data[$name] ?? $this->data['lang'][$this->languages[(int)$_SESSION['languages_id']]] ?? null;
+        return $this->data[$name] ?? $this->data['lang'][$this->languages[(int)$_SESSION['languages_id']]][$name] ?? null;
     }
 
     /**


### PR DESCRIPTION
Seeing logs like the following, using the Bootstrap template and demo products
```
[25-May-2024 13:18:41 America/New_York] PHP Fatal error: Uncaught TypeError: zen_get_products_manufacturers_name(): Return value must be of type string, array returned in C:\xampp\htdocs\zc200w\includes\functions\functions_products.php:520
Stack trace:
#0 C:\xampp\htdocs\zc200w\includes\classes\ajax\zcAjaxBootstrapSearch.php(63): zen_get_products_manufacturers_name('43')
#1 C:\xampp\htdocs\zc200w\ajax.php(72): zcAjaxBootstrapSearch->searchProducts()
#2 {main}
thrown in C:\xampp\htdocs\zc200w\includes\functions\functions_products.php on line 520

[25-May-2024 13:18:41 America/New_York] Request URI: /zc200w/ajax.php?act=ajaxBootstrapSearch&method=searchProducts, IP address: 127.0.0.1
--> PHP Fatal error: Uncaught TypeError: zen_get_products_manufacturers_name(): Return value must be of type string, array returned in C:\xampp\htdocs\zc200w\includes\functions\functions_products.php:520
Stack trace:
#0 C:\xampp\htdocs\zc200w\includes\classes\ajax\zcAjaxBootstrapSearch.php(63): zen_get_products_manufacturers_name('43')
#1 C:\xampp\htdocs\zc200w\ajax.php(72): zcAjaxBootstrapSearch->searchProducts()
#2 {main}
thrown in C:\xampp\htdocs\zc200w\includes\functions\functions_products.php on line 520.

[25-May-2024 13:18:41 America/New_York] Request URI: /zc200w/ajax.php?act=ajaxBootstrapSearch&method=searchProducts, IP address: 127.0.0.1
--> PHP Fatal error: Uncaught TypeError: zen_get_products_manufacturers_name(): Return value must be of type string, array returned in C:\xampp\htdocs\zc200w\includes\functions\functions_products.php:520
Stack trace:
#0 C:\xampp\htdocs\zc200w\includes\classes\ajax\zcAjaxBootstrapSearch.php(63): zen_get_products_manufacturers_name('43')
#1 C:\xampp\htdocs\zc200w\ajax.php(72): zcAjaxBootstrapSearch->searchProducts()
#2 {main}
thrown in C:\xampp\htdocs\zc200w\includes\functions\functions_products.php on line 520.
```