### PR TITLE
Fix PHP 8.1 syntax in ipncheck.php utility

### DIFF
--- a/extras/ipncheck.php
+++ b/extras/ipncheck.php
@@ -34,7 +34,6 @@ $testBoth = (isset($_GET['both']) && $_GET['both'] == '0') ? FALSE : TRUE;
 $testSandbox = (isset($_GET['sandbox'])) ? TRUE : FALSE;
 
 $_POST = array();
-if (isset($GLOBALS)) unset($GLOBALS);
 if (isset($_GET)) unset($_GET);
 if (isset($_REQUEST)) unset($_REQUEST);
 $_POST['ipn_mode'] = 'communication_test';


### PR DESCRIPTION
From PHP 8,1 and later, certain changes to the $GLOBALS array throws fatal errors. In general, modifying individual array elements is allowed, but making mass changes are not allowed.

Current code throws a fatal error which shows as an HTTP 500. 
