### PR TITLE
Enable zc_plugin `extra_definitions` to be overridden by templates

### DIFF
--- a/includes/classes/ResourceLoaders/CatalogArraysLanguageLoader.php
+++ b/includes/classes/ResourceLoaders/CatalogArraysLanguageLoader.php
@@ -47,13 +47,13 @@ class CatalogArraysLanguageLoader extends ArraysLanguageLoader
         $defineList = $this->loadArraysFromDirectory(DIR_WS_LANGUAGES, $_SESSION['language'], '/extra_definitions');
         $this->addLanguageDefines($defineList);
 
-        $defineList = $this->loadArraysFromDirectory(DIR_WS_LANGUAGES, $_SESSION['language'], '/extra_definitions/' . $this->templateDir);
-        $this->addLanguageDefines($defineList);
-
         $defineList = $this->pluginLoadArraysFromDirectory($_SESSION['language'], '/extra_definitions', 'catalog');
         $this->addLanguageDefines($defineList);
 
         $defineList = $this->pluginLoadArraysFromDirectory($_SESSION['language'], '/extra_definitions/default');
+        $this->addLanguageDefines($defineList);
+        
+        $defineList = $this->loadArraysFromDirectory(DIR_WS_LANGUAGES, $_SESSION['language'], '/extra_definitions/' . $this->templateDir);
         $this->addLanguageDefines($defineList);
     }
 


### PR DESCRIPTION
While a `zc_plugin`'s page-specific language files _can_ be overridden by a template-override language file, a plugin's `extra_definitions` language files cannot be.

This PR corrects that condition, ensuring that any template-overrides (er) override.