### PR TITLE
Add zen_to_boolean() function

### DIFF
--- a/includes/functions/functions_general_shared.php
+++ b/includes/functions/functions_general_shared.php
@@ -419,6 +419,23 @@ function utilDumpRequest($mode = 'p', $out = 'log')
 }
 
 /**
+ * Convert a truthy/falsey string to boolean.
+ * Recognizes words like Yes, No, Off, On, True/False (both string and native types); and is not case-sensitive
+ * Also recognizes numbers both as strings and integers ('0', '1') as booleans
+ * Blank (empty string) is treated as false.
+ *
+ * By default, will return null if the passed value is neither truthy/falsey (ie: 'red', or '2')
+ */
+function zen_to_boolean(mixed $value, bool $null_on_failure = true): bool|null
+{
+    if ($null_on_failure) {
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+    }
+
+    return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+}
+
+/**
  * this function will need to be removed if
  * we ever revert to a full laravel install
  */


### PR DESCRIPTION
Intended for use with configuration switches whose values are truthy/falsey but stored as strings. eg: "True", 'true', 'On', 'OFF', 'Yes', 'no'

Instead of converting `==` to `===` when refactoring comparisons with configuration switches that are really boolean-ish, use `zen_is_boolean(CONSTANT)` and treat the response as boolean.

eg:
`SHOW_PRODUCTS_SOLD_OUT_IMAGE == '1'` could be replaced with 
`zen_is_boolean(SHOW_PRODUCTS_SOLD_OUT_IMAGE) === true` (even leave off the `=== true` part)

`strtolower(IMAGE_USE_CSS_BUTTONS) === 'yes'` 
could be replaced with `zen_is_boolean(IMAGE_USE_CSS_BUTTONS) === true` (again, can leave out the `=== true` suffix)