### PR TITLE
`install_suggested` and `phpupgrade`, correct missing constant warning/error

### DIFF
--- a/includes/templates/template_default/templates/tpl_zc_install_suggested_default.php
+++ b/includes/templates/template_default/templates/tpl_zc_install_suggested_default.php
@@ -14,7 +14,7 @@ $instPath = (file_exists('zc_install/index.php')) ? 'zc_install/index.php' : (fi
 $docsPath = (file_exists('docs/index.html')) ? 'docs/index.html' : (file_exists('../docs/index.html') ? '../docs/index.html' : '');
 ?>
 <!DOCTYPE html>
-<html <?php echo defined('HTML_PARAMS') ? HTML_PARAMS : '';?>>
+<html dir="ltr" lang="en">
   <head>
     <title>System Setup Required</title>
     <meta content="utf-8">

--- a/includes/templates/template_default/templates/tpl_zc_phpupgrade_default.php
+++ b/includes/templates/template_default/templates/tpl_zc_phpupgrade_default.php
@@ -16,7 +16,7 @@ $relPath = (file_exists('includes/templates/template_default/images/logo.gif')) 
 include 'includes/version.php';
 ?>
 <!DOCTYPE html>
-<html <?php echo HTML_PARAMS; ?>>
+<html dir="ltr" lang="en">
   <head>
     <title>PHP Version Upgrade Required</title>
     <meta content="utf-8">


### PR DESCRIPTION
In PHP8, we get a warning about this constant because the base language file isn't pulled in. 
Let's just remove the constant.

```
[31-May-2024 11:53:23 UTC] PHP Warning:  Use of undefined constant HTML_PARAMS - assumed 'HTML_PARAMS' (this will throw an Error in a future version of PHP) in /home/client/public_html/store/includes/templates/template_default/templates/tpl_zc_phpupgrade_default.php on line 19
```