### PR TITLE
Admin: retire $zc_products class

### DIFF
--- a/admin/attributes_controller.php
+++ b/admin/attributes_controller.php
@@ -716,7 +716,7 @@ function zen_js_option_values_list($selectedName, $fieldName)
                 <?php
                 }
                 ?>
-                <?php if ($zc_products->get_allow_add_to_cart($products_filter) == "Y") { ?>
+                <?php if (zen_get_products_allow_add_to_cart($products_filter) === 'Y') { ?>
                   <li role="presentation"><a role="menuitem" href="<?php echo zen_href_link(FILENAME_PRODUCTS_PRICE_MANAGER, '&products_filter=' . $products_filter . '&current_category_id=' . $current_category_id); ?>"><?php echo IMAGE_PRODUCTS_PRICE_MANAGER; ?></a></li>
                 <?php } ?>
                 <?php

--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -11,7 +11,7 @@ require DIR_WS_CLASSES . 'currencies.php';
 $currencies = new currencies();
 
 if (isset($_POST['products_id'])) {
-    $product_type = zen_get_products_type($_POST['products_id']);
+    $product_type = (int)zen_get_products_type($_POST['products_id']);
 } elseif (isset($_GET['product_type'])) {
     $product_type = (int)$_GET['product_type'];
 } else {
@@ -166,7 +166,7 @@ if (!empty($action)) {
             $cascaded_prod_cat_for_delete = [];
             $cascaded_prod_cat_for_delete[] = $categories[$i]['id'];
             // determine product-type-specific override script for this product
-            $product_type = zen_get_products_type($category_product);
+            $product_type = (int)zen_get_products_type($category_product);
             // now loop thru the delete_product_confirm script for each product in the current category
             require zen_get_admin_module_from_directory($product_type, 'delete_product_confirm.php');
           }
@@ -912,7 +912,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
                 $pInfo = new objectInfo($product);
               }
 
-              $type_handler = $zc_products->get_handler($product['products_type']);
+              $type_handler = zen_get_handler_from_type($product['products_type']);
               $products_wholesale_indicator = ($wholesale_pricing_enabled === true && $product['products_price_w'] !== '0') ? $wholesale_pricing_indicator : '';
               ?>
               <tr class="product-listing-row" data-pid="<?= $product['products_id'] ?>">
@@ -1040,7 +1040,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
                       <?php } else { ?>
                         <a href="<?= zen_href_link(FILENAME_ATTRIBUTES_CONTROLLER, 'products_filter=' . $product['products_id'] . '&current_category_id=' . $current_category_id) ?>" class="btn btn-sm btn-default btn-attributes-off" role="button" title="<?= BOX_CATALOG_CATEGORIES_ATTRIBUTES_CONTROLLER ?>"><strong>A</strong></a>
                       <?php } ?>
-                      <?php if ($zc_products->get_allow_add_to_cart($product['products_id']) === "Y") { ?>
+                      <?php if (zen_get_products_allow_add_to_cart($product['products_id']) === 'Y') { ?>
 <?php
                      $ppm_color = 'btn-pricemanager-on';
                      if (zen_has_product_discounts($product['products_id']) === 'true') {

--- a/admin/includes/auto_loaders/config.core.php
+++ b/admin/includes/auto_loaders/config.core.php
@@ -309,15 +309,17 @@ $autoLoadConfig[80][] = [
 /**
  * Breakpoint 90.
  *
- * $zc_products = new products();
+ * $zc_products = new products(); // deprecated v2.1.0
  * require DIR_WS_FUNCTIONS . 'datepicker.php';
  *
  */
+// zc_products deprecated v2.1.0; use Product class instead.
 $autoLoadConfig[90][] = [
     'autoType' => 'classInstantiate',
     'className' => 'products',
     'objectName' => 'zc_products',
 ];
+
 $autoLoadConfig[90][] = [
     'autoType' => 'require',
     'loadFile' => DIR_WS_FUNCTIONS . 'datepicker.php',

--- a/admin/includes/modules/copy_product_confirm.php
+++ b/admin/includes/modules/copy_product_confirm.php
@@ -22,7 +22,7 @@ if (isset($_POST['products_id'], $_POST['categories_id'])) {
         }
     } elseif ($_POST['copy_as'] === 'duplicate') {
 
-        $product = zen_get_product_details($products_id);
+        $product = (new Product((int)$products_id))->withDefaultLanguage();
 
         // fix Product copy from if Unit is 0
         if ($product->fields['products_quantity_order_units'] == 0) {

--- a/admin/media_manager.php
+++ b/admin/media_manager.php
@@ -303,7 +303,7 @@
       $products_linked = $db->Execute($products_linked_query);
       if ($products_linked->RecordCount() > 0) $contents[] = array('text' => '<hr>');
       while (!$products_linked->EOF) {
-        $contents[] = array('text'=>zen_draw_form('remove_product', FILENAME_MEDIA_MANAGER, 'action=remove_product&page=' . $_GET['page']) . '<input type="hidden" name="mID" value="' . $mInfo->media_id . '">' . '<input type="hidden" name="product_id" value="' . $products_linked->fields['product_id'] . '">' . '<button type="submit" class="btn btn-danger">' . IMAGE_DELETE . '</button>'. '&nbsp;' . $zc_products->products_name($products_linked->fields['product_id']) . '<br>' . '</form>');
+        $contents[] = array('text'=>zen_draw_form('remove_product', FILENAME_MEDIA_MANAGER, 'action=remove_product&page=' . $_GET['page']) . '<input type="hidden" name="mID" value="' . $mInfo->media_id . '">' . '<input type="hidden" name="product_id" value="' . $products_linked->fields['product_id'] . '">' . '<button type="submit" class="btn btn-danger">' . IMAGE_DELETE . '</button>'. '&nbsp;' . zen_get_products_name($products_linked->fields['product_id']) . '<br>' . '</form>');
         $products_linked->MoveNext();
       }
       $contents[] = array('align' => 'center', 'text' =>  '<br><a href="' . zen_href_link(FILENAME_MEDIA_MANAGER, 'page=' . $_GET['page'] . $mManager_parameter) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>');

--- a/admin/product.php
+++ b/admin/product.php
@@ -4,8 +4,6 @@
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: lat9 2023 Oct 28 Modified in v2.0.0-alpha1 $
- *
- * @var products $zc_products
  */
 require 'includes/application_top.php';
 
@@ -14,18 +12,19 @@ $action = $_GET['action'] ?? '';
 require DIR_WS_CLASSES . 'currencies.php';
 $currencies = new currencies();
 
-$product_type = (isset($_POST['product_type']) ? (int)$_POST['product_type'] : (isset($_GET['pID']) ? zen_get_products_type($_GET['pID']) : 1));
+$product_type = (int)($_POST['product_type'] ?? $_GET['products_type'] ?? 1);
 
-// -----
-// If the product_type is an empty string, zen_get_products_type has indicated that the
-// requested product is not found in the database.
-//
-if ($product_type === '') {
+if (isset($_GET['pID'])) {
+    $product_lookup = (new Product((int)$_GET['pID']));
+    $product_type = $product_lookup->get('products_type');
+    $type_handler = $product_lookup->getTypeHandler() . '.php';
+}
+
+if ($product_lookup === null || !$product_lookup->exists()) {
     $messageStack->add_session(sprintf(WARNING_PRODUCT_DOES_NOT_EXIST, (int)($_GET['pID'] ?? 0)), 'warning');
     zen_redirect(zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING));
 }
 
-$type_handler = $zc_products->get_admin_handler($product_type);
 $zco_notifier->notify('NOTIFY_BEGIN_ADMIN_PRODUCTS', $action, $action);
 
 if (!empty($action)) {

--- a/admin/products_price_manager.php
+++ b/admin/products_price_manager.php
@@ -320,7 +320,7 @@ if (!empty($action)) {
 
       <?php
 // only show if allowed in cart
-      if ($zc_products->get_allow_add_to_cart($products_filter) == 'Y') {
+      if (zen_get_products_allow_add_to_cart($products_filter) === 'Y') {
 
 // featured information
         $featuredParameters = [
@@ -817,9 +817,9 @@ if (!empty($action)) {
                   <div class="col-sm-9 col-md-6 text-center">
                     <?php
 // Specials cannot be added to Gift Vouchers when false
-                    // prevent log on null 
-                    if (empty($pInfo->products_model)) { 
-                        $pInfo->products_model = ''; 
+                    // prevent log on null
+                    if (empty($pInfo->products_model)) {
+                        $pInfo->products_model = '';
                     }
                     if ((substr($pInfo->products_model, 0, 4) != 'GIFT') || (substr($pInfo->products_model, 0, 4) == 'GIFT' && (defined('MODULE_ORDER_TOTAL_GV_SPECIAL') && MODULE_ORDER_TOTAL_GV_SPECIAL == 'true'))) {
                       ?>

--- a/admin/stats_products_lowstock.php
+++ b/admin/stats_products_lowstock.php
@@ -43,7 +43,7 @@ require('includes/application_top.php');
         </thead>
         <tbody>
             <?php
-            $products_query_raw = "SELECT p.products_id, pd.products_name, p.products_quantity, p.products_type
+            $products_query_raw = "SELECT p.products_id, pd.products_name, p.products_quantity
                                    FROM " . TABLE_PRODUCTS . " p,
                                         " . TABLE_PRODUCTS_DESCRIPTION . " pd
                                    WHERE p.products_id = pd.products_id
@@ -51,10 +51,13 @@ require('includes/application_top.php');
                                    ORDER BY p.products_quantity, pd.products_name";
             $products_split = new splitPageResults($_GET['page'], MAX_DISPLAY_SEARCH_RESULTS_REPORTS, $products_query_raw, $products_query_numrows);
             $products = $db->Execute($products_query_raw);
-            foreach ($products as $product) {
-// only show low stock on products that can be added to the cart
-              if ($zc_products->get_allow_add_to_cart($product['products_id']) == 'Y') {
-                $type_handler = $zc_products->get_admin_handler($product['products_type']);
+
+            foreach ($products as $productRecord) {
+                $productData = (new Product((int)$productRecord['products_id']))->withDefaultLanguage();
+                $product = $productData->getData();
+
+              // only show low stock on products that can be added to the cart
+              if ($productData->allowsAddToCart()) {
                 $cPath = zen_get_product_path($product['products_id']);
                 ?>
               <tr class="dataTableRow" onclick="document.location.href = '<?php echo zen_href_link(FILENAME_PRODUCT, '&product_type=' . $product['products_type'] . '&cPath=' . $cPath . '&pID=' . $product['products_id'] . '&action=new_product'); ?>'">

--- a/admin/stats_products_purchased.php
+++ b/admin/stats_products_purchased.php
@@ -111,7 +111,6 @@ $products_filter_name_model = (isset($_GET['products_filter_name_model']) ? $_GE
                 $cPath = zen_get_product_path($orders_products['products_id']);
               }
               $product_type = zen_get_products_type($orders_products['products_id']);
-              $type_handler = $zc_products->get_admin_handler($product_type);
               ?>
               <tr class="dataTableRow">
                 <td class="dataTableContent"><a href="<?php echo zen_href_link(FILENAME_CUSTOMERS, zen_get_all_get_params(array('cID', 'action', 'page', 'products_filter')) . 'cID=' . $orders_products['customers_id'] . '&action=edit', 'NONSSL'); ?>"><?php echo $orders_products['customers_id']; ?></a></td>
@@ -155,7 +154,6 @@ $products_filter_name_model = (isset($_GET['products_filter_name_model']) ? $_GE
           foreach ($products as $product) {
             $cPath = zen_get_product_path($product['products_id']);
             $product_type = zen_get_products_type($product['products_id']);
-            $type_handler = $zc_products->get_admin_handler($product_type);
             ?>
             <tr class="dataTableRow" onclick="document.location.href = '<?php echo zen_href_link(FILENAME_PRODUCT, '&product_type=' . $product_type . '&cPath=' . $cPath . '&pID=' . $product['products_id'] . '&action=new_product'); ?>'">
               <td class="dataTableContent text-right"><a href="<?php echo zen_href_link(FILENAME_STATS_PRODUCTS_PURCHASED, zen_get_all_get_params(array('oID', 'action', 'page', 'products_filter')) . 'products_filter=' . $product['products_id']); ?>"><?php echo $product['products_id']; ?></a></td>

--- a/includes/classes/products.php
+++ b/includes/classes/products.php
@@ -12,8 +12,10 @@ if (!defined('IS_ADMIN_FLAG')) {
 }
 /**
  * products class
- * Class used for managing various product information
+ * Deprecated class formerly used for managing various product information
  *
+ * @deprecated v2.1.0 - use Product class instead
+ * or call zen_get_products_name(), zen_get_handler_from_type(), zen_get_products_allow_add_to_cart()
  */
 class products extends base {
 

--- a/includes/functions/functions_files.php
+++ b/includes/functions/functions_files.php
@@ -204,10 +204,8 @@ function zen_get_module_sidebox_directory($check_file)
  */
 function zen_get_admin_module_from_directory(int $product_type, string $filename_to_check, bool $dir_only = false): string
 {
-    global $zc_products;
-
     $dir = DIR_WS_MODULES;
-    $product_type_foldername = $zc_products->get_handler($product_type);
+    $product_type_foldername = zen_get_handler_from_type($product_type);
     if (file_exists(DIR_WS_MODULES . $product_type_foldername . '/' . $filename_to_check)) {
         $dir = DIR_WS_MODULES . $product_type_foldername . '/';
     }

--- a/includes/functions/functions_lookups.php
+++ b/includes/functions/functions_lookups.php
@@ -14,13 +14,20 @@
  * get the type_handler value for the specified product_type
  * @param int $product_type
  */
-function zen_get_handler_from_type($product_type)
+function zen_get_handler_from_type($product_type): string
 {
     global $db;
 
-    $sql = "select type_handler from " . TABLE_PRODUCT_TYPES . " where type_id = " . (int)$product_type;
+    // this is a fallback safety to protect against damaged (inaccessible) data caused by incorrect code in custom product types
+    if ((int)$product_type === 0) {
+        $product_type = 1;
+    }
+
+    $sql = "SELECT type_handler FROM " . TABLE_PRODUCT_TYPES . " WHERE type_id = " . (int)$product_type;
     $handler = $db->Execute($sql);
-    if ($handler->EOF) return 'ERROR: Invalid type_handler. Your product_type settings are wrong, incomplete, or damaged.';
+    if ($handler->EOF) {
+        throw new ValueError('ERROR: Invalid type_handler. Your product_type settings are wrong, incomplete, or damaged.');
+    }
     return $handler->fields['type_handler'];
 }
 

--- a/includes/functions/functions_products.php
+++ b/includes/functions/functions_products.php
@@ -584,10 +584,9 @@ function zen_get_info_page($product_id): string
  * @param int $product_id
  * @return int|string
  */
-function zen_get_products_type($product_id): int|string
+function zen_get_products_type($product_id): int
 {
-    // NOTE: Empty string return is used by the admin/product.php to identify a product that doesn't exist in the database!
-    return (new Product((int)$product_id))->get('products_type') ?? '';
+    return (new Product((int)$product_id))->get('products_type') ?? 1;
 }
 
 /**


### PR DESCRIPTION
Partly fixes #6504 

The `products` class (global var `$zc_products`) contains several helper functions that are basically subsumed by the `Product` class and/or some helper functions already used across the code base.

This moves toward deprecating that class. Nothing changes inside it, so won't cause a breaking change until we actually delete the class in a future version.