### PR TITLE
Enhance queryFactoryMeta class to track more data

### DIFF
--- a/admin/includes/modules/copy_product_confirm.php
+++ b/admin/includes/modules/copy_product_confirm.php
@@ -73,11 +73,20 @@ if (isset($_POST['products_id'], $_POST['categories_id'])) {
         //
         $zco_notifier->notify('NOTIFY_MODULES_COPY_PRODUCT_CONFIRM_DUPLICATE_FIELDS', $product, $separately_updated_fields, $casted_fields);
 
+        $db_fields = $db->metaColumns(TABLE_PRODUCTS);
+
         foreach ($product->fields as $key => $value) {
-            if (in_array($key, $separately_updated_fields)) {
+            // only prepare fields that are part of TABLE_PRODUCTS
+            if (!in_array($key, $db_fields, true)) {
                 continue;
             }
 
+            // skip any fields that are handled already or will be done differently
+            if (in_array($key, $separately_updated_fields, true)) {
+                continue;
+            }
+
+            // cast types according to rules
             $value = zen_db_input($value);
             if (array_key_exists($key, $casted_fields)) {
                 if ($casted_fields[$key] === 'int') {


### PR DESCRIPTION
The `$db->metaColumns(tablename)` function returns a list of db fields, and with this PR now also returns field types and other schema data that could be used for casting to native types, determining whether NULL could be expected, and more.

Fixes errors occurring in #6504 by using this meta data to determine which fields can actually be cloned when duplicating a product, thus ignoring all "fields" derived from other product data prepared by the `Product` class.