### PR TITLE
Fixes undefined array key log when sessions config uses Check User agent

### DIFF
--- a/includes/init_includes/init_sessions.php
+++ b/includes/init_includes/init_sessions.php
@@ -147,7 +147,7 @@ if ($request_type === 'SSL' && SESSION_CHECK_SSL_SESSION_ID === 'True' && ENABLE
  * verify the browser user agent if the feature is enabled
  */
 if (SESSION_CHECK_USER_AGENT === 'True') {
-    $http_user_agent = $_SERVER['HTTP_USER_AGENT'];
+    $http_user_agent = $_SERVER['HTTP_USER_AGENT'] ?? '';
     if (empty($_SESSION['SESSION_USER_AGENT'])) {
         $_SESSION['SESSION_USER_AGENT'] = $http_user_agent;
     }


### PR DESCRIPTION
```
--> PHP Warning: Undefined array key "HTTP_USER_AGENT" in /home/client/catalog/includes/init_includes/init_sessions.php on line 150.
```