### PR TITLE
CatalogArraysLanguageLoader: Use correct 3rd parameter

### DIFF
--- a/includes/classes/ResourceLoaders/CatalogArraysLanguageLoader.php
+++ b/includes/classes/ResourceLoaders/CatalogArraysLanguageLoader.php
@@ -50,7 +50,7 @@ class CatalogArraysLanguageLoader extends ArraysLanguageLoader
         $defineList = $this->pluginLoadArraysFromDirectory($_SESSION['language'], '/extra_definitions', 'catalog');
         $this->addLanguageDefines($defineList);
 
-        $defineList = $this->pluginLoadArraysFromDirectory($_SESSION['language'], '/extra_definitions/default');
+        $defineList = $this->pluginLoadArraysFromDirectory($_SESSION['language'], '/extra_definitions/default', 'catalog');
         $this->addLanguageDefines($defineList);
         
         $defineList = $this->loadArraysFromDirectory(DIR_WS_LANGUAGES, $_SESSION['language'], '/extra_definitions/' . $this->templateDir);


### PR DESCRIPTION
A corollary to https://github.com/zencart/zencart/pull/6493.

The default 3rd parameter for `pluginLoadArraysFromDirectory` is "admin'.