### PR TITLE
Use `$psr4Autoload` instead of `config.core.php` to handle the base class' loading

### DIFF
--- a/admin/includes/auto_loaders/config.core.php
+++ b/admin/includes/auto_loaders/config.core.php
@@ -114,11 +114,6 @@ $autoLoadConfig[0][] = [
 ];
 $autoLoadConfig[0][] = [
     'autoType' => 'class',
-    'loadFile' => 'Customer.php',
-    'classPath' => DIR_FS_CATALOG . DIR_WS_CLASSES,
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
     'loadFile' => 'zcDate.php',
     'classPath' => DIR_FS_CATALOG . DIR_WS_CLASSES,
 ];

--- a/admin/includes/auto_loaders/config.core.php
+++ b/admin/includes/auto_loaders/config.core.php
@@ -36,12 +36,8 @@ $autoLoadConfig[0][] = [
     'autoType' => 'require',
     'loadFile' => DIR_FS_CATALOG . DIR_WS_INCLUDES . 'version.php',
 ];
-//  $autoLoadConfig[0][] = array('autoType'=>'class',
-//                               'loadFile'=>'class.base.php');
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'class.notifier.php',
-];
+
+//- notifier class loaded via psr4Autoload.php
 $autoLoadConfig[0][] = [
     'autoType' => 'classInstantiate',
     'className' => 'notifier',
@@ -49,83 +45,14 @@ $autoLoadConfig[0][] = [
 ];
 $autoLoadConfig[0][] = [
     'autoType' => 'class',
-    'loadFile' => 'sniffer.php',
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'shopping_cart.php',
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'products.php',
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'table_block.php',
-    'classPath' => DIR_WS_CLASSES,
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'box.php',
-    'classPath' => DIR_WS_CLASSES,
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'message_stack.php',
-    'classPath' => DIR_WS_CLASSES,
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'object_info.php',
-    'classPath' => DIR_WS_CLASSES,
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
     'loadFile' => 'class.phpmailer.php',
 ];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'upload.php',
-    'classPath' => DIR_FS_CATALOG . DIR_WS_CLASSES,
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'class.zcPassword.php',
-];
+
+//- zcPassword class loaded via psr4Autoload.php
 $autoLoadConfig[0][] = [
     'autoType' => 'classInstantiate',
     'className' => 'zcPassword',
     'objectName' => 'zcPassword',
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'VersionServer.php',
-    'classPath' => DIR_WS_CLASSES,
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'configurationValidation.php',
-    'classPath' => DIR_WS_CLASSES,
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'WhosOnline.php',
-    'classPath' => DIR_WS_CLASSES,
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'zcDate.php',
-    'classPath' => DIR_FS_CATALOG . DIR_WS_CLASSES,
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'Coupon.php',
-    'classPath' => DIR_FS_CATALOG . DIR_WS_CLASSES,
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'CouponValidation.php',
-    'classPath' => DIR_FS_CATALOG . DIR_WS_CLASSES,
 ];
 /**
  * Breakpoint 5.
@@ -133,6 +60,7 @@ $autoLoadConfig[0][] = [
  * $zcDate = new zcDate();
  *
  */
+//- zcDate class loaded via psr4Autoload.php
 $autoLoadConfig[5][] = [
     'autoType' => 'classInstantiate',
     'className' => 'zcDate',
@@ -193,6 +121,8 @@ $autoLoadConfig[30][] = [
     'autoType' => 'init_script',
     'loadFile' => 'init_gzip.php',
 ];
+
+//- sniffer class loaded via psr4Autoload.php
 $autoLoadConfig[30][] = [
     'autoType' => 'classInstantiate',
     'className' => 'sniffer',
@@ -204,6 +134,7 @@ $autoLoadConfig[30][] = [
  * $messageStack = new messageStack();
  *
  */
+//- messageStack class loaded via psr4Autoload.php
 $autoLoadConfig[32][] = [
     'autoType' => 'classInstantiate',
     'className' => 'messageStack',
@@ -309,6 +240,7 @@ $autoLoadConfig[80][] = [
  *
  */
 // zc_products deprecated v2.1.0; use Product class instead.
+//- products class loaded via psr4Autoload.php
 $autoLoadConfig[90][] = [
     'autoType' => 'classInstantiate',
     'className' => 'products',
@@ -392,6 +324,7 @@ $autoLoadConfig[170][] = [
  * require DIR_FS_CATALOG . 'includes/init_includes/init_observers.php';
  *
  */
+//- configurationValidation class loaded via psr4Autoload.php
 $autoLoadConfig[175][] = [
     'autoType' => 'classInstantiate',
     'className' => 'configurationValidation',

--- a/includes/auto_loaders/config.core.php
+++ b/includes/auto_loaders/config.core.php
@@ -101,10 +101,6 @@ $autoLoadConfig[0][] = [
 ];
 $autoLoadConfig[0][] = [
     'autoType' => 'class',
-    'loadFile' => 'Customer.php',
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
     'loadFile' => 'class.search.php',
 ];
 $autoLoadConfig[0][] = [

--- a/includes/auto_loaders/config.core.php
+++ b/includes/auto_loaders/config.core.php
@@ -37,14 +37,8 @@ $autoLoadConfig[0][] = [
     'autoType' => 'include',
     'loadFile' => DIR_WS_INCLUDES . 'version.php',
 ];
-//$autoLoadConfig[0][] = [
-//    'autoType' => 'class',
-//    'loadFile' => 'class.base.php',
-//];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'class.notifier.php',
-];
+
+//- notifier class loaded via psr4Autoload.php
 $autoLoadConfig[0][] = [
     'autoType' => 'classInstantiate',
     'className' => 'notifier',
@@ -58,62 +52,12 @@ $autoLoadConfig[0][] = [
     'autoType' => 'class',
     'loadFile' => 'boxes.php',
 ];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'category_tree.php',
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'template_func.php',
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'sniffer.php',
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'shopping_cart.php',
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'navigation_history.php',
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'currencies.php',
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'message_stack.php',
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'breadcrumb.php',
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'class.zcPassword.php',
-];
+
+//- zcPassword class loaded via psr4Autoload.php
 $autoLoadConfig[0][] = [
     'autoType' => 'classInstantiate',
     'className' => 'zcPassword',
     'objectName' => 'zcPassword',
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'class.search.php',
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'zcDate.php',
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'Coupon.php',
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'CouponValidation.php',
 ];
 /**
  * Breakpoint 5.
@@ -121,6 +65,7 @@ $autoLoadConfig[0][] = [
  * $zcDate = new zcDate(); ... will be re-initialized when/if the require_languages.php module is run.
  *
  */
+//- zcDate class loaded via psr4Autoload.php
 $autoLoadConfig[5][] = [
     'autoType' => 'classInstantiate',
     'className' => 'zcDate',
@@ -165,6 +110,7 @@ $autoLoadConfig[45][] = [
  * require 'includes/init_includes/init_gzip.php';
  * require 'includes/init_includes/init_sefu.php';
  */
+//- sniffer class loaded via psr4Autoload.php
 $autoLoadConfig[50][] = [
     'autoType' => 'classInstantiate',
     'className' => 'sniffer',
@@ -222,6 +168,7 @@ $autoLoadConfig[70][] = [
  * if (!$_SESSION['cart']) $_SESSION['cart'] = new shoppingCart();
  *
  */
+//- shoppingCart class loaded via psr4Autoload.php
 $autoLoadConfig[80][] = [
     'autoType' => 'classInstantiate',
     'className' => 'shoppingCart',
@@ -229,6 +176,7 @@ $autoLoadConfig[80][] = [
     'checkInstantiated' => true,
     'classSession' => true,
 ];
+//- Zencart\Search\Search loaded via psr4Autoload.php
 $autoLoadConfig[80][] = [
     'autoType' => 'classInstantiate',
     'className' => 'Zencart\Search\Search',
@@ -240,6 +188,7 @@ $autoLoadConfig[80][] = [
  * currencies = new currencies();
  *
  */
+//- currencies class loaded via psr4Autoload.php
 $autoLoadConfig[90][] = [
     'autoType' => 'classInstantiate',
     'className' => 'currencies',
@@ -262,11 +211,13 @@ $autoLoadConfig[96][] = [
  * $template = new template_func();
  *
  */
+//- template_func class loaded via psr4Autoload.php
 $autoLoadConfig[100][] = [
     'autoType' => 'classInstantiate',
     'className' => 'template_func',
     'objectName' => 'template',
 ];
+//- navigationHistory class loaded via psr4Autoload.php
 $autoLoadConfig[100][] = [
     'autoType' => 'classInstantiate',
     'className' => 'navigationHistory',
@@ -320,6 +271,7 @@ $autoLoadConfig[120][] = [
  * messageStack = new messageStack();
  *
  */
+//- messageStack class loaded via psr4Autoload.php
 $autoLoadConfig[130][] = [
     'autoType' => 'classInstantiate',
     'className' => 'messageStack',
@@ -371,6 +323,7 @@ $autoLoadConfig[150][] = [
  * require 'includes/init_includes/init_category_path.php';
  * $breadcrumb = new breadcrumb();
  */
+//- breadcrumb class loaded via psr4Autoloader.php
 $autoLoadConfig[160][] = [
     'autoType' => 'classInstantiate',
     'className' => 'breadcrumb',

--- a/includes/auto_loaders/paypal_ipn.core.php
+++ b/includes/auto_loaders/paypal_ipn.core.php
@@ -62,10 +62,6 @@ $autoLoadConfig[0][] = [
 ];
 $autoLoadConfig[0][] = [
     'autoType' => 'class',
-    'loadFile' => 'Customer.php',
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
     'loadFile' => 'zcDate.php',
 ];
 /**

--- a/includes/auto_loaders/paypal_ipn.core.php
+++ b/includes/auto_loaders/paypal_ipn.core.php
@@ -15,10 +15,7 @@ $autoLoadConfig[0][] = [
     'autoType' => 'include',
     'loadFile' => DIR_WS_INCLUDES . 'version.php',
 ];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'class.notifier.php',
-];
+//- notifier class loaded via psr4Autoload.php
 $autoLoadConfig[0][] = [
     'autoType' => 'classInstantiate',
     'className' => 'notifier',
@@ -28,48 +25,13 @@ $autoLoadConfig[0][] = [
     'autoType' => 'class',
     'loadFile' => 'class.phpmailer.php',
 ];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'template_func.php',
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'language.php',
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'sniffer.php',
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'shopping_cart.php',
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'navigation_history.php',
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'currencies.php',
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'message_stack.php',
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'breadcrumb.php',
-];
-$autoLoadConfig[0][] = [
-    'autoType' => 'class',
-    'loadFile' => 'zcDate.php',
-];
 /**
  * Breakpoint 5.
  *
  * $zcDate = new zcDate(); ... will be re-initialized when/if the require_languages.php module is run.
  *
  */
+//- zcDate class loaded via psr4Autoload.php
 $autoLoadConfig[5][] = [
     'autoType' => 'classInstantiate',
     'className' => 'zcDate',
@@ -102,6 +64,7 @@ $autoLoadConfig[40][] = [
  * $sniffer = new sniffer();
  * require('includes/init_includes/init_sefu.php');
  */
+//- sniffer class loaded via psr4Autoload.php
 $autoLoadConfig[50][] = [
     'autoType' => 'classInstantiate',
     'className' => 'sniffer',
@@ -158,6 +121,7 @@ $autoLoadConfig[71][] = [
  * if(!$_SESSION['cart']) $_SESSION['cart'] = new shoppingCart();
  *
  */
+//- shoppingCart class loaded via psr4Autoload.php
 $autoLoadConfig[80][] = [
     'autoType' => 'classInstantiate',
     'className' => 'shoppingCart',
@@ -171,6 +135,7 @@ $autoLoadConfig[80][] = [
  * currencies = new currencies();
  *
  */
+//- currencies class loaded via psr4Autoload.php
 $autoLoadConfig[90][] = [
     'autoType' => 'classInstantiate',
     'className' => 'currencies',
@@ -183,6 +148,7 @@ $autoLoadConfig[90][] = [
  * $template = new template_func();
  *
  */
+//- template_func class loaded via psr4Autoload.php
 $autoLoadConfig[100][] = [
     'autoType' => 'classInstantiate',
     'className' => 'template_func',
@@ -223,6 +189,7 @@ $autoLoadConfig[120][] = [
  * messageStack = new messageStack();
  *
  */
+//- messageStack class loaded via psr4Autoload.php
 $autoLoadConfig[130][] = [
     'autoType' => 'classInstantiate',
     'className' => 'messageStack',

--- a/includes/classes/shopping_cart.php
+++ b/includes/classes/shopping_cart.php
@@ -2017,10 +2017,8 @@ class shoppingCart extends base
                     $real_ids = $_POST['id'] ?? [];
                     if (isset($_GET['number_of_uploads']) && $_GET['number_of_uploads'] > 0) {
                         /**
-                         * Need the upload class for attribute type that allows user uploads.
-                         *
+                         * Need the upload class for attribute type that allows user uploads. Now psr4Autoloaded!
                          */
-                        include_once DIR_WS_CLASSES . 'upload.php';
                         for ($i = 1, $n = $_GET['number_of_uploads']; $i <= $n; $i++) {
                             $upload_prefix = UPLOAD_PREFIX . $i;
                             $text_prefix = TEXT_PREFIX . ($_POST[$upload_prefix] ?? '');

--- a/includes/psr4Autoload.php
+++ b/includes/psr4Autoload.php
@@ -5,7 +5,6 @@
  * @version $Id: DrByte 2024 Mar 07 Modified in v2.0.0-rc1 $
  */
 /** @var \Aura\Autoload\Loader $psr4Autoloader */
-$psr4Autoloader->setClassFile('Zencart\SessionHandler', DIR_FS_CATALOG . DIR_WS_CLASSES . 'SessionHandler.php' );
 $psr4Autoloader->addPrefix('Zencart\QueryBuilder', DIR_FS_CATALOG . DIR_WS_CLASSES);
 $psr4Autoloader->addPrefix('Zencart\Traits', DIR_FS_CATALOG . DIR_WS_CLASSES . 'traits');
 $psr4Autoloader->addPrefix('Zencart\FileSystem', DIR_FS_CATALOG . DIR_WS_CLASSES );
@@ -15,18 +14,56 @@ $psr4Autoloader->addPrefix('Zencart\LanguageLoader', DIR_FS_CATALOG . DIR_WS_CLA
 $psr4Autoloader->addPrefix('Zencart\ResourceLoaders', DIR_FS_CATALOG . DIR_WS_CLASSES . 'ResourceLoaders');
 $psr4Autoloader->addPrefix('Zencart\PageLoader', DIR_FS_CATALOG . DIR_WS_CLASSES . 'ResourceLoaders');
 $psr4Autoloader->addPrefix('Zencart\Events', DIR_FS_CATALOG . DIR_WS_CLASSES );
-$psr4Autoloader->setClassFile('MeasurementUnits', DIR_FS_CATALOG . DIR_WS_CLASSES . 'MeasurementUnits.php' );
 $psr4Autoloader->addPrefix('Zencart\PluginSupport', DIR_FS_CATALOG . DIR_WS_CLASSES . 'PluginSupport');
 $psr4Autoloader->addPrefix('Zencart\ViewBuilders', DIR_FS_CATALOG . DIR_WS_CLASSES . 'ViewBuilders');
 $psr4Autoloader->addPrefix('Zencart\Exceptions', DIR_FS_CATALOG . DIR_WS_CLASSES . 'Exceptions');
 $psr4Autoloader->addPrefix('Zencart\Filters', DIR_FS_CATALOG . DIR_WS_CLASSES . 'Filters');
 $psr4Autoloader->addPrefix('Zencart\Request', DIR_FS_CATALOG . DIR_WS_CLASSES);
+
+// -----
+// Admin-only classes
+//
 if (defined('DIR_FS_ADMIN')) {
     $psr4Autoloader->addPrefix('Zencart\Paginator', DIR_FS_ADMIN . DIR_WS_CLASSES);
+
+    $psr4Autoloader->setClassFile('box', DIR_FS_ADMIN . DIR_WS_CLASSES . 'box.php');
+    $psr4Autoloader->setClassFile('boxTableBlock', DIR_FS_ADMIN . DIR_WS_CLASSES . 'table_block.php');
+    $psr4Autoloader->setClassFile('configurationValidation', DIR_FS_ADMIN . DIR_WS_CLASSES . 'configurationValidation.php');
+    $psr4Autoloader->setClassFile('messageStack', DIR_FS_ADMIN . DIR_WS_CLASSES . 'message_stack.php');
+    $psr4Autoloader->setClassFile('objectInfo', DIR_FS_ADMIN . DIR_WS_CLASSES . 'object_info.php');
+    $psr4Autoloader->setClassFile('products', DIR_FS_CATALOG . DIR_WS_CLASSES . 'products.php');    //- Deprecated v2.1.0
+    $psr4Autoloader->setClassFile('VersionServer', DIR_FS_ADMIN . DIR_WS_CLASSES . 'VersionServer.php');
+    $psr4Autoloader->setClassFile('WhosOnline', DIR_FS_ADMIN . DIR_WS_CLASSES . 'WhosOnline.php');
+// -----
+// Storefront-only classes
+//
+} else {
+    $psr4Autoloader->setClassFile('breadcrumb', DIR_FS_CATALOG . DIR_WS_CLASSES . 'breadcrumb.php');
+    $psr4Autoloader->setClassFile('currencies', DIR_FS_CATALOG . DIR_WS_CLASSES . 'currencies.php');
+    $psr4Autoloader->setClassFile('messageStack', DIR_FS_CATALOG . DIR_WS_CLASSES . 'message_stack.php');
+    $psr4Autoloader->setClassFile('navigationHistory', DIR_FS_CATALOG . DIR_WS_CLASSES . 'navigation_history.php');
+    $psr4Autoloader->setClassFile('template_func', DIR_FS_CATALOG . DIR_WS_CLASSES . 'template_func.php');
+    $psr4Autoloader->setClassFile('Zencart\Search\Search', DIR_FS_CATALOG . DIR_WS_CLASSES . 'class.search.php');
+    $psr4Autoloader->setClassFile('Zencart\Search\SearchOptions', DIR_FS_CATALOG . DIR_WS_CLASSES . 'class.search.php');
 }
-$psr4Autoloader->setClassFile('language', DIR_FS_CATALOG . DIR_WS_CLASSES . 'language.php' );
-$psr4Autoloader->setClassFile('Product', DIR_FS_CATALOG . DIR_WS_CLASSES . 'Product.php' );
-$psr4Autoloader->setClassFile('Settings', DIR_FS_CATALOG . DIR_WS_CLASSES . 'Settings.php' );
-$psr4Autoloader->setClassFile('TemplateSettings', DIR_FS_CATALOG . DIR_WS_CLASSES . 'TemplateSettings.php' );
-$psr4Autoloader->setClassFile('ZenShipping', DIR_FS_CATALOG . DIR_WS_CLASSES . 'ZenShipping.php');
+
+// -----
+// Common admin/storefront classes
+//
+$psr4Autoloader->setClassFile('category_tree', DIR_FS_CATALOG . DIR_WS_CLASSES . 'category_tree.php');
+$psr4Autoloader->setClassFile('Coupon', DIR_FS_CATALOG . DIR_WS_CLASSES . 'Coupon.php');
+$psr4Autoloader->setClassFile('CouponValidation', DIR_FS_CATALOG . DIR_WS_CLASSES . 'CouponValidation.php');
 $psr4Autoloader->setClassFile('Customer', DIR_FS_CATALOG . DIR_WS_CLASSES . 'Customer.php');
+$psr4Autoloader->setClassFile('language', DIR_FS_CATALOG . DIR_WS_CLASSES . 'language.php');
+$psr4Autoloader->setClassFile('MeasurementUnits', DIR_FS_CATALOG . DIR_WS_CLASSES . 'MeasurementUnits.php');
+$psr4Autoloader->setClassFile('notifier', DIR_FS_CATALOG . DIR_WS_CLASSES . 'class.notifier.php');
+$psr4Autoloader->setClassFile('Product', DIR_FS_CATALOG . DIR_WS_CLASSES . 'Product.php');
+$psr4Autoloader->setClassFile('Settings', DIR_FS_CATALOG . DIR_WS_CLASSES . 'Settings.php');
+$psr4Autoloader->setClassFile('shoppingCart', DIR_FS_CATALOG . DIR_WS_CLASSES . 'shopping_cart.php');
+$psr4Autoloader->setClassFile('sniffer', DIR_FS_CATALOG . DIR_WS_CLASSES . 'sniffer.php');
+$psr4Autoloader->setClassFile('TemplateSettings', DIR_FS_CATALOG . DIR_WS_CLASSES . 'TemplateSettings.php');
+$psr4Autoloader->setClassFile('upload', DIR_FS_CATALOG . DIR_WS_CLASSES . 'upload.php');
+$psr4Autoloader->setClassFile('zcDate', DIR_FS_CATALOG . DIR_WS_CLASSES . 'zcDate.php');
+$psr4Autoloader->setClassFile('zcPassword', DIR_FS_CATALOG . DIR_WS_CLASSES . 'class.zcPassword.php');
+$psr4Autoloader->setClassFile('ZenShipping', DIR_FS_CATALOG . DIR_WS_CLASSES . 'ZenShipping.php');
+$psr4Autoloader->setClassFile('Zencart\SessionHandler', DIR_FS_CATALOG . DIR_WS_CLASSES . 'SessionHandler.php' );

--- a/includes/psr4Autoload.php
+++ b/includes/psr4Autoload.php
@@ -29,3 +29,4 @@ $psr4Autoloader->setClassFile('Product', DIR_FS_CATALOG . DIR_WS_CLASSES . 'Prod
 $psr4Autoloader->setClassFile('Settings', DIR_FS_CATALOG . DIR_WS_CLASSES . 'Settings.php' );
 $psr4Autoloader->setClassFile('TemplateSettings', DIR_FS_CATALOG . DIR_WS_CLASSES . 'TemplateSettings.php' );
 $psr4Autoloader->setClassFile('ZenShipping', DIR_FS_CATALOG . DIR_WS_CLASSES . 'ZenShipping.php');
+$psr4Autoloader->setClassFile('Customer', DIR_FS_CATALOG . DIR_WS_CLASSES . 'Customer.php');


### PR DESCRIPTION
... thus enabling ~~that class~~ those classes to be overridden if needed.