### PR TITLE
Realign Icons for Downloads Manager

### DIFF
--- a/admin/downloads_manager.php
+++ b/admin/downloads_manager.php
@@ -62,8 +62,6 @@ if (!empty($action)) {
             <i class="fa-regular fa-circle fa-stack-1x txt-black"></i>
           </div>
           <?php echo TEXT_WARNING_PRODUCT_MISCONFIGURED_SHORT; ?>
-        </div>
-        <div class="col-sm-6">
           <div class="fa-stack fa-fw">
             <i class="fa-solid fa-circle fa-stack-1x txt-red"></i>
             <i class="fa-regular fa-circle fa-stack-1x txt-black"></i>


### PR DESCRIPTION
As it is now, closing the col-sm-6 and re-opening it between the misconfigured and missing listings forces them to be separated and confuse the store owner. https://www.zen-cart.com/showthread.php?230203-Downloadable-Product-is-misconfigured.

before
![image](https://github.com/zencart/zencart/assets/5122886/69753cc2-a8b1-4b18-8735-9ec4c58ba135)

after
![image](https://github.com/zencart/zencart/assets/5122886/89e49216-52d6-4e82-b3ca-421e74545ba6)
