### PR TITLE
Fix issue on admin/index.php?cmd=configuration&gID=6

### DIFF
--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -427,6 +427,9 @@ function zen_remove_order($order_id, $restock = false)
 
 function zen_call_function($function, $parameter, $object = '')
 {
+    if (!function_exists($function)) { 
+        return 'Unknown';
+    }
     if ($object === '') {
         return $function($parameter);
     }


### PR DESCRIPTION
Possibly caused by Advanced Shipper bad configuration.  

```
[19-Jun-2024 13:17:02 UTC] PHP Fatal error:  Uncaught Error: Call to undefined function _cfg_zones_status() in /Users/scott/sites/client/admin/includes/functions/general.php:432
Stack trace:
#0 /Users/scott/sites/client/admin/configuration.php(142): zen_call_function('_cfg_zones_stat...', '')
#1 /Users/scott/sites/client/admin/index.php(16): require('/Users/scott/si...')
#2 {main}
  thrown in /Users/scott/sites/client/admin/includes/functions/general.php on line 432
```