### PR TITLE
Language in admin stuck to deleted language

### DIFF
--- a/admin/languages.php
+++ b/admin/languages.php
@@ -247,10 +247,9 @@ if (!empty($action)) {
       $db->Execute("DELETE FROM " . TABLE_EZPAGES_CONTENT . " WHERE languages_id = " . (int)$lID);
 
       // if we just deleted our currently-selected language, need to switch to default lang:
-      if ((int)$_SESSION['languages_id'] == (int)$_POST['lID']) {
+      $getlang = '';
+      if ((int)$_SESSION['languages_id'] === (int)$_POST['lID']) {
           $getlang = '&language=' . DEFAULT_LANGUAGE;
-      } else {
-          $getlang = '';
       }
 
       $zco_notifier->notify('NOTIFY_ADMIN_LANGUAGE_DELETE', (int)$lID);

--- a/admin/languages.php
+++ b/admin/languages.php
@@ -250,12 +250,16 @@ if (!empty($action)) {
       $lng = $db->Execute("SELECT languages_id
                            FROM " . TABLE_LANGUAGES . "
                            WHERE code = '" . zen_db_input(DEFAULT_LANGUAGE) . "'");
-      if ((int)$_SESSION['languages_id'] == (int)$_POST['lID'])
-        $_SESSION['languages_id'] = $lng->fields['languages_id'];
+      if ((int)$_SESSION['languages_id'] == (int)$_POST['lID']) {
+          $_SESSION['languages_id'] = $lng->fields['languages_id'];
+          $getlang = '&language=' . DEFAULT_LANGUAGE;
+      } else {
+          $getlang = '';
+      }
 
       $zco_notifier->notify('NOTIFY_ADMIN_LANGUAGE_DELETE', (int)$lID);
 
-      zen_redirect(zen_href_link(FILENAME_LANGUAGES, 'page=' . $_GET['page']));
+      zen_redirect(zen_href_link(FILENAME_LANGUAGES, 'page=' . $_GET['page'] . $getlang));
       break;
     case 'delete':
       $lID = zen_db_prepare_input($_GET['lID']);

--- a/admin/languages.php
+++ b/admin/languages.php
@@ -247,11 +247,7 @@ if (!empty($action)) {
       $db->Execute("DELETE FROM " . TABLE_EZPAGES_CONTENT . " WHERE languages_id = " . (int)$lID);
 
       // if we just deleted our currently-selected language, need to switch to default lang:
-      $lng = $db->Execute("SELECT languages_id
-                           FROM " . TABLE_LANGUAGES . "
-                           WHERE code = '" . zen_db_input(DEFAULT_LANGUAGE) . "'");
       if ((int)$_SESSION['languages_id'] == (int)$_POST['lID']) {
-          $_SESSION['languages_id'] = $lng->fields['languages_id'];
           $getlang = '&language=' . DEFAULT_LANGUAGE;
       } else {
           $getlang = '';


### PR DESCRIPTION
In Admin pages, when using 2 languages and deleting the one (not default) that you are actually using through languages page, you get stuck in that language.
The language drop down menu is not there anymore and although in languages page there is only the default language English, you can't change back to it...
With this modification, language will change back to default using GET parameter when deleting the language that is actually in use.