### PR TITLE
Protects against non-existent order statuses

### DIFF
--- a/admin/orders.php
+++ b/admin/orders.php
@@ -1064,7 +1064,7 @@ if ($show_orders_weights === true) {
                         }
                         ?>
                     </td>
-                    <td><?php echo $orders_status_array[$item['orders_status_id']]; ?></td>
+                    <td><?php echo $orders_status_array[$item['orders_status_id']] ?? ''; ?></td>
 <?php
                     // -----
                     // A watching observer can provide an associative array in the form:


### PR DESCRIPTION
If a plugin writes to the order_status_history table and uses a status of 0 (or any non-existent status), this will produce a log. 

```
--> PHP Warning: Undefined array key 0 in /home/client/public_html/store/admin/orders.php on line 1057.
```