### PR TITLE
Ensure that `{$loaderPrefix}.core.php` is the first auto-loaded file

### DIFF
--- a/includes/classes/InitSystem.php
+++ b/includes/classes/InitSystem.php
@@ -175,7 +175,7 @@ class InitSystem
     protected function loadAutoLoadersFromSystem($loaderType, $rootDir, $plugin = [])
     {
         $fileList = $this->fileSystem->listFilesFromDirectoryAlphaSorted($rootDir);
-        $fileList = $this->processForOverrides($fileList, $rootDir);
+        $fileList = $this->processForOverrides($loaderType, $fileList, $rootDir);
         $loaderList = $this->getLoadersFromFileList($fileList);
         $loaderList = $this->processLoaderListForType($loaderType, $loaderList, $plugin);
         return $loaderList;
@@ -193,13 +193,24 @@ class InitSystem
         return $pluginLoaderList;
     }
 
-    protected function processForOverrides($fileList, $rootDir)
+    protected function processForOverrides(string $loaderType, array $fileList, string $rootDir): array
     {
         $newFileList = [];
         $baseDir = $rootDir;
         $overrideDir = $baseDir . '/overrides';
+        $core_loader_file = '';
+        if ($loaderType === 'core') {
+            $core_loader_file = $this->loaderPrefix . '.core.php';
+            if ($this->overrideFileExists($core_loader_file, $overrideDir)) {
+                $newFileList[] = $orderrideDir . '/' . $core_loader_file;
+            } else {
+                $newFileList[] = $baseDir . '/' . $core_loader_file;
+            }
+        }
         foreach ($fileList as $file) {
-            if (!$this->fileMatchesLoaderPrefix($file)) continue;
+            if ($file === $core_loader_file || !$this->fileMatchesLoaderPrefix($file)) {
+                continue;
+            }
             $filePath = $baseDir . '/' . $file;
             if ($this->overrideFileExists($file, $overrideDir)) $filePath = $overrideDir . '/' . $file;
             $newFileList[] = $filePath;


### PR DESCRIPTION
Starting with zc157 (!) via [this](https://github.com/zencart/zencart/commit/a838c137bd5f686028cc9ab7807ac9009eb11ca4) commit, the "core" auto-loader is no longer loaded first (i.e. `config.core.php` or `paypal_ipn.core.php`).

Essentially, all files in the `auto_loaders` directory are now loaded alphabetically, with no special casing for the "core" file.  To see the potential for problems:
1. Create a file `includes/auto_loaders/config.aaaa.php` containing:
```php
<?php
$autoLoadConfig[0][] = [
    'autoType'=>'init_script',
    'loadFile'=> 'init_aaaa.php'
];

```
2. Create a file `includes/init_includes/init_aaaa.php` containing:
```php
<?php
if (PROJECT_VERSION_MAJOR === '2') {
    //- do something
}

```

Load the associated storefront to be met with a whitescreen and a log similar to
```
[11-Jul-2024 17:00:32 America/New_York] PHP Fatal error:  Uncaught Error: Undefined constant "PROJECT_VERSION_MAJOR" in C:\xampp\htdocs\zc200w\includes\init_includes\init_aaaa.php:2
Stack trace:
#0 C:\xampp\htdocs\zc200w\includes\autoload_func.php(40): require_once()
#1 C:\xampp\htdocs\zc200w\includes\application_top.php(253): require('C:\\xampp\\htdocs...')
#2 C:\xampp\htdocs\zc200w\index.php(25): require('C:\\xampp\\htdocs...')
#3 {main}
  thrown in C:\xampp\htdocs\zc200w\includes\init_includes\init_aaaa.php on line 2

[11-Jul-2024 17:00:32 America/New_York] Request URI: /zc200w/, IP address: 127.0.0.1
--> PHP Fatal error: Uncaught Error: Undefined constant "PROJECT_VERSION_MAJOR" in C:\xampp\htdocs\zc200w\includes\init_includes\init_aaaa.php:2
Stack trace:
#0 C:\xampp\htdocs\zc200w\includes\autoload_func.php(40): require_once()
#1 C:\xampp\htdocs\zc200w\includes\application_top.php(253): require('C:\\xampp\\htdocs...')
#2 C:\xampp\htdocs\zc200w\index.php(25): require('C:\\xampp\\htdocs...')
#3 {main}
  thrown in C:\xampp\htdocs\zc200w\includes\init_includes\init_aaaa.php on line 2.

[11-Jul-2024 17:00:32 America/New_York] Request URI: /zc200w/, IP address: 127.0.0.1
--> PHP Fatal error: Uncaught Error: Undefined constant "PROJECT_VERSION_MAJOR" in C:\xampp\htdocs\zc200w\includes\init_includes\init_aaaa.php:2
Stack trace:
#0 C:\xampp\htdocs\zc200w\includes\autoload_func.php(40): require_once()
#1 C:\xampp\htdocs\zc200w\includes\application_top.php(253): require('C:\\xampp\\htdocs...')
#2 C:\xampp\htdocs\zc200w\index.php(25): require('C:\\xampp\\htdocs...')
#3 {main}
  thrown in C:\xampp\htdocs\zc200w\includes\init_includes\init_aaaa.php on line 2.
```

The log identifies that `includes/version.php` which is _supposed to be_ the first file loaded ... isn't!  This PR corrects that issue.

P.S. I'll be following up with some PSR-12 refactoring of the `InitSystem.php` class.