### PR TITLE
Typos with language file name in configuration.php

### DIFF
--- a/admin/configuration.php
+++ b/admin/configuration.php
@@ -58,7 +58,7 @@ if ($cfg_group->RecordCount() == 0) {
     $cfg_group->fields['configuration_group_title'] = '';
 } else {
     // multilanguage support:
-    // For example, in admin/includes/languages/spanish/configuration.php
+    // For example, in admin/includes/languages/spanish/lang.configuration.php
     // define('CFG_GRP_TITLE_MY_STORE', 'Mi Tienda');
     $str = $cfg_group->fields['configuration_group_title'];
     $str = preg_replace('/[^a-zA-Z0-9_\x80-\xff]/', '_', $str);
@@ -161,7 +161,7 @@ if ($gID == 7) {
                   ?>
                   <?php
                   // multilanguage support:
-                  // For example, in admin/includes/languages/spanish/configuration.php
+                  // For example, in admin/includes/languages/spanish/lang.configuration.php
                   // define('CFGTITLE_STORE_NAME', 'Nombre de la Tienda');
                   // define('CFGDESC_STORE_NAME', 'El nombre de mi tienda');
                   if (defined('CFGTITLE_' . $item['configuration_key'])) {


### PR DESCRIPTION
Typos with language file name (lang. missing)  in comments in configuration.php.