### PR TITLE
Fix error on query cache miss

### DIFF
--- a/includes/classes/query_cache.php
+++ b/includes/classes/query_cache.php
@@ -49,7 +49,7 @@ class QueryCache
      */
     public function inCache(string $query)
     {
-        return (isset($this->queries[$query]));
+        return (isset($this->queries[$query]) && $this->queries[$query] instanceof mysqli_result);
     }
 
     /**


### PR DESCRIPTION
When running a query which fails (for example due to a schema issue) but which still lands in cache as a boolean `false` instead of a proper mysqli_result, a fatal error is thrown: `PHP Fatal error:  Uncaught TypeError: mysqli_data_seek(): Argument #1 ($result) must be of type mysqli_result, false given in query_cache.php:42`

The cache retrieval can be avoided by adding an additional type check in the `inCache()` check method.

This scenario is unusual because the query cache is in-memory ("memoized") and refreshed on each page-visit. To trigger the problem, one would need to re-run the same query again in the same visit. Usually this doesn't happen because a fatal error normally halts execution. But if that fatal error is bypassed (eg: with $dieOnFailure = false), then this cache bug is exposed.