### PR TITLE
Restore auto-focus to admin search

### DIFF
--- a/admin/customers.php
+++ b/admin/customers.php
@@ -1181,6 +1181,11 @@ if ($action === 'edit' || $action === 'update') {
             </div>
 <?php
 } else {
+    // -----
+    // For a "Password Reset" action, the "New Password" field should
+    // get the autofocus, not the search-input.
+    //
+    $no_searchbox_autofocus = ($action === 'pwreset');
 ?>
             <div class="col-sm-offset-8 col-sm-4">
                 <?php include DIR_WS_MODULES . 'search_box.php'; ?>

--- a/admin/includes/modules/search_box.php
+++ b/admin/includes/modules/search_box.php
@@ -10,7 +10,7 @@
   <?php echo zen_draw_label(HEADING_TITLE_SEARCH_DETAIL, 'search', 'class="control-label col-sm-3"'); ?>
   <div class="col-sm-9">
     <div class="input-group">
-      <?php echo zen_draw_input_field('search', '', 'class="form-control" id="search"', false, 'search'); ?>
+      <?php echo zen_draw_input_field('search', '', 'class="form-control" id="search" autofocus="autofocus"', false, 'search'); ?>
       <span class="input-group-btn">
         <button type="submit" class="btn btn-info"><i class="fa-solid fa-magnifying-glass fa-lg"></i></button>
       </span>

--- a/admin/includes/modules/search_box.php
+++ b/admin/includes/modules/search_box.php
@@ -4,13 +4,19 @@
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: lat9 2023 Jul 10 Modified in v2.0.0-alpha1 $
  */
+// -----
+// The search-box's input defaults to 'autofocus' unless the including
+// script has indicated that it doesn't want the search-field to have
+// that attribute.
+//
+$autofocus_search = empty($no_searchbox_autofocus) ? ' autofocus="autofocus"' : '';
 ?>
 <?php echo zen_draw_form('searchForm', basename($PHP_SELF, '.php'), '', 'get', 'class="form-horizontal"', true); ?>
 <div class="form-group">
   <?php echo zen_draw_label(HEADING_TITLE_SEARCH_DETAIL, 'search', 'class="control-label col-sm-3"'); ?>
   <div class="col-sm-9">
     <div class="input-group">
-      <?php echo zen_draw_input_field('search', '', 'class="form-control" id="search" autofocus="autofocus"', false, 'search'); ?>
+      <?php echo zen_draw_input_field('search', '', 'class="form-control" id="search"' . $autofocus_search, false, 'search'); ?>
       <span class="input-group-btn">
         <button type="submit" class="btn btn-info"><i class="fa-solid fa-magnifying-glass fa-lg"></i></button>
       </span>


### PR DESCRIPTION
It was lost in the zc157->zc158 transition.  Used to be only on Categories/Product, but now since the search-box is used multiple places, it'll be widespread.