### PR TITLE
zc_install - add systemCheck "skipWhen" configuration option

### DIFF
--- a/zc_install/includes/classes/class.systemChecker.php
+++ b/zc_install/includes/classes/class.systemChecker.php
@@ -79,6 +79,17 @@ class systemChecker
 //echo print_r($this->systemChecks);
         foreach ($this->systemChecks as $systemCheckName => $systemCheck) {
 //echo print_r($systemCheck);
+            // check for bypass
+            if (isset($systemCheck['skipWhen'])) {
+                $parts = explode('=', $systemCheck['skipWhen']);
+                $what = $parts[0];
+                $when = $parts[1];
+
+                if ($what === 'server' && $when === 'nginx' && str_starts_with($_SERVER['SERVER_SOFTWARE'], 'nginx')) {
+                    continue;
+                }
+            }
+
             if (in_array($systemCheck['runLevel'], $runLevels, false)) {
                 $resultCombined = true;
                 $criticalError = false;

--- a/zc_install/includes/systemChecks.yml
+++ b/zc_install/includes/systemChecks.yml
@@ -288,6 +288,7 @@ systemChecks:
     errorLevel: WARN
     mainErrorText: <?php echo TEXT_ERROR_GZIP .PHP_EOL; ?>
     mainErrorTextHelpId: helpIdGzip
+    skipWhen: server=nginx
     methods:
       checkIniGet:
         parameters:


### PR DESCRIPTION
With nginx, the `gzip` check that we do isn't accurate, so best to skip it without triggering warnings that just get ignored.