### PR TITLE
Buy now button for showcase

### DIFF
--- a/includes/functions/functions_general.php
+++ b/includes/functions/functions_general.php
@@ -118,7 +118,7 @@ function zen_get_buy_now_button($product_id, string $buy_now_link, $additional_l
 
 // show case only supercedes all other settings
     if (STORE_STATUS != '0') {
-        return '<a href="' . zen_href_link(FILENAME_CONTACT_US, '', 'SSL') . '">' . TEXT_SHOWCASE_ONLY . '</a>';
+        return '<a href="' . zen_href_link(FILENAME_ASK_A_QUESTION, 'pid=' . (int)$product_id, 'SSL') . '">' . TEXT_SHOWCASE_ONLY . '</a>';
     }
 
 // 0 = normal shopping


### PR DESCRIPTION
Now that AAQ is built-in, I think the contact us link shown instead of the buy now button should indicate the product, as the ask a question page does. 