### PR TITLE
`pulldown` class: Align name with usage

### DIFF
--- a/includes/classes/pulldown.php
+++ b/includes/classes/pulldown.php
@@ -182,7 +182,7 @@
          *
          * @return string
          */
-        public function generatePullDownHtml(string $name, string $parameters = '', bool $required = false)
+        public function generatePulldownHtml(string $name, string $parameters = '', bool $required = false)
         {
             $this->processSQL();
 


### PR DESCRIPTION
All callers use lower case 'd' (`generatePulldownHtml`). 