### PR TITLE
allow changes to ot_coupon; fixes #6710

### DIFF
--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -687,7 +687,7 @@ class order extends base
                 foreach ($products[$i]['attributes'] as $option => $value) {
 
                     $sql = "SELECT popt.products_options_name, poval.products_options_values_name,
-                                   pa.options_values_price, pa.price_prefix
+                                   pa.options_values_price, pa.price_prefix, pa.attributes_discounted
                             FROM " . TABLE_PRODUCTS_OPTIONS . " popt,
                                  " . TABLE_PRODUCTS_OPTIONS_VALUES . " poval,
                                  " . TABLE_PRODUCTS_ATTRIBUTES . " pa
@@ -715,6 +715,7 @@ class order extends base
                         'value_id' => $value,
                         'prefix' => $attributes->fields['price_prefix'],
                         'price' => $attributes->fields['options_values_price'],
+                        'discountable' => $attributes->fields['attributes_discounted'],
                     ];
 
                     $this->notify('NOTIFY_ORDER_CART_ADD_ATTRIBUTE_LIST', ['index' => $index, 'subindex' => $subindex, 'products' => $products[$i], 'attributes' => $attributes]);

--- a/includes/modules/order_total/ot_coupon.php
+++ b/includes/modules/order_total/ot_coupon.php
@@ -693,7 +693,7 @@ class ot_coupon extends base
         //echo 'Current $orderTotalFull less taxes: ' . $orderTotalFull . '<br>';
         // left for total order amount ($orderTotalDetails['totalFull']) vs qualified order amount ($order_total['orderTotal']) - to include both in array
         // add total order amount ($orderTotalFull) to array for $order_total['totalFull'] vs $order_total['orderTotal']
-        return [
+        $return = [
             'totalFull' => $orderTotalFull,
             'orderTotal' => $orderTotal,
             'orderTaxGroups' => $orderTaxGroups,
@@ -701,6 +701,8 @@ class ot_coupon extends base
             'shipping' => $order->info['shipping_cost'] ?? 0,
             'shippingTax' => $order->info['shipping_tax'] ?? 0,
         ];
+        $this->notify('NOTIFY_OT_COUPON_ORDER_TOTAL_FINISHED', null, $return);
+        return $return;
     }
 
     /**


### PR DESCRIPTION
i can get by without the change to the order class; but it just seems adding that value to the order object saves a whole bunch of database hits.