### PR TITLE
Translate copied order-status names when installing new language

### DIFF
--- a/admin/languages.php
+++ b/admin/languages.php
@@ -147,7 +147,7 @@ if (!empty($action)) {
           $db->Execute("INSERT INTO " . TABLE_ORDERS_STATUS . " (orders_status_id, language_id, orders_status_name, sort_order)
                         VALUES (" . $status['orders_status_id'] . ",
                                 " . (int)$insert_id . ",
-                                '" . zen_db_input($status['orders_status_name']) . "',
+                                '" . zen_db_input(zen_lookup_admin_menu_language_override('install_order_status', $status['orders_status_name'], $status['orders_status_name'])) . "',
                                 " . $status['sort_order'] . ")");
         }
 

--- a/includes/functions/functions_lookups.php
+++ b/includes/functions/functions_lookups.php
@@ -318,6 +318,9 @@ function zen_lookup_admin_menu_language_override(string $lookup_type, string $lo
         case 'plugin_description':
             $lookup = strtoupper('ADMIN_PLUGIN_MANAGER_DESCRIPTION_FOR_' . $lookup_key);
             break;
+        case 'install_order_status':
+            $lookup = strtoupper('INSTALL_ORDER_STATUS_' . $lookup_key);
+            break;
     }
 
     if (isset($lookup) && defined($lookup)) {


### PR DESCRIPTION
Expects admin `lang.languages.php` or a file in `extra_definitions` to contain order status defines for each pre-existing english status name. 
Any statuses for which a matching define is not found, will just use the English value, as before, and can be manually translated via the Admin UI as before.

French example for pending, processing, delivered, update:
```
'INSTALL_ORDER_STATUS_PENDING' => 'En attente',
'INSTALL_ORDER_STATUS_PROCESSING' => 'En cours',
'INSTALL_ORDER_STATUS_DELIVERED' => 'Livré',
'INSTALL_ORDER_STATUS_UPDATE' => 'Mise à jour',
```

Addendum to #6584 