### PR TITLE
Updating database with translated local strings when adding language

### DIFF
--- a/admin/includes/languages/english/extra_definitions/lang.install_orders_satus_en.php
+++ b/admin/includes/languages/english/extra_definitions/lang.install_orders_satus_en.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @copyright Copyright 2003-2024 Zen Cart Development Team
+ * @copyright Portions Copyright 2003 osCommerce
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: piloujp 2024 Aug 30 Modified in v2.1.0-alpha1 $
+*/
+
+$define = [
+    'INSTALL_ORDERS_STATUS_1_EN' => 'Pending', // Pending
+    'INSTALL_ORDERS_STATUS_2_EN' => 'Processing', // Processing
+    'INSTALL_ORDERS_STATUS_3_EN' => 'Delivered', // Delivered
+    'INSTALL_ORDERS_STATUS_4_EN' => 'Update', //Update
+];
+
+return $define;

--- a/admin/includes/languages/english/extra_definitions/lang.install_pos_name_en.php
+++ b/admin/includes/languages/english/extra_definitions/lang.install_pos_name_en.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @copyright Copyright 2003-2024 Zen Cart Development Team
+ * @copyright Portions Copyright 2003 osCommerce
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: piloujp 2024 Aug 30 Modified in v2.1.0-alpha1 $
+*/
+
+$define = [
+    'INSTALL_PLUGIN_POS_NAME_1_EN' => 'Back-ordered',
+];
+
+return $define;

--- a/admin/includes/languages/english/extra_definitions/lang.install_posm_name_en.php
+++ b/admin/includes/languages/english/extra_definitions/lang.install_posm_name_en.php
@@ -7,7 +7,7 @@
 */
 
 $define = [
-    'INSTALL_PLUGIN_POS_NAME_1_EN' => 'Back-ordered',
+    'INSTALL_PLUGIN_POSM_NAME_1_EN' => 'Back-ordered',
 ];
 
 return $define;

--- a/admin/languages.php
+++ b/admin/languages.php
@@ -139,6 +139,9 @@ if (!empty($action)) {
         }
 
 // create additional orders_status records
+        $lang_data = $db->Execute("SELECT code FROM " . TABLE_LANGUAGES . " WHERE languages_id = " . (int)$insert_id);
+        $lang_suffix = (!empty($lang_data->fields['code'])) ? $lang_data->fields['code'] : '';
+
         $orders_status = $db->Execute("SELECT orders_status_id, orders_status_name, sort_order
                                        FROM " . TABLE_ORDERS_STATUS . "
                                        WHERE language_id = " . (int)$_SESSION['languages_id']);
@@ -147,7 +150,7 @@ if (!empty($action)) {
           $db->Execute("INSERT INTO " . TABLE_ORDERS_STATUS . " (orders_status_id, language_id, orders_status_name, sort_order)
                         VALUES (" . $status['orders_status_id'] . ",
                                 " . (int)$insert_id . ",
-                                '" . zen_db_input(zen_lookup_admin_menu_language_override('install_order_status', $status['orders_status_name'], $status['orders_status_name'])) . "',
+                                '" . zen_db_input(zen_lookup_database_localization_language_switch('install_orders_status', $status['orders_status_id'], $status['orders_status_name'], (string)$lang_suffix)) . "',
                                 " . $status['sort_order'] . ")");
         }
 

--- a/includes/functions/functions_lookups.php
+++ b/includes/functions/functions_lookups.php
@@ -318,8 +318,26 @@ function zen_lookup_admin_menu_language_override(string $lookup_type, string $lo
         case 'plugin_description':
             $lookup = strtoupper('ADMIN_PLUGIN_MANAGER_DESCRIPTION_FOR_' . $lookup_key);
             break;
-        case 'install_order_status':
-            $lookup = strtoupper('INSTALL_ORDER_STATUS_' . $lookup_key);
+    }
+
+    if (isset($lookup) && defined($lookup)) {
+        return constant($lookup);
+    }
+
+    return $fallback;
+}
+
+
+function zen_lookup_database_localization_language_switch(string $lookup_type, string $lookup_key, string $fallback, string $lgcode): string
+{
+    $str = $lookup_key;
+    $str .= (!empty($lgcode)) ? '_' . $lgcode : '';
+    switch ($lookup_type) {
+        case 'install_orders_status':
+            $lookup = strtoupper('INSTALL_ORDERS_STATUS_' . $str);
+            break;
+        case 'install_plugin':
+            $lookup = strtoupper('INSTALL_PLUGIN_' . $str);
             break;
     }
 

--- a/zc_plugins/POSM/v6.0.0/Installer/ScriptedInstaller.php
+++ b/zc_plugins/POSM/v6.0.0/Installer/ScriptedInstaller.php
@@ -133,7 +133,7 @@ class ScriptedInstaller extends ScriptedInstallBase
                 "INSERT IGNORE INTO " . TABLE_PRODUCTS_OPTIONS_STOCK_NAMES . "
                     (pos_name_id, language_id, pos_name)
                  VALUES
-                    (1, " . $current_language['id'] . ", '" . zen_db_input(zen_lookup_database_localization_language_switch('install_plugin', 'POS_NAME_1', 'Back-ordered', (string)$current_language['code'])) . "')"
+                    (1, " . $current_language['id'] . ", '" . zen_db_input(zen_lookup_database_localization_language_switch('install_plugin', 'POSM_NAME_1', 'Back-ordered', (string)$current_language['code'])) . "')"
             );
         }
 

--- a/zc_plugins/POSM/v6.0.0/Installer/ScriptedInstaller.php
+++ b/zc_plugins/POSM/v6.0.0/Installer/ScriptedInstaller.php
@@ -133,7 +133,7 @@ class ScriptedInstaller extends ScriptedInstallBase
                 "INSERT IGNORE INTO " . TABLE_PRODUCTS_OPTIONS_STOCK_NAMES . "
                     (pos_name_id, language_id, pos_name)
                  VALUES
-                    (1, " . $current_language['id'] . ", 'Back-ordered')"
+                    (1, " . $current_language['id'] . ", '" . zen_db_input(zen_lookup_database_localization_language_switch('install_plugin', 'POS_NAME_1', 'Back-ordered', (string)$current_language['code'])) . "')"
             );
         }
 

--- a/zc_plugins/POSM/v6.0.0/admin/includes/classes/observers/class.products_options_stock_admin_observer.php
+++ b/zc_plugins/POSM/v6.0.0/admin/includes/classes/observers/class.products_options_stock_admin_observer.php
@@ -595,12 +595,15 @@ class products_options_stock_observer extends base
               WHERE language_id = " . (int)$_SESSION['languages_id']
         );
 
+        $lang_data = $db->Execute("SELECT code FROM " . TABLE_LANGUAGES . " WHERE languages_id = " . (int)$insert_id);
+        $lang_suffix = (!empty($lang_data->fields['code'])) ? $lang_data->fields['code'] : '';
+
         foreach ($products_option_stock_names as $option_stock_name) {
           $db->Execute(
               "INSERT IGNORE INTO " . TABLE_PRODUCTS_OPTIONS_STOCK_NAMES . "
                   (pos_name_id, language_id, pos_name)
                VALUES
-                  (" . $option_stock_name['pos_name_id'] . ", $insert_id, '" . zen_db_input($option_stock_name['pos_name']) . "')"
+                  (" . $option_stock_name['pos_name_id'] . ", $insert_id, '" . zen_db_input(zen_lookup_database_localization_language_switch('install_plugin', 'POS_NAME_' . $option_stock_name['pos_name_id'], $option_stock_name['pos_name'], (string)$lang_suffix)) . "')"
           );
         }
     }

--- a/zc_plugins/POSM/v6.0.0/admin/includes/classes/observers/class.products_options_stock_admin_observer.php
+++ b/zc_plugins/POSM/v6.0.0/admin/includes/classes/observers/class.products_options_stock_admin_observer.php
@@ -603,7 +603,7 @@ class products_options_stock_observer extends base
               "INSERT IGNORE INTO " . TABLE_PRODUCTS_OPTIONS_STOCK_NAMES . "
                   (pos_name_id, language_id, pos_name)
                VALUES
-                  (" . $option_stock_name['pos_name_id'] . ", $insert_id, '" . zen_db_input(zen_lookup_database_localization_language_switch('install_plugin', 'POS_NAME_' . $option_stock_name['pos_name_id'], $option_stock_name['pos_name'], (string)$lang_suffix)) . "')"
+                  (" . $option_stock_name['pos_name_id'] . ", $insert_id, '" . zen_db_input(zen_lookup_database_localization_language_switch('install_plugin', 'POSM_NAME_' . $option_stock_name['pos_name_id'], $option_stock_name['pos_name'], (string)$lang_suffix)) . "')"
           );
         }
     }


### PR DESCRIPTION
Added languages files and a new lookup function for translation of database local records when adding a new language.
Actually used to automatically update orders status strings and POSM back ordered label name when adding a new language.
The function uses language constants in files `admin\includes\languages\english\extra_definitions\lang.install_orders_satus_(language code here).php` and `admin\includes\languages\english\extra_definitions\lang.install_pos_name_(language code here).php`.

Language files for French are available in [French language pack on Github](https://github.com/piloujp/French_Language_Pack_for_ZC).