### PR TITLE
Catalog language loader: Don't strip `lang.` prefix from known file

### DIFF
--- a/includes/classes/ResourceLoaders/CatalogArraysLanguageLoader.php
+++ b/includes/classes/ResourceLoaders/CatalogArraysLanguageLoader.php
@@ -75,7 +75,6 @@ class CatalogArraysLanguageLoader extends ArraysLanguageLoader
 
         $files = $this->fileSystem->listFilesFromDirectoryAlphaSorted($directory, $files_regex);
         foreach ($files as $file) {
-            $file = substr($file, 5);    //- Drop the leading 'lang.' from the file's name
             $defines = $this->loadArrayDefineFile($directory . '/' . $file);
             $this->makeConstants($defines);
         }


### PR DESCRIPTION
I've no clue where I had that idea from!