### PR TITLE
Simplify style-overrides for category-tabs template

### DIFF
--- a/includes/modules/categories_tabs.php
+++ b/includes/modules/categories_tabs.php
@@ -2,37 +2,61 @@
 /**
  * categories_tabs.php module
  *
- * @copyright Copyright 2003-2022 Zen Cart Development Team
+ * @copyright Copyright 2003-2024 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: DrByte 2020 Dec 28 Modified in v1.5.8-alpha $
+ * @version $Id: v2.1.0-alpha3 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
-  die('Illegal Access');
+    die('Illegal Access');
 }
-$order_by = " order by c.sort_order, cd.categories_name ";
+$link_class_active ??= 'category-top';
+$link_class_inactive ??= 'category-top';
+$span_wrapper_for_active ??= 'category-subs-selected';
+$includeAllCategories ??= true;
 
-$sql = "SELECT c.sort_order, c.categories_id, cd.categories_name
-        FROM " . TABLE_CATEGORIES . " c
-        LEFT JOIN " . TABLE_CATEGORIES_DESCRIPTION . " cd ON (c.categories_id = cd.categories_id AND cd.language_id = " . (int)$_SESSION['languages_id'] . ")
-        WHERE c.parent_id= " . (int)TOPMOST_CATEGORY_PARENT_ID . "
-        AND c.categories_status=1 " .
-        $order_by;
-$categories_tab = $db->Execute($sql);
+// BS4 template overrides:
+//$link_class_active = 'nav-item nav-link m-1 activeLink';
+//$link_class_inactive = 'nav-item nav-link m-1';
+//$span_wrap_active = '';
+//$includeAllCategories = $zca_include_zero_product_categories ?? true;
 
-$links_list = array();
-while (!$categories_tab->EOF) {
+$categories_tab_query =
+    "SELECT c.sort_order, c.categories_id, cd.categories_name
+       FROM " . TABLE_CATEGORIES . " c, " . TABLE_CATEGORIES_DESCRIPTION . " cd
+      WHERE c.categories_id = cd.categories_id
+        AND c.parent_id = " . (int)TOPMOST_CATEGORY_PARENT_ID . "
+        AND cd.language_id = " . (int)$_SESSION['languages_id'] . "
+        AND c.categories_status = 1
+    ORDER BY c.sort_order, cd.categories_name";
+$results = $db->Execute($categories_tab_query);
 
-  // currently selected category
-  if ((int)$cPath == $categories_tab->fields['categories_id']) {
-    $new_style = 'category-top';
-    $categories_tab_current = '<span class="category-subs-selected">' . $categories_tab->fields['categories_name'] . '</span>';
-  } else {
-    $new_style = 'category-top';
-    $categories_tab_current = $categories_tab->fields['categories_name'];
-  }
+$links_list = [];
+$links_list_by_category = [];
+$current_category_tab = (int)$cPath;
 
-  // create link to top level category
-  $links_list[] = '<a class="' . $new_style . '" href="' . zen_href_link(FILENAME_DEFAULT, 'cPath=' . (int)$categories_tab->fields['categories_id']) . '">' . $categories_tab_current . '</a> ';
-  $categories_tab->MoveNext();
+foreach ($results as $category) {
+    // currently selected category
+    if ($current_category_tab === (int)$category['categories_id']) {
+        $new_style = $link_class_active;
+        $categories_tab_current = $category['categories_name'];
+        if ($span_wrapper_for_active !== '') {
+            $categories_tab_current = '<span class="' . $span_wrapper_for_active . '">' . $categories_tab_current . '</span>';
+        }
+    } else {
+        if (!$includeAllCategories) {
+            $count = zen_products_in_category_count($category['categories_id']);
+            if ($count === 0) {
+                continue;
+            }
+        }
+        $new_style = $link_class_inactive;
+        $categories_tab_current = $category['categories_name'];
+    }
+    // create link to top level category
+    $link = '<a class="' . $new_style . '" href="' . zen_href_link(FILENAME_DEFAULT, 'cPath=' . (int)$category['categories_id']) . '">' . $categories_tab_current . '</a> ';
+    $links_list[] = $link;
+    // stuff category id into array for later querying; note: we add the 'c' prefix to avoid array renumbering of numeric values (it can be stripped later where used)
+    $links_list_by_category['c' . $category['categories_id']] = $link;
 }
+

--- a/includes/templates/template_default/templates/tpl_modules_categories_tabs.php
+++ b/includes/templates/template_default/templates/tpl_modules_categories_tabs.php
@@ -4,22 +4,32 @@
  *
  * Template stub used to display categories-tabs output
  *
- * @copyright Copyright 2003-2022 Zen Cart Development Team
+ * @copyright Copyright 2003-2024 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: DrByte 2020 Jul 10 Modified in v1.5.8-alpha $
+ * @version $Id: v2.1.0-alpha3 $
  */
 
-  include(DIR_WS_MODULES . zen_get_module_directory(FILENAME_CATEGORIES_TABS));
+include DIR_WS_MODULES . zen_get_module_directory(FILENAME_CATEGORIES_TABS);
+
+if (CATEGORIES_TABS_STATUS === '1' && (!empty($links_list) || !empty($links_list_by_category))) {
 ?>
-<?php if (CATEGORIES_TABS_STATUS == '1' && sizeof($links_list) >= 1) { ?>
+
 <div id="navCatTabsWrapper">
 <div id="navCatTabs">
 <ul>
-<?php for ($i=0, $n=sizeof($links_list); $i<$n; $i++) { ?>
-  <li><?php echo $links_list[$i];?></li>
+<?php foreach (($links_list_by_category ?? $links_list) as $link_key => $link_val) { ?>
+    <?php
+    // Since v2.1.0, if $links_list_by_category is not empty,
+    // then $link_key is the category_id prefixed by the letter 'c'.
+    // So, $category_id = ltrim($link_key, 'c')
+    // ... which can then be used to query alternate details about the category or its products
+    // ... and therefore can be used inside this loop to do more things with this menu
+    ?>
+    <li><?php echo $link_val;?></li>
 <?php } ?>
 </ul>
 </div>
 </div>
 <?php } ?>
+


### PR DESCRIPTION
Inspired by #6719

The template optionally allows referring back to already-queried categories_id if an override template wants to do more with that information (such as show subcategories/products).