### PR TITLE
Language loading, catalog per-page and template-override updates/corrections

### DIFF
--- a/includes/classes/ResourceLoaders/AdminArraysLanguageLoader.php
+++ b/includes/classes/ResourceLoaders/AdminArraysLanguageLoader.php
@@ -19,13 +19,7 @@ class AdminArraysLanguageLoader extends ArraysLanguageLoader
 
     protected function loadLanguageForView(): void
     {
-        $defineList = $this->loadDefinesFromArrayFile(DIR_WS_LANGUAGES, $this->fallback, $this->currentPage);
-        $this->addLanguageDefines($defineList);
-
-        if ($_SESSION['language'] !== $this->fallback) {
-            $defineList = $this->loadDefinesFromArrayFile(DIR_WS_LANGUAGES, $_SESSION['language'], $this->currentPage);
-            $this->addLanguageDefines($defineList);
-        }
+        $this->loadDefinesFromDirFileWithFallback(DIR_WS_LANGUAGES, $this->currentPage);
 
         $defineList = $this->pluginLoadDefinesFromArrayFile($this->fallback, $this->currentPage, 'admin', '');
         $this->addLanguageDefines($defineList);
@@ -57,45 +51,38 @@ class AdminArraysLanguageLoader extends ArraysLanguageLoader
 
     protected function loadBaseLanguageFiles()
     {
+        // -----
+        // First, load the main language file(). The 'lang.english.php' file is always
+        // loaded, with its constant values possibly overwritten by a different main
+        // language file (e.g. lang.spanish.php).
+        //
+        // These definitions are added to the to-be-generated constants' list.
+        //
         $mainFile = DIR_WS_LANGUAGES . 'lang.' . $_SESSION['language'] . '.php';
         $fallbackFile = DIR_WS_LANGUAGES . 'lang.' . $this->fallback . '.php';
         $defineList = $this->loadDefinesWithFallback($mainFile, $fallbackFile);
         $this->addLanguageDefines($defineList);
 
-        $defineList = $this->loadDefinesFromArrayFile(DIR_WS_LANGUAGES, $this->fallback, 'gv_name.php');
-        $this->addLanguageDefines($defineList);
+        // -----
+        // Next, load some other files with multi-page-use constants, adding their
+        // definitions to the to-be-generated constants' list.
+        //
+        // Each file is first loaded from the 'english' sub-directory for the given
+        // directory and then, if the session's language is non-english, overwritten
+        // by any such file found in that language sub-directory (e.g. 'spanish').
+        //
+        $this->loadDefinesFromDirFileWithFallback(DIR_WS_LANGUAGES, 'gv_name.php');
+        $this->loadDefinesFromDirFileWithFallback(DIR_WS_LANGUAGES, FILENAME_EMAIL_EXTRAS);
+        $this->loadDefinesFromDirFileWithFallback(DIR_FS_CATALOG . DIR_WS_LANGUAGES, FILENAME_OTHER_IMAGES_NAMES);
 
-        if ($_SESSION['language'] !== $this->fallback) {
-            $defineList = $this->loadDefinesFromArrayFile(DIR_WS_LANGUAGES, $_SESSION['language'], 'gv_name.php');
+        // -----
+        // Finally, if the 'lang.other_images_names.php' has a template-override file **in the
+        // current session's language**, load those definitions, adding to the
+        // to-be-generated constants' list.
+        //
+        if ($this->fileSystem->hasTemplateLanguageOverride($this->templateDir, DIR_FS_CATALOG . DIR_WS_LANGUAGES, $_SESSION['language'], FILENAME_OTHER_IMAGES_NAMES)) {
+            $defineList = $this->loadDefinesFromArrayFile(DIR_FS_CATALOG . DIR_WS_LANGUAGES, $_SESSION['language'], FILENAME_OTHER_IMAGES_NAMES, '/' . $this->templateDir);
             $this->addLanguageDefines($defineList);
-        }
-
-        $defineList = $this->loadDefinesFromArrayFile(DIR_WS_LANGUAGES, $this->fallback, FILENAME_EMAIL_EXTRAS);
-        $this->addLanguageDefines($defineList);
-
-        if ($_SESSION['language'] !== $this->fallback) {
-            $defineList = $this->loadDefinesFromArrayFile(DIR_WS_LANGUAGES, $_SESSION['language'], FILENAME_EMAIL_EXTRAS);
-            $this->addLanguageDefines($defineList);
-        }
-
-        $defineList = $this->loadDefinesFromArrayFile(DIR_FS_CATALOG . DIR_WS_LANGUAGES, $this->fallback, FILENAME_OTHER_IMAGES_NAMES);
-        $this->addLanguageDefines($defineList);
-
-        if ($_SESSION['language'] !== $this->fallback) {
-            $defineList = $this->loadDefinesFromArrayFile(DIR_FS_CATALOG . DIR_WS_LANGUAGES, $_SESSION['language'], FILENAME_OTHER_IMAGES_NAMES);
-            $this->addLanguageDefines($defineList);
-        }
-
-        if ($this->fileSystem->hasTemplateLanguageOverride($this->templateDir, DIR_FS_CATALOG . DIR_WS_LANGUAGES, $this->fallback, FILENAME_OTHER_IMAGES_NAMES)) {
-            $defineList = $this->loadDefinesFromArrayFile(DIR_FS_CATALOG . DIR_WS_LANGUAGES, $this->fallback, FILENAME_OTHER_IMAGES_NAMES, $this->templateDir . '/');
-            $this->addLanguageDefines($defineList);
-        }
-
-        if ($_SESSION['language'] !== $this->fallback) {
-            if ($this->fileSystem->hasTemplateLanguageOverride($this->templateDir, DIR_FS_CATALOG . DIR_WS_LANGUAGES, $_SESSION['language'], FILENAME_OTHER_IMAGES_NAMES)) {
-                $defineList = $this->loadDefinesFromArrayFile(DIR_FS_CATALOG . DIR_WS_LANGUAGES, $_SESSION['language'], FILENAME_OTHER_IMAGES_NAMES, $this->templateDir . '/');
-                $this->addLanguageDefines($defineList);
-            }
         }
     }
 }

--- a/includes/classes/ResourceLoaders/ArraysLanguageLoader.php
+++ b/includes/classes/ResourceLoaders/ArraysLanguageLoader.php
@@ -57,7 +57,7 @@ class ArraysLanguageLoader extends BaseLanguageLoader
     {
         $defineList = [];
         foreach ($this->pluginList as $plugin) {
-            $pluginDir = DIR_FS_CATALOG . 'zc_plugins/' . $plugin['unique_key'] . '/' . $plugin['version'] . '/' . $context . '/includes/languages/';
+            $pluginDir = $this->zcPluginsDir . $plugin['unique_key'] . '/' . $plugin['version'] . '/' . $context . '/includes/languages/';
             $defines = $this->loadArraysFromDirectory($pluginDir, $language, $extraPath);
             $defineList = array_merge($defineList, $defines);
         }
@@ -132,7 +132,7 @@ class ArraysLanguageLoader extends BaseLanguageLoader
     {
         $defineList = [];
         foreach ($this->pluginList as $plugin) {
-            $pluginDir = DIR_FS_CATALOG . 'zc_plugins/' . $plugin['unique_key'] . '/' . $plugin['version'];
+            $pluginDir = $this->zcPluginsDir . $plugin['unique_key'] . '/' . $plugin['version'];
             $pluginDir .=  '/' . $context . '/includes/languages/';
             $pluginDefineList = $this->loadDefinesFromArrayFile($pluginDir, $language, $fileName, $extraPath);
             $defineList = array_merge($defineList, $pluginDefineList);

--- a/includes/classes/ResourceLoaders/BaseLanguageLoader.php
+++ b/includes/classes/ResourceLoaders/BaseLanguageLoader.php
@@ -16,6 +16,7 @@ class BaseLanguageLoader
     protected array $languageDefines = [];
     protected array $pluginList;
     protected string $templateDir;
+    protected string $zcPluginsDir;
 
     public string $currentPage;
 
@@ -26,5 +27,6 @@ class BaseLanguageLoader
         $this->fallback = $fallback;
         $this->fileSystem = new FileSystem();
         $this->templateDir = $templateDir;
+        $this->zcPluginsDir = DIR_FS_CATALOG . 'zc_plugins/';
     }
 }

--- a/includes/classes/ResourceLoaders/CatalogArraysLanguageLoader.php
+++ b/includes/classes/ResourceLoaders/CatalogArraysLanguageLoader.php
@@ -20,64 +20,130 @@ class CatalogArraysLanguageLoader extends ArraysLanguageLoader
 
     public function loadLanguageForView(): void
     {
-        $languages = [
-            $_SESSION['language'],
-        ];
+        // -----
+        // First, load all the array files for the current page, creating the
+        // constants for the 'base' current-page's file.
+        //
+        $this->loadCurrentPageBaseFile();
+
+        // -----
+        // Next, build up the constant-definition array for additional 'base' per-page
+        // language files, i.e. files that are 'similar' to the current page's name
+        // but not specifically the 'base' current-page file.
+        //
+        // Start with any such files in the 'english' language directory.  If the current
+        // session language is different than 'english', load those files, overwriting any
+        // similarly-named definitions present in 'english'.
+        //
+        $definesList = $this->loadCurrentPageExtraFilesFromDir(DIR_WS_LANGUAGES . $this->fallback);
         if ($_SESSION['language'] !== $this->fallback) {
-            $languages[] = $this->fallback;
+            $definesList = array_merge($definesList, $this->loadCurrentPageExtraFilesFromDir(DIR_WS_LANGUAGES . $_SESSION['language']));
         }
 
-        $this->loadCurrentPageBaseFile($languages);
+        // -----
+        // Bring in any additional per-page files from enabled zc_plugins.
+        //
+        // Any definitions found in these directories overwrite any of the 'base' per-page
+        // definitions.
+        //
+        foreach ($this->pluginList as $plugin) {
+            $pluginDir = DIR_FS_CATALOG . 'zc_plugins/' . $plugin['unique_key'] . '/' . $plugin['version'] . '/catalog/includes/languages/';
 
-        foreach ($languages as $next_lang) {
-            $baseDir = DIR_WS_LANGUAGES . $next_lang;
-
-            $this->loadCurrentPageExtraFilesFromDir($baseDir . '/' . $this->templateDir);
-
-            foreach ($this->pluginList as $plugin) {
-                $pluginDir = DIR_FS_CATALOG . 'zc_plugins/' . $plugin['unique_key'] . '/' . $plugin['version'] . '/catalog/includes/languages/' . $next_lang;
-
-                $this->loadCurrentPageExtraFilesFromDir($pluginDir . '/default');
-                $this->loadCurrentPageExtraFilesFromDir($pluginDir);
+            $definesListPlugin = $this->loadCurrentPageExtraFilesFromDir($pluginDir . $this->fallback);
+            if ($_SESSION['language'] !== $this->fallback) {
+                $definesListPlugin = array_merge($definesListPlugin, $this->loadCurrentPageExtraFilesFromDir($pluginDir . $_SESSION['language']));
             }
 
-            $this->loadCurrentPageExtraFilesFromDir($baseDir);
-        }
-    }
+            $definesList = array_merge($definesList, $definesListPlugin);
 
-    protected function loadCurrentPageBaseFile(array $languages): void
-    {
-        $filename = 'lang.' . $this->currentPage . '.php';
-        foreach ($languages as $next_lang) {
-            $baseDir = DIR_WS_LANGUAGES . $next_lang . '/';
-
-            $defines = $this->loadArrayDefineFile($baseDir . $this->templateDir . '/' . $filename);
-            $this->makeConstants($defines);
-
-            foreach ($this->pluginList as $plugin) {
-                $pluginDir = DIR_FS_CATALOG . 'zc_plugins/' . $plugin['unique_key'] . '/' . $plugin['version'] . '/catalog/includes/languages/' . $next_lang;
-
-                $defines = $this->loadArrayDefineFile($pluginDir . '/default/' . $filename);
-                $this->makeConstants($defines);
-
-                $defines = $this->loadArrayDefineFile($pluginDir . '/' . $filename);
-                $this->makeConstants($defines);
+            $definesListPlugin = $this->loadCurrentPageExtraFilesFromDir($pluginDir . $this->fallback . '/default');
+            if ($_SESSION['language'] !== $this->fallback) {
+                $definesListPlugin = array_merge($definesListPlugin, $this->loadCurrentPageExtraFilesFromDir($pluginDir . $_SESSION['language'] . '/default'));
             }
 
-            $defines = $this->loadArrayDefineFile($baseDir . $filename);
-            $this->makeConstants($defines);
+            $definesList = array_merge($definesList, $definesListPlugin);
         }
+
+        // -----
+        // Finally, if there are additional per-page files in the current language's active template's
+        // directory, those overwrite any definitions previously loaded.
+        //
+        $definesListTemplate = $this->loadCurrentPageExtraFilesFromDir(DIR_WS_LANGUAGES . $_SESSION['language'] . '/' . $this->templateDir);
+        $definesList = array_merge($definesList, $definesListTemplate);
+
+        // -----
+        // Create language constants from the definitions loaded here.
+        //
+        $this->makeConstants($definesList);
     }
 
-    protected function loadCurrentPageExtraFilesFromDir(string $directory): void
+    protected function loadCurrentPageBaseFile(): void
     {
-        $files_regex = '~^' . 'lang.' . $this->currentPage  . '(.+)\.php$~i';
+        // -----
+        // First, load the main language file(s) for the current page . The 'english/lang.{page-name}.php'
+        // file is always loaded, with its constant values possibly overwritten by a different page-specific
+        // language file (e.g. 'spanish/lang.{page-name}.php').
+        //
+        // These definitions are added to the to-be-generated constants' list.
+        //
+        $currentPageBaseFile = '/lang.' . $this->currentPage . '.php';
 
+        $mainFile = DIR_WS_LANGUAGES . $_SESSION['language'] . $currentPageBaseFile;
+        $fallbackFile = DIR_WS_LANGUAGES . $this->fallback . $currentPageBaseFile;
+        $defineList = $this->loadDefinesWithFallback($mainFile, $fallbackFile);
+
+        // -----
+        // Next, check each enabled zc_plugin to see if any page-specific language file
+        // is present.
+        //
+        $pluginBaseDir = DIR_FS_CATALOG . 'zc_plugins/';
+        foreach ($this->pluginList as $plugin) {
+            $pluginDir = $pluginBaseDir . $plugin['unique_key'] . '/' . $plugin['version'] . '/catalog/includes/languages/';
+
+            $mainFile = $pluginDir . $_SESSION['language'] . $currentPageBaseFile;
+            $fallbackFile = $pluginDir . $this->fallback . $currentPageBaseFile;
+            $defineList = array_merge($defineList, $this->loadDefinesWithFallback($mainFile, $fallbackFile));
+
+            $mainFile = $pluginDir . $_SESSION['language'] . '/default' . $currentPageBaseFile;
+            $fallbackFile = $pluginDir . $this->fallback . '/default' . $currentPageBaseFile;
+            $defineList = array_merge($defineList, $this->loadDefinesWithFallback($mainFile, $fallbackFile));
+        }
+
+        // -----
+        // Finally, if there is a template-override file **in the current session's language**,
+        // load those definitions, adding to the to-be-generated constants' list.
+        //
+        // Any definitions found in this file overwrite all previously-loaded definitions for
+        // the page-specific base language file.
+        //
+        $template_dir = '/' . $this->templateDir;
+        $templateMainFile = DIR_WS_LANGUAGES . $_SESSION['language'] . $template_dir . $currentPageBaseFile;
+        $defineList = array_merge($defineList, $this->loadArrayDefineFile($templateMainFile));
+
+        // -----
+        // Make constants from the list of array-based language definitions for the
+        // current page.
+        //
+        $this->makeConstants($defineList);
+    }
+
+    protected function loadCurrentPageExtraFilesFromDir(string $directory): array
+    {
+        // -----
+        // The specified directory is searched for 'lang.' files (alphabetically sorted) that
+        // apply to the current page (i.e. $current_page_base) that have at least 1 character
+        // difference with the 'base' file for the page.  For example, lang.account_information.php
+        // but not lang.account.php for the 'account' page.
+        //
+        $files_regex = '~^lang.' . $this->currentPage  . '(.+)\.php$~i';
+
+        $defines = [];
         $files = $this->fileSystem->listFilesFromDirectoryAlphaSorted($directory, $files_regex);
         foreach ($files as $file) {
-            $defines = $this->loadArrayDefineFile($directory . '/' . $file);
-            $this->makeConstants($defines);
+            $defines = array_merge($defines, $this->loadArrayDefineFile($directory . '/' . $file));
         }
+
+        return $defines;
     }
 
     protected function loadLanguageExtraDefinitions(): void
@@ -155,13 +221,12 @@ class CatalogArraysLanguageLoader extends ArraysLanguageLoader
         $this->addLanguageDefines($defineList);
 
         // -----
-        // Next, if there is a template-override file **in the current session's language**,
+        // Next, if there is a template-override file **for the current session's language**,
         // load those definitions, adding to the to-be-generated constants' list.
         //
         // Any definitions found in this file overwrite the 'base' main language files.
         //
-        $template_dir = '/' . $this->templateDir;
-        $templateMainFile = DIR_WS_LANGUAGES . $_SESSION['language'] . $template_dir . '/' . $mainFile;
+        $templateMainFile = DIR_WS_LANGUAGES . $this->templateDir . '/lang.' . $_SESSION['language'] . '.php';
         $defineList = $this->loadArrayDefineFile($templateMainFile);
         $this->addLanguageDefines($defineList);
 
@@ -172,6 +237,8 @@ class CatalogArraysLanguageLoader extends ArraysLanguageLoader
         // Each of these files is first loaded from the 'fallback' (i.e. 'english') subdirectory,
         // followed by the current session language directory and finally (if present) in the current
         // language's template-override directory.
+        //
+        // Note: These files are not checked for presence in zc_plugins!
         //
         $extraFiles = [
             FILENAME_EMAIL_EXTRAS,
@@ -187,7 +254,7 @@ class CatalogArraysLanguageLoader extends ArraysLanguageLoader
             $file = basename($file, '.php') . '.php';
             $this->loadDefinesFromDirFileWithFallback(DIR_WS_LANGUAGES, $file);
 
-            $defineList = $this->loadArrayDefineFile(DIR_WS_LANGUAGES . $_SESSION['language'] . $template_dir . '/lang.' . $file);
+            $defineList = $this->loadArrayDefineFile(DIR_WS_LANGUAGES . $_SESSION['language'] . '/' . $this->templateDir . '/lang.' . $file);
             $this->addLanguageDefines($defineList);
         }
     }

--- a/includes/classes/ResourceLoaders/CatalogArraysLanguageLoader.php
+++ b/includes/classes/ResourceLoaders/CatalogArraysLanguageLoader.php
@@ -47,7 +47,7 @@ class CatalogArraysLanguageLoader extends ArraysLanguageLoader
         // definitions.
         //
         foreach ($this->pluginList as $plugin) {
-            $pluginDir = DIR_FS_CATALOG . 'zc_plugins/' . $plugin['unique_key'] . '/' . $plugin['version'] . '/catalog/includes/languages/';
+            $pluginDir = $this->zcPluginsDir . $plugin['unique_key'] . '/' . $plugin['version'] . '/catalog/includes/languages/';
 
             $definesListPlugin = $this->loadCurrentPageExtraFilesFromDir($pluginDir . $this->fallback);
             if ($_SESSION['language'] !== $this->fallback) {
@@ -96,9 +96,8 @@ class CatalogArraysLanguageLoader extends ArraysLanguageLoader
         // Next, check each enabled zc_plugin to see if any page-specific language file
         // is present.
         //
-        $pluginBaseDir = DIR_FS_CATALOG . 'zc_plugins/';
         foreach ($this->pluginList as $plugin) {
-            $pluginDir = $pluginBaseDir . $plugin['unique_key'] . '/' . $plugin['version'] . '/catalog/includes/languages/';
+            $pluginDir = $this->zcPluginsDir . $plugin['unique_key'] . '/' . $plugin['version'] . '/catalog/includes/languages/';
 
             $mainFile = $pluginDir . $_SESSION['language'] . $currentPageBaseFile;
             $fallbackFile = $pluginDir . $this->fallback . $currentPageBaseFile;


### PR DESCRIPTION
Essentially, aligning with the docs: https://docs.zen-cart.com/dev/languages/language_constant_logic/