### PR TITLE
Correct load of encapsulated ot/shipping/payment modules

### DIFF
--- a/includes/classes/order_total.php
+++ b/includes/classes/order_total.php
@@ -7,6 +7,8 @@
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: lat9 2024 Aug 26 Modified in v2.1.0-alpha2 $
  */
+use Zencart\FileSystem\FileSystem;
+use Zencart\ResourceLoaders\ModuleFinder;
 use Zencart\Traits\NotifierManager;
 
 /**
@@ -39,9 +41,17 @@ class order_total
     // class constructor
     public function __construct()
     {
-        global $messageStack, $languageLoader;
+        global $messageStack, $languageLoader, $installedPlugins;
 
         if (defined('MODULE_ORDER_TOTAL_INSTALLED') && MODULE_ORDER_TOTAL_INSTALLED !== '') {
+            // -----
+            // Locate all order_total modules, looking in both /includes/modules/order_total
+            // and for those provided by zc_plugins.  Note that any module provided by a
+            // zc_plugin overrides the processing present in any 'base' file.
+            //
+            $moduleFinder = new ModuleFinder('order_total', new Filesystem());
+            $modules_found = $moduleFinder->findFromFilesystem($installedPlugins);
+
             $module_list = explode(';', MODULE_ORDER_TOTAL_INSTALLED);
 
             foreach ($module_list as $value) {
@@ -59,9 +69,8 @@ class order_total
                     continue;
                 }
 
-                $module_file = DIR_FS_CATALOG . DIR_WS_MODULES . 'order_total/' . $value;
-                if (file_exists($module_file)) {
-                    include_once $module_file;
+                if (isset($modules_found[$value])) {
+                    include_once DIR_FS_CATALOG . $modules_found[$value] . $value;
                     $class = pathinfo($value, PATHINFO_FILENAME);
                     $GLOBALS[$class] = new $class();
                     $this->modules[] = $value;

--- a/includes/classes/payment.php
+++ b/includes/classes/payment.php
@@ -7,6 +7,8 @@
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: lat9 2024 Aug 26 Modified in v2.1.0-alpha2 $
  */
+use Zencart\FileSystem\FileSystem;
+use Zencart\ResourceLoaders\ModuleFinder;
 use Zencart\Traits\NotifierManager;
 
 if (!defined('IS_ADMIN_FLAG')) {
@@ -50,7 +52,7 @@ class payment
 
     public function __construct($module = '')
     {
-        global $PHP_SELF, $language, $credit_covers, $messageStack, $languageLoader;
+        global $language, $credit_covers, $messageStack, $languageLoader, $installedPlugins;
 
         $this->doesCollectsCardDataOnsite = false;
 
@@ -63,25 +65,31 @@ class payment
             return;
         }
 
+        // -----
+        // Locate all payment modules, looking in both /includes/modules/payment
+        // and for those provided by zc_plugins.  Note that any module provided by a
+        // zc_plugin overrides the processing present in any 'base' file.
+        //
+        $moduleFinder = new ModuleFinder('payment', new Filesystem());
+        $modules_found = $moduleFinder->findFromFilesystem($installedPlugins);
+
         $include_modules = [];
 
-        if (!empty($module) && in_array($module . '.' . substr($PHP_SELF, (strrpos($PHP_SELF, '.') + 1)), $this->modules)) {
+        if (!empty($module) && in_array($module . '.php', $this->modules) && isset($modules_found[$module . '.php'])) {
             $this->selected_module = $module;
 
             $include_modules[] = ['class' => $module, 'file' => $module . '.php'];
         } else {
             // Free Payment Only shows
-            $freecharger_enabled = (defined('MODULE_PAYMENT_FREECHARGER_STATUS') && MODULE_PAYMENT_FREECHARGER_STATUS === 'True');
+            $freecharger_enabled = (defined('MODULE_PAYMENT_FREECHARGER_STATUS') && MODULE_PAYMENT_FREECHARGER_STATUS === 'True' && isset($modules_found['freecharger.php']));
             if ($freecharger_enabled && $_SESSION['cart']->show_total() == 0 && (!isset($_SESSION['shipping']['cost']) || $_SESSION['shipping']['cost'] == 0)) {
                 $this->selected_module = $module;
-                if (file_exists(DIR_FS_CATALOG . DIR_WS_MODULES . '/payment/' . 'freecharger.php')) {
-                    $include_modules[] = ['class'=> 'freecharger', 'file' => 'freecharger.php'];
-                }
+                $include_modules[] = ['class'=> 'freecharger', 'file' => 'freecharger.php'];
             } else {
                 // All Other Payment Modules show
                 foreach ($this->modules as $value) {
                     // double check that the module really exists before adding to the array
-                    if (file_exists(DIR_FS_CATALOG . DIR_WS_MODULES . '/payment/' . $value)) {
+                    if (isset($modules_found[$value])) {
                         $class = pathinfo($value, PATHINFO_FILENAME);
                         // Don't show Free Payment Module
                         if ($class !== 'freecharger') {
@@ -107,7 +115,7 @@ class payment
                 continue;
             }
 
-            include_once DIR_WS_MODULES . 'payment/' . $next_module['file'];
+            include_once DIR_FS_CATALOG . $modules_found[$next_module['file']] . $next_module['file'];
 
             $this->paymentClass = new $next_module['class']();
             $this->notify('NOTIFY_PAYMENT_MODULE_ENABLE');

--- a/includes/classes/shipping.php
+++ b/includes/classes/shipping.php
@@ -7,6 +7,8 @@
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: lat9 2024 Aug 26 Modified in v2.1.0-alpha2 $
  */
+use Zencart\FileSystem\FileSystem;
+use Zencart\ResourceLoaders\ModuleFinder;
 use Zencart\Traits\NotifierManager;
 
 if (!defined('IS_ADMIN_FLAG')) {
@@ -59,14 +61,23 @@ class shipping
      */
     protected function initialize_modules($module = null): void
     {
-        global $PHP_SELF, $messageStack, $languageLoader;
+        global $messageStack, $languageLoader, $installedPlugins;
+
+        // -----
+        // Locate all shipping modules, looking in both /includes/modules/shipping
+        // and for those provided by zc_plugins.  Note that any module provided by a
+        // zc_plugin overrides the processing present in any 'base' file.
+        //
+        $moduleFinder = new ModuleFinder('shipping', new Filesystem());
+        $modules_found = $moduleFinder->findFromFilesystem($installedPlugins);
 
         $modules_to_quote = [];
 
-        if (!empty($module) && (in_array(substr($module['id'], 0, strpos($module['id'], '_')) . '.' . substr($PHP_SELF, (strrpos($PHP_SELF, '.') + 1)), $this->modules))) {
+        $module_name = (empty($module)) ? '0' : substr($module['id'], 0, strpos($module['id'], '_'));
+        if (!empty($module) && in_array($module_name . '.php', $this->modules) && isset($modules_found[$module_name])) {
             $modules_to_quote[] = [
-                'class' => substr($module['id'], 0, strpos($module['id'], '_')),
-                'file' => substr($module['id'], 0, strpos($module['id'], '_')) . '.' . substr($PHP_SELF, (strrpos($PHP_SELF, '.') + 1)),
+                'class' => $module_name,
+                'file' => $module_name . '.php',
             ];
         } else {
             foreach ($this->modules as $value) {
@@ -94,10 +105,10 @@ class shipping
             }
 
             $this->enabled = true;
-            $module_file = DIR_FS_CATALOG . DIR_WS_MODULES . 'shipping/' . $quote_module['file'];
+
             $this->notify('NOTIFY_SHIPPING_MODULE_ENABLE', $quote_module['class'], $quote_module['class']);
-            if ($this->enabled) {
-                include_once $module_file;
+            if ($this->enabled && isset($modules_found[$quote_module['file']])) {
+                include_once DIR_FS_CATALOG . $modules_found[$quote_module['file']] . $quote_module['file'];
                 $GLOBALS[$quote_module['class']] = new $quote_module['class']();
 
                 $enabled = $this->check_enabled($GLOBALS[$quote_module['class']]);


### PR DESCRIPTION
A corollary to PR #6682.  While the admin "Modules" finds the encapsulated modules and both admin/storefront find their _language_ files, the storefront classes didn't get updated to also locate the processing portion in encapsulated plugins.