### PR TITLE
implode 2nd argument requires array; string errors out

### DIFF
--- a/admin/includes/modules/update_product.php
+++ b/admin/includes/modules/update_product.php
@@ -18,7 +18,7 @@ $redirect_search = (isset($_POST['search'])) ? '&search=' . $_POST['search'] : '
 
 if (isset($_POST['edit']) && $_POST['edit'] === 'edit') {
     $action = 'new_product';
-} elseif (($_POST['products_model'] ?? '') . implode('', $_POST['products_url'] ?? '') . implode('', $_POST['products_name'] ?? '') . implode('', $_POST['products_description'] ?? '') === '') {
+} elseif (($_POST['products_model'] ?? '') . implode('', $_POST['products_url'] ?? []) . implode('', $_POST['products_name'] ?? []) . implode('', $_POST['products_description'] ?? []) === '') {
     $messageStack->add_session(ERROR_NO_DATA_TO_SAVE, 'error');
     zen_redirect(zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING, 'cPath=' . $cPath . '&pID=' . $products_id . $redirect_page . $redirect_search));
 } else {
@@ -33,7 +33,7 @@ if (isset($_POST['edit']) && $_POST['edit'] === 'edit') {
     }
     $products_date_available = (date('Y-m-d') < $products_date_available) ? $products_date_available : 'null';
 
-    if (!empty($products_id)) { 
+    if (!empty($products_id)) {
         $zco_notifier->notify('NOTIFY_MODULES_UPDATE_PRODUCT_START', ['action' => $action, 'products_id' => $products_id]);
     }
 


### PR DESCRIPTION
while i have not been able to reproduce, i have come across this error:
```
PHP Fatal error:  Uncaught TypeError: implode(): Argument #2 ($array) must be of type ?array, string given in /worsthost/worstadminrename/includes/modules/update_product.php:21
```
so if these `$_POST` vars are not set, we are passing a string.  which causes a FATAL error.

this can easily be reproduced by executing this 1 line script:
```php
// good
$test2 = implode(' ', $test ?? []);
//bad
$test2 = implode(' ', $test ?? '');
```