### PR TITLE
Module language fallback; legacy only for session language

### DIFF
--- a/admin/modules.php
+++ b/admin/modules.php
@@ -117,7 +117,7 @@ if (!empty($action)) {
             }
 
             if (in_array($class_file, array_keys($modules_found))) {
-                if ($languageLoader->loadModuleLanguageFile($_SESSION['language'], $class_file, $module_type)) {
+                if ($languageLoader->loadModuleLanguageFile($class_file, $module_type)) {
                     require DIR_FS_CATALOG . $modules_found[$class_file] . $class_file;
                     $module = new $class();
                     $msg = sprintf(TEXT_EMAIL_MESSAGE_ADMIN_MODULE_INSTALLED, preg_replace('/[^\w]/', '*', $_POST['module']), $admname);
@@ -145,7 +145,7 @@ if (!empty($action)) {
             $class = basename($_POST['module']);
             $class_file = $class . '.' . $file_extension;
             if (in_array($class_file, array_keys($modules_found))) {
-                if ($languageLoader->loadModuleLanguageFile($_SESSION['language'], $class_file, $module_type)) {
+                if ($languageLoader->loadModuleLanguageFile($class_file, $module_type)) {
                     require DIR_FS_CATALOG . $modules_found[$class_file] . $class_file;
                     $module = new $class();
                     $msg = sprintf(TEXT_EMAIL_MESSAGE_ADMIN_MODULE_REMOVED, preg_replace('/[^\w]/', '*', $_POST['module']), $admname);
@@ -207,7 +207,7 @@ $installed_modules = [];
 $temp_for_sort = [];
 $module_directory = DIR_FS_CATALOG . DIR_WS_MODULES . $module_type;
 foreach ($modules_found as $module_name => $module_file_dir) {
-    if (!$languageLoader->loadModuleLanguageFile($_SESSION['language'], $module_name, $module_type)) {
+    if (!$languageLoader->loadModuleLanguageFile($module_name, $module_type)) {
         echo ERROR_MODULE_FILE_NOT_FOUND . DIR_FS_CATALOG_LANGUAGES . $_SESSION['language'] . '/modules/' . $module_type . '/' . $module_name . '<br>';
         continue;
     }

--- a/includes/classes/ResourceLoaders/FilesLanguageLoader.php
+++ b/includes/classes/ResourceLoaders/FilesLanguageLoader.php
@@ -22,15 +22,16 @@ class FilesLanguageLoader extends BaseLanguageLoader
         }
     }
 
-    public function loadModuleLanguageFile(string $language, string $fileName, string $module_type): bool
+    public function loadModuleLanguageFile(string $fileName, string $module_type): bool
     {
-        $rootPath = DIR_FS_CATALOG . DIR_WS_LANGUAGES;
-        $extraPath = '/modules/' . $module_type;
-        
-        if ($this->mainLoader->hasLanguageFile($rootPath, $language, $fileName, $extraPath .  '/' . $this->templateDir)) {
-            return $this->loadFileDefineFile($rootPath . $language . $extraPath . '/' . $this->templateDir . '/' . $fileName);
+        $rootPath = DIR_FS_CATALOG . DIR_WS_LANGUAGES . $_SESSION['language'];
+        $extraPath = '/modules/' . $module_type . '/';
+
+        if ($this->loadFileDefineFile($rootPath . $extraPath . $this->templateDir . '/' . $fileName) === true) {
+            return true;
         }
-        return $this->loadFileDefineFile($rootPath . $language . $extraPath . '/' . $fileName);
+
+        return $this->loadFileDefineFile($rootPath . $extraPath . $fileName);
     }
 
     protected function loadFileDefineFile(string $defineFile): bool

--- a/includes/classes/ResourceLoaders/LanguageLoader.php
+++ b/includes/classes/ResourceLoaders/LanguageLoader.php
@@ -95,12 +95,12 @@ class LanguageLoader
         return false;
     }
 
-    public function loadModuleLanguageFile(string $language, string $fileName, string $moduleType): bool
+    public function loadModuleLanguageFile(string $fileName, string $moduleType): bool
     {
-        $defineList = $this->arrayLoader->loadModuleLanguageFile($language, $fileName, $moduleType);
-        $legacy_file_loaded = $this->fileLoader->loadModuleLanguageFile($language, $fileName, $moduleType);
+        $array_constants_created = $this->arrayLoader->loadModuleLanguageFile($fileName, $moduleType);
+        $legacy_file_loaded = $this->fileLoader->loadModuleLanguageFile($fileName, $moduleType);
 
-        return ($legacy_file_loaded || count($defineList) !== 0);
+        return ($legacy_file_loaded === true || $array_constants_created === true);
     }
 
     public function isFileAlreadyLoaded(string $defineFile): bool

--- a/includes/classes/order_total.php
+++ b/includes/classes/order_total.php
@@ -55,7 +55,7 @@ class order_total
             $module_list = explode(';', MODULE_ORDER_TOTAL_INSTALLED);
 
             foreach ($module_list as $value) {
-                if (!$languageLoader->loadModuleLanguageFile($_SESSION['language'], $value, 'order_total')) {
+                if (!$languageLoader->loadModuleLanguageFile($value, 'order_total')) {
                     $language_dir = (IS_ADMIN_FLAG === false) ? DIR_WS_LANGUAGES : (DIR_FS_CATALOG . DIR_WS_LANGUAGES);
                     $lang_file = zen_get_file_directory($language_dir . $_SESSION['language'] . '/modules/order_total/', $value, 'false');
  

--- a/includes/classes/payment.php
+++ b/includes/classes/payment.php
@@ -103,7 +103,7 @@ class payment
         for ($i = 0, $n = count($include_modules); $i < $n; $i++) {
             $next_module = $include_modules[$i];
 
-            if (!$languageLoader->loadModuleLanguageFile($_SESSION['language'], $next_module['file'], 'payment')) {
+            if (!$languageLoader->loadModuleLanguageFile($next_module['file'], 'payment')) {
                 $lang_file = zen_get_file_directory(DIR_WS_LANGUAGES . $_SESSION['language'] . '/modules/payment/', $next_module['file'], 'false');
                 if (is_object($messageStack)) {
                     if (IS_ADMIN_FLAG === false) {

--- a/includes/classes/shipping.php
+++ b/includes/classes/shipping.php
@@ -90,7 +90,7 @@ class shipping
         }
 
         foreach ($modules_to_quote as $quote_module) {
-            if (!$languageLoader->loadModuleLanguageFile($_SESSION['language'], $quote_module['file'], 'shipping')) {
+            if (!$languageLoader->loadModuleLanguageFile($quote_module['file'], 'shipping')) {
                 $language_dir = (IS_ADMIN_FLAG === false) ? DIR_WS_LANGUAGES : (DIR_FS_CATALOG . DIR_WS_LANGUAGES);
                 $lang_file = zen_get_file_directory($language_dir . $_SESSION['language'] . '/modules/shipping/', $quote_module['file'], 'false');
 


### PR DESCRIPTION
- Provide 'fallback' (i.e. 'english') language processing for module-type language files
- Legacy (i.e. non-`lang.` prefixed) language files load _only_ for the current session language, following previous Zen Cart versions' handling.