### PR TITLE
Extract `hreflang` logic to separate module, adding notifier

### DIFF
--- a/includes/modules/hreflang.php
+++ b/includes/modules/hreflang.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * hreflang module
+ *
+ * @copyright Copyright 2003-2024 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: New in 2.1.0 $
+ *
+ * @var notifier $zco_notifier
+ */
+if (!defined('IS_ADMIN_FLAG')) {
+  die('Illegal Access');
+}
+// BOF hreflang for multilingual sites
+if (!isset($lng) || !$lng instanceof language) {
+    $lng = new language;
+}
+if (method_exists($lng, 'get_language_list')) {
+    $languages = $lng->get_language_list();
+} else {
+    // fallback for pre-v2.0.0 with old language class
+    $languages = array_keys($lng->catalog_languages);
+}
+
+$bypass = false;
+$zco_notifier->notify('NOTIFY_MODULE_START_HREFLANG', $current_page_base, $bypass, $lng, $languages, $canonicalLink);
+if ($bypass) {
+    return;
+}
+
+if (count($languages) <= 1) {
+    // skip when site has only one language
+    return;
+}
+if (empty($canonicalLink)) {
+    // canonical link is needed
+    return;
+}
+
+foreach($languages as $key) {
+    if ($this_is_home_page) {
+        $link = zen_href_link(FILENAME_DEFAULT, 'language=' . $key, $request_type, false);
+    } else {
+        $link = $canonicalLink . (str_contains($canonicalLink, '?') ? '&amp;' : '?') . 'language=' . $key;
+    }
+    echo '<link rel="alternate" hreflang="' . $key . '" href="' . $link . '"/>' . "\n";
+}
+// include x-default
+echo '<link rel="alternate" hreflang="x-default" href="' . $canonicalLink . '"/>' . "\n";
+

--- a/includes/templates/responsive_classic/common/html_header.php
+++ b/includes/templates/responsive_classic/common/html_header.php
@@ -76,16 +76,10 @@ $zco_notifier->notify('NOTIFY_HTML_HEAD_TAG_START', $current_page_base);
   <link rel="canonical" href="<?php echo $canonicalLink; ?>">
 <?php } ?>
 <?php
-  // BOF hreflang for multilingual sites
-  if (!isset($lng) || (isset($lng) && !is_object($lng))) {
-    $lng = new language;
-  }
-if (count($languages = $lng->get_language_list()) > 1) {
-  foreach($languages as $key) {
-    echo '<link rel="alternate" href="' . ($this_is_home_page ? zen_href_link(FILENAME_DEFAULT, 'language=' . $key, $request_type, false) : $canonicalLink . (strpos($canonicalLink, '?') ? '&amp;' : '?') . 'language=' . $key) . '" hreflang="' . $key . '">' . "\n";
-  }
-  }
-  // EOF hreflang for multilingual sites
+/**
+ * generate hreflang for multilingual sites (ignored if only 1 language configured)
+ */
+require DIR_WS_MODULES . zen_get_module_directory('hreflang.php');
 ?>
 
 <?php

--- a/includes/templates/template_default/common/html_header.php
+++ b/includes/templates/template_default/common/html_header.php
@@ -62,16 +62,10 @@ $zco_notifier->notify('NOTIFY_HTML_HEAD_TAG_START', $current_page_base);
 <link rel="canonical" href="<?php echo $canonicalLink; ?>"/>
 <?php } ?>
 <?php
-// BOF hreflang for multilingual sites
-if (!isset($lng) || (isset($lng) && !is_object($lng))) {
-  $lng = new language;
-}
-if (count($languages = $lng->get_language_list()) > 1) {
-  foreach($languages as $key) {
-    echo '<link rel="alternate" href="' . ($this_is_home_page ? zen_href_link(FILENAME_DEFAULT, 'language=' . $key, $request_type, false) : $canonicalLink . (strpos($canonicalLink, '?') ? '&amp;' : '?') . 'language=' . $key) . '" hreflang="' . $key . '"/>' . "\n";
-  }
-}
-// EOF hreflang for multilingual sites
+/**
+ * generate hreflang for multilingual sites (ignored if only 1 language configured)
+ */
+require DIR_WS_MODULES . zen_get_module_directory('hreflang.php');
 
 /**
  * Load all template-specific stylesheets, via the common CSS loader.


### PR DESCRIPTION
- relocated hreflang-generation logic to separate module file
- added notifier to allow bypass (ie: to intercept and output different format)
- added x-default "fallback" link, which simply points to the no-language-specified version of the page (ie: default language)

Retains bi-directional linking.
Retains former behavior of only outputting hreflang links if more than 1 language is installed.

Retains prior language-choosing via $_GET parameter provided in URL:
> (eg: If a visitor is directed to a page with `language=` in the URL, that page will display using that language, if still installed (and will also set the language in the session, for subsequent clicks to stay in that language). 
**Further**, if visitor "first" hits the x-default or canonical (eg: without a GET param or a session setting), their language will be auto-selected via the browser's language-default if resolvable, or presented in the store's default language.)

If one wanted to change the entire way that the URLs are generated (such as using subdomains-per-language), they could use the notifier hook and bypass this default operation in conjunction with any other notifier hooks that relate to URL generation.

Change in output:
```diff
    <link rel="alternate" hreflang="en" href="https://example.com/index.php?main_page=product_info&amp;products_id=34&amp;language=en"/>
    <link rel="alternate" hreflang="fr" href="https://example.com/index.php?main_page=product_info&amp;products_id=34&amp;language=fr"/>
+    <link rel="alternate" hreflang="x-default" href="https://example.com/index.php?main_page=product_info&amp;products_id=34"/>
```

Easily integrated into any existing template.

Related to #6543