### PR TITLE
Product-class: New notifier when requested product isn't found

### DIFF
--- a/includes/classes/Product.php
+++ b/includes/classes/Product.php
@@ -225,7 +225,9 @@ class Product
         $product = $db->Execute($sql, 1, true, 900);
 
         if ($product->EOF) {
-            return [];
+            $data_override = [];
+            $this->notify('NOTIFY_GET_PRODUCT_OBJECT_DETAILS_NOT_FOUND', ['product_id' => $product_id, 'language_id' => $language_id], $data_override);
+            return $data_override;
         }
 
         $data = $product->fields;


### PR DESCRIPTION
Needed for the Edit Orders update, in case a product in an order no longer exists on the site.

The `$data_override` variable, if updated, _must_ be an array type or a PHP Warning/Error will occur.