### PR TITLE
Correct storefront search PHP Warning

### DIFF
--- a/includes/functions/functions_search.php
+++ b/includes/functions/functions_search.php
@@ -134,7 +134,7 @@ function zen_parse_search_string($search_str = '', &$objects = []) {
             $temp[] = ADVANCED_SEARCH_DEFAULT_OPERATOR;
         }
     }
-    $temp[] = $objects[$i];
+    $temp[] = $objects[$i] ?? [];
     $objects = $temp;
 
     $keyword_count = 0;


### PR DESCRIPTION
As originally identified in [this](https://www.zen-cart.com/showthread.php?230339-PHP-Warning-Undefined-array-key-0-in-functions_search-php) forum posting, a search for `"/linkiFrAme src="jAvasCript:alert(1);"/iframe]` results in a PHP Warning from the `zen_parse_search_string` function.

This PR corrects that warning.