### PR TITLE
`order` class: Gather all order-status entries for admin use

### DIFF
--- a/admin/orders.php
+++ b/admin/orders.php
@@ -1049,12 +1049,9 @@ if ($show_orders_weights === true) {
             </thead>
             <tbody>
                 <?php
-                $orders_history = $db->Execute("SELECT *
-                                              FROM " . TABLE_ORDERS_STATUS_HISTORY . "
-                                              WHERE orders_id = " . zen_db_input($oID) . "
-                                              ORDER BY orders_status_history_id");
+                $orders_history = $order->statuses;
 
-                if ($orders_history->RecordCount() > 0) {
+                if (count($orders_history) !== 0) {
                   $first = true;
                   foreach ($orders_history as $item) {
                     ?>
@@ -1078,7 +1075,7 @@ if ($show_orders_weights === true) {
                     //
                     // $extra_data = array(
                     //     array(
-                    //       'align' => $alignment,    // One of 'center', 'right', or 'left' (optional)
+                    //       'align' => $alignment,    // One of 'center', 'right' or 'left' (optional)
                     //       'text' => $value
                     //     ),
                     // );
@@ -1087,7 +1084,7 @@ if ($show_orders_weights === true) {
                     // multiple observers might be injecting content!
                     //
                     $extra_data = false;
-                    $zco_notifier->notify('NOTIFY_ADMIN_ORDERS_STATUS_HISTORY_EXTRA_COLUMN_DATA', $orders_history->fields, $extra_data);
+                    $zco_notifier->notify('NOTIFY_ADMIN_ORDERS_STATUS_HISTORY_EXTRA_COLUMN_DATA', $item, $extra_data);
                     if (is_array($extra_data)) {
                         foreach ($extra_data as $data_info) {
                             $align = (isset($data_info['align'])) ? (' text-' . $data_info['align']) : '';

--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -394,12 +394,13 @@ class order extends base
             }
         }
 
+        $customer_notified_clause = (IS_ADMIN_FLAG === true) ? '' : ' AND osh.customer_notified >= 0';
         $sql = "SELECT os.orders_status_name, osh.*
                 FROM   " . TABLE_ORDERS_STATUS . " os
                 LEFT JOIN " . TABLE_ORDERS_STATUS_HISTORY . " osh USING (orders_status_id)
                 WHERE osh.orders_id = :ordersID
                 AND os.language_id = :languageID
-                AND osh.customer_notified >= 0
+                $customer_notified_clause
                 ORDER BY osh.date_added";
 
         $sql = $db->bindVars($sql, ':ordersID', $order_id, 'integer');


### PR DESCRIPTION
... otherwise, the admin's base `orders.php` and/or EO needs to, essentially, repeat that query to also pull in the records hidden from the customer's view.