### PR TITLE
Update Plugin Manager translations support

### DIFF
--- a/admin/plugin_manager.php
+++ b/admin/plugin_manager.php
@@ -37,7 +37,13 @@ $tableDefinition = [
     'maxRowCount' => 20,
     'defaultRowAction' => '',
     'columns' => [
-        'name' => ['title' => TABLE_HEADING_NAME],
+        'name' => [
+            'title' => TABLE_HEADING_NAME,
+            'derivedItem' => [
+                'type' => 'local',
+                'method' => 'getLanguageTranslationForName'
+                ],
+            ],
         'unique_key' => ['title' => TABLE_HEADING_KEY],
         'filespace' => [
             'title' => TABLE_HEADING_FILE_SPACE,

--- a/includes/classes/ViewBuilders/DerivedItemsManager.php
+++ b/includes/classes/ViewBuilders/DerivedItemsManager.php
@@ -60,4 +60,9 @@ class DerivedItemsManager
         $dirSize = $fs->getDirectorySize($filePath);
         return $dirSize;
     }
+
+    protected function getLanguageTranslationForName(Model $tableRow, string $colName, array $columnInfo) : string
+    {
+        return zen_lookup_admin_menu_language_override('plugin_name', $tableRow['unique_key'], $tableRow['name']);
+    }
 }

--- a/includes/classes/ViewBuilders/PluginManagerController.php
+++ b/includes/classes/ViewBuilders/PluginManagerController.php
@@ -25,7 +25,7 @@ class PluginManagerController extends BaseController
 
     protected function processDefaultAction()
     {
-        $this->setBoxHeader('<h4>' . $this->currentFieldValue('name') . '</h4>');
+        $this->setBoxHeader('<h4>' . zen_lookup_admin_menu_language_override('plugin_name', $this->currentFieldValue('unique_key'), $this->currentFieldValue('name')) . '</h4>');
         if ($this->currentFieldValue('status') == 1) {
             $this->setBoxContent('<br>' . sprintf(TEXT_VERSION_INSTALLED, $this->currentFieldValue('version')) . '<br>');
         }
@@ -94,11 +94,11 @@ class PluginManagerController extends BaseController
 
     protected function processActionInstall()
     {
-        $this->setBoxHeader('<h4>' . $this->currentFieldValue('name') . '</h4>');
+        $this->setBoxHeader('<h4>' . zen_lookup_admin_menu_language_override('plugin_name', $this->currentFieldValue('unique_key'), $this->currentFieldValue('name')) . '</h4>');
         $this->setBoxForm(
             zen_draw_form('plugininstall', FILENAME_PLUGIN_MANAGER, $this->pageLink() . '&' . $this->colKeylink() . '&action=doInstall', 'post', 'class="form-horizontal"')
         );
-        $this->setBoxContent('<br>' . TEXT_INFO_DESCRIPTION . '<br>' . $this->currentFieldValue('description'));
+        $this->setBoxContent('<br>' . TEXT_INFO_DESCRIPTION . '<br>' . zen_lookup_admin_menu_language_override('plugin_description', $this->currentFieldValue('unique_key'), $this->currentFieldValue('description')));
         $versions = $this->pluginManager->getPluginVersionsForPlugin($this->currentFieldValue('unique_key'));
         $hasMultiple = (count($versions) > 1);
         $firstKey = key($versions);
@@ -152,7 +152,7 @@ class PluginManagerController extends BaseController
 
     protected function processActionUninstall()
     {
-        $this->setBoxHeader('<h4>' . $this->currentFieldValue('name') . '</h4>');
+        $this->setBoxHeader('<h4>' . zen_lookup_admin_menu_language_override('plugin_name', $this->currentFieldValue('unique_key'), $this->currentFieldValue('name')) . '</h4>');
         $this->setBoxForm(
             zen_draw_form(
                 'pluginuninstall',
@@ -213,7 +213,7 @@ class PluginManagerController extends BaseController
             );
         }
         $versions = $this->pluginManager->getVersionsForUpgrade($this->currentFieldValue('unique_key'), $this->currentFieldValue('version'));
-        $this->setBoxHeader('<h4>' . $this->currentFieldValue('name') . '</h4>');
+        $this->setBoxHeader('<h4>' . zen_lookup_admin_menu_language_override('plugin_name', $this->currentFieldValue('unique_key'), $this->currentFieldValue('name')) . '</h4>');
         $this->setBoxForm(zen_draw_form('pluginupgrade', FILENAME_PLUGIN_MANAGER, $this->pageLink() . '&' . $this->colKeylink() . '&action=confirmUpgrade', 'post', 'class="form-horizontal"'));
         $this->setBoxContent('<br>' . TEXT_INFO_UPGRADE . '<br>');
         $firstKey = key($versions);
@@ -251,7 +251,7 @@ class PluginManagerController extends BaseController
                 )
             );
         }
-        $this->setBoxHeader('<h4>' . $this->currentFieldValue('name') . '</h4>');
+        $this->setBoxHeader('<h4>' . zen_lookup_admin_menu_language_override('plugin_name', $this->currentFieldValue('unique_key'), $this->currentFieldValue('name')) . '</h4>');
         $this->setBoxForm(zen_draw_form(
                 'pluginupgrade',
                 FILENAME_PLUGIN_MANAGER,
@@ -310,7 +310,7 @@ class PluginManagerController extends BaseController
     protected function processActionCleanUp()
     {
         $versions = $this->pluginManager->getPluginVersionsToClean($this->currentFieldValue('unique_key'), $this->currentFieldValue('version'));
-        $this->setBoxHeader('<h4>' . zen_output_string_protected($this->currentFieldValue('name')) . '</h4>');
+        $this->setBoxHeader('<h4>' . zen_output_string_protected(zen_lookup_admin_menu_language_override('plugin_name', $this->currentFieldValue('unique_key'), $this->currentFieldValue('name'))) . '</h4>');
         $this->setBoxForm(
             zen_draw_form(
                 'pluginupgrade',
@@ -352,7 +352,7 @@ class PluginManagerController extends BaseController
                 )
             );
         }
-        $this->setBoxHeader('<h4>' . $this->currentFieldValue('name') . '</h4>');
+        $this->setBoxHeader('<h4>' . zen_lookup_admin_menu_language_override('plugin_name', $this->currentFieldValue('unique_key'), $this->currentFieldValue('name')) . '</h4>');
         $this->setBoxForm(zen_draw_form(
             'pluginupgrade',
             FILENAME_PLUGIN_MANAGER,
@@ -401,7 +401,7 @@ class PluginManagerController extends BaseController
 
     protected function processActionEnable()
     {
-        $this->setBoxHeader('<h4>' . $this->currentFieldValue('name') . '</h4>');
+        $this->setBoxHeader('<h4>' . zen_lookup_admin_menu_language_override('plugin_name', $this->currentFieldValue('unique_key'), $this->currentFieldValue('name')) . '</h4>');
         $this->setBoxForm(zen_draw_form(
                 'pluginuninstall',
                 FILENAME_PLUGIN_MANAGER,
@@ -442,7 +442,7 @@ class PluginManagerController extends BaseController
 
     protected function processActionDisable()
     {
-        $this->setBoxHeader('<h4>' . $this->currentFieldValue('name') . '</h4>');
+        $this->setBoxHeader('<h4>' . zen_lookup_admin_menu_language_override('plugin_name', $this->currentFieldValue('unique_key'), $this->currentFieldValue('name')) . '</h4>');
         $this->setBoxForm(zen_draw_form(
                 'pluginuninstall',
                 FILENAME_PLUGIN_MANAGER,

--- a/includes/functions/functions_lookups.php
+++ b/includes/functions/functions_lookups.php
@@ -315,8 +315,19 @@ function zen_lookup_admin_menu_language_override(string $lookup_type, string $lo
             $str = preg_replace('/[^a-zA-Z0-9_\x80-\xff]/', '', $str);
             $lookup = strtoupper('CFG_GRP_TITLE_' . $str);
             break;
+        case 'plugin_name':
+            $str = $lookup_key;
+            $str = preg_replace('/[\s -]+/', '_', $str);
+            $str = preg_replace('/[^a-zA-Z0-9_\x80-\xff]/', '', $str);
+            $str = preg_replace('/_+/', '_', $str);
+            $lookup = strtoupper('ADMIN_PLUGIN_MANAGER_NAME_FOR_' . $str);
+            break;
         case 'plugin_description':
-            $lookup = strtoupper('ADMIN_PLUGIN_MANAGER_DESCRIPTION_FOR_' . $lookup_key);
+            $str = $lookup_key;
+            $str = preg_replace('/[\s -]+/', '_', $str);
+            $str = preg_replace('/[^a-zA-Z0-9_\x80-\xff]/', '', $str);
+            $str = preg_replace('/_+/', '_', $str);
+            $lookup = strtoupper('ADMIN_PLUGIN_MANAGER_DESCRIPTION_FOR_' . $str);
             break;
     }
 


### PR DESCRIPTION
If a plugin contains language defines for
 `ADMIN_PLUGIN_MANAGER_NAME_FOR_xyz`
or
`ADMIN_PLUGIN_MANAGER_DESCRIPTION_FOR_xyz`
... then they will be used when displaying details of **installed and enabled** plugins in the Plugin Manager, 
according to whatever language is actively selected in the Admin interface.