### PR TITLE
Correct filepaths for plugin's psr4Autoload prefix settings

### DIFF
--- a/admin/includes/application_bootstrap.php
+++ b/admin/includes/application_bootstrap.php
@@ -190,8 +190,8 @@ foreach ($installedPlugins as $plugin) {
     $namespaceAdmin = 'Zencart\\Plugins\\Admin\\' . ucfirst($plugin['unique_key']);
     $namespaceCatalog = 'Zencart\\Plugins\\Catalog\\' . ucfirst($plugin['unique_key']);
     $filePath = DIR_FS_CATALOG . 'zc_plugins/' . $plugin['unique_key'] . '/' . $plugin['version'] . '/';
-    $filePathAdmin = $filePath . 'classes/admin';
-    $filePathCatalog = $filePath . 'classes/';
+    $filePathAdmin = $filePath . 'admin/includes/classes/';
+    $filePathCatalog = $filePath . 'catalog/includes/classes/';
     $psr4Autoloader->addPrefix($namespaceAdmin, $filePathAdmin);
     $psr4Autoloader->addPrefix($namespaceCatalog, $filePathCatalog);
 }

--- a/includes/application_top.php
+++ b/includes/application_top.php
@@ -305,8 +305,8 @@ foreach ($installedPlugins as $plugin) {
     $namespaceAdmin = 'Zencart\\Plugins\\Admin\\' . ucfirst($plugin['unique_key']);
     $namespaceCatalog = 'Zencart\\Plugins\\Catalog\\' . ucfirst($plugin['unique_key']);
     $filePath = DIR_FS_CATALOG . 'zc_plugins/' . $plugin['unique_key'] . '/' . $plugin['version'] . '/';
-    $filePathAdmin = $filePath . 'classes/admin';
-    $filePathCatalog = $filePath . 'classes/';
+    $filePathAdmin = $filePath . 'admin/includes/classes/';
+    $filePathCatalog = $filePath . 'catalog/includes/classes/';
     $psr4Autoloader->addPrefix($namespaceAdmin, $filePathAdmin);
     $psr4Autoloader->addPrefix($namespaceCatalog, $filePathCatalog);
 }


### PR DESCRIPTION
Those filepaths need to point to a plugin's `admin/includes/classes` or `catalog/includes/classes` directories; the ones currently used (`classes/admin` and `classes`) don't exist.