### PR TITLE
Encap plugin installer logic error?

### DIFF
--- a/includes/classes/PluginSupport/InstallerFactory.php
+++ b/includes/classes/PluginSupport/InstallerFactory.php
@@ -30,12 +30,14 @@ class InstallerFactory
         if (!file_exists($versionDir . 'manifest.php')) {
             throw new PluginInstallerException('NO VERSION MANIFEST');
         }
-        if (!file_exists($versionDir . 'installer/' . 'Installer.php')) {
+
+        if (!file_exists($versionDir . 'Installer/Installer.php')) {
             $installer = new BasePluginInstaller($this->dbConn, $this->pluginInstaller, $this->errorContainer);
             return $installer;
         }
-        require_once($versionDir . 'Installer');
-        $installer = new Installer($this->dbConn, $this->pluginInstaller, $this->errorContainer);
+
+        require_once $versionDir . 'Installer/Installer.php';
+        $installer = new \Installer($this->dbConn, $this->pluginInstaller, $this->errorContainer);
         return $installer;
     }
 }


### PR DESCRIPTION
@zcwilt

It would seem that it checks here for `$versionDir/installer/Installer.php` and then tries to load `$versionDir/Installer.php` Plus the use of `new Installer()` missing the `\` as in `new \Installer()` potentially clashes with the main `Installer` class, which has none of the methods on it that are expected by the code using this Factory to generate an "installer" object for.

So, I'm not convinced that this PR is even a proper "fix", but it does point out where there are mismatches that need attention.

What was the "Installer/Installer.php" fallback intended to be used for?  Is there a use-case for other than `BasePluginInstaller`, which `ScriptedPluginInstaller` uses?