### PR TITLE
Correct best-sellers' sidebox index

### DIFF
--- a/includes/modules/sideboxes/best_sellers.php
+++ b/includes/modules/sideboxes/best_sellers.php
@@ -36,12 +36,14 @@ $limit = (trim(MAX_DISPLAY_BESTSELLERS) === '') ? '' : (' LIMIT ' . (int)MAX_DIS
 $best_sellers_query .= $limit;
 $best_sellers = $db->Execute($best_sellers_query);
 if ($best_sellers->RecordCount() >= MIN_DISPLAY_BESTSELLERS) {
+    $rows = 0;
     $bestsellers_list = [];
     foreach ($best_sellers as $bestseller) {
         $product_info = (new Product((int)$bestseller['products_id']))->withDefaultLanguage();
         $bestseller = array_merge($bestseller, $product_info->getData());
         $best_products_id = $bestseller['products_id'];
-        $bestsellers_list[] = [
+        $rows++;
+        $bestsellers_list[$rows] = [
             'id' => $best_products_id,
             'name'  => $bestseller['products_name'],
             'image' => zen_image(DIR_WS_IMAGES . $bestseller['products_image'], $bestseller['products_name'], SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT),

--- a/includes/templates/template_default/sideboxes/tpl_best_sellers.php
+++ b/includes/templates/template_default/sideboxes/tpl_best_sellers.php
@@ -7,12 +7,16 @@
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: DrByte 2020 Jul 10 Modified in v1.5.8-alpha $
  */
-  $content = '';
-  $content .= '<div id="' . str_replace('_', '-', $box_id . 'Content') . '" class="sideBoxContent">' . "\n";
-  $content .= '<div class="wrapper">' . "\n" . '<ul class="list-links">' . "\n";
-  for ($i=1, $j=sizeof($bestsellers_list); $i<=$j; $i++) {
-    $content .= '<li><a href="' . zen_href_link(zen_get_info_page($bestsellers_list[$i]['id']), 'products_id=' . $bestsellers_list[$i]['id']) . '">' . zen_trunc_string($bestsellers_list[$i]['name'], BEST_SELLERS_TRUNCATE, BEST_SELLERS_TRUNCATE_MORE) . '</a></li>' . "\n";
-  }
-  $content .= '</ul>' . "\n";
-  $content .= '</div>' . "\n";
-  $content .= '</div>';
+$content = '<div id="' . str_replace('_', '-', $box_id . 'Content') . '" class="sideBoxContent">' . "\n";
+$content .= '<div class="wrapper">' . "\n" . '<ul class="list-links">' . "\n";
+for ($i = 1, $j = count($bestsellers_list); $i <= $j; $i++) {
+    $content .=
+        '<li>' .
+            '<a href="' . zen_href_link(zen_get_info_page($bestsellers_list[$i]['id']), 'products_id=' . $bestsellers_list[$i]['id']) . '">' .
+                zen_trunc_string($bestsellers_list[$i]['name'], BEST_SELLERS_TRUNCATE, BEST_SELLERS_TRUNCATE_MORE) .
+            '</a>' .
+        '</li>' . "\n";
+}
+$content .= '</ul>' . "\n";
+$content .= '</div>' . "\n";
+$content .= '</div>';

--- a/includes/templates/template_default/sideboxes/tpl_best_sellers.php
+++ b/includes/templates/template_default/sideboxes/tpl_best_sellers.php
@@ -9,11 +9,11 @@
  */
 $content = '<div id="' . str_replace('_', '-', $box_id . 'Content') . '" class="sideBoxContent">' . "\n";
 $content .= '<div class="wrapper">' . "\n" . '<ul class="list-links">' . "\n";
-for ($i = 1, $j = count($bestsellers_list); $i <= $j; $i++) {
+foreach ($bestsellers_list as $next_bestseller) {
     $content .=
         '<li>' .
-            '<a href="' . zen_href_link(zen_get_info_page($bestsellers_list[$i]['id']), 'products_id=' . $bestsellers_list[$i]['id']) . '">' .
-                zen_trunc_string($bestsellers_list[$i]['name'], BEST_SELLERS_TRUNCATE, BEST_SELLERS_TRUNCATE_MORE) .
+            '<a href="' . zen_href_link(zen_get_info_page($next_bestseller['id']), 'products_id=' . $next_bestseller['id']) . '">' .
+                zen_trunc_string($next_bestseller['name'], BEST_SELLERS_TRUNCATE, BEST_SELLERS_TRUNCATE_MORE) .
             '</a>' .
         '</li>' . "\n";
 }

--- a/includes/templates/template_default/sideboxes/tpl_best_sellers.php
+++ b/includes/templates/template_default/sideboxes/tpl_best_sellers.php
@@ -10,7 +10,7 @@
   $content = '';
   $content .= '<div id="' . str_replace('_', '-', $box_id . 'Content') . '" class="sideBoxContent">' . "\n";
   $content .= '<div class="wrapper">' . "\n" . '<ul class="list-links">' . "\n";
-  for ($i=1, $j=sizeof($bestsellers_list); $i<$j; $i++) {
+  for ($i=1, $j=sizeof($bestsellers_list); $i<=$j; $i++) {
     $content .= '<li><a href="' . zen_href_link(zen_get_info_page($bestsellers_list[$i]['id']), 'products_id=' . $bestsellers_list[$i]['id']) . '">' . zen_trunc_string($bestsellers_list[$i]['name'], BEST_SELLERS_TRUNCATE, BEST_SELLERS_TRUNCATE_MORE) . '</a></li>' . "\n";
   }
   $content .= '</ul>' . "\n";


### PR DESCRIPTION
... as identified in [this](https://www.zen-cart.com/showthread.php?223910-ZCA-Bootstrap-4-Template-Support-Thread&p=1403427#post1403427) forum-post and introduced in [this](https://github.com/zencart/zencart/pull/5599) PR.

Templates are _obviously_ expecting that the array returned has an index that starts with 1.