### PR TITLE
Don't consider `keepalive` as an invalid page-access

### DIFF
--- a/admin/includes/init_includes/init_admin_auth.php
+++ b/admin/includes/init_includes/init_admin_auth.php
@@ -71,7 +71,7 @@ if (basename($PHP_SELF) !== FILENAME_ALERT_PAGE . '.php') {
         }
 
         // check page authorization access
-        if (!in_array($page, [FILENAME_DEFAULT, FILENAME_ADMIN_ACCOUNT, FILENAME_LOGOFF, FILENAME_ALERT_PAGE, FILENAME_PASSWORD_FORGOTTEN, FILENAME_DENIED, FILENAME_ALT_NAV], true)
+        if (!in_array($page, ['keepalive', FILENAME_DEFAULT, FILENAME_ADMIN_ACCOUNT, FILENAME_LOGOFF, FILENAME_ALERT_PAGE, FILENAME_PASSWORD_FORGOTTEN, FILENAME_DENIED, FILENAME_ALT_NAV], true)
             && !zen_is_superuser())
         {
             if (check_page($page, $_GET) === false && check_related_page($page, $_GET) === false) {

--- a/zc_install/sql/updates/mysql_upgrade_zencart_210.sql
+++ b/zc_install/sql/updates/mysql_upgrade_zencart_210.sql
@@ -31,10 +31,8 @@
 
 #PROGRESS_FEEDBACK:!TEXT=Purging caches ...
 # Clear out active customer sessions. Truncating helps the database clean up behind itself.
-# Also, remove uninteresting 'keepalive.php' accesses logged in the admin_activity_logs table.
 TRUNCATE TABLE whos_online;
 TRUNCATE TABLE db_cache;
-DELETE FROM admin_activity_log WHERE page_accessed = 'keepalive.php';
 
 #PROGRESS_FEEDBACK:!TEXT=Adding error logging to email archive ...
 # Add column to store any errorinfo returned from phpmailer.


### PR DESCRIPTION
A corollary to [this](https://github.com/zencart/zencart/pull/6765) PR.  Non-superuser admins were not only getting a page-access log for `keepalive.php` but also another log for page-access denied since `keepalive` isn't in the list of permitted pages.

This also backs out the zc_install update that removes page-access logs for `keepalive.php`, otherwise the follow-on `denied.php` record becomes an orphan:
![image](https://github.com/user-attachments/assets/3163c316-68c6-43fe-9ebd-b4b4e3bb5b1c)
