### PR TITLE
Add `tpl_`+template_name to `body` class list

### DIFF
--- a/includes/templates/responsive_classic/common/tpl_main_page.php
+++ b/includes/templates/responsive_classic/common/tpl_main_page.php
@@ -91,7 +91,7 @@ $left_column_file = 'column_left.php';
 $right_column_file = 'column_right.php';
 $body_id = ($this_is_home_page) ? 'indexHome' : str_replace('_', '', $_GET['main_page']);
 ?>
-<body id="<?php echo $body_id . 'Body'; ?>"<?php if($zv_onload !='') echo ' onload="'.$zv_onload.'"'; ?>>
+<body id="<?php echo $body_id . 'Body'; ?>"<?php if($zv_onload !='') echo ' onload="'.$zv_onload.'"'; ?> class="<?= 'tpl_' . $template_dir ?>">
 <?php /* add any start-of-body-section code via an observer class */
 $zco_notifier->notify('NOTIFY_PAGE_BODY_BEGIN', $current_page);
 ?>

--- a/includes/templates/template_default/common/tpl_main_page.php
+++ b/includes/templates/template_default/common/tpl_main_page.php
@@ -67,7 +67,7 @@ if (in_array($current_page_base,explode(",",'list_pages_to_skip_all_right_sidebo
   $right_column_file = 'column_right.php';
   $body_id = ($this_is_home_page) ? 'indexHome' : str_replace('_', '', $_GET['main_page']);
 ?>
-<body id="<?php echo $body_id . 'Body'; ?>"<?php if($zv_onload !='') echo ' onload="'.$zv_onload.'"'; ?>>
+<body id="<?php echo $body_id . 'Body'; ?>"<?php if($zv_onload !='') echo ' onload="'.$zv_onload.'"'; ?> class="<?= 'tpl_' . $template_dir ?>">
 <?php /* add any start-of-body-section code via an observer class */
 $zco_notifier->notify('NOTIFY_PAGE_BODY_BEGIN', $current_page);
 ?>


### PR DESCRIPTION
This added CSS class would allow plugins to pre-target formatting for specific templates.

eg: 
```diff
-<body id="productInfo">
+<body id="productInfo" class="tpl_responsive_classic">
```

There are pros and cons to this. 
Pros include convenience. 

Cons, as far as plugins go, include accidentally excluding "all" templates from necessary formatting by neglecting including generic styles.