### PR TITLE
Check for null entity

### DIFF
--- a/includes/modules/pages/ask_a_question/header_php.php
+++ b/includes/modules/pages/ask_a_question/header_php.php
@@ -73,7 +73,7 @@ if (isset($_GET['action']) && ($_GET['action'] == 'send')) {
     $name = zen_db_prepare_input($_POST['contactname']);
     $email_address = zen_db_prepare_input($_POST['email']);
     $telephone = zen_db_prepare_input($_POST['telephone']);
-    $enquiry = zen_db_prepare_input(strip_tags($_POST['enquiry']));
+    $enquiry = zen_db_prepare_input(strip_tags($_POST['enquiry'] ?? ''));
     $antiSpam = !empty($_POST[$antiSpamFieldName]) ? 'spam' : '';
     if (!empty($_POST['contactname']) && preg_match('~https?://?~', $_POST['contactname'])) $antiSpam = 'spam';
 


### PR DESCRIPTION
Seeing more of these.  Happens when people go directly to the URL 

`index.php?main_page=ask_a_question&action=send&pid=NNN`

This prevents the log; the check done later will bounce them back to the AAQ page.