### PR TITLE
Changing admin image display to size via CSS instead of HTML attribute

### DIFF
--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -694,7 +694,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
                       <a href="<?= zen_catalog_href_link('index', zen_get_path($category['categories_id'])) ?>" rel="noopener" target="_blank" title="<?= BOX_HEADING_CATALOG ?>"><?= zen_icon('popup', BOX_HEADING_CATALOG, '') ?></a>
                   <a href="<?= zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING, zen_get_path($category['categories_id'])) ?>" class="folder"><i class="fa-solid fa-lg fa-folder"></i>&nbsp;<strong><?= $category['categories_name'] ?></strong></a>
                 </td>
-                  <td class="hidden-sm hidden-xs imageView <?= $additionalClass ?>"><?= zen_image(DIR_WS_CATALOG_IMAGES . $category['categories_image'], $category['categories_name'], IMAGE_SHOPPING_CART_WIDTH, IMAGE_SHOPPING_CART_HEIGHT) ?></td>
+                  <td class="hidden-sm hidden-xs imageView <?= $additionalClass ?>"><?= zen_image(DIR_WS_CATALOG_IMAGES . $category['categories_image'], $category['categories_name'], IMAGE_SHOPPING_CART_WIDTH, IMAGE_SHOPPING_CART_HEIGHT, 'style="object-fit: contain;"') ?></td>
                 <?php if ($show_prod_labels) { ?>
                   <td class="hidden-sm hidden-xs"><!-- no model for categories --></td>
                   <td class="hidden-sm hidden-xs"><!-- no price for categories --></td>

--- a/admin/includes/functions/html_output.php
+++ b/admin/includes/functions/html_output.php
@@ -139,12 +139,10 @@ function zen_catalog_base_link($connection = '')
     if ($alt) {
       $image .= ' title="' . zen_output_string($alt) . '"';
     }
-    if ($width) {
-      $image .= ' width="' . $width . '"';
-    }
-    if ($height) {
-      $image .= ' height="' . $height . '"';
-    }
+
+    // If either attribute is set, use CSS to size the image, not the old HTML attribute. (This allows for keeping the image proportional where necessary (ie. category listing).)
+    if ($height != '' || $width != '') $image .= ' style="' . ($width ? 'width="' . $width . 'px;" ' : '') . ($height ? 'height="' . $height . 'px;" ' : '') . '"';
+
     if ($params) {
       $image .= ' ' . $params;
     }

--- a/admin/includes/functions/html_output.php
+++ b/admin/includes/functions/html_output.php
@@ -140,11 +140,27 @@ function zen_catalog_base_link($connection = '')
       $image .= ' title="' . zen_output_string($alt) . '"';
     }
 
-    // If either attribute is set, use CSS to size the image, not the old HTML attribute. (This allows for keeping the image proportional where necessary (ie. category listing).)
-    if ($height != '' || $width != '') $image .= ' style="' . ($width ? 'width="' . $width . 'px;" ' : '') . ($height ? 'height="' . $height . 'px;" ' : '') . '"';
+    $styles = '';
+
+    if ($width !== '' && !str_contains($params, 'width:')) {
+        $width = trim($width);
+        $styles .= 'width:' . $width . (!str_ends_with($width, '%') ? 'px' : '') . '; ';
+    }
+
+    if ($height !== '' && !str_contains($params, 'height:')) {
+        $height = trim($height);
+        $styles .= 'height:' . $height . (!str_ends_with($height, '%') ? 'px' : '') . '; ';
+    }
+
+    if (str_contains($params, 'style=')) {
+        $params = str_replace('style="', 'style="' . $styles, $params);
+    } else {
+        $params .= ' style="' . $styles . '"';
+    }
+
 
     if ($params) {
-      $image .= ' ' . $params;
+      $image .= ' ' . trim($params);
     }
     $image .= '>';
 


### PR DESCRIPTION
This change allows the image to be resized dynamically via CSS instead of hardcoded via HTML <img> attributes.

For example: the pictures in the category listing would be stretched to fit both the height and width of the image settings as designated in the admin backend. This change moves the setting of the image's height and width to CSS where appropriate (ie. where the image's height or width are set in the function call).