### PR TITLE
remove 0 count categories from `zen_get_categories()` when requesting active categories

### DIFF
--- a/includes/functions/functions_categories.php
+++ b/includes/functions/functions_categories.php
@@ -160,6 +160,12 @@ function zen_get_categories($categories_array = array(), $parent_id = TOPMOST_CA
     $results = $db->Execute($categories_query);
 
     foreach ($results as $result) {
+        if ($status_flag !== null) {
+            $count = zen_products_in_category_count($result['categories_id']);
+            if ($count === 0) {
+                continue;
+            }
+        }
         $categories_array[] = [
             'id' => $result['categories_id'],
             'text' => $indent . $result['categories_name'],


### PR DESCRIPTION
if the request is made to only include active categories, it seems appropriate to NOT include categories where the count of items in the category is 0.