### PR TITLE
admin, orders: prevent console error on expanding extra payment info

### DIFF
--- a/admin/orders.php
+++ b/admin/orders.php
@@ -829,7 +829,7 @@ if (is_array($address_footer_suffix)) {
           ?>
           <br>
           <div class="row noprint">
-            <a href="javascript:void();" class="noprint" data-toggle="collapse" data-target="#payment-details-section">
+            <a href="javascript:void(0);" class="noprint" data-toggle="collapse" data-target="#payment-details-section">
                 <?php echo TEXT_ADDITIONAL_PAYMENT_OPTIONS; ?>
             </a>
           </div>


### PR DESCRIPTION
When clicking on the link to expand the section:

![image](https://github.com/user-attachments/assets/defd83a9-2e06-4374-bd5d-40eb623132b8)

All examples I find use the (0).