### PR TITLE
Admin, Delete product: notifier for InfoBox data

### DIFF
--- a/admin/includes/modules/delete_product.php
+++ b/admin/includes/modules/delete_product.php
@@ -33,6 +33,8 @@ for ($i = 0, $n = count($product_categories); $i < $n; $i++) {
 }
 if (!isset($product_master_category_string)) $product_master_category_string = zen_get_category_name($pInfo->master_categories_id, (int)$_SESSION['languages_id']);
 
+$zco_notifier->notify('NOTIFY_ADMIN_DELETE_PRODUCT_INFOBOX', $pInfo, $product_master_category_string, $product_categories_string);
+
 $heading = [];
 $heading[] = ['text' => '<h4>' . TEXT_INFO_HEADING_DELETE_PRODUCT . '</h4>'];
 $contents = ['form' => zen_draw_form('delete_products', FILENAME_CATEGORY_PRODUCT_LISTING, 'action=delete_product_confirm&product_type=' . $product_type . '&cPath=' . $cPath . (isset($_GET['page']) ? '&page=' . $_GET['page'] : ''), 'post', 'class="form-horizontal"') . zen_draw_hidden_field('products_id', $pInfo->products_id)];


### PR DESCRIPTION
To potential warn/prevent deletion for specific products (used for a lurking plugin for product kits).