### PR TITLE
Admin, copy_product_confirm: notifier to prevent redirect

### DIFF
--- a/admin/includes/modules/copy_product_confirm.php
+++ b/admin/includes/modules/copy_product_confirm.php
@@ -245,8 +245,15 @@ if (isset($_POST['products_id'], $_POST['categories_id'])) {
     // reset products_price_sorter for searches etc.
     zen_update_products_price_sorter($products_id);
 }
-if ($_POST['copy_as'] === 'duplicate' && !empty($_POST['edit_duplicate'])) {
-    zen_redirect(zen_href_link(FILENAME_PRODUCT, 'action=new_product&cPath=' . $categories_id . '&pID=' . $dup_products_id . '&products_type=' . (int)$product->fields['products_type']));
-} else {
-    zen_redirect(zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING, 'cPath=' . $categories_id . '&pID=' . $products_id . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '')));
+// -----
+// Give an observer the chance to prevent the redirection/allow multiple execution.
+//
+$redirect = true;
+$zco_notifier->notify('NOTIFY_MODULES_COPY_PRODUCT_CONFIRM_REDIRECT', '', $redirect);
+if ($redirect) {
+    if ($_POST['copy_as'] === 'duplicate' && !empty($_POST['edit_duplicate'])) {
+        zen_redirect(zen_href_link(FILENAME_PRODUCT, 'action=new_product&cPath=' . $categories_id . '&pID=' . $dup_products_id . '&products_type=' . (int)$product->fields['products_type']));
+    } else {
+        zen_redirect(zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING, 'cPath=' . $categories_id . '&pID=' . $products_id . (isset($_GET['page']) ? '&page=' . $_GET['page'] : '')));
+    }
 }


### PR DESCRIPTION
I'm on a plugin that copies multiple products in one operation, so the redirect after each copy needs to be prevented, as this file is called in a foreach.
Maybe there's a better way...


