### PR TITLE
Missing alias for table products in tpl_categories.php

### DIFF
--- a/includes/templates/responsive_classic/sideboxes/tpl_categories.php
+++ b/includes/templates/responsive_classic/sideboxes/tpl_categories.php
@@ -74,7 +74,7 @@ if (SHOW_CATEGORIES_BOX_SPECIALS === 'true' || SHOW_CATEGORIES_BOX_PRODUCTS_NEW 
         // display limits
         $display_limit = zen_get_new_date_range();
 
-        $show_this = $db->Execute("SELECT products_id FROM " . TABLE_PRODUCTS . " WHERE products_status = 1 " . $display_limit . " limit 1");
+        $show_this = $db->Execute("SELECT products_id FROM " . TABLE_PRODUCTS . " p WHERE products_status = 1 " . $display_limit . " limit 1");
         if (!$show_this->EOF) {
             $content .= '<li><a class="category-links" href="' . zen_href_link(FILENAME_PRODUCTS_NEW) . '">' . CATEGORIES_BOX_HEADING_WHATS_NEW . '</a></li>' . "\n";
         }


### PR DESCRIPTION
Missing alias for table products in responsive classic side box file tpl_categories.php.
This causes an error 500 on catalog when SHOW_NEW_PRODUCTS_LIMIT is set to anything else than 0 (default) in `Configuration::Maximum values:New Product Listing - Limited to ...`

`PHP Fatal error: MySQL error 1054: Field 'p.products_date_added' unknown in where clause :: SELECT products_id FROM products WHERE products_status = 1  AND p.products_date_added >= 20241001 limit 1 ==> (as called by) ...\includes\templates\responsive_classic\sideboxes\tpl_categories.php on line 77 ...`

I checked all other 6 files that uses function `zen_get_new_date_range` where the error was actually originating, and they all use 'p' as alias for table products.
Adding it to tpl_categories.php on line 77 resolved the problem.