### PR TITLE
Replace uniqid() with better entropy

### DIFF
--- a/admin/includes/init_includes/init_sessions.php
+++ b/admin/includes/init_includes/init_sessions.php
@@ -45,7 +45,7 @@ zen_session_start();
 $session_started = true;
 
 if (!isset($_SESSION ['securityToken'])) {
-    $_SESSION ['securityToken'] = md5(uniqid(rand(), true));
+    $_SESSION ['securityToken'] = \bin2hex(\random_bytes(16));
 }
 if ((isset($_GET ['action']) || isset($_POST['action'])) && $_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!isset($_SESSION ['securityToken'], $_POST ['securityToken']) || $_SESSION ['securityToken'] !== $_POST ['securityToken']) {

--- a/includes/functions/sessions.php
+++ b/includes/functions/sessions.php
@@ -43,11 +43,11 @@ function zen_session_start(): bool
     @ini_set('session.gc_divisor', 2);
 
     if (preg_replace('/[a-zA-Z0-9,-]/', '', session_id()) !== '') {
-        zen_session_id(md5(uniqid(rand(), true)));
+        zen_session_id(\bin2hex(\random_bytes(16)));
     }
     $temp = session_start();
     if (!isset($_SESSION['securityToken'])) {
-        $_SESSION['securityToken'] = md5(uniqid(rand(), true));
+        $_SESSION['securityToken'] = \bin2hex(\random_bytes(16));
     }
 
     return $temp;
@@ -58,7 +58,7 @@ function zen_session_id($sessid = ''): bool|string
     if (!empty($sessid)) {
         $tempSessid = $sessid;
         if (preg_replace('/[a-zA-Z0-9,-]/', '', $tempSessid) != '') {
-            $sessid = md5(uniqid(rand(), true));
+            $sessid = \bin2hex(\random_bytes(16));
         }
 
         return session_id($sessid);

--- a/includes/init_includes/init_sanitize.php
+++ b/includes/init_includes/init_sanitize.php
@@ -31,7 +31,7 @@ foreach ($_GET as $varname => $varvalue) {
 $csrfBlackListLocal = [];
 $csrfBlackList = (isset($csrfBlackListCustom)) ? array_merge($csrfBlackListLocal, $csrfBlackListCustom) : $csrfBlackListLocal;
 if (!isset($_SESSION ['securityToken'])) {
-    $_SESSION ['securityToken'] = md5(uniqid(rand(), true));
+    $_SESSION ['securityToken'] = \bin2hex(\random_bytes(16));
 }
 
 if (zen_is_hmac_login()) {

--- a/includes/modules/payment/paypal/paypal_curl.php
+++ b/includes/modules/payment/paypal/paypal_curl.php
@@ -431,7 +431,7 @@ class paypal_curl extends base {
 
     // request-id must be unique within 30 days
     if ($requestId === null) {
-      $requestId = md5(uniqid(mt_rand()));
+      $requestId = \bin2hex(\random_bytes(16));
     }
 
     $headers[] = 'Content-Type: text/namevalue';


### PR DESCRIPTION
The PHP core team is considering deprecating `uniqid()` in favor of better alternates in future PHP versions. 
Given that we only use it for one purpose, changing it here is straightforward.