### PR TITLE
Fix nullable type signature declarations

### DIFF
--- a/admin/includes/classes/class.admin.zcObserverLogEventListener.php
+++ b/admin/includes/classes/class.admin.zcObserverLogEventListener.php
@@ -18,7 +18,7 @@
 class zcObserverLogEventListener extends base {
 
     private $notifier;
-    
+
   /**
    * using integer values implemented by monolog API
    */
@@ -45,7 +45,7 @@ class zcObserverLogEventListener extends base {
           600 => 'EMERGENCY',
   );
 
-  public function __construct(notifier $zco_notifier = null) {
+  public function __construct(?notifier $zco_notifier = null) {
     if (!$zco_notifier) $zco_notifier = new notifier;
     $this->notifier = $zco_notifier;
     $this->notifier->attach($this, array('NOTIFY_ADMIN_ACTIVITY_LOG_EVENT', 'NOTIFY_ADMIN_ACTIVITY_LOG_RESET'));

--- a/admin/includes/classes/class.admin.zcObserverLogWriterTextfile.php
+++ b/admin/includes/classes/class.admin.zcObserverLogWriterTextfile.php
@@ -13,7 +13,7 @@ class zcObserverLogWriterTextfile extends base {
   private $destinationLogFilename = '';
   private $notifier;
 
-  public function __construct(notifier $zco_notifier = null) {
+  public function __construct(?notifier $zco_notifier = null) {
     if (!$zco_notifier) $zco_notifier = new notifier;
     $this->notifier = $zco_notifier;
     $this->notifier->attach($this, array('NOTIFY_ADMIN_FIRE_LOG_WRITERS', 'NOTIFY_ADMIN_FIRE_LOG_WRITER_RESET'));

--- a/includes/functions/functions_general_shared.php
+++ b/includes/functions/functions_general_shared.php
@@ -372,7 +372,7 @@ function zen_convert_linefeeds($from, $to, $string)
 /**
  * Return a random value
  */
-function zen_rand($min = null, $max = null)
+function zen_rand(?int $min = null, ?int $max = null): int
 {
     static $seeded;
 

--- a/zc_install/includes/functions/general.php
+++ b/zc_install/includes/functions/general.php
@@ -37,7 +37,7 @@ function logDetails(string $details, string $location = "General"): void
     }
 }
 
-function zen_rand(int $min = null, int $max = null): int
+function zen_rand(?int $min = null, ?int $max = null): int
 {
     static $seeded;
 


### PR DESCRIPTION
PHP 8.4 will deprecate the use of null as default if the type is not also declared as nullable (using `?`)