### PR TITLE
Fix checkAll() button on profile-edit page

### DIFF
--- a/admin/profiles.php
+++ b/admin/profiles.php
@@ -93,7 +93,7 @@ switch ($action) {
     <script>
       function checkAll(form, header, value) {
           for (var i = 0; i < form.elements.length; i++) {
-              if (form.elements[i].className == header) {
+              if (form.elements[i].classList.contains(header)) {
                   form.elements[i].checked = value;
               }
           }


### PR DESCRIPTION
Multiple CSS classes are now applied to checkbox elements, so we can't check for `element.className == val`; instead, must use `element.classList.contains(val)`