### PR TITLE
Change hashing functions to use modern methods

### DIFF
--- a/includes/classes/PluginSupport/PluginErrorContainer.php
+++ b/includes/classes/PluginSupport/PluginErrorContainer.php
@@ -48,7 +48,7 @@ class PluginErrorContainer
         }
         $this->logErrors[] = $logMessage;
         if ($friendlyMessage === '') return;
-        $friendlyHash = md5($friendlyMessage);
+        $friendlyHash = hash('md5', $friendlyMessage);
         $this->friendlyErrors[$friendlyHash] = $friendlyMessage;
         if ($this->logger) {
             // do something here for external logging;

--- a/includes/classes/cache.php
+++ b/includes/classes/cache.php
@@ -199,13 +199,13 @@ class cache extends base {
   function cache_generate_cache_name($zf_query) {
     switch (SQL_CACHE_METHOD) {
       case 'file':
-      return 'zc_' . md5($zf_query);
+      return 'zc_' . hash('md5', $zf_query);
       break;
       case 'database':
-      return 'zc_' . md5($zf_query);
+      return 'zc_' . hash('md5', $zf_query);
       break;
       case 'memory':
-      return 'zc_' . md5($zf_query);
+      return 'zc_' . hash('md5', $zf_query);
       break;
       case 'none':
       default:

--- a/includes/classes/class.zcPassword.php
+++ b/includes/classes/class.zcPassword.php
@@ -95,7 +95,7 @@ class zcPassword extends base
       $stack = explode(':', $encrypted);
       if (sizeof($stack) != 2)
         return false;
-      if (md5($stack [1] . $plain) == $stack [0]) {
+      if (hash('md5', $stack [1] . $plain) == $stack [0]) {
         return true;
       }
     }

--- a/includes/classes/traits/ObserverManager.php
+++ b/includes/classes/traits/ObserverManager.php
@@ -38,7 +38,7 @@ trait ObserverManager
             }
 
             // handle attach
-            $nameHash = md5(get_class($observer) . $eventID);
+            $nameHash = hash('md5', get_class($observer) . $eventID);
             EventDto::getInstance()->setObserver($nameHash, ['obs' => &$observer, 'eventID' => $eventID]);
         }
     }
@@ -52,7 +52,7 @@ trait ObserverManager
     public function detach($observer, array $eventIDArray): void
     {
         foreach ($eventIDArray as $eventID) {
-            $nameHash = md5(get_class($observer) . $eventID);
+            $nameHash = hash('md5', get_class($observer) . $eventID);
             EventDto::getInstance()->removeObserver($nameHash);
         }
     }

--- a/includes/functions/functions_products.php
+++ b/includes/functions/functions_products.php
@@ -385,7 +385,7 @@ function zen_get_uprid(int|string $prid, array|string $params): string
         }
     }
 
-    $md_uprid = md5($uprid);
+    $md_uprid = hash('md5', $uprid);
     return $prid . ':' . $md_uprid;
 }
 

--- a/includes/functions/password_funcs.php
+++ b/includes/functions/password_funcs.php
@@ -147,7 +147,7 @@ function zen_get_entropy($hash = 'sha1', $size = 32)
 
         if ($entropy) {
           // echo('Adding random data to entropy using CAPICOM.Utilities');
-          $stat ['CAPICOM_Utilities_random'] = md5($entropy, TRUE);
+          $stat ['CAPICOM_Utilities_random'] = hash('md5', $entropy, TRUE);
         }
         unset($CAPI_Util, $entropy);
       } catch ( Exception $ex ) {

--- a/includes/modules/pages/order_status/header_php.php
+++ b/includes/modules/pages/order_status/header_php.php
@@ -43,7 +43,7 @@ $query_email_address = '';
 // -----
 // Create the store-specific name of the spam "honeypot" by hashing the store's defined name.
 //
-$spam_input_name = md5(STORE_NAME);
+$spam_input_name = hash('md5', STORE_NAME);
 
 if (isset($_GET['action']) && $_GET['action'] === 'status') {
     $error = false;

--- a/zc_install/includes/functions/password_funcs.php
+++ b/zc_install/includes/functions/password_funcs.php
@@ -32,7 +32,7 @@ function zen_validate_password(string $plain, string $encrypted): bool
     // split apart the hash / salt
     $stack = explode(':', $encrypted);
     if (count($stack) === 2) {
-        return (md5($stack[1] . $plain) === $stack[0]);
+        return (hash('md5', $stack[1] . $plain) === $stack[0]);
     }
 
     return false;
@@ -175,7 +175,7 @@ function zen_get_entropy(string $hash = 'sha1', int $size = 32): string
 
                 if ($entropy) {
                     //echo('Adding random data to entrohy using CAPICOM.Utilities');
-                    $stat['CAPICOM_Utilities_random'] = md5($entropy, true);
+                    $stat['CAPICOM_Utilities_random'] = hash('md5', $entropy, true);
                 }
                 unset($CAPI_Util, $entropy);
             } catch (Exception $ex) {

--- a/zc_plugins/DisplayLogs/v3.0.2/admin/display_logs.php
+++ b/zc_plugins/DisplayLogs/v3.0.2/admin/display_logs.php
@@ -77,7 +77,7 @@ foreach (array (DIR_FS_LOGS, DIR_FS_SQL_CACHE, DIR_FS_CATALOG . '/includes/modul
             if ( ($file != '.') && ($file != '..') && substr($file, 0, 1) != '.') {
                 if (preg_match('/^' . $files_to_match . '\.log$/', $file)) {
                     if ($files_to_exclude == '' || !preg_match('/^' . $files_to_exclude . '\.log$/', $file)) {
-                        $hash = sha1($logFolder . '/' . $file);
+                        $hash = hash('sha1', $logFolder . '/' . $file);
                         $logFiles[$hash] = array (
                             'name'  => $logFolder . '/' . $file,
                             'mtime' => filemtime($logFolder . '/' . $file),

--- a/zc_plugins/POSM/v6.0.0/admin/includes/classes/PosmSalesReport.php
+++ b/zc_plugins/POSM/v6.0.0/admin/includes/classes/PosmSalesReport.php
@@ -102,7 +102,7 @@ class PosmSalesReport
                 $this->options[$options_id]['values'][$options_values_id]['total_price'] += $product_price;
             }
 
-            $options_hash = md5($options);
+            $options_hash = hash('md5', $options);
             if (!isset($this->orders[$options_hash])) {
                 $this->orders[$options_hash] = [
                     'options' => $options_array,

--- a/zc_plugins/POSM/v6.0.0/catalog/includes/functions/products_options_stock_functions.php
+++ b/zc_plugins/POSM/v6.0.0/catalog/includes/functions/products_options_stock_functions.php
@@ -100,7 +100,7 @@ function generate_pos_option_hash($pID, $options_array): string
             }
         }
     }
-    $hash_out = md5($hash_in);
+    $hash_out = hash('md5', $hash_in);
     $posObserver->debug_message(
         "products_options_stock_functions: $hash_out = generate_pos_option_hash($pID, options_array\n" .
         json_encode($options_array, JSON_PRETTY_PRINT) . "\n" .


### PR DESCRIPTION
`md5()` -> `hash('md5')`
We're not currently using `sha1()` directly: we're already using `hash('sha1')`.

The bulk of our use of `md5()` is just to prepare a token, or to identify one element from another with some uniqueness. So this is not really a change that affects cryptography per se. It merely steps away from using the (potentially-being-retired) `md5()` function.

This change is backward-compatible to PHP 7.0, and sets future compatibility when the PHP team finally agrees to retire the md5/sha1 functions in favor of `hash()`, probably to be re-proposed in PHP 9.0