### PR TITLE
Retire obsolete rand() in favor of newer methods

### DIFF
--- a/includes/classes/Coupon.php
+++ b/includes/classes/Coupon.php
@@ -198,11 +198,10 @@ class Coupon extends base
             return '';
         }
         $random_string = bin2hex(random_bytes(128));
-        mt_srand((int)microtime() * 1000000); // seed the random number generator
         $good_result = 0;
         $new_code = '';
         while ($good_result === 0) {
-            $random_start = @rand(0, (128 - $length));
+            $random_start = random_int(0, (128 - $length));
             $new_code = substr($random_string, $random_start, $length);
 
             $new_code = strtoupper($new_code);

--- a/includes/functions/functions_general_shared.php
+++ b/includes/functions/functions_general_shared.php
@@ -389,12 +389,12 @@ function zen_rand($min = null, $max = null)
     if (isset($min) && isset($max)) {
         if ($min >= $max) {
             return $min;
-        } else {
-            return mt_rand($min, $max);
         }
-    } else {
-        return mt_rand();
+
+        return random_int($min, $max);
     }
+
+    return mt_rand();
 }
 
 

--- a/includes/modules/payment/authorizenet.php
+++ b/includes/modules/payment/authorizenet.php
@@ -304,7 +304,7 @@ class authorizenet extends base {
   function process_button() {
     global $order;
 
-    $sequence = rand(1, 1000);
+    $sequence = random_int(1, 1000);
     $submit_data_core = array(
       'x_login' => MODULE_PAYMENT_AUTHORIZENET_LOGIN,
       'x_amount' => round($order->info['total'], 2),

--- a/zc_install/includes/functions/general.php
+++ b/zc_install/includes/functions/general.php
@@ -50,7 +50,7 @@ function zen_rand(int $min = null, int $max = null): int
         if ($min >= $max) {
             return $min;
         }
-        return mt_rand($min, $max);
+        return random_int($min, $max);
     }
 
     return mt_rand();


### PR DESCRIPTION
`rand()` was retired in PHP 7.2, being made an alias of `mt_rand()`, which has since been superceded by `random_int()` when specifying a range. mt_rand() is still valid for the ways in which we use it.