### PR TITLE
Refine coupon-generator function

### DIFF
--- a/includes/classes/Coupon.php
+++ b/includes/classes/Coupon.php
@@ -169,13 +169,12 @@ class Coupon extends base
     /**
      * Create a Coupon Code. Returns blank if cannot generate a unique code using the passed criteria.
      * @param string $salt - this is an optional string to help seed the random code with greater entropy
-     * @param int $length - this is the desired length of the generated code
+     * @param int $length - this is the desired length of the generated code; will be ignored if longer than length of db field
      * @param string $prefix - include a prefix string if you want to force the generated code to start with a specific string
      * @return string (new coupon code) (will be blank if the function failed)
      */
     public static function generateRandomCouponCode(string $salt = "secret", $length = SECURITY_CODE_LENGTH, string $prefix = ''): string
     {
-        global $db;
         $length = (int)$length;
         static $max_db_length;
 
@@ -197,23 +196,25 @@ class Coupon extends base
             // if the recalculated length (esp in respect to prefixes) is less than 4 (for very basic entropy) then abort
             return '';
         }
-        $random_string = bin2hex(random_bytes(128));
-        $good_result = 0;
-        $new_code = '';
-        while ($good_result === 0) {
-            $random_start = random_int(0, (128 - $length));
+        $random_string = bin2hex(random_bytes(128)); // 128 generates 256 chars
+        $random_string_length = strlen($random_string);
+        if ($length > ($random_string_length / 4)) {
+            // safeguard: this should never happen, but can't pass a negative max-number to random_int when min is 0 (which we need)
+            $length = (int)($length / 4);
+        }
+        for ($i = 0; $i < $random_string_length; $i++) {
+            $random_start = random_int(0, ($random_string_length - $length));
             $new_code = substr($random_string, $random_start, $length);
 
             $new_code = strtoupper($new_code);
 
-            $result = static::codeExists($prefix . $new_code);
-            if ($result === false) {
-                $good_result = 1;
+            if (!static::codeExists($prefix . $new_code)) {
+                return $prefix . $new_code;
             }
         }
 
         // blank means couldn't generate a unique code (typically because the max length was encountered before being able to generate unique)
-        return ($good_result === 1) ? $prefix . $new_code : '';
+        return '';
     }
 
     public static function getAllCouponsByName(): array


### PR DESCRIPTION
Removes redundant code
Addresses edge-case fatal error crashes if wildly invalid parameters are set