### PR TITLE
Admin product listing: include products which are missing a description record

### DIFF
--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -882,10 +882,10 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
             $products_query_raw .= " FROM " . TABLE_PRODUCTS . " p";
             $products_query_raw .= $extra_from;
 
-            $products_query_raw .= " LEFT JOIN " . TABLE_PRODUCTS_DESCRIPTION . " pd ON (pd.products_id = p.products_id)";
+            $products_query_raw .= " LEFT JOIN " . TABLE_PRODUCTS_DESCRIPTION . " pd ON (pd.products_id = p.products_id AND pd.language_id = " . (int)$_SESSION['languages_id'] . ")";
             $products_query_raw .= $extra_joins;
 
-            $where = " WHERE pd.language_id = " . (int)$_SESSION['languages_id'];
+            $where = " WHERE 1 ";
             $where .= $extra_ands;
 
             if ($search_result && $action !== 'edit_category') {

--- a/admin/includes/modules/collect_info.php
+++ b/admin/includes/modules/collect_info.php
@@ -53,11 +53,9 @@ if (isset($_GET['pID']) && empty($_POST)) {
   $product = $db->Execute("SELECT pd.products_name, pd.products_description, pd.products_url,
                                   p.*,
                                   date_format(p.products_date_available, '" .  zen_datepicker_format_forsql() . "') as products_date_available
-                           FROM " . TABLE_PRODUCTS . " p,
-                                " . TABLE_PRODUCTS_DESCRIPTION . " pd
-                           WHERE p.products_id = " . (int)$_GET['pID'] . "
-                           AND p.products_id = pd.products_id
-                           AND pd.language_id = " . (int)$_SESSION['languages_id']);
+                           FROM " . TABLE_PRODUCTS . " p
+                           LEFT JOIN " . TABLE_PRODUCTS_DESCRIPTION . " pd ON (p.products_id = pd.products_id AND pd.language_id = " . (int)$_SESSION['languages_id'] . ")
+                           WHERE p.products_id = " . (int)$_GET['pID']);
 
   $pInfo->updateObjectInfo($product->fields);
   $pInfo->product_type = $pInfo->products_type;

--- a/admin/includes/modules/document_general/collect_info.php
+++ b/admin/includes/modules/document_general/collect_info.php
@@ -52,11 +52,9 @@ if (isset($_GET['pID']) && empty($_POST)) {
   $product = $db->Execute("SELECT pd.products_name, pd.products_description, pd.products_url,
                                   p.*,
                                   date_format(p.products_date_available, '" .  zen_datepicker_format_forsql() . "') as products_date_available
-                           FROM " . TABLE_PRODUCTS . " p,
-                                " . TABLE_PRODUCTS_DESCRIPTION . " pd
-                           WHERE p.products_id = " . (int)$_GET['pID'] . "
-                           AND p.products_id = pd.products_id
-                           AND pd.language_id = " . (int)$_SESSION['languages_id']);
+                           FROM " . TABLE_PRODUCTS . " p
+                           LEFT JOIN " . TABLE_PRODUCTS_DESCRIPTION . " pd ON (p.products_id = pd.products_id AND pd.language_id = " . (int)$_SESSION['languages_id'] . ")
+                           WHERE p.products_id = " . (int)$_GET['pID']);
 
   $pInfo->updateObjectInfo($product->fields);
   $pInfo->product_type = $pInfo->products_type;

--- a/admin/includes/modules/document_general/preview_info.php
+++ b/admin/includes/modules/document_general/preview_info.php
@@ -19,16 +19,15 @@ if (!empty($_POST)) {
   $products_description = $_POST['products_description'];
   $products_url = $_POST['products_url'];
   foreach ($products_url as &$url){ // remove protocol
-      $url = str_replace(array('http://', 'https://'), '', $url);
+      $url = str_replace(['http://', 'https://'], '', $url);
   }
   unset ($url);
 } else {
   $product = $db->Execute("SELECT p.*,
                                   pd.language_id, pd.products_name, pd.products_description, pd.products_url
-                           FROM " . TABLE_PRODUCTS . " p,
-                                " . TABLE_PRODUCTS_DESCRIPTION . " pd
-                           WHERE p.products_id = pd.products_id
-                           AND p.products_id = " . (int)$_GET['pID']);
+                           FROM " . TABLE_PRODUCTS . " p
+                           LEFT JOIN " . TABLE_PRODUCTS_DESCRIPTION . " pd ON (p.products_id = pd.products_id)
+                           WHERE p.products_id = " . (int)$_GET['pID']);
 
   $pInfo = new objectInfo($product->fields);
   $products_image_name = $pInfo->products_image;

--- a/admin/includes/modules/document_product/collect_info.php
+++ b/admin/includes/modules/document_product/collect_info.php
@@ -52,11 +52,9 @@ if (isset($_GET['pID']) && empty($_POST)) {
   $product = $db->Execute("SELECT pd.products_name, pd.products_description, pd.products_url,
                                   p.*,
                                   date_format(p.products_date_available, '" .  zen_datepicker_format_forsql() . "') as products_date_available
-                           FROM " . TABLE_PRODUCTS . " p,
-                                " . TABLE_PRODUCTS_DESCRIPTION . " pd
-                           WHERE p.products_id = " . (int)$_GET['pID'] . "
-                           AND p.products_id = pd.products_id
-                           AND pd.language_id = " . (int)$_SESSION['languages_id']);
+                           FROM " . TABLE_PRODUCTS . " p
+                           LEFT JOIN " . TABLE_PRODUCTS_DESCRIPTION . " pd ON (p.products_id = pd.products_id AND pd.language_id = " . (int)$_SESSION['languages_id'] . ")
+                           WHERE p.products_id = " . (int)$_GET['pID']);
 
   $pInfo->updateObjectInfo($product->fields);
   $pInfo->product_type = $pInfo->products_type;

--- a/admin/includes/modules/preview_info.php
+++ b/admin/includes/modules/preview_info.php
@@ -19,16 +19,15 @@ if (!empty($_POST)) {
   $products_description = $_POST['products_description'];
   $products_url = $_POST['products_url'];
   foreach ($products_url as &$url){ // remove protocol
-      $url = str_replace(array('http://', 'https://'), '', $url);
+      $url = str_replace(['http://', 'https://'], '', $url);
   }
   unset ($url);
 } else {
   $product = $db->Execute("SELECT p.*,
                                   pd.language_id, pd.products_name, pd.products_description, pd.products_url
-                           FROM " . TABLE_PRODUCTS . " p,
-                                " . TABLE_PRODUCTS_DESCRIPTION . " pd
-                           WHERE p.products_id = pd.products_id
-                           AND p.products_id = " . (int)$_GET['pID']);
+                           FROM " . TABLE_PRODUCTS . " p
+                           LEFT JOIN " . TABLE_PRODUCTS_DESCRIPTION . " pd ON (p.products_id = pd.products_id)
+                           WHERE p.products_id = " . (int)$_GET['pID']);
 
   $pInfo = new objectInfo($product->fields);
   $products_image_name = $pInfo->products_image;

--- a/admin/includes/modules/product_free_shipping/collect_info.php
+++ b/admin/includes/modules/product_free_shipping/collect_info.php
@@ -52,11 +52,9 @@ if (isset($_GET['pID']) && empty($_POST)) {
   $product = $db->Execute("SELECT pd.products_name, pd.products_description, pd.products_url,
                                   p.*,
                                   date_format(p.products_date_available, '" .  zen_datepicker_format_forsql() . "') as products_date_available
-                           FROM " . TABLE_PRODUCTS . " p,
-                                " . TABLE_PRODUCTS_DESCRIPTION . " pd
-                           WHERE p.products_id = " . (int)$_GET['pID'] . "
-                           AND p.products_id = pd.products_id
-                           AND pd.language_id = " . (int)$_SESSION['languages_id']);
+                           FROM " . TABLE_PRODUCTS . " p
+                           LEFT JOIN " . TABLE_PRODUCTS_DESCRIPTION . " pd ON (p.products_id = pd.products_id AND pd.language_id = " . (int)$_SESSION['languages_id'] . ")
+                           WHERE p.products_id = " . (int)$_GET['pID']);
 
   $pInfo->updateObjectInfo($product->fields);
   $pInfo->product_type = $pInfo->products_type;

--- a/admin/includes/modules/product_music/collect_info.php
+++ b/admin/includes/modules/product_music/collect_info.php
@@ -53,13 +53,10 @@ if (isset($_GET['pID']) && empty($_POST)) {
                                   p.*,
                                   pe.artists_id, pe.record_company_id,pe.music_genre_id,
                                   date_format(p.products_date_available, '" .  zen_datepicker_format_forsql() . "') as products_date_available
-                           FROM " . TABLE_PRODUCTS . " p,
-                                " . TABLE_PRODUCTS_DESCRIPTION . " pd,
-                                " . TABLE_PRODUCT_MUSIC_EXTRA . " pe
-                           WHERE p.products_id = " . (int)$_GET['pID'] . "
-                           AND p.products_id = pd.products_id
-                           AND p.products_id = pe.products_id
-                           AND pd.language_id = " . (int)$_SESSION['languages_id']);
+                           FROM " . TABLE_PRODUCTS . " p
+                           LEFT JOIN " . TABLE_PRODUCTS_DESCRIPTION . " pd ON (p.products_id = pd.products_id AND pd.language_id = " . (int)$_SESSION['languages_id'] . ")
+                           LEFT JOIN " . TABLE_PRODUCT_MUSIC_EXTRA . " pe ON (p.products_id = pe.products_id)
+                           WHERE p.products_id = " . (int)$_GET['pID']);
 
   $pInfo->updateObjectInfo($product->fields);
   $pInfo->product_type = $pInfo->products_type;

--- a/admin/includes/modules/update_product.php
+++ b/admin/includes/modules/update_product.php
@@ -138,7 +138,12 @@ if (isset($_POST['edit']) && $_POST['edit'] === 'edit') {
           'products_url' => zen_db_prepare_input($_POST['products_url'][$language_id])
         ];
 
-        if ($action === 'insert_product') {
+        // For database consistency, check whether a record exists for this language already; if not, we will create it even if we're in update mode
+        $sql = "SELECT count(products_id) AS found FROM " . TABLE_PRODUCTS_DESCRIPTION . " WHERE products_id = " . (int)$products_id . " AND language_id = " . (int)$language_id;
+        $result = $db->Execute($sql, 1);
+        $record_exists = !empty($result->fields['found']);
+
+        if ($action === 'insert_product' || !$record_exists) {
             $insert_sql_data = [
                 'products_id' => (int)$products_id,
                 'language_id' => (int)$language_id,


### PR DESCRIPTION
Admin product listing: include products which are missing a description record

Fixes #6828

- requires the search to include missing-lang products, in order to "find" such products
- requires all the fallback-lookups used when editing/previewing/updating to allow for missing data, in order to prevent filled-in-data from being blanked-out due to failed joins
- requires checking whether the "update" record exists, and fallback to "insert" mode if not found, instead of trying to update the missing record
