### PR TITLE
Contact us form: telephone was omitted from html email, remove brackets around email address

### DIFF
--- a/includes/modules/pages/contact_us/header_php.php
+++ b/includes/modules/pages/contact_us/header_php.php
@@ -94,7 +94,8 @@ if (isset($_GET['action']) && ($_GET['action'] === 'send')) {
             $extra_info['TEXT'];
             // Prepare HTML-portion of message
             $html_msg['EMAIL_MESSAGE_HTML'] = $enquiry;
-            $html_msg['CONTACT_US_OFFICE_FROM'] = OFFICE_FROM . ' ' . $name . '<br>' . OFFICE_EMAIL . '(' . $email_address . ')';
+            $html_msg['CONTACT_US_OFFICE_FROM'] = OFFICE_FROM . ' ' . $name . '<br>' . OFFICE_EMAIL . ' ' . $email_address .
+                (!empty($telephone) ? '<br>' . OFFICE_LOGIN_PHONE . ' ' . $telephone : '');
             $html_msg['EXTRA_INFO'] = $extra_info['HTML'];
             // Send message
             zen_mail($send_to_name, $send_to_email, EMAIL_SUBJECT, $text_message, $name, $email_address, $html_msg, 'contact_us');


### PR DESCRIPTION
Telephone is included in the text email, but not the html version.
Also, there are brackets around the email address for no apparent reason.
Before
![image](https://github.com/user-attachments/assets/9cbf790d-f8d4-49ec-aac0-550ef45d0818)

After
![image](https://github.com/user-attachments/assets/2d470dc7-46b1-450b-a8af-51d97b670fe9)



