### PR TITLE
Fix code scanning alert no. 9: DOM text reinterpreted as HTML

### DIFF
--- a/zc_plugins/POSM/v6.0.0/catalog/includes/templates/default/jscript/jquery.posm_dependencies.js
+++ b/zc_plugins/POSM/v6.0.0/catalog/includes/templates/default/jscript/jquery.posm_dependencies.js
@@ -34,6 +34,24 @@ $(function(){
     // 8. attribImgSelector.  Identifies the selector for attributes' images' blocks' wrapper.
     // 9. showModelNum.  Identifies whether/not each variant's model-number is shown when the final attribute choices are displayed.
     //
+    function escapeHtml(unsafe) {
+        return unsafe.replace(/[&<"']/g, function (m) {
+            switch (m) {
+                case '&':
+                    return '&amp;';
+                case '<':
+                    return '&lt;';
+                case '>':
+                    return '&gt;';
+                case '"':
+                    return '&quot;';
+                case "'":
+                    return '&#039;';
+                default:
+                    return m;
+            }
+        });
+    }
     let firstGroup = null;
     let firstGroupIsImage = false;
     let optionID = 0;
@@ -438,7 +456,7 @@ $(function(){
             if ($(this).find(inputTypes).length > 0) {
                 if ($(this).find('option:selected, input[type="radio"]:checked').length === 0 || $(this).find('option[value=0]:selected').length !== 0) {
                     submitAllowed = false;
-                    let optionName = $(this).find(optionNameSelector).text().replace(/:/g, '');
+                    let optionName = escapeHtml($(this).find(optionNameSelector).text().replace(/:/g, ''));
                     $(this).find(optionNameSelector).after('<span class="posm-error">' + noSelectionText + optionName + '<\/span>');
                 }
             }


### PR DESCRIPTION
Fixes [https://github.com/zencart/zencart/security/code-scanning/9](https://github.com/zencart/zencart/security/code-scanning/9)

To fix the problem, we need to ensure that any user-controlled data is properly escaped before being inserted into the DOM as HTML. This can be achieved by using a function that escapes special HTML characters, thereby preventing the execution of any injected scripts.

The best way to fix this issue without changing existing functionality is to create a utility function that escapes HTML characters and use it to sanitize the `optionName` before concatenating it into the HTML string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
