### PR TITLE
Changing admin image display to size via CSS instead of HTML attribute for products

### DIFF
--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -951,7 +951,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
                         <?= $product['products_name'] ?>
                     </a>
                 </td>
-                <td class="hidden-sm hidden-xs imageView <?= $additionalClass ?>"><?= zen_image(DIR_WS_CATALOG_IMAGES . zen_get_products_image($product['products_id']),'', IMAGE_SHOPPING_CART_WIDTH, IMAGE_SHOPPING_CART_HEIGHT) ?></td>
+                <td class="hidden-sm hidden-xs imageView <?= $additionalClass ?>"><?= zen_image(DIR_WS_CATALOG_IMAGES . zen_get_products_image($product['products_id']),'', IMAGE_SHOPPING_CART_WIDTH, IMAGE_SHOPPING_CART_HEIGHT, 'style="object-fit: contain;"') ?></td>
                 <td class="hidden-sm hidden-xs"><?= $product['products_model'] ?></td>
                 <td class="text-right hidden-sm hidden-xs"><?= zen_get_products_display_price($product['products_id']) . $products_wholesale_indicator ?></td>
 <?php

--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -701,7 +701,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
                       <a href="<?= zen_catalog_href_link('index', zen_get_path($category['categories_id'])) ?>" rel="noopener" target="_blank" title="<?= BOX_HEADING_CATALOG ?>"><?= zen_icon('popup', BOX_HEADING_CATALOG, '') ?></a>
                   <a href="<?= zen_href_link(FILENAME_CATEGORY_PRODUCT_LISTING, zen_get_path($category['categories_id'])) ?>" class="folder"><i class="fa-solid fa-lg fa-folder"></i>&nbsp;<strong><?= $category['categories_name'] ?></strong></a>
                 </td>
-                  <td class="hidden-sm hidden-xs imageView <?= $additionalClass ?>"><?= zen_image(DIR_WS_CATALOG_IMAGES . $category['categories_image'], $category['categories_name'], IMAGE_SHOPPING_CART_WIDTH, IMAGE_SHOPPING_CART_HEIGHT, 'style="object-fit: contain;"') ?></td>
+                  <td class="hidden-sm hidden-xs imageView <?= $additionalClass ?>"><?= zen_image(DIR_WS_CATALOG_IMAGES . $category['categories_image'], $category['categories_name'], IMAGE_SHOPPING_CART_WIDTH, IMAGE_SHOPPING_CART_HEIGHT, 'class="object-fit-contain"') ?></td>
                 <?php if ($show_prod_labels) { ?>
                   <td class="hidden-sm hidden-xs"><!-- no model for categories --></td>
                   <td class="hidden-sm hidden-xs"><!-- no price for categories --></td>
@@ -951,7 +951,7 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
                         <?= $product['products_name'] ?>
                     </a>
                 </td>
-                <td class="hidden-sm hidden-xs imageView <?= $additionalClass ?>"><?= zen_image(DIR_WS_CATALOG_IMAGES . zen_get_products_image($product['products_id']),'', IMAGE_SHOPPING_CART_WIDTH, IMAGE_SHOPPING_CART_HEIGHT, 'style="object-fit: contain;"') ?></td>
+                <td class="hidden-sm hidden-xs imageView <?= $additionalClass ?>"><?= zen_image(DIR_WS_CATALOG_IMAGES . zen_get_products_image($product['products_id']),'', IMAGE_SHOPPING_CART_WIDTH, IMAGE_SHOPPING_CART_HEIGHT, 'class="object-fit-contain"') ?></td>
                 <td class="hidden-sm hidden-xs"><?= $product['products_model'] ?></td>
                 <td class="text-right hidden-sm hidden-xs"><?= zen_get_products_display_price($product['products_id']) . $products_wholesale_indicator ?></td>
 <?php

--- a/admin/includes/css/stylesheet.css
+++ b/admin/includes/css/stylesheet.css
@@ -1199,6 +1199,21 @@ tbody>tr>td.align-bottom {
     padding-bottom: 3rem !important;
     padding-top: 3rem !important;
 }
+.object-fit-contain {
+    object-fit: contain;
+}
+.object-fit-cover {
+    object-fit: cover;
+}
+.object-fit-fill {
+    object-fit: fill;
+}
+.object-fit-scale {
+    object-fit: scale-down;
+}
+.object-fit-none {
+    object-fit: none;
+}
 /**/
 
 /* CKEditor */


### PR DESCRIPTION
In my other edit (#6793), I made this change to allow the images displayed to keep their proportions. I failed to realize I had only changed the category icon in that edit. This change now makes the same change for the images of the product listing rows.

(Duplicate of #6863, since other edits were added. This PR is the correct one to use since it only contains just the one edit.)