### PR TITLE
Change description of MFA to add "Zen Cart" suffix, for disambiguation

### DIFF
--- a/admin/includes/functions/functions_mfa.php
+++ b/admin/includes/functions/functions_mfa.php
@@ -89,7 +89,8 @@ function zen_mfa_by_totp(array $admin_info = []): bool
         $_SESSION['mfa'] = [];
     }
 
-    $domain = str_replace(['http'.'://', 'https://'], '', HTTP_SERVER);
+    $domain = str_replace(['http'.'://', 'https://'], '', HTTP_SERVER) . ' - Zen Cart';
+    $domain = defined('MFA_DESCRIPTIVE_NAME') ? MFA_DESCRIPTIVE_NAME : $domain;
 
     $ga = new MultiFactorAuth();
 
@@ -97,7 +98,7 @@ function zen_mfa_by_totp(array $admin_info = []): bool
     $secret = !empty($user_mfa_data['secret']) ? $user_mfa_data['secret'] : $ga->createSecret();
     if (empty($user_mfa_data['secret'])) {
         $_SESSION['mfa']['secret_not_yet_persisted'] = true;
-        $qrCode = $ga->getQrCode(STORE_NAME . " - ZenCart", $secret, $admin_info['admin_name'] ?? '', 200);
+        $qrCode = $ga->getQrCode($domain, $secret, $admin_info['admin_name'] ?? '', 200);
         $_SESSION['mfa']['qrcode'] = $qrCode;
     }
 

--- a/admin/includes/functions/functions_mfa.php
+++ b/admin/includes/functions/functions_mfa.php
@@ -90,7 +90,7 @@ function zen_mfa_by_totp(array $admin_info = []): bool
     }
 
     $domain = str_replace(['http'.'://', 'https://'], '', HTTP_SERVER) . ' - Zen Cart';
-    $domain = defined('MFA_DESCRIPTIVE_NAME') ? MFA_DESCRIPTIVE_NAME : $domain;
+    $domain = defined('MFA_DESCRIPTIVE_NAME') && !empty(MFA_DESCRIPTIVE_NAME) ? MFA_DESCRIPTIVE_NAME : $domain;
 
     $ga = new MultiFactorAuth();
 

--- a/admin/includes/functions/functions_mfa.php
+++ b/admin/includes/functions/functions_mfa.php
@@ -97,7 +97,7 @@ function zen_mfa_by_totp(array $admin_info = []): bool
     $secret = !empty($user_mfa_data['secret']) ? $user_mfa_data['secret'] : $ga->createSecret();
     if (empty($user_mfa_data['secret'])) {
         $_SESSION['mfa']['secret_not_yet_persisted'] = true;
-        $qrCode = $ga->getQrCode($domain, $secret, $admin_info['admin_name'] ?? '', 200);
+        $qrCode = $ga->getQrCode(STORE_NAME . " - ZenCart", $secret, $admin_info['admin_name'] ?? '', 200);
         $_SESSION['mfa']['qrcode'] = $qrCode;
     }
 


### PR DESCRIPTION
Since a person can have multiple services installed on their domain which may use MFA, this edit changes the description of the MFA Handle to better represent what it entails.

In this case, it is the store's name (retrieved from the DB Constant `STORE_NAME`) and the name of the software (ZenCart). For example: if the store's name is "Blockbuster Video", when you scan the MFA QR Code, it will show as "Blockbuster Video - ZenCart" in the MFA tool. This change does NOT affect any already issued MFA tokens as it is only changing the Issuer field and does not touch anything of the issued Secret.