### PR TITLE
admin/banner_manager:  Stop trying to select a non-existent banner

### DIFF
--- a/admin/banner_manager.php
+++ b/admin/banner_manager.php
@@ -603,7 +603,7 @@ if (!empty($action)) {
                 $contents[] = ['align' => 'text-center', 'text' => '<button type="submit" class="btn btn-danger">' . IMAGE_DELETE . '</button> <a href="' . zen_href_link(FILENAME_BANNER_MANAGER, 'page=' . $_GET['page'] . '&bID=' . $_GET['bID']) . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>'];
                 break;
               default:
-                if (is_object($bInfo)) {
+                if (isset($bInfo) && is_object($bInfo)) {
                   $heading[] = ['text' => '<h4>' . $bInfo->banners_title . '</h4>'];
 
                   $contents[] = ['align' => 'text-center', 'text' => '<a href="' . zen_href_link(FILENAME_BANNER_MANAGER, 'page=' . $_GET['page'] . '&bID=' . $bInfo->banners_id . '&action=new') . '" class="btn btn-primary" role="button">' . IMAGE_EDIT . '</a> <a href="' . zen_href_link(FILENAME_BANNER_MANAGER, 'page=' . $_GET['page'] . '&bID=' . $bInfo->banners_id . '&action=del') . '" class="btn btn-warning" role="button">' . IMAGE_DELETE . '</a>'];


### PR DESCRIPTION
If no banners were available in the DB, the switch/if statement would still try to pull info from an empty or unset variable `$bInfo`.

This change stops that effort by seeing if `$bInfo` is set.