### PR TITLE
Creates a Notifier Hook on Config Change

### DIFF
--- a/admin/configuration.php
+++ b/admin/configuration.php
@@ -35,6 +35,9 @@ if (!empty($action)) {
                               LIMIT 1");
       zen_record_admin_activity('Configuration setting changed for ' . $result->fields['configuration_key'] . ': ' . $configuration_value, 'warning');
 
+      // Send a notifier that a configuration change has been made
+      $zco_notifier->notify('NOTIFY_ADMIN_CONFIG_CHANGE', $result->fields['configuration_key']);
+
       // set the WARN_BEFORE_DOWN_FOR_MAINTENANCE to false if DOWN_FOR_MAINTENANCE = true
       if ((WARN_BEFORE_DOWN_FOR_MAINTENANCE == 'true') && (DOWN_FOR_MAINTENANCE == 'true')) {
         $db->Execute("UPDATE " . TABLE_CONFIGURATION . "


### PR DESCRIPTION
This may be possible in other ways, but the creates a hook when a setting in the Configuration Table has been changed by the admin area. It won't pick up if the change is performed by script, SQL import, or other external means).

Some ideas might be if the measuring weight or store's measurement standard has been allowed for all items in the store to be changed quickly. Or if the location itself has changed as well.