### PR TITLE
Fix misspelling in notifier hook name

### DIFF
--- a/admin/invoice.php
+++ b/admin/invoice.php
@@ -204,7 +204,7 @@ if (empty($order->info)) {
           //   'NOTIFY_ADMIN_INVOICE_DATA_AFTER_TAX' notification.
           //
           $extra_headings = false;
-          $zco_notifier->notify('NOTIFY_ADMIN_INVOIVE_HEADERS_AFTER_TAX', '', $extra_headings);
+          $zco_notifier->notify('NOTIFY_ADMIN_INVOICE_HEADERS_AFTER_TAX', '', $extra_headings);
           if (is_array($extra_headings)) {
               foreach ($extra_headings as $heading_info) {
                   $align = (isset($heading_info['align'])) ? (' text-' . $heading_info['align']) : '';

--- a/includes/classes/traits/NotifierManager.php
+++ b/includes/classes/traits/NotifierManager.php
@@ -12,11 +12,12 @@ use Zencart\Events\EventDto;
 trait NotifierManager
 {
     /**
-     * @var array of aliases
+     * Array of notifier aliases (where Notifier hook names have been renamed, such as for minor misspellings)
+     * In your own application code, you may add to this list by calling $this->registerObserverAlias($old,$new)
      */
     private array $observerAliases = [
-        // this one is an alias to accommodate an old misspelling:
         'NOTIFIY_ORDER_CART_SUBTOTAL_CALCULATE' => 'NOTIFY_ORDER_CART_SUBTOTAL_CALCULATE',
+        'NOTIFY_ADMIN_INVOIVE_HEADERS_AFTER_TAX' => 'NOTIFY_ADMIN_INVOICE_HEADERS_AFTER_TAX',
     ];
 
     public function getRegisteredObservers(): array

--- a/includes/classes/traits/NotifierManager.php
+++ b/includes/classes/traits/NotifierManager.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @copyright Copyright 2003-2024 Zen Cart Development Team
+ * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: DrByte 2024 May 22 Modified in v2.1.0-alpha1 $
+ * @version $Id: DrByte 2025 Jan 02  $
  */
 
 namespace Zencart\Traits;


### PR DESCRIPTION
Fixes #6896
Ref #4518

NOTE: Documentation is needed in release notes, as existing plugins or custom modifications may be impacted. (Fix is a simple search-replace in one's code-base)