### PR TITLE
add override ability for upper menu items

### DIFF
--- a/admin/includes/header.php
+++ b/admin/includes/header.php
@@ -225,12 +225,50 @@ if (defined('MODULE_ORDER_TOTAL_GV_SHOW_QUEUE_IN_ADMIN') && MODULE_ORDER_TOTAL_G
     </div>
     <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4 noprint">
         <ul class="nav nav-pills upperMenu">
-            <li><a href="<?php echo zen_href_link(FILENAME_DEFAULT, '', 'NONSSL'); ?>" class="headerLink"><?php echo HEADER_TITLE_TOP; ?></a></li>
-            <li><a href="<?php echo zen_catalog_href_link(FILENAME_DEFAULT); ?>" class="headerLink" rel="noopener" target="_blank"><?php echo HEADER_TITLE_ONLINE_CATALOG; ?></a></li>
-            <li><a href="https://www.zen-cart.com/forum" class="headerLink" rel="noopener" target="_blank"><?php echo HEADER_TITLE_SUPPORT_SITE; ?></a></li>
-            <li><a href="<?php echo zen_href_link(FILENAME_SERVER_INFO, '', 'NONSSL'); ?>" class="headerLink"><?php echo HEADER_TITLE_VERSION; ?></a></li>
-            <li><a href="<?php echo zen_href_link(FILENAME_ADMIN_ACCOUNT, '', 'NONSSL'); ?>" class="headerLink"><?php echo HEADER_TITLE_ACCOUNT; ?></a></li>
-            <li><a href="<?php echo zen_href_link(FILENAME_LOGOFF, '', 'NONSSL'); ?>" class="headerLink"><?php echo HEADER_TITLE_LOGOFF; ?></a></li>
+        <?php
+        $upperMenuArray = [
+            [
+                'a' => zen_href_link(FILENAME_DEFAULT),
+                'params' => 'class="headerLink"',
+                'title' => HEADER_TITLE_TOP,
+            ],
+            [
+                'a' => zen_catalog_href_link(FILENAME_DEFAULT),
+                'params' => 'class="headerLink" rel="noopener" target="_blank"',
+                'title' => HEADER_TITLE_ONLINE_CATALOG,
+            ],
+            [
+                'a' => 'https://www.zen-cart.com/forum',
+                'params' => 'class="headerLink"',
+                'title' => HEADER_TITLE_SUPPORT_SITE,
+            ],
+            [
+                'a' => zen_href_link(FILENAME_SERVER_INFO),
+                'params' => 'class="headerLink"',
+                'title' => HEADER_TITLE_VERSION,
+            ],
+            [
+                'a' => zen_href_link(FILENAME_ADMIN_ACCOUNT),
+                'params' => 'class="headerLink"',
+                'title' => HEADER_TITLE_ACCOUNT,
+            ],
+            [
+                'a' => zen_href_link(FILENAME_LOGOFF),
+                'params' => 'class="headerLink"',
+                'title' => HEADER_TITLE_LOGOFF,
+            ],
+        ];
+        $upperMenuOverrideArray = '';
+        $zco_notifier->notify('NOTIFY_ADMIN_HEADER_UPPERMENU', $upperMenuArray, $upperMenuOverrideArray);
+        if (!empty($upperMenuOverrideArray) && is_array($upperMenuOverrideArray)) {
+            $upperMenuArray = $upperMenuOverrideArray;
+        }
+        foreach ($upperMenuArray as $upperMenu) {
+        ?>
+            <li><a href="<?= $upperMenu['a'] . '" ' . ($upperMenu['params'] ?? 'class="headerLink"') . '>' . $upperMenu['title'] ?></a></li>
+            <?php
+                }
+                ?>
         </ul>
     </div>
   </div>

--- a/admin/includes/header_navigation.php
+++ b/admin/includes/header_navigation.php
@@ -32,13 +32,14 @@ $menuTitles = zen_get_menu_titles();
                 <?php } ?>
               </ul>
             </li>
-          <?php } ?>
-          <li class="upperMenuItems"><a href="<?php echo zen_href_link(FILENAME_DEFAULT, '', 'NONSSL'); ?>" class="headerLink"><?php echo HEADER_TITLE_TOP; ?></a></li>
-          <li class="upperMenuItems"><a href="<?php echo zen_catalog_href_link(FILENAME_DEFAULT); ?>" class="headerLink" rel="noopener" target="_blank"><?php echo HEADER_TITLE_ONLINE_CATALOG; ?></a></li>
-          <li class="upperMenuItems"><a href="https://www.zen-cart.com/forum" class="headerLink" rel="noopener" target="_blank"><?php echo HEADER_TITLE_SUPPORT_SITE; ?></a></li>
-          <li class="upperMenuItems"><a href="<?php echo zen_href_link(FILENAME_SERVER_INFO, '', 'NONSSL'); ?>" class="headerLink"><?php echo HEADER_TITLE_VERSION; ?></a></li>
-          <li class="upperMenuItems"><a href="<?php echo zen_href_link(FILENAME_ADMIN_ACCOUNT, '', 'NONSSL'); ?>" class="headerLink"><?php echo HEADER_TITLE_ACCOUNT; ?></a></li>
-          <li class="upperMenuItems"><a href="<?php echo zen_href_link(FILENAME_LOGOFF, '', 'NONSSL'); ?>" class="headerLink"><?php echo HEADER_TITLE_LOGOFF; ?></a></li>
+          <?php
+          }
+          foreach ($upperMenuArray as $upperMenu) {
+          ?>
+          <li class="upperMenuItems"><a href="<?= $upperMenu['a'] . '" '. ($upperMenu['params'] ?? 'class="headerLink"') . '>' . $upperMenu['title'] ?></a></li>
+          <?php
+              }
+              ?>
     </ul>
   </div><!-- /.navbar-collapse -->
 </nav>


### PR DESCRIPTION
this PR does 2 things:

- removes duplicate code so that items do not have to match every time we want to change the upper menu items.
- adds the ability to override those links via a notifier.

admins want quick links to get where they want to go.  this PR will allow people to customize those links to their choosing as opposed to the maintainers choosing.