### PR TITLE
Correct PHP warning for empty shipping quote returned

### DIFF
--- a/includes/classes/shipping.php
+++ b/includes/classes/shipping.php
@@ -259,7 +259,7 @@ class shipping
                     $quotes['tax'] = 0;
                 }
                 $shipping_weight = $save_shipping_weight;
-                if (is_array($quotes)) {
+                if (!empty($quotes) && is_array($quotes)) {
                     $quotes_array[] = $quotes;
                 }
             }

--- a/includes/templates/template_default/templates/tpl_checkout_shipping_default.php
+++ b/includes/templates/template_default/templates/tpl_checkout_shipping_default.php
@@ -63,7 +63,7 @@
       // bof: field set
 // allows FedEx to work comment comment out Standard and Uncomment FedEx
 //      if ($quotes[$i]['id'] != '' || $quotes[$i]['module'] != '') { // FedEx
-      if ($quotes[$i]['module'] != '') { // Standard
+      if (!empty($quotes[$i]['module'])) { // Standard
 ?>
 <fieldset>
 <legend><?php echo $quotes[$i]['module']; ?>&nbsp;<?php if (isset($quotes[$i]['icon']) && !empty($quotes[$i]['icon'])) { echo $quotes[$i]['icon']; } ?></legend>


### PR DESCRIPTION
If a shipping module returns an empty array for its quotes, a PHP warning is issued:
```
[03-Jan-2025 23:17:03 America/Chicago] Request URI: /index.php?main_page=checkout_shipping, IP address: xx.xx.xx.xx, Language id 1
#0 /includes/templates/template_default/templates/tpl_checkout_shipping_default.php(66): zen_debug_error_handler()
#1 /includes/templates/responsive_classic/common/tpl_main_page.php(181): require('/home/mysite/...')
#2 /index.php(94): require('/home/mysite/...')
--> PHP Warning: Undefined array key "module" in /includes/templates/template_default/templates/tpl_checkout_shipping_default.php on line 66.
```
This can be triggered by configuring the `zones.php` shipping module with a single zone to offer a fixed-price to any non-US-destined order:

![image](https://github.com/user-attachments/assets/eee083ed-c4d6-4120-8114-793a786c119f)
