### PR TITLE
Fix !!empty() to empty()

### DIFF
--- a/admin/sqlpatch.php
+++ b/admin/sqlpatch.php
@@ -454,7 +454,7 @@ function zen_drop_index_command($param) {
   }
   //this is only slightly different from the ALTER TABLE DROP INDEX command
   global $db;
-  if (!!empty($param)) {
+  if (empty($param)) {
     return "Empty SQL Statement";
   }
   $index = $param[2];
@@ -479,7 +479,7 @@ function zen_create_index_command($param) {
     return sprintf(REASON_NO_PRIVILEGES, 'INDEX');
   }
   global $db;
-  if (!!empty($param)) {
+  if (empty($param)) {
     return "Empty SQL Statement";
   }
   $index = (strtoupper($param[1]) == 'INDEX') ? $param[2] : $param[3];
@@ -506,7 +506,7 @@ function zen_create_index_command($param) {
 
 function zen_check_alter_command($param) {
   global $db;
-  if (!!empty($param)) {
+  if (empty($param)) {
     return "Empty SQL Statement";
   }
   if (!$checkprivs = zen_check_database_privs('ALTER')) {

--- a/includes/classes/http_client.php
+++ b/includes/classes/http_client.php
@@ -298,7 +298,7 @@ if (!defined('IS_ADMIN_FLAG')) {
           $port = $this->url['port'];
         }
 
-        if (!!empty($port)) $port = 80;
+        if (empty($port)) $port = 80;
 
         if (!$this->socket = @fsockopen($host, $port, $this->reply, $this->replyString, $this->timeout)) {
           return false;

--- a/includes/classes/upload.php
+++ b/includes/classes/upload.php
@@ -39,7 +39,7 @@ class upload extends base
         $this->set_destination($destination);
         $this->set_permissions($permissions);
 
-        if (!!empty($extensions)) {
+        if (empty($extensions)) {
             $extensions = explode(" ", preg_replace('/[.,;\s]+/', ' ', UPLOAD_FILENAME_EXTENSIONS_LIST));
         }
         $this->set_extensions($extensions);


### PR DESCRIPTION
In commit 3f13e22bd98fadff3516d3c44428c59367523bc3 
which was focused on migrating from zen_not_null() to empty(), 
the copy and replace had a small issue in a handful of places: 

`!zen_not_null()`

was changed to 

`!!empty()`.

This PR simplifies those changes to just `empty()` (since !!empty is the same as empty).

Credit to @lat9 for finding this issue.