### PR TITLE
remove hard coded zc_install

### DIFF
--- a/zc_install/includes/systemChecks.yml
+++ b/zc_install/includes/systemChecks.yml
@@ -151,7 +151,7 @@ systemChecks:
     methods:
       checkWriteableDir:
         parameters:
-          fileDir: <?php echo DIR_FS_ROOT . 'zc_install/includes/nginx_conf' . PHP_EOL; ?>
+          fileDir: <?php echo DIR_FS_INSTALL . 'includes/nginx_conf' . PHP_EOL; ?>
   htaccessSupport:
     runLevel: always
     errorLevel: WARN


### PR DESCRIPTION
we should not be hard coding directories when there is a constant defined for where we are.