### PR TITLE
Prevent log while editing current admin user

### DIFF
--- a/admin/users.php
+++ b/admin/users.php
@@ -108,7 +108,7 @@ switch ($action) {
         }
         break;
     case 'update': // update existing user's details in database. Post data is prep'd for db in the first function call
-        $errors = zen_update_user($_POST['name'], $_POST['email'], $_POST['id'], $_POST['profile']);
+        $errors = zen_update_user($_POST['name'], $_POST['email'], $_POST['id'], $_POST['profile'] ?? 0);
         if (count($errors) > 0) {
             foreach ($errors as $error) {
                 $messageStack->add($error, 'error');


### PR DESCRIPTION
```
[25-Jan-2025 12:04:40 UTC] Request URI: /gh_demo_200/admin/index.php?cmd=users, IP address: ::1, Language id 1
#0 /Users/scott/Sites/gh_demo_200/admin/users.php(111): zen_debug_error_handler()
#1 /Users/scott/Sites/gh_demo_200/admin/index.php(16): require('/Users/scott/Si...')
--> PHP Warning: Undefined array key "profile" in /Users/scott/Sites/gh_demo_200/admin/users.php on line 111.

```

Reproduction: 
- login to admin 
- Admins > Admin Users > Edit (on currently logged in account)
- change the username, then save

Profile is not passed in when current user is being edited.