### PR TITLE
Send password-reset URL instead of new password

### DIFF
--- a/admin/includes/languages/english/lang.configuration.php
+++ b/admin/includes/languages/english/lang.configuration.php
@@ -61,6 +61,7 @@ $define = [
     'TEXT_MAX_ADMIN_DISPLAY_SEARCH_RESULTS_FEATURED_ADMIN_LENGTH' => 'Value must be an integer.',
     'TEXT_MAX_ADMIN_DISPLAY_SEARCH_RESULTS_FEATURED_LENGTH' => 'Value must be an integer.',
     'TEXT_MAX_ADMIN_DISPLAY_SEARCH_RESULTS_FEATURED_PRODUCTS_LENGTH' => 'Value must be an integer.',
+    'TEXT_MAX_ADMIN_RANDOM_SELECT_FEATURED_CATEGORIES_LENGTH' => 'Value must be an integer.',
     'TEXT_MAX_ADMIN_RANDOM_SELECT_FEATURED_PRODUCTS_LENGTH' => 'Value must be an integer.',
     'TEXT_MAX_ADMIN_DISPLAY_SPECIAL_PRODUCTS_INDEX_LENGTH' => 'Value must be an integer.',
     'TEXT_MAX_ADMIN_SHOW_NEW_PRODUCTS_LIMIT_LENGTH' => 'Value must be an integer.',
@@ -70,6 +71,8 @@ $define = [
     'TEXT_MAX_ADMIN_DISPLAY_PRODUCTS_TO_CATEGORIES_COLUMNS_LENGTH' => 'Value must be an integer.',
     'TEXT_MAX_ADMIN_DISPLAY_SEARCH_RESULTS_EZPAGE_LENGTH' => 'Value must be an integer.',
     'TEXT_MAX_PREVIEW' => 'Value must be an integer.',
+    'TEXT_HINT_PASSWORD_RESET_TOKEN_LENGTH' => 'Value must be an integer between 12-100.',
+    'TEXT_HINT_PASSWORD_RESET_TOKEN_VALID_MINUTES' => 'Value must be an integer between 1-1440.',
 ];
 
 return $define;

--- a/includes/classes/class.zcPassword.php
+++ b/includes/classes/class.zcPassword.php
@@ -123,12 +123,13 @@ class zcPassword extends base
   /**
    * Update a logged in Customer password.
    * e.g. when customer wants to change password
+   * Also used with password_reset page when reset_token links to a customer_id
    *
    * @param string $plain
-   * @param integer $customerId
+   * @param ?integer $customerId
    * @return string
    */
-  public function updateLoggedInCustomerPassword($plain, $customerId)
+  public function updateLoggedInCustomerPassword(string $plain, ?int $customerId): string
   {
     $this->confirmDbSchema('customer');
     global $db;
@@ -137,7 +138,7 @@ class zcPassword extends base
               SET customers_password = :password:
               WHERE customers_id = :customersId:";
 
-    $sql = $db->bindVars($sql, ':customersId:', $_SESSION ['customer_id'], 'integer');
+    $sql = $db->bindVars($sql, ':customersId:', $customerId ?? $_SESSION['customer_id'] ?? 0, 'integer');
     $sql = $db->bindVars($sql, ':password:', $updatedPassword, 'string');
     $db->Execute($sql);
     return $updatedPassword;

--- a/includes/database_tables.php
+++ b/includes/database_tables.php
@@ -47,6 +47,7 @@ define('TABLE_CUSTOMERS_BASKET_ATTRIBUTES', DB_PREFIX . 'customers_basket_attrib
 define('TABLE_CUSTOMERS_INFO', DB_PREFIX . 'customers_info');
 define('TABLE_CUSTOMER_GROUPS', DB_PREFIX . 'customer_groups');
 define('TABLE_CUSTOMERS_TO_GROUPS', DB_PREFIX . 'customers_to_groups');
+define('TABLE_CUSTOMER_PASSWORD_RESET_TOKENS', DB_PREFIX . 'customer_password_reset_tokens');
 define('TABLE_DB_CACHE', DB_PREFIX . 'db_cache');
 define('TABLE_EMAIL_ARCHIVE', DB_PREFIX . 'email_archive');
 define('TABLE_EZPAGES', DB_PREFIX . 'ezpages');

--- a/includes/filenames.php
+++ b/includes/filenames.php
@@ -126,6 +126,7 @@ define('FILENAME_PAGE_2', 'page_2');
 define('FILENAME_PAGE_3', 'page_3');
 define('FILENAME_PAGE_4', 'page_4');
 define('FILENAME_PASSWORD_FORGOTTEN', 'password_forgotten');
+define('FILENAME_PASSWORD_RESET', 'password_reset');
 define('FILENAME_PLUGIN_MANAGER', 'plugin_manager');
 define('FILENAME_POPUP_COUPON_HELP', 'popup_coupon_help');
 define('FILENAME_POPUP_IMAGE', 'popup_image');

--- a/includes/languages/english/lang.password_forgotten.php
+++ b/includes/languages/english/lang.password_forgotten.php
@@ -3,10 +3,12 @@ $define = [
     'NAVBAR_TITLE_1' => 'Login',
     'NAVBAR_TITLE_2' => 'Password Forgotten',
     'HEADING_TITLE' => 'Forgotten Password',
-    'TEXT_MAIN' => 'Enter your email address below and we\'ll send you an email message containing your new password.',
-    'EMAIL_PASSWORD_REMINDER_SUBJECT' => STORE_NAME . ' - New Password',
-    'EMAIL_PASSWORD_REMINDER_BODY' => 'A new password was requested from ' . $_SERVER['REMOTE_ADDR'] . '.' . "\n\n" . 'Your new password to \'' . STORE_NAME . '\' is:' . "\n\n" . '   %s' . "\n\nAfter you have logged in using the new password, you may change it by going to the 'My Account' area.",
-    'SUCCESS_PASSWORD_SENT' => 'Thank you. If that email address is in our system, we will send password recovery instructions to that email address (remember to check your Spam folder)',
+    'TEXT_MAIN' => "Enter your email address below and we'll send you instructions on how to reset your password.",
+
+    'EMAIL_PASSWORD_RESET_SUBJECT' => '%%STORE_NAME%% - Password Reset',
+    'EMAIL_PASSWORD_RESET_BODY' => "A password reset was requested from %1s. \n\nTo reset your password for '%2s' please visit the following URL:\n\n%3s \n\n",
+
+    'SUCCESS_PASSWORD_RESET_SENT' => 'Thank you. If that email address is in our system, we will send password recovery instructions to that email address (remember to check your Spam folder)',
 ];
 
 return $define;

--- a/includes/languages/english/lang.password_reset.php
+++ b/includes/languages/english/lang.password_reset.php
@@ -1,0 +1,12 @@
+<?php
+$define = [
+    'NAVBAR_TITLE_1' => 'Login',
+    'NAVBAR_TITLE_2' => 'Password Reset',
+    'HEADING_TITLE' => 'Password Reset',
+
+    'PASSWORD_RESET_ENTRY_PASSWORD_TOKEN_ERROR' => 'Your password cannot be reset at this time. Invalid or expired token. Please ensure that you have copied the URL exactly as it appears in the email that you received.',
+    'PASSWORD_RESET_SUCCESS_PASSWORD_UPDATED' =>'Your password has been successfully updated. Please login using your email address and the password you have just created.',
+
+];
+
+return $define;

--- a/includes/modules/pages/password_reset/header_php.php
+++ b/includes/modules/pages/password_reset/header_php.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * @copyright Copyright 2003-2025 Zen Cart Development Team
+ * @copyright Portions Copyright 2003 osCommerce
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: header_php.php  $
+ *
+ * @var queryFactory $db
+ * @var messageStack $messageStack
+ * @var breadcrumb $breadcrumb
+ * @var notifier $zco_notifier
+ * @var sniffer $sniffer
+ */
+
+// This should be first line of the script:
+$zco_notifier->notify('NOTIFY_HEADER_START_ACCOUNT_PASSWORD_RESET');
+
+require DIR_WS_MODULES . zen_get_module_directory('require_languages.php');
+
+$error = false;
+$token_error = false;
+
+$reset_token = $db->prepare_input($_GET['reset_token'] ?? $_POST['reset_token'] ?? '');
+
+$token_valid_minutes = defined('PASSWORD_RESET_TOKEN_MINUTES_VALID') ? (int)constant('PASSWORD_RESET_TOKEN_MINUTES_VALID') : 60;
+if ($token_valid_minutes < 1 || $token_valid_minutes > 1440) {
+    $token_valid_minutes = 60;
+}
+
+$sql = "SELECT c.customers_nick, c.customers_id
+        FROM   " . TABLE_CUSTOMERS . " c, " . TABLE_CUSTOMER_PASSWORD_RESET_TOKENS . " ct
+        WHERE  ct.token = :reset_token AND c.customers_id = ct.customer_id AND ct.created_at > DATE_SUB(CURRENT_TIMESTAMP, INTERVAL $token_valid_minutes MINUTE)";
+$sql = $db->bindVars($sql, ':reset_token', $reset_token, 'string');
+$result = $db->Execute($sql);
+
+if (empty($result->fields['customers_id'])) {
+    // no matching token found within date range of unexpired tokens
+    $messageStack->add('reset_password', PASSWORD_RESET_ENTRY_PASSWORD_TOKEN_ERROR);
+    $error = true;
+    $token_error = true;
+} else {
+    $customer_id = $result->fields['customers_id'];
+    $nickname = $result->fields['customers_nick'];
+}
+
+if (isset($_POST['action']) && ($_POST['action'] === 'process') && !empty($customer_id)) {
+    $password_new = zen_db_prepare_input($_POST['password_new']);
+    $password_confirmation = zen_db_prepare_input($_POST['password_confirmation']);
+
+    $error = false;
+
+    if (strlen($password_new) < ENTRY_PASSWORD_MIN_LENGTH) {
+        $error = true;
+        $messageStack->add('reset_password', ENTRY_PASSWORD_NEW_ERROR);
+    } elseif ($password_new !== $password_confirmation) {
+        $error = true;
+        $messageStack->add('reset_password', ENTRY_PASSWORD_NEW_ERROR_NOT_MATCHING);
+    }
+
+    if ($error === false) {
+        zcPassword::getInstance(PHP_VERSION)->updateLoggedInCustomerPassword($password_new, $customer_id);
+
+        $sql = "UPDATE " . TABLE_CUSTOMERS_INFO . "
+                SET customers_info_date_account_last_modified = now()
+                WHERE customers_info_id = :customersID";
+        $sql = $db->bindVars($sql, ':customersID', $customer_id, 'integer');
+        $db->Execute($sql);
+
+        $sql = "DELETE FROM " . TABLE_CUSTOMER_PASSWORD_RESET_TOKENS . " WHERE customer_id = :customerID";
+        $sql = $db->bindVars($sql, ':customerID', $customer_id, 'integer');
+        $db->Execute($sql);
+
+        $messageStack->add_session('login', PASSWORD_RESET_SUCCESS_PASSWORD_UPDATED, 'success');
+
+        // handle 3rd-party integrations
+        // same notifier as main_page=account_password
+        $zco_notifier->notify('NOTIFY_HEADER_ACCOUNT_PASSWORD_CHANGED', $customer_id, $password_new, $nickname);
+
+        zen_redirect(zen_href_link(FILENAME_LOGIN, '', 'SSL'));
+    }
+}
+
+// This should be last line of the script:
+$zco_notifier->notify('NOTIFY_HEADER_END_PASSWORD_RESET');

--- a/includes/modules/pages/password_reset/jscript_form_check.php
+++ b/includes/modules/pages/password_reset/jscript_form_check.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * jscript_form_check
+ *
+ * @copyright Copyright 2003-2025 Zen Cart Development Team
+ * @copyright Portions Copyright 2003 osCommerce
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: Added in v2.2.0 $
+ */
+
+require $template->get_template_dir('zen_jscript_form_check.php', DIR_WS_TEMPLATE, $current_page_base, 'jscript') . '/zen_jscript_form_check.php';

--- a/includes/templates/template_default/templates/tpl_password_reset_default.php
+++ b/includes/templates/template_default/templates/tpl_password_reset_default.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Loaded automatically by index.php?main_page=password_reset.<br />
+ * Allows customer to change their password via a requested reset_token
+ *
+ * @copyright Copyright 2003-2025 Zen Cart Development Team
+ * @copyright Portions Copyright 2003 osCommerce
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: tpl_password_reset_default.php $
+ *
+ *  NOTE: changes made to this file should also be made in tpl_account_password_default.php where relevant
+ */
+
+?>
+<div class="centerColumn" id="passwordReset">
+    <h1><?= HEADING_TITLE ?></h1>
+    <?php
+    if ($messageStack->size('reset_password') > 0) {
+        echo $messageStack->output('reset_password');
+    } ?>
+
+    <?php
+    if (!$token_error) {
+    ?>
+    <?= zen_draw_form('account_password', zen_href_link(FILENAME_PASSWORD_RESET, '', 'SSL'), 'post', 'onsubmit="return check_form(account_password);"') ?>
+    <?= zen_draw_hidden_field('action', 'process') ?>
+    <?= zen_draw_hidden_field('reset_token', $reset_token) ?>
+
+    <fieldset>
+        <div class="alert forward"><?= FORM_REQUIRED_INFORMATION ?></div>
+        <br class="clearBoth">
+
+        <label class="inputLabel" for="password-new"><?= ENTRY_PASSWORD_NEW ?></label>
+        <?= zen_draw_password_field('password_new', '', 'id="password-new" autocomplete="new-password" placeholder="' . ENTRY_PASSWORD_NEW_TEXT . '" required') ?>
+        <br class="clearBoth">
+
+        <label class="inputLabel" for="password-confirm"><?= ENTRY_PASSWORD_CONFIRMATION ?></label>
+        <?= zen_draw_password_field('password_confirmation', '', 'id="password-confirm" autocomplete="new-password" placeholder="' . ENTRY_PASSWORD_CONFIRMATION_TEXT . '" required') ?>
+        <br class="clearBoth">
+
+    </fieldset>
+    <div class="buttonRow forward"><?= zen_image_submit(BUTTON_IMAGE_SUBMIT, BUTTON_SUBMIT_ALT) ?></div>
+    <div class="buttonRow back"><?= '<a href="' . zen_href_link(FILENAME_ACCOUNT, '', 'SSL') . '">' . zen_image_button(BUTTON_IMAGE_BACK, BUTTON_BACK_ALT) . '</a>' ?></div>
+    </form>
+<?php
+}
+?>
+</div>

--- a/zc_install/sql/install/mysql_zencart.sql
+++ b/zc_install/sql/install/mysql_zencart.sql
@@ -718,6 +718,19 @@ CREATE TABLE customer_groups (
 );
 
 # --------------------------------------------------------
+#
+# Table structure for table 'customer_password_reset_tokens'
+#
+
+DROP TABLE IF EXISTS customer_password_reset_tokens;
+CREATE TABLE customer_password_reset_tokens (
+  customer_id int(11) NOT NULL default 0,
+  token varchar(100) NOT NULL default '',
+  created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY  (token, customer_id)
+);
+
+# --------------------------------------------------------
 
 #
 # Table structure for table customers_to_groups
@@ -2491,6 +2504,8 @@ INSERT INTO configuration (configuration_title, configuration_key, configuration
 INSERT INTO configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, last_modified, date_added, use_function, set_function) VALUES ('PA-DSS Admin Session Timeout Enforced?', 'PADSS_ADMIN_SESSION_TIMEOUT_ENFORCED', '1', 'PA-DSS Compliance requires that any Admin login sessions expire after 15 minutes of inactivity. <strong>Disabling this makes your site NON-COMPLIANT with PA-DSS rules, thus invalidating any certification.</strong>', 1, 30, now(), now(), NULL, 'zen_cfg_select_drop_down(array(array(\'id\'=>\'0\', \'text\'=>\'Non-Compliant\'), array(\'id\'=>\'1\', \'text\'=>\'On\')),');
 INSERT INTO configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, last_modified, date_added, use_function, set_function) VALUES ('PA-DSS Strong Password Rules Enforced?', 'PADSS_PWD_EXPIRY_ENFORCED', '1', 'PA-DSS Compliance requires that admin passwords must be changed after 90 days and cannot re-use the last 4 passwords. <strong>Disabling this makes your site NON-COMPLIANT with PA-DSS rules, thus invalidating any certification.</strong>', 1, 30, now(), now(), NULL, 'zen_cfg_select_drop_down(array(array(\'id\'=>\'0\', \'text\'=>\'Non-Compliant\'), array(\'id\'=>\'1\', \'text\'=>\'On\')),');
 INSERT INTO configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, last_modified, date_added, use_function, set_function) VALUES ('PA-DSS Ajax Checkout?', 'PADSS_AJAX_CHECKOUT', '1', 'PA-DSS Compliance requires that for some inbuilt payment methods, that we use ajax to draw the checkout confirmation screen. While this will only happen if one of those payment methods is actually present, some people may want the traditional checkout flow <strong>Disabling this makes your site NON-COMPLIANT with PA-DSS rules, thus invalidating any certification.</strong>', 1, 30, now(), now(), NULL, 'zen_cfg_select_drop_down(array(array(\'id\'=>\'0\', \'text\'=>\'Non-Compliant\'), array(\'id\'=>\'1\', \'text\'=>\'On\')),');
+INSERT INTO configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, last_modified, date_added, val_function) VALUES ('Password Reset Token Length', 'PASSWORD_RESET_TOKEN_LENGTH', '24', 'Number of characters in a generated password-reset token. Default is 24. Allowed: 12-100, but it affects the URL length, so 12-30 is most ideal', 1, 32, NULL, now(), '{\"error\":\"TEXT_HINT_PASSWORD_RESET_TOKEN_LENGTH\",\"id\":\"FILTER_VALIDATE_INT\",\"options\":{\"options\":{\"min_range\":10, \"max_range\":100}}}');
+INSERT INTO configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, last_modified, date_added, val_function) VALUES ('Password Reset Token Valid For', 'PASSWORD_RESET_TOKEN_MINUTES_VALID', '60', 'How many minutes a password-reset token is valid for. Default: 60 minutes (1 hour). Allowed: 1-1440. Best is 60-120 minutes.', 1, 32, NULL, now(), '{\"error\":\"TEXT_HINT_PASSWORD_RESET_TOKEN_VALID_MINUTES\",\"id\":\"FILTER_VALIDATE_INT\",\"options\":{\"options\":{\"min_range\":1, \"max_range\":1440}}}');
 
 # Admin storefront login configuration.  Using INSERT IGNORE followed by an UPDATE in consideration of shops with EMP already installed.
 INSERT IGNORE INTO configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) VALUES ('Customer <em>Place Order</em>: Single Admin ID', 'EMP_LOGIN_ADMIN_ID', '0', 'Identify the ID number of an admin that is permitted to use the <em>Place Order</em> feature on the customers list, regardless of their assigned admin-profile. Set the value to 0 to disable the <em>Single Admin ID</em> feature.', 1, 300, now());

--- a/zc_install/sql/updates/mysql_upgrade_zencart_220.sql
+++ b/zc_install/sql/updates/mysql_upgrade_zencart_220.sql
@@ -4,7 +4,7 @@
 # * @access private
 # * @copyright Copyright 2003-2025 Zen Cart Development Team
 # * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
-# * @version $Id: Scott Wilson 2024 Nov 23 Modified in v2.1.0 $
+# * @version $Id: New in v2.2.0 $
 #
 
 ############ IMPORTANT INSTRUCTIONS ###############
@@ -34,8 +34,21 @@
 TRUNCATE TABLE whos_online;
 TRUNCATE TABLE db_cache;
 
+#PROGRESS_FEEDBACK:!TEXT=Updating table structures!
+DROP TABLE IF EXISTS customer_password_reset_tokens;
+CREATE TABLE customer_password_reset_tokens (
+    customer_id int(11) NOT NULL default 0,
+    token varchar(100) NOT NULL default '',
+    created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY  (token, customer_id)
+);
+
+
 #PROGRESS_FEEDBACK:!TEXT=Updating configuration settings...
 DELETE FROM configuration WHERE configuration_key IN ('REPORT_ALL_ERRORS_ADMIN', 'REPORT_ALL_ERRORS_STORE', 'REPORT_ALL_ERRORS_NOTICE_BACKTRACE');
+INSERT INTO configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, last_modified, date_added, val_function) VALUES ('Password Reset Token Length', 'PASSWORD_RESET_TOKEN_LENGTH', '24', 'Number of characters in a generated password-reset token. Default is 24. Allowed: 12-100, but it affects the URL length, so 12-30 is most ideal', 1, 32, NULL, now(), '{\"error\":\"TEXT_HINT_PASSWORD_RESET_TOKEN_LENGTH\",\"id\":\"FILTER_VALIDATE_INT\",\"options\":{\"options\":{\"min_range\":10, \"max_range\":100}}}');
+INSERT INTO configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, last_modified, date_added, val_function) VALUES ('Password Reset Token Valid For', 'PASSWORD_RESET_TOKEN_MINUTES_VALID', '60', 'How many minutes a password-reset token is valid for. Default: 60 minutes (1 hour). Allowed: 1-1440. Best is 60-120 minutes.', 1, 32, NULL, now(), '{\"error\":\"TEXT_HINT_PASSWORD_RESET_TOKEN_VALID_MINUTES\",\"id\":\"FILTER_VALIDATE_INT\",\"options\":{\"options\":{\"min_range\":1, \"max_range\":1440}}}');
+
 
 #PROGRESS_FEEDBACK:!TEXT=Finalizing ... Done!
 


### PR DESCRIPTION
OLD: When a customer requests a password reset, the old behavior was to generate a new password for them, reset it to that password, and email that password to the customer. These emails often got lost in spam traps, and if the email never arrived then the customer could never login again even if they remembered their old password because their old password had been replaced.

NEW: This updated logic now generates a temporary reset token and emails that token in the form of a URL to click to take them to the password_reset page where they can choose their own new password. Once the token is validated and the user selects a (suitable-length) password, their account is updated to use that new password, and the token is deleted.

Tokens also auto-expire after an admin-configurable timeframe, so that old links in old emails don't present a security risk.

NOTE: Retires notifier `NOTIFY_PASSWORD_FORGOTTEN_CHANGED` which is superceded by `NOTIFY_PASSWORD_RESET_URL_SENT` But the same former notifier hooks used with the account_password page (when user chooses their own new password) still fire, for the benefit of 3rd party integrations.