### PR TITLE
developer email override; fixes #6905

### DIFF
--- a/includes/functions/functions_email.php
+++ b/includes/functions/functions_email.php
@@ -64,9 +64,6 @@
         if (defined('DEVELOPER_OVERRIDE_EMAIL_STATUS') && DEVELOPER_OVERRIDE_EMAIL_STATUS === 'false') {
             return false;
         }  // disable email sending when in developer mode
-        if (defined('DEVELOPER_OVERRIDE_EMAIL_ADDRESS') && DEVELOPER_OVERRIDE_EMAIL_ADDRESS !== '') {
-            $to_address = DEVELOPER_OVERRIDE_EMAIL_ADDRESS;
-        }
 
         // ignore sending emails for any of the following pages
         // (The EMAIL_MODULES_TO_SKIP constant can be defined in a new file in the "extra_configures" folder)
@@ -363,6 +360,15 @@
             // if mailserver requires that all outgoing mail must go "from" an email address matching domain on server, set it to store address
             if (EMAIL_SEND_MUST_BE_STORE === 'Yes') {
                 $mail->From = EMAIL_FROM;
+            }
+            // override to developer email address if set
+            if (defined('DEVELOPER_OVERRIDE_EMAIL_ADDRESS') && DEVELOPER_OVERRIDE_EMAIL_ADDRESS !== '') {
+                $to_email_address = DEVELOPER_OVERRIDE_EMAIL_ADDRESS;
+                // ensure the address is valid, to prevent unnecessary delivery failures
+                if (!zen_validate_email($to_email_address)) {
+                    error_log(sprintf(EMAIL_SEND_FAILED . ' (devEmail failed validation)', $to_name, $to_email_address, $email_subject));
+                    continue;
+                }
             }
 
             $mail->addAddress($to_email_address, $to_name);


### PR DESCRIPTION
i was on the fence about validating the dev email override; but i feel it is not a bad idea, with minimal processing time.

i'm a fan of logging that error; but not including the notifier `NOTIFY_EMAIL_ADDRESS_VALIDATION_FAILURE`. if you are a developer, learn to read logs, and enter a valid email address.

in addition, if there are multiple email addresses in the `$to_address`, you will now get 1 email for each of those addresses in the format requested by said customer.  which i think is a better testing methodology for ensuring that all of those emails are getting created and getting sent.  which i think mimics the behavior of all of you fancy developers with your own custom email server doing your own fancy overrides there as opposed to within ZC.

Fixes #6905 