### PR TITLE
Refactor categories_ul_generator class to allow specifying max_level

### DIFF
--- a/includes/classes/categories_ul_generator.php
+++ b/includes/classes/categories_ul_generator.php
@@ -1,26 +1,26 @@
 <?php
 /**
- * @copyright Copyright 2003-2024 Zen Cart Development Team
+ * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: John 2023 Dec 09 Modified in v2.0.0-alpha1 $
+ * @version $Id:  Modified in v2.2.0 $
  */
 
 class zen_categories_ul_generator
 {
-    protected $root_category_id = TOPMOST_CATEGORY_PARENT_ID,
-        $max_level = 0,
-        $data = [],
-        $parent_group_start_string = '<ul%s>',
-        $parent_group_end_string = '</ul>',
-        $child_start_string = '<li%s>',
-        $child_end_string = '</li>',
-        $spacer_string = '
-',
-        $spacer_multiplier = 1;
+    protected array $data = [];
 
-    function __construct($load_from_database = true)
-    {
+    public function __construct(
+        protected int|string $root_category_id = TOPMOST_CATEGORY_PARENT_ID,
+        protected int $max_level = 0,
+        protected string $parent_group_start_string = "\n<ul%s>",
+        protected string $parent_group_end_string = "</ul>\n",
+        protected string $child_start_string = "<li%s>",
+        protected string $child_end_string = "</li>\n",
+        protected string $spacer_string = '
+', // line-break and new line are intentional
+        protected int $spacer_multiplier = 1,
+    ) {
         global $db;
         $this->data = [];
         $categories_query = "SELECT c.categories_id, cd.categories_name, c.parent_id
@@ -29,32 +29,35 @@ class zen_categories_ul_generator
                              AND c.categories_status = 1
                              AND cd.language_id = " . (int)$_SESSION['languages_id'] . "
                              ORDER BY c.parent_id, c.sort_order, cd.categories_name";
-        $categories = $db->Execute($categories_query);
-        while (!$categories->EOF) {
-            $this->data[$categories->fields['parent_id']][$categories->fields['categories_id']] = ['name' => $categories->fields['categories_name'], 'count' => 0];
-            $categories->MoveNext();
+
+        $results = $db->Execute($categories_query, null, true, 300);
+
+        foreach ($results as $result) {
+            $this->data[$result['parent_id']][$result['categories_id']] = ['name' => $result['categories_name'], 'count' => 0];
         }
     }
 
-    function buildBranch($parent_id, $level = 0, $submenu = true, $parent_link = '')
+    public function buildBranch($parent_id, $level = 0, $submenu = true, string $parent_link = ''): string
     {
         $parent_id = (int)$parent_id;
         $level = (int)$level;
-        $result = sprintf($this->parent_group_start_string, ($submenu === true) ? ' class="level' . ($level + 1) . '"' : '');
+        $class_attribute = ($submenu === true) ? ' class="level' . ($level + 1) . '"' : '';
+        $result = sprintf($this->parent_group_start_string, $class_attribute);
 
         if (($this->data[$parent_id])) {
             foreach ($this->data[$parent_id] as $category_id => $category) {
                 $category_link = $parent_link . $category_id;
+
+                $class_attribute = '';
                 if (isset($this->data[$category_id])) {
-                    $result .= sprintf($this->child_start_string, ($submenu === true) ? ' class="submenu"' : '');
-                } else {
-                    $result .= sprintf($this->child_start_string, '');
+                    $class_attribute = ($submenu === true) ? ' class="submenu"' : '';
                 }
+                $result .= sprintf($this->child_start_string, $class_attribute);
                 $result .= str_repeat($this->spacer_string, $this->spacer_multiplier * 1) . '<a href="' . zen_href_link(FILENAME_DEFAULT, 'cPath=' . $category_link) . '">';
                 $result .= $category['name'];
                 $result .= '</a>';
 
-                if (isset($this->data[$category_id]) && (($this->max_level == '0') || ($this->max_level > $level + 1))) {
+                if (isset($this->data[$category_id]) && (empty($this->max_level) || $this->max_level > $level + 1)) {
                     $result .= $this->buildBranch($category_id, $level + 1, $submenu, $category_link . '_');
                 }
                 $result .= $this->child_end_string;
@@ -65,12 +68,16 @@ class zen_categories_ul_generator
         return $result;
     }
 
-    function buildTree($submenu = false)
+    public function buildTree($submenu = false, ?int $max_levels = null): string
     {
         if (empty($this->data)) {
             return '';
         }
 
-        return $this->buildBranch($this->root_category_id, '', $submenu);
+        if ($max_levels !== null) {
+            $this->max_level = $max_levels;
+        }
+
+        return $this->buildBranch($this->root_category_id, 0, $submenu);
     }
 }


### PR DESCRIPTION
One can now override any of the configurable properties of the class without extending it. 
And one can now specify a $max_levels value when calling `->buildTree()` to limit the levels to 1 or some other value, instead of getting the entire nested list. 
Also caches the db query for 5 minutes, to improve performance when site is getting higher traffic volume.
