### PR TITLE
Fix PayPal log

### DIFF
--- a/includes/modules/payment/paypaldp.php
+++ b/includes/modules/payment/paypaldp.php
@@ -1642,7 +1642,7 @@ class paypaldp extends base {
       // Move shipping tax amount from Tax subtotal into Shipping subtotal for submission to PayPal, since PayPal applies tax to each line-item individually
       $module = substr($_SESSION['shipping']['id'], 0, strpos($_SESSION['shipping']['id'], '_'));
       if (!empty($order->info['shipping_method']) && DISPLAY_PRICE_WITH_TAX != 'true') {
-        if ($GLOBALS[$module]->tax_class > 0) {
+        if (isset($GLOBALS[$module]) && $GLOBALS[$module]->tax_class > 0) {
           $shipping_tax_basis = (!isset($GLOBALS[$module]->tax_basis)) ? STORE_SHIPPING_TAX_BASIS : $GLOBALS[$module]->tax_basis;
           $shippingOnBilling = zen_get_tax_rate($GLOBALS[$module]->tax_class, $order->billing['country']['id'], $order->billing['zone_id']);
           $shippingOnDelivery = zen_get_tax_rate($GLOBALS[$module]->tax_class, $order->delivery['country']['id'], $order->delivery['zone_id']);


### PR DESCRIPTION
Add same check as `paypalwpp.php.`

Original log:
```
[07-Feb-2025 08:24:44 America/Los_Angeles] Request URI: /cart/index.php?main_page=checkout_process, IP address: xx.xx.xx.xx, Language id 1
#0 /home/client/public_html/cart/includes/modules/payment/paypaldp.php(1645): zen_debug_error_handler()
#1 /home/client/public_html/cart/includes/modules/payment/paypaldp.php(744): paypaldp->getLineItemDetails()
#2 /home/client/public_html/cart/includes/classes/payment.php(350): paypaldp->before_process()
#3 /home/client/public_html/cart/includes/modules/checkout_process.php(98): payment->before_process()
#4 /home/client/public_html/cart/includes/modules/pages/checkout_process/header_php.php(13): require('/home/client/...')
#5 /home/client/public_html/cart/index.php(35): require('/home/client/...')
--> PHP Warning: Undefined global variable $free in /home/client/public_html/cart/includes/modules/payment/paypaldp.php on line 1645.

[07-Feb-2025 08:24:44 America/Los_Angeles] Request URI: /cart/index.php?main_page=checkout_process, IP address: xx.xx.xx.xx, Language id 1
#0 /home/client/public_html/cart/includes/modules/payment/paypaldp.php(1645): zen_debug_error_handler()
#1 /home/client/public_html/cart/includes/modules/payment/paypaldp.php(744): paypaldp->getLineItemDetails()
#2 /home/client/public_html/cart/includes/classes/payment.php(350): paypaldp->before_process()
#3 /home/client/public_html/cart/includes/modules/checkout_process.php(98): payment->before_process()
#4 /home/client/public_html/cart/includes/modules/pages/checkout_process/header_php.php(13): require('/home/client/...')
#5 /home/client/public_html/cart/index.php(35): require('/home/client/...')
--> PHP Warning: Attempt to read property "tax_class" on null in /home/client/public_html/cart/includes/modules/payment/paypaldp.php on line 1645.

```