### PR TITLE
Corrected Light Green Round Icon Mapping with Font Awesome

### DIFF
--- a/admin/includes/functions/html_output.php
+++ b/admin/includes/functions/html_output.php
@@ -206,6 +206,10 @@ $iconMap = [
     'fa-solid fa-circle fa-stack-1x txt-status-on',
     'fa-regular fa-circle fa-stack-1x txt-black'
   ],
+  'status-green-light' => [
+    'fa-solid fa-circle fa-stack-1x txt-status-on txt-light',
+    'fa-regular fa-circle fa-stack-1x txt-black'
+  ],
   'status-yellow' => [
     'fa-solid fa-circle fa-stack-1x txt-linked',
     'fa-regular fa-circle fa-stack-1x txt-black'


### PR DESCRIPTION
Partial fix for issue #6983 
3- Light green status icon missing/not mapped in Font Awesome class.

