### PR TITLE
fix zone_id in order class

### DIFF
--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -252,7 +252,7 @@ class order extends base
             'telephone' => $order->fields['customers_telephone'],
             'email_address' => $order->fields['customers_email_address'],
         ];
-        $this->customer['zone_id'] = $this->getCountryZoneId((int)$this->customer['country'], $this->customer['state']);
+        $this->customer['zone_id'] = $this->getCountryZoneId((int)$this->customer['country']['id'], $this->customer['state']);
 
         $this->delivery = [
             'name' => $order->fields['delivery_name'],
@@ -283,7 +283,7 @@ class order extends base
             'country' => $this->getCountryInfo($order->fields['billing_country']),
             'format_id' => $order->fields['billing_address_format_id'],
         ];
-        $this->billing['zone_id'] = $this->getCountryZoneId((int)$this->billing['country'], $this->billing['state']);
+        $this->billing['zone_id'] = $this->getCountryZoneId((int)$this->billing['country']['id'], $this->billing['state']);
 
         $index = 0;
         $orders_products_query = "SELECT *


### PR DESCRIPTION
casting an array to an int will not give you the id of the country.

`$this->customer['country']` and `$this->billing['country']` are arrays.  the `['id']` element is what is needed for the method.

this bug is very clearly seem in the commit 65cff41ab3 as the delivery array got it correct.