### PR TITLE
Allow search to find recs with missing descs

### DIFF
--- a/admin/category_product_listing.php
+++ b/admin/category_product_listing.php
@@ -885,7 +885,11 @@ if (is_dir(DIR_FS_CATALOG_IMAGES)) {
             $products_query_raw .= " LEFT JOIN " . TABLE_PRODUCTS_DESCRIPTION . " pd ON (pd.products_id = p.products_id)";
             $products_query_raw .= $extra_joins;
 
-            $where = " WHERE pd.language_id = " . (int)$_SESSION['languages_id'];
+            if (!empty($_REQUEST['restrictIDs']) && $_REQUEST['restrictIDs'] === 'on') {
+                $where = " WHERE 1=1 "; 
+            } else { 
+                $where = " WHERE pd.language_id = " . (int)$_SESSION['languages_id'];
+            }
             $where .= $extra_ands;
 
             if ($search_result && $action !== 'edit_category') {


### PR DESCRIPTION
Right now if a database has a damaged product record with a missing products description, it's not possible to find and fix (or delete) it in the admin interface.  This change allows the use of the "Restrict Search to Product/Category ID" checkbox to find such records.

Fixes #6828. 
