### PR TITLE
Add notification to override Customer's wholesale information

### DIFF
--- a/includes/classes/Customer.php
+++ b/includes/classes/Customer.php
@@ -60,6 +60,8 @@ class Customer extends base
                     ];
                 }
             }
+            global $zco_notifier;
+            $zco_notifier->notify('NOTIFY_GET_CUSTOMER_WHOLESALE_INFO', $wholesale->fields ?? [], $wholesaleInfo);
         }
         return $wholesaleInfo;
     }


### PR DESCRIPTION
Some older sites have customized versions of the "Dual Pricing" plugin (on which the zc200+ Wholesale pricing was based).  This notification enables those sites to make use of the now-core pricing calculations with minor customization overrides (i.e. the addition of an observer).