### PR TITLE
CSS fix for product attributes box / product variations on desktop devices of 1215PX and over #7014

### DIFF
--- a/includes/templates/responsive_classic/css/stylesheet.css
+++ b/includes/templates/responsive_classic/css/stylesheet.css
@@ -380,6 +380,7 @@ h4.optionName{font-size:1.1em;line-height:1.5em;margin:1% 30px 0 30px;padding:0;
 .attributesComments {font-weight:normal;}
 .wrapperAttribsOptions select{width:100%;}
 .wrapperAttribsOptions{margin:10px 0;}
+@media(min-width: 1215px) { .wrapperAttribsOptions { display: grid; }}
 #productDescription {padding:0.5em;clear:both;margin:20px 0;line-height:150%;}
 .max-qty{margin-bottom:10px;}
 .qty-text{display:none;}


### PR DESCRIPTION
Fix attributes/product variations box layout on product pages on desktop devices from 1215PX and over.

Noticed that if you use product attributes / product variations, e.g: you have a product that is available for example in various different colours.

Depending on the length of the text for these attributes, on desktop devices of 1215PX and over you can end up with some of the variations on one single line, and the others taking up two lines, which looks quite messy.

A simple fix is to use display: grid for devices over 1215PX.

Have tested in the latest version V2.1.0, using PHP 8.4,

I've submitted a pull request which fixes this issue (link below):

https://github.com/zencart/zencart/commit/0e10310a0ffd42322914ae35ef566c397b5dffb4

Kind Regards,

Andy