### PR TITLE
Expand option/option-value names to 191 characters

### DIFF
--- a/zc_install/sql/install/mysql_zencart.sql
+++ b/zc_install/sql/install/mysql_zencart.sql
@@ -1269,7 +1269,7 @@ CREATE TABLE orders_products_attributes (
   orders_products_attributes_id int(11) NOT NULL auto_increment,
   orders_id int(11) NOT NULL default '0',
   orders_products_id int(11) NOT NULL default '0',
-  products_options varchar(32) NOT NULL default '',
+  products_options varchar(191) NOT NULL default '',
   products_options_values text NOT NULL,
   options_values_price decimal(15,4) NOT NULL default '0.0000',
   price_prefix char(1) NOT NULL default '',
@@ -1859,7 +1859,7 @@ DROP TABLE IF EXISTS products_options;
 CREATE TABLE products_options (
   products_options_id int(11) NOT NULL default '0',
   language_id int(11) NOT NULL default '1',
-  products_options_name varchar(32) NOT NULL default '',
+  products_options_name varchar(191) NOT NULL default '',
   products_options_sort_order int(11) NOT NULL default '0',
   products_options_type int(5) NOT NULL default '0',
   products_options_length smallint(2) NOT NULL default '32',
@@ -1898,7 +1898,7 @@ DROP TABLE IF EXISTS products_options_values;
 CREATE TABLE products_options_values (
   products_options_values_id int(11) NOT NULL default '0',
   language_id int(11) NOT NULL default '1',
-  products_options_values_name varchar(64) NOT NULL default '',
+  products_options_values_name varchar(191) NOT NULL default '',
   products_options_values_sort_order int(11) NOT NULL default '0',
   PRIMARY KEY (products_options_values_id,language_id),
   KEY idx_products_options_values_name_zen (products_options_values_name),

--- a/zc_install/sql/updates/mysql_upgrade_zencart_220.sql
+++ b/zc_install/sql/updates/mysql_upgrade_zencart_220.sql
@@ -42,6 +42,9 @@ CREATE TABLE customer_password_reset_tokens (
     created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY  (token, customer_id)
 );
+ALTER TABLE orders_products_attributes MODIFY products_options varchar(191) NOT NULL default '';
+ALTER TABLE products_options MODIFY products_options_name varchar(191) NOT NULL default '';
+ALTER TABLE products_options_values MODIFY products_options_values_name varchar(191) NOT NULL default '';
 
 
 #PROGRESS_FEEDBACK:!TEXT=Updating configuration settings...


### PR DESCRIPTION
Fixes #6988

Using `varchar(191)` consistently, since the fields in the `products_options` and `products_options_values` tables are keys.