### PR TITLE
`zen_db_prepare_input`: Add `int` type to input and output

### DIFF
--- a/includes/functions/database.php
+++ b/includes/functions/database.php
@@ -49,26 +49,29 @@ function zen_db_output(string $string)
  * NOTE: SHOULD NOT BE USED FOR DB QUERIES!!!  Use $db->prepare_input() or zen_db_input() instead
  *
  */
-function zen_db_prepare_input(array|string|null $string, bool $trimspace = true): array|string|null
+function zen_db_prepare_input(array|string|int|null $input, bool $trimspace = true): array|string|int|null
 {
-
-    if (!IS_ADMIN_FLAG && is_string($string)) {
-        $string = zen_sanitize_string($string);
+    if (is_int($input)) {
+        return $input;
     }
-    if (is_string($string)) {
+
+    if (!IS_ADMIN_FLAG && is_string($input)) {
+        $input = zen_sanitize_string($input);
+    }
+    if (is_string($input)) {
         if ($trimspace === true) {
-            return trim(stripslashes($string));
+            return trim(stripslashes($input));
         }
-        return stripslashes($string);
+        return stripslashes($input);
     }
 
-    if (is_array($string)) {
-        foreach ($string as $key => $value) {
-            $string[$key] = zen_db_prepare_input($value);
+    if (is_array($input)) {
+        foreach ($input as $key => $value) {
+            $input[$key] = zen_db_prepare_input($value);
         }
     }
 
-    return $string;
+    return $input;
 }
 
 

--- a/includes/functions/database.php
+++ b/includes/functions/database.php
@@ -49,12 +49,8 @@ function zen_db_output(string $string)
  * NOTE: SHOULD NOT BE USED FOR DB QUERIES!!!  Use $db->prepare_input() or zen_db_input() instead
  *
  */
-function zen_db_prepare_input(array|string|int|null $input, bool $trimspace = true): array|string|int|null
+function zen_db_prepare_input(array|string|int|float|null $input, bool $trimspace = true): array|string|int|float|null
 {
-    if (is_int($input)) {
-        return $input;
-    }
-
     if (!IS_ADMIN_FLAG && is_string($input)) {
         $input = zen_sanitize_string($input);
     }
@@ -73,7 +69,6 @@ function zen_db_prepare_input(array|string|int|null $input, bool $trimspace = tr
 
     return $input;
 }
-
 
 /**
  * Performs an INSERT or UPDATE based on a supplied array of field data.


### PR DESCRIPTION
Fixes #7013

Note: Changed input name to (er) `$input` (was `$string`).