### PR TITLE
Fix errors in banner manager when Group names don't conform to pattern

### DIFF
--- a/admin/banner_manager.php
+++ b/admin/banner_manager.php
@@ -551,7 +551,7 @@ if (!empty($action)) {
                             // remove text prior to the hyphen in the configuraiton_title to leave the position (e.g. "Banner Display Group - Side Box banner_box_all"  "Banner Display Groups - Footer Position 3")
                             // allows for optional spaces around hyphens
                             $position_texts = preg_split('/\s?-\s?/', $banner_position['configuration_title']);
-                            $positions[] = $position_texts !== false ? $position_texts[1] : '';
+                            $positions[] = $position_texts[1] ?? '';
                         }
                         echo '<div class="text-nowrap">' . implode('<br>', $positions) . '</div>';
                         ?>


### PR DESCRIPTION
```
[05-Mar-2025 11:52:02 UTC] Request URI: /client/admin/index.php?cmd=banner_manager&page=1&bID=6, IP address: ::1, Language id 1
#0 /Users/scott/Sites/client/admin/banner_manager.php(554): zen_debug_error_handler()
#1 /Users/scott/Sites/client/admin/index.php(16): require('/Users/scott/Si...')
--> PHP Warning: Undefined array key 1 in /Users/scott/Sites/client/admin/banner_manager.php on line 554.

```