### PR TITLE
Ensure methods array key is set before reference

### DIFF
--- a/includes/modules/pages/checkout_shipping/header_php.php
+++ b/includes/modules/pages/checkout_shipping/header_php.php
@@ -188,7 +188,7 @@ if (isset($_SESSION['cart']->cartID)) {
   if (isset($_SESSION['shipping']['id'])) {
     $checklist = [];
     foreach ($quotes as $key=>$val) {
-      if (is_array($val['methods'])) {
+      if (isset($val['methods']) && is_array($val['methods'])) {
         foreach($val['methods'] as $key2=>$method) {
           $checklist[] = $val['id'] . '_' . $method['id'];
         }


### PR DESCRIPTION
It is possible that the `$quotes` array will not have the `methods` key set.  For example, in zones shipping if MODULE_SHIPPING_ZONES_SKIPPED is the current zone (see includes/modules/shipping/zones.php line 316).

Associated log:
```
[06-Mar-2025 22:31:20 UTC] Request URI: /client/index.php?main_page=checkout_shipping, IP address: ::1, Language id 1
#0 /Users/scott/Sites/client/includes/modules/pages/checkout_shipping/header_php.php(191): zen_debug_error_handler()
#1 /Users/scott/Sites/client/index.php(35): require('/Users/scott/Si...')
--> PHP Warning: Undefined array key "methods" in /Users/scott/Sites/client/includes/modules/pages/checkout_shipping/header_php.php on line 191.

```
