### PR TITLE
Handle gender radio button not selected

### DIFF
--- a/includes/modules/checkout_new_address.php
+++ b/includes/modules/checkout_new_address.php
@@ -29,7 +29,7 @@ if (isset($_POST['action']) && ($_POST['action'] === 'submit')) {
     if (!empty($_POST['firstname']) && !empty($_POST['lastname']) && !empty($_POST['street_address'])) {
         $process = true;
         if (ACCOUNT_GENDER === 'true') {
-            $gender = zen_db_prepare_input($_POST['gender']);
+            $gender = zen_db_prepare_input($_POST['gender'] ?? '');
         }
         if (ACCOUNT_COMPANY === 'true') {
             $company = zen_db_prepare_input($_POST['company']);


### PR DESCRIPTION
For the new shipping address and new billing address screens, the gender is not preselected.  We must anticipate someone not selecting a gender when the form is submitted. 

Sample log created: 
```
[06-Mar-2025 18:32:25 UTC] Request URI: /store/index.php?main_page=checkout_shipping_address, IP address: xxx.xxx.xx.xxx, Language id 1
#0 /home/client/public_html/store/includes/modules/checkout_new_address.php(32): store_debug_error_handler()
#1 /home/client/public_html/store/includes/modules/pages/checkout_shipping_address/header_php.php(46): require('/home/client/publi...')
#2 /home/client/public_html/store/index.php(35): require('/home/client/publi...')
--> PHP Warning: Undefined array key "gender" in /home/client/public_html/store/includes/modules/checkout_new_address.php on line 32.

```