### PR TITLE
add identification titles to base inline css/jscript files

### DIFF
--- a/admin/includes/javascript_loader.php
+++ b/admin/includes/javascript_loader.php
@@ -9,14 +9,14 @@
  */
 ?>
 <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
-<script>window.jQuery || document.write('<script src="includes/javascript/jquery.min.js"><\/script>');</script>
+<script title="jQuery check">window.jQuery || document.write('<script src="includes/javascript/jquery.min.js"><\/script>');</script>
 
 <script src="https://code.jquery.com/ui/1.14.0/jquery-ui.min.js" integrity="sha256-Fb0zP4jE3JHqu+IBB9YktLcSjI1Zc6J2b6gTjB0LpoM=" crossorigin="anonymous"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 <!--<script src="includes/javascript/bootstrap.min.js"></script>-->
 
 <script src="includes/javascript/jquery-ui-i18n.min.js"></script>
-<script>
+<script title="jQuery.datepicker">
 // init datepicker defaults with localization
   jQuery(function () {
     jQuery.datepicker.setDefaults(jQuery.extend({}, jQuery.datepicker.regional["<?php echo $_SESSION['languages_code'] == 'en' ? '' : $_SESSION['languages_code']; ?>"], {

--- a/admin/includes/javascript_loader.php
+++ b/admin/includes/javascript_loader.php
@@ -16,7 +16,7 @@
 <!--<script src="includes/javascript/bootstrap.min.js"></script>-->
 
 <script src="includes/javascript/jquery-ui-i18n.min.js"></script>
-<script title="jQuery.datepicker">
+<script title="jQuery plugin initializations">
 // init datepicker defaults with localization
   jQuery(function () {
     jQuery.datepicker.setDefaults(jQuery.extend({}, jQuery.datepicker.regional["<?php echo $_SESSION['languages_code'] == 'en' ? '' : $_SESSION['languages_code']; ?>"], {

--- a/admin/includes/keepalive_module.php
+++ b/admin/includes/keepalive_module.php
@@ -34,7 +34,7 @@ if ((int)$timeoutAfter < 30) $timeoutAfter = 1440;
 //$timeoutAfter = 15;
 //$mouseDebounce = 10;
 ?>
-<style>
+<style title="jAlert">
 .jAlert {font-size: 1.5rem;}
 .ja_btn {font-size: 1.5rem; padding: 15px !important;}
 </style>

--- a/includes/templates/classic/css/stylesheet_image_modals.php
+++ b/includes/templates/classic/css/stylesheet_image_modals.php
@@ -1,8 +1,7 @@
-<style>
+<style title="image_modals">
 <?php
 // This file generates CSS for a few dynamic settings used by image modals
 ?>
   .image-grid {grid-template-columns: repeat(auto-fill, minmax(<?php echo (int)SMALL_IMAGE_WIDTH; ?>px, 1fr));}
   .centered-image-medium {max-height: <?php echo (int)MEDIUM_IMAGE_HEIGHT; ?>px;}
 </style>
-

--- a/includes/templates/responsive_classic/common/html_header.php
+++ b/includes/templates/responsive_classic/common/html_header.php
@@ -94,9 +94,9 @@ require $template->get_template_dir('html_header_css_loader.php', DIR_WS_TEMPLAT
 ?>
 <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
 <?php if (file_exists(DIR_WS_TEMPLATE . "jscript/jquery.min.js")) { ?>
-<script>window.jQuery || document.write(unescape('%3Cscript src="<?php echo $template->get_template_dir('.js',DIR_WS_TEMPLATE, $current_page_base,'jscript'); ?>/jquery.min.js"%3E%3C/script%3E'));</script>
+<script title="jQuery check - template">window.jQuery || document.write(unescape('%3Cscript src="<?php echo $template->get_template_dir('.js',DIR_WS_TEMPLATE, $current_page_base,'jscript'); ?>/jquery.min.js"%3E%3C/script%3E'));</script>
 <?php } ?>
-<script>window.jQuery || document.write(unescape('%3Cscript src="<?php echo $template->get_template_dir('.js','template_default', $current_page_base,'jscript'); ?>/jquery.min.js"%3E%3C/script%3E'));</script>
+<script title="jQuery check - template_default">window.jQuery || document.write(unescape('%3Cscript src="<?php echo $template->get_template_dir('.js','template_default', $current_page_base,'jscript'); ?>/jquery.min.js"%3E%3C/script%3E'));</script>
 
 <?php
 $zco_notifier->notify('NOTIFY_HTML_HEAD_JS_BEGIN', $current_page_base);

--- a/includes/templates/responsive_classic/css/stylesheet_image_modals.php
+++ b/includes/templates/responsive_classic/css/stylesheet_image_modals.php
@@ -1,4 +1,4 @@
-<style>
+<style title="image_modals">
 <?php
 /**
  * This file generates CSS for a few dynamic settings used by image modals
@@ -11,4 +11,3 @@
   .image-grid {grid-template-columns: repeat(auto-fill, minmax(<?php echo (int)SMALL_IMAGE_WIDTH; ?>px, 1fr));}
   .centered-image-medium {max-height: <?php echo (int)MEDIUM_IMAGE_HEIGHT; ?>px;}
 </style>
-

--- a/includes/templates/responsive_classic/jscript/jscript_responsive_framework.php
+++ b/includes/templates/responsive_classic/jscript/jscript_responsive_framework.php
@@ -6,7 +6,7 @@
  */
 ?>
 
-<script>
+<script title="responsive_framework">
 
 (function($) {
 $(document).ready(function() {

--- a/includes/templates/template_default/common/html_header.php
+++ b/includes/templates/template_default/common/html_header.php
@@ -76,7 +76,7 @@ require $template->get_template_dir('html_header_css_loader.php', DIR_WS_TEMPLAT
 /** CDN for jQuery core **/
 ?>
 <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
-<script>window.jQuery || document.write(unescape('%3Cscript src="<?php echo $template->get_template_dir('.js',DIR_WS_TEMPLATE, $current_page_base,'jscript'); ?>/jquery.min.js"%3E%3C/script%3E'));</script>
+<script title="jQuery check - template">window.jQuery || document.write(unescape('%3Cscript src="<?php echo $template->get_template_dir('.js',DIR_WS_TEMPLATE, $current_page_base,'jscript'); ?>/jquery.min.js"%3E%3C/script%3E'));</script>
 
 <?php
 $zco_notifier->notify('NOTIFY_HTML_HEAD_JS_BEGIN', $current_page_base);
@@ -91,4 +91,3 @@ $zco_notifier->notify('NOTIFY_HTML_HEAD_END', $current_page_base);
 
 </head>
 <?php // NOTE: Blank line following is intended: ?>
-

--- a/includes/templates/template_default/css/stylesheet_image_modals.php
+++ b/includes/templates/template_default/css/stylesheet_image_modals.php
@@ -1,4 +1,4 @@
-<style>
+<style title="image_modals">
 <?php
 /**
  * This file generates CSS for a few dynamic settings used by image modals
@@ -11,4 +11,3 @@
   .image-grid {grid-template-columns: repeat(auto-fill, minmax(<?php echo (int)SMALL_IMAGE_WIDTH; ?>px, 1fr));}
   .centered-image-medium {max-height: <?php echo (int)MEDIUM_IMAGE_HEIGHT; ?>px;}
 </style>
-

--- a/includes/templates/template_default/jscript/jscript_framework.php
+++ b/includes/templates/template_default/jscript/jscript_framework.php
@@ -5,7 +5,7 @@
  * @version $Id: torvista 2019 Oct 21 Modified in v1.5.7 $
  */
 ?>
-<script>
+<script title="zcJS.ajax">
 if (typeof zcJS == "undefined" || !zcJS) {
   window.zcJS = { name: 'zcJS', version: '0.1.0.0' };
 }

--- a/includes/templates/template_default/jscript/jscript_sidebox_select_form.php
+++ b/includes/templates/template_default/jscript/jscript_sidebox_select_form.php
@@ -17,7 +17,7 @@
 //       the 'select' tag itself must include the 'required' attribute.
 //
 ?>
-<script>
+<script title="sidebox_select">
 jQuery(document).ready(function() {
 <?php
     // -----


### PR DESCRIPTION
As discussed
https://github.com/zencart/zencart/issues/6966

Admin
![admin head before](https://github.com/user-attachments/assets/6cd2ebf0-b362-4e25-9fd7-c00066f7a082)

to

![admin head xafter](https://github.com/user-attachments/assets/9cfe947a-4536-43d2-8ee7-45ac49244a5e)

Storefront
![storefront a](https://github.com/user-attachments/assets/ae772451-5ced-4694-9322-f08c14add518)

to

![storefront b](https://github.com/user-attachments/assets/e5427a7d-7719-40ca-94db-6b9d2c3008d1)

There are loads of/too many page-specific scripts, better to do those when a file is updated.
