### PR TITLE
POSM/EO-5: Correct PHP warnings when added product isn't POSM-managed

### DIFF
--- a/zc_plugins/POSM/v6.1.0/admin/includes/classes/observers/class.products_options_stock_admin_observer.php
+++ b/zc_plugins/POSM/v6.1.0/admin/includes/classes/observers/class.products_options_stock_admin_observer.php
@@ -1,7 +1,7 @@
 <?php
 // -----
 // Part of the "Product Options Stock" plugin by Cindy Merkin (cindy@vinosdefrutastropicales.com)
-// Copyright (c) 2014-2024 Vinos de Frutas Tropicales
+// Copyright (c) 2014-2025 Vinos de Frutas Tropicales
 //
 // Last Updated:  POSM v6.1.0
 //
@@ -1080,7 +1080,7 @@ class products_options_stock_observer extends base
               LIMIT 1"
         );
 
-        if ($pos_record !== false) {
+        if ($pos_record !== false && !$pos_record->EOF) {
             $available_qty = $pos_record->fields['products_quantity'];
         } else {
             $available_qty = $product->fields['products_quantity'] ?? 0;


### PR DESCRIPTION
Seeing logs similar to the following prior to the included change:
```
[14-Mar-2025 16:01:01 America/New_York] Request URI: /zc210/admin210/ajax.php?act=ajaxEditOrdersAdmin&method=newProductChosen, IP address: 127.0.0.1, Language id 1
#0 C:\xampp\htdocs\zc210\zc_plugins\POSM\v6.1.0\admin\includes\classes\observers\class.products_options_stock_admin_observer.php(1084): zen_debug_error_handler()
#1 C:\xampp\htdocs\zc210\zc_plugins\POSM\v6.1.0\admin\includes\classes\observers\class.products_options_stock_admin_observer.php(1062): products_options_stock_observer->getProductsStockMessage()
#2 C:\xampp\htdocs\zc210\zc_plugins\POSM\v6.1.0\admin\includes\classes\observers\class.products_options_stock_admin_observer.php(664): products_options_stock_observer->getProductNameWithMessage()
#3 C:\xampp\htdocs\zc210\includes\classes\traits\NotifierManager.php(107): products_options_stock_observer->notify_eo_add_product_to_cart()
#4 C:\xampp\htdocs\zc210\zc_plugins\EditOrders\v5.0.0\admin\includes\classes\EditOrders.php(142): Zencart\Plugins\Admin\EditOrders\EditOrders->notify()
#5 C:\xampp\htdocs\zc210\zc_plugins\EditOrders\v5.0.0\catalog\includes\classes\ajax\zcAjaxEditOrdersAdmin.php(481): Zencart\Plugins\Admin\EditOrders\EditOrders->addProductToCart()
#6 C:\xampp\htdocs\zc210\ajax.php(77): zcAjaxEditOrdersAdmin->newProductChosen()
#7 C:\xampp\htdocs\zc210\admin210\ajax.php(17): require('C:\\xampp\\htdocs...')
--> PHP Warning: Undefined array key "products_quantity" in C:\xampp\htdocs\zc210\zc_plugins\POSM\v6.1.0\admin\includes\classes\observers\class.products_options_stock_admin_observer.php on line 1084.
```