### PR TITLE
move order_total->process to pages and outside of template

### DIFF
--- a/includes/modules/pages/checkout_confirmation/header_php.php
+++ b/includes/modules/pages/checkout_confirmation/header_php.php
@@ -70,6 +70,9 @@ require(DIR_WS_CLASSES . 'order_total.php');
 $order_total_modules = new order_total;
 $order_total_modules->collect_posts();
 $order_total_modules->pre_confirmation_check();
+    if (MODULE_ORDER_TOTAL_INSTALLED) {
+        $order_totals = $order_total_modules->process();
+    }
 
 // load the selected payment module
 require(DIR_WS_CLASSES . 'payment.php');

--- a/includes/modules/pages/checkout_payment/header_php.php
+++ b/includes/modules/pages/checkout_payment/header_php.php
@@ -99,6 +99,9 @@ require(DIR_WS_CLASSES . 'order_total.php');
 $order_total_modules = new order_total;
 $order_total_modules->collect_posts();
 $order_total_modules->pre_confirmation_check();
+    if (MODULE_ORDER_TOTAL_INSTALLED) {
+        $order_totals = $order_total_modules->process();
+    }
 
 //  $_SESSION['comments'] = '';
 $comments = !empty($_SESSION['comments']) ? $_SESSION['comments'] : '';

--- a/includes/templates/responsive_classic/templates/tpl_checkout_confirmation_default.php
+++ b/includes/templates/responsive_classic/templates/tpl_checkout_confirmation_default.php
@@ -155,7 +155,7 @@
 
 <?php
   if (MODULE_ORDER_TOTAL_INSTALLED) {
-    $order_totals = $order_total_modules->process();
+//    $order_totals = $order_total_modules->process();
 ?>
 <div id="orderTotals"><?php $order_total_modules->output(); ?></div>
 <?php

--- a/includes/templates/template_default/templates/tpl_checkout_confirmation_default.php
+++ b/includes/templates/template_default/templates/tpl_checkout_confirmation_default.php
@@ -156,7 +156,7 @@
 
 <?php
   if (MODULE_ORDER_TOTAL_INSTALLED) {
-    $order_totals = $order_total_modules->process();
+//    $order_totals = $order_total_modules->process();
 ?>
 <div id="orderTotals"><?php $order_total_modules->output(); ?></div>
 <?php

--- a/includes/templates/template_default/templates/tpl_checkout_payment_default.php
+++ b/includes/templates/template_default/templates/tpl_checkout_payment_default.php
@@ -45,7 +45,7 @@
 <legend id="checkoutPaymentHeadingTotal"><?php echo TEXT_YOUR_TOTAL; ?></legend>
 <?php
   if (MODULE_ORDER_TOTAL_INSTALLED) {
-    $order_totals = $order_total_modules->process();
+//    $order_totals = $order_total_modules->process();
 ?>
 <?php $order_total_modules->output(); ?>
 <?php


### PR DESCRIPTION
persuant to this discussion #7038 (with myself), we should not be doing any processing in templates.  it makes little sense to me, in addition to screwing up totals for any payment modules.

there is a trend in payment modules to use javascript to isolate the store owner from touching any sensitive cardholder data.  in that regard, the payment module should NOT have to figure out what the order total is.  the payment module module needs to rely on the `$order->info['total']` to be correct at the time of the page rendering.

this PR only refactors when that happens.  it moves it from the template rendering to the page processing part of the page rendering.

here is [a forum posting](https://www.zen-cart.com/showthread.php?222449-Square-Payment-Module-for-Zen-Cart-Support-Thread&p=1406720#post1406720) that documents the issue.

in [a follow up post](https://www.zen-cart.com/showthread.php?222449-Square-Payment-Module-for-Zen-Cart-Support-Thread&p=1406822#post1406822), there are some screencasts that show the results.