### PR TITLE
paypaldp: Account for shipping modules with no tax_class

### DIFF
--- a/includes/modules/payment/paypaldp.php
+++ b/includes/modules/payment/paypaldp.php
@@ -1642,7 +1642,7 @@ class paypaldp extends base {
       // Move shipping tax amount from Tax subtotal into Shipping subtotal for submission to PayPal, since PayPal applies tax to each line-item individually
       $module = substr($_SESSION['shipping']['id'], 0, strpos($_SESSION['shipping']['id'], '_'));
       if (!empty($order->info['shipping_method']) && DISPLAY_PRICE_WITH_TAX != 'true') {
-        if (isset($GLOBALS[$module]) && $GLOBALS[$module]->tax_class > 0) {
+        if (isset($GLOBALS[$module]) && ($GLOBALS[$module]->tax_class ?? 0) > 0) {
           $shipping_tax_basis = (!isset($GLOBALS[$module]->tax_basis)) ? STORE_SHIPPING_TAX_BASIS : $GLOBALS[$module]->tax_basis;
           $shippingOnBilling = zen_get_tax_rate($GLOBALS[$module]->tax_class, $order->billing['country']['id'], $order->billing['zone_id']);
           $shippingOnDelivery = zen_get_tax_rate($GLOBALS[$module]->tax_class, $order->delivery['country']['id'], $order->delivery['zone_id']);


### PR DESCRIPTION
As noted in [this](https://www.zen-cart.com/showthread.php?230670-A-few-of-PHP-Warnings&p=1406836#post1406836) Zen Cart posting:

lastly, I received this PHP warning when a customer uses a coupon code in the Discount Coupon area during checkout, to get the product for free

```
Request URI: /shop/index.php?main_page=checkout_process, IP address: 66.61.47.189, Language id 1
#0 /home/shop/includes/modules/payment/paypaldp.php(1645): zen_debug_error_handler()
#1/home/public_html/shop/includes/modules/payment/paypaldp.php(744): paypaldp->getLineItemDetails()
#2 /home/public_html/shop/includes/classes/payment.php(350): paypaldp->before_process()
#3 /home/public_html/shop/includes/modules/checkout_process.php(98): payment->before_process()
#4 /home/public_html/shop/includes/modules/pages/checkout_process/header_php.php(13): require('...')
#5 /home/public_html/shop/index.php(35): require('...')
--> PHP Warning: Undefined global variable $free in /home/public_html/shop/includes/modules/payment/paypaldp.php on line 1645.

[26-Mar-2025 08:45:43 America] Request URI: /shop/index.php?main_page=checkout_process, IP address: 66.61.47.189, Language id 1
#0 /home/public_html/shop/includes/modules/payment/paypaldp.php(1645): zen_debug_error_handler()
#1 /home/public_html/shop/includes/modules/payment/paypaldp.php(744): paypaldp->getLineItemDetails()
#2 /home/public_html/shop/includes/classes/payment.php(350): paypaldp->before_process()
#3 /home/public_html/shop/includes/modules/checkout_process.php(98): payment->before_process()
#4 /home/public_html/shop/includes/modules/pages/checkout_process/header_php.php(13): require('...')
#5 /home/public_html/shop/index.php(35): require('...')
--> PHP Warning: Attempt to read property "tax_class" on null in /home/public_html/shop/includes/modules/payment/paypaldp.php on line 1645.
```