### PR TITLE
Additional UA santization

### DIFF
--- a/includes/functions/whos_online.php
+++ b/includes/functions/whos_online.php
@@ -31,7 +31,8 @@ function zen_update_whos_online()
 
     $wo_session_id = zen_session_id();
     $wo_ip_address = substr(isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : 'Unknown', 0, 45);
-    $wo_user_agent = substr(zen_db_prepare_input(isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : ''), 0, 254);
+    $wo_user_agent = preg_replace('#[a-zA-Z0-9/\.;:\(\)]#', '~', preg_quote($_SERVER['HTTP_USER_AGENT'] ?? '', '#'));
+    $wo_user_agent = substr(zen_db_prepare_input($wo_user_agent), 0, 254);
 
     $_SERVER['QUERY_STRING'] = (isset($_SERVER['QUERY_STRING']) && $_SERVER['QUERY_STRING'] != '') ? $_SERVER['QUERY_STRING'] : zen_get_all_get_params();
     if (isset($_SERVER['REQUEST_URI'])) {


### PR DESCRIPTION
Strip out non-standard characters.

Injection is already protected against, but this avoids unsupported characters.

Fixes #7050