### PR TITLE
fix tax exempt customers to not get tax

### DIFF
--- a/includes/functions/functions_taxes.php
+++ b/includes/functions/functions_taxes.php
@@ -173,6 +173,11 @@ function zen_get_multiple_tax_rates($class_id, $country_id = -1, $zone_id = -1, 
     if (is_array($rates_array)) {
         return $rates_array;
     }
+    if (Customer::isTaxExempt() === true) {
+        return [
+            TAX_EXEMPT_DESCRIPTION => 0,
+        ];
+    }
 
     $rates_array = [];
 
@@ -434,6 +439,11 @@ function zen_get_all_tax_descriptions($country_id = -1, $zone_id = -1)
     );
     if (is_array($tax_descriptions)) {
         return $tax_descriptions;
+    }
+    if (Customer::isTaxExempt() === true) {
+        return [
+            TAX_EXEMPT_DESCRIPTION => 0,
+        ];
     }
 
     if ($country_id == -1 && $zone_id == -1) {

--- a/includes/languages/lang.english.php
+++ b/includes/languages/lang.english.php
@@ -367,6 +367,7 @@ $define = [
     'TABLE_HEADING_UPCOMING_PRODUCTS' => 'Upcoming Products',
     'TABLE_HEADING_WEIGHT' => 'Weight',
     'TABLE_HEADING_FEATURED_CATEGORIES' => 'Featured Categories',
+    'TAX_EXEMPT_DESCRIPTION' => 'Tax Exempt',
     'TEXT_ADMIN_DOWN_FOR_MAINTENANCE' => 'NOTICE: The website is currently down for maintenance to the public',
     'TEXT_ALL_CATEGORIES' => 'All Categories',
     'TEXT_ALL_MANUFACTURERS' => 'All Manufacturers',


### PR DESCRIPTION
this bit of code is not enough:

https://github.com/zencart/zencart/blob/02b6efdd442a0ba89d28511e90d62c42a5ac53c9/includes/functions/functions_taxes.php#L22-L27

most US clients show taxes separate from the line item and utilize what in ZC we call an `order_total` module.  without this PR, when a store is set up with wholesale customers being tax exempt, and taxes are not shown in the price, ie `(DISPLAY_PRICE_WITH_TAX !== 'true')`, the tax amount is not calculated as 0.

this PR addresses that issue.

