### PR TITLE
Handle country id not set

### DIFF
--- a/includes/modules/order_total/ot_shipping.php
+++ b/includes/modules/order_total/ot_shipping.php
@@ -59,7 +59,9 @@ class ot_shipping extends base
  
         $this->output = [];
         unset($_SESSION['shipping_tax_description']);
-        
+        if (empty($order->delivery['country_id'])) {
+            $order->delivery['country_id'] = '';
+        } 
         if (MODULE_ORDER_TOTAL_SHIPPING_FREE_SHIPPING === 'true') {
             $pass = false;
             switch (MODULE_ORDER_TOTAL_SHIPPING_DESTINATION) {


### PR DESCRIPTION
```
[27-Apr-2025 03:39:09 America/New_York] Request URI: /ipn_main_handler.php?type=ec&token=****&PayerID=***, IP address: XX.XXX.XXX.XX, Language id 1
#0 /home/client/public_html/includes/modules/order_total/ot_shipping.php(67): zen_debug_error_handler()
#1 /home/client/public_html/includes/classes/order_total.php(229): ot_shipping->process()
#2 /home/client/public_html/includes/modules/payment/paypalwpp.php(2001): order_total->pre_confirmation_check()
#3 /home/client/public_html/ipn_main_handler.php(85): paypalwpp->ec_step2()
--> PHP Warning: Undefined array key "country_id" in /home/client/public_html/includes/modules/order_total/ot_shipping.php on line 67.
```