### PR TITLE
Sanitize `alpha_filter_id`

### DIFF
--- a/includes/index_filters/default_filter.php
+++ b/includes/index_filters/default_filter.php
@@ -23,7 +23,7 @@ if (isset($_GET['sort']) && strlen($_GET['sort']) > 3) {
     $_GET['sort'] = substr($_GET['sort'], 0, 3);
 }
 if (isset($_GET['alpha_filter_id']) && (int)$_GET['alpha_filter_id'] > 0) {
-    $alpha_sort = " AND pd.products_name LIKE '" . chr((int)$_GET['alpha_filter_id']) . "%' ";
+    $alpha_sort = " AND pd.products_name LIKE '" . zen_db_input(chr((int)$_GET['alpha_filter_id'])) . "%' ";
 } else {
     $alpha_sort = '';
 }

--- a/includes/index_filters/music_genre_filter.php
+++ b/includes/index_filters/music_genre_filter.php
@@ -23,7 +23,7 @@ if (isset($_GET['sort']) && strlen($_GET['sort']) > 3) {
     $_GET['sort'] = substr($_GET['sort'], 0, 3);
 }
 if (isset($_GET['alpha_filter_id']) && (int)$_GET['alpha_filter_id'] > 0) {
-    $alpha_sort = " AND pd.products_name LIKE '" . chr((int)$_GET['alpha_filter_id']) . "%' ";
+    $alpha_sort = " AND pd.products_name LIKE '" . zen_db_input(chr((int)$_GET['alpha_filter_id'])) . "%' ";
 } else {
     $alpha_sort = '';
 }

--- a/includes/index_filters/record_company_filter.php
+++ b/includes/index_filters/record_company_filter.php
@@ -23,7 +23,7 @@ if (isset($_GET['sort']) && strlen($_GET['sort']) > 3) {
     $_GET['sort'] = substr($_GET['sort'], 0, 3);
 }
 if (isset($_GET['alpha_filter_id']) && (int)$_GET['alpha_filter_id'] > 0) {
-    $alpha_sort = " AND pd.products_name LIKE '" . chr((int)$_GET['alpha_filter_id']) . "%' ";
+    $alpha_sort = " AND pd.products_name LIKE '" . zen_db_input(chr((int)$_GET['alpha_filter_id'])) . "%' ";
 } else {
     $alpha_sort = '';
 }


### PR DESCRIPTION
Seeing logs like the following, note that `(int)39` is a single-quote:
```
[29-Apr-2025 14:15:31 America/New_York] Request URI: /zc210/index.php?main_page=index&cPath=3_10&disp_order=8&filter_id=&alpha_filter_id=39, IP address: 127.0.0.1, Language id 1
#0 [internal function]: zen_debug_error_handler()
#1 C:\xampp\htdocs\zc210\includes\classes\db\mysql\query_factory.php(734): trigger_error()
#2 C:\xampp\htdocs\zc210\includes\classes\db\mysql\query_factory.php(679): queryFactory->show_error()
#3 C:\xampp\htdocs\zc210\includes\classes\db\mysql\query_factory.php(307): queryFactory->set_error()
#4 C:\xampp\htdocs\zc210\includes\modules\pages\index\header_php.php(131): queryFactory->Execute()
#5 C:\xampp\htdocs\zc210\index.php(35): require('C:\\xampp\\htdocs...')
--> PHP Fatal error: FATAL MySQL error 1064: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ''   ORDER BY p.products_sort_order, pd.products_name' at line 13 :: SELECT  p.products_id, p.products_type, p.master_categories_id,
                       p.manufacturers_id, p.products_price, p.products_tax_class_id, pd.products_description,
                       IF(s.status = 1, s.specials_new_products_price, NULL) AS specials_new_products_price,
                       IF(s.status = 1, s.specials_new_products_price, p.products_price) AS final_price,
                       p.products_sort_order, p.product_is_call, p.product_is_always_free_shipping, p.products_qty_box_status
                FROM products p
                LEFT JOIN specials s ON s.products_id = p.products_id
                LEFT JOIN products_description pd ON pd.products_id = p.products_id AND pd.language_id = 1
                LEFT JOIN manufacturers m ON m.manufacturers_id = p.manufacturers_id
                 LEFT JOIN products_to_categories p2c ON p2c.products_id = p.products_id
                WHERE p.products_status = 1
                 AND p2c.categories_id = 10
                 AND pd.products_name LIKE ''%'   ORDER BY p.products_sort_order, pd.products_name  ==> (as called by) C:\xampp\htdocs\zc210\includes\modules\pages\index\header_php.php on line 131 <== in C:\xampp\htdocs\zc210\includes\classes\db\mysql\query_factory.php on line 734.
```