### PR TITLE
Prevent array input where undesired

### DIFF
--- a/includes/classes/observers/auto.non_captcha_observer.php
+++ b/includes/classes/observers/auto.non_captcha_observer.php
@@ -94,10 +94,20 @@ class zcObserverNonCaptchaObserver extends base
         ];
 
         // prepare for inspection
+        $array_found = false; 
         foreach ($fields as $field) {
             if (!empty($_POST[$field])) {
-                $test_string .= $_POST[$field];
+                if (is_array($_POST[$field])) {
+                   $array_found = true; 
+                   $_POST[$field] = '';
+                } else {
+                   $test_string .= $_POST[$field];
+                }
             }
+        }
+        if ($array_found) { 
+            $GLOBALS['antiSpam'] = 'spam';
+            return; 
         }
 
         if (empty(trim($test_string))) return;


### PR DESCRIPTION
```
[30-Apr-2025 13:24:40 America/Los_Angeles] Request URI: /index.php?action=send&main_page=contact_us, IP address: 184.75.190.2, Language id 1
#0 /home/client/public_html/includes/classes/observers/auto.non_captcha_observer.php(99): zen_debug_error_handler()
#1 /home/client/public_html/includes/classes/observers/auto.non_captcha_observer.php(35): zcObserverNonCaptchaObserver->testURLSpam()
#2 /home/client/public_html/includes/classes/observers/auto.non_captcha_observer.php(45): zcObserverNonCaptchaObserver->update()
#3 /home/client/public_html/includes/classes/traits/NotifierManager.php(106): zcObserverNonCaptchaObserver->updateNotifyContactUsCaptchaCheck()
#4 /home/client/public_html/includes/modules/pages/contact_us/header_php.php(31): base->notify()
#5 /home/client/public_html/index.php(35): require('/home/client/p...')
--> PHP Warning: Array to string conversion in /home/client/public_html/includes/classes/observers/auto.non_captcha_observer.php on line 99.

```
