### PR TITLE
Correct "greedy" search via `get_template_dir`

### DIFF
--- a/includes/templates/template_default/common/html_header_css_loader.php
+++ b/includes/templates/template_default/common/html_header_css_loader.php
@@ -16,9 +16,9 @@ if (!defined('IS_ADMIN_FLAG')) {
 /**
  * load all template-specific stylesheets, named like "style*.css", alphabetically
  */
-$directory_array = $template->get_template_part($template->get_template_dir('.css', DIR_WS_TEMPLATE, $current_page_base, 'css'), '/^style/', '.css');
+$directory_array = $template->get_template_part($template->get_template_dir('^style.*\.css', DIR_WS_TEMPLATE, $current_page_base, 'css'), '/^style/', '.css');
 foreach ($directory_array as $value) {
-    echo '<link rel="stylesheet" href="' . $template->get_template_dir('.css', DIR_WS_TEMPLATE, $current_page_base, 'css') . '/' . $value . '">' . "\n";
+    echo '<link rel="stylesheet" href="' . $template->get_template_dir('^' . $value, DIR_WS_TEMPLATE, $current_page_base, 'css') . '/' . $value . '">' . "\n";
 }
 
 /**
@@ -42,7 +42,7 @@ $sheets_array = [
     '/' . $_SESSION['language'] . '_p_' . $tmp_products_id,
 ];
 foreach ($sheets_array as $value) {
-    $perpagefile = $template->get_template_dir('.css', DIR_WS_TEMPLATE, $current_page_base, 'css') . $value . '.css';
+    $perpagefile = $template->get_template_dir('^' . $value . '.css', DIR_WS_TEMPLATE, $current_page_base, 'css') . $value . '.css';
     if (file_exists($perpagefile)) {
         echo '<link rel="stylesheet" href="' . $perpagefile . '">' . "\n";
     }
@@ -55,11 +55,13 @@ $tmp_cats = explode('_', $cPath);
 $value = '';
 foreach ($tmp_cats as $val) {
     $value .= $val;
-    $perpagefile = $template->get_template_dir('.css', DIR_WS_TEMPLATE, $current_page_base, 'css') . '/c_' . $value . '_children.css';
+    $ppfile = 'c_' . $value . '_children.css';
+    $perpagefile = $template->get_template_dir('^' . $ppfile, DIR_WS_TEMPLATE, $current_page_base, 'css') . '/' . $ppfile;
     if (file_exists($perpagefile)) {
         echo '<link rel="stylesheet" href="' . $perpagefile . '">' . "\n";
     }
-    $perpagefile = $template->get_template_dir('.css', DIR_WS_TEMPLATE, $current_page_base, 'css') . '/' . $_SESSION['language'] . '_c_' . $value . '_children.css';
+    $ppfile = $_SESSION['language'] . '_c_' . $value . '_children.css';
+    $perpagefile = $template->get_template_dir('^' . $ppfile, DIR_WS_TEMPLATE, $current_page_base, 'css') . '/' . $ppfile;
     if (file_exists($perpagefile)) {
         echo '<link rel="stylesheet" href="' . $perpagefile . '">' . "\n";
     }
@@ -69,17 +71,17 @@ foreach ($tmp_cats as $val) {
 /**
  * load printer-friendly stylesheets -- named like "print*.css", alphabetically
  */
-$directory_array = $template->get_template_part($template->get_template_dir('.css', DIR_WS_TEMPLATE, $current_page_base, 'css'), '/^print/', '.css');
+$directory_array = $template->get_template_part($template->get_template_dir('^print.*\.css', DIR_WS_TEMPLATE, $current_page_base, 'css'), '/^print/', '.css');
 foreach ($directory_array as $value) {
-    echo '<link rel="stylesheet" media="print" href="' . $template->get_template_dir('.css', DIR_WS_TEMPLATE, $current_page_base, 'css') . '/' . $value . '">' . "\n";
+    echo '<link rel="stylesheet" media="print" href="' . $template->get_template_dir('^' . $value, DIR_WS_TEMPLATE, $current_page_base, 'css') . '/' . $value . '">' . "\n";
 }
 
 /**
  * load all DYNAMIC template-specific stylesheets, named like "style*.php", alphabetically
  */
-$directory_array = $template->get_template_part($template->get_template_dir('.php', DIR_WS_TEMPLATE, $current_page_base, 'css'), '/^style/', '.php');
+$directory_array = $template->get_template_part($template->get_template_dir('^style.*\.php', DIR_WS_TEMPLATE, $current_page_base, 'css'), '/^style/', '.php');
 foreach ($directory_array as $value) {
-    require $template->get_template_dir('.php', DIR_WS_TEMPLATE, $current_page_base, 'css') . '/' . $value;
+    require $template->get_template_dir('^' . $value, DIR_WS_TEMPLATE, $current_page_base, 'css') . '/' . $value;
 }
 
 // User defined styles come last

--- a/includes/templates/template_default/common/html_header_js_loader.php
+++ b/includes/templates/template_default/common/html_header_js_loader.php
@@ -16,9 +16,9 @@ if (!defined('IS_ADMIN_FLAG')) {
 /**
  * load all site-wide jscript_*.js files from includes/templates/YOURTEMPLATE/jscript, alphabetically
  */
-$directory_array = $template->get_template_part($template->get_template_dir('.js', DIR_WS_TEMPLATE, $current_page_base, 'jscript'), '/^jscript_/', '.js');
+$directory_array = $template->get_template_part($template->get_template_dir('^jscript_.*\.js', DIR_WS_TEMPLATE, $current_page_base, 'jscript'), '/^jscript_/', '.js');
 foreach ($directory_array as $value) {
-    echo '<script src="' .  $template->get_template_dir('.js', DIR_WS_TEMPLATE, $current_page_base, 'jscript') . '/' . $value . '"></script>' . "\n";
+    echo '<script src="' .  $template->get_template_dir('^' . $value, DIR_WS_TEMPLATE, $current_page_base, 'jscript') . '/' . $value . '"></script>' . "\n";
 }
 
 /**
@@ -32,13 +32,13 @@ foreach ($directory_array as $value) {
 /**
  * load all site-wide jscript_*.php files from includes/templates/YOURTEMPLATE/jscript, alphabetically
  */
-$directory_array = $template->get_template_part($template->get_template_dir('.php', DIR_WS_TEMPLATE, $current_page_base, 'jscript'), '/^jscript_/', '.php');
+$directory_array = $template->get_template_part($template->get_template_dir('^jscript_.*\.php', DIR_WS_TEMPLATE, $current_page_base, 'jscript'), '/^jscript_/', '.php');
 foreach ($directory_array as $value) {
     /**
      * include content from all site-wide jscript_*.php files from includes/templates/YOURTEMPLATE/jscript, alphabetically.
      * These .PHP files can be manipulated by PHP when they're called, and are copied in-full to the browser page
      */
-    require $template->get_template_dir('.php', DIR_WS_TEMPLATE, $current_page_base, 'jscript') . '/' . $value;
+    require $template->get_template_dir('^' . $value, DIR_WS_TEMPLATE, $current_page_base, 'jscript') . '/' . $value;
     echo "\n";
 }
 


### PR DESCRIPTION
The `$template->template_dir` method calls `$pageLoader->getTemplateDirectory` which uses a `regex` search to locate a collection of template files.

Since the current regex on the search strings when loading named CSS, JS and PHP files in a template's `/css` and/or `/jscript` sub-directories is 'loose' this results in false-positive location of files when using a template's page-override feature:
https://github.com/zencart/zencart/blob/02b6efdd442a0ba89d28511e90d62c42a5ac53c9/includes/templates/template_default/common/tpl_main_page.php#L7-L10

This unwanted behavior can be viewed most easily via a page-override using the `bootstrap` template.  Simply create the sub-directory `/includes/templates/bootstrap/privacy` (or your clone's name) and add a file with a `.php` extension in that directory.  You'll note that the coloring of the `privacy` page goes wonky since the `css/stylesheet_zca_colors.php` file isn't loaded.

This PR provides more specific search parameters for the `template_dir` requests for the common CSS/JS loading.