### PR TITLE
Invoice/packingslip/confirmation email: Don't include empty phone number

### DIFF
--- a/admin/invoice.php
+++ b/admin/invoice.php
@@ -97,11 +97,17 @@ if (empty($order->info)) {
               <tr>
                 <td><?php echo zen_draw_separator('pixel_trans.gif', '1', '5'); ?></td>
               </tr>
+<?php
+    if (!empty($order->customer['telephone'])) {
+?>
               <tr>
                 <td class="main">
                     <?php echo ENTRY_TELEPHONE_NUMBER . ' ' . $order->customer['telephone']; ?>
                 </td>
               </tr>
+<?php
+    }
+?>
               <tr>
                 <td class="main"><?php echo '<a href="mailto:' . $order->customer['email_address'] . '">' . $order->customer['email_address'] . '</a>'; ?></td>
               </tr>

--- a/admin/packingslip.php
+++ b/admin/packingslip.php
@@ -92,11 +92,17 @@ if (empty($order->info)) {
               <tr>
                 <td><?php echo zen_draw_separator('pixel_trans.gif', '1', '5'); ?></td>
               </tr>
+<?php
+    if (!empty($order->customer['telephone'])) {
+?>
               <tr>
                 <td class="main">
                     <?php echo ENTRY_TELEPHONE_NUMBER . ' ' . $order->customer['telephone']; ?>
                 </td>
               </tr>
+<?php
+    }
+?>
               <tr>
                 <td class="main"><?php echo '<a href="mailto:' . $order->customer['email_address'] . '">' . $order->customer['email_address'] . '</a>'; ?></td>
               </tr>

--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -1388,8 +1388,14 @@ class order extends base
         $html_msg['INTRO_DATE_ORDERED'] = $zcDate->output(DATE_FORMAT_LONG);
         $html_msg['INTRO_URL_TEXT'] = EMAIL_TEXT_INVOICE_URL_CLICK;
         $html_msg['INTRO_URL_VALUE'] = zen_href_link(FILENAME_ACCOUNT_HISTORY_INFO, 'order_id=' . $zf_insert_id, 'SSL', false);
-        $html_msg['EMAIL_CUSTOMER_PHONE'] = $this->customer['telephone'];
-        $html_msg['EMAIL_TEXT_TELEPHONE'] = EMAIL_TEXT_TELEPHONE;
+
+        if (empty($this->customer['telephone'])) {
+            $html_msg['EMAIL_CUSTOMER_PHONE'] = '';
+            $html_msg['EMAIL_TEXT_TELEPHONE'] = '';
+        } else {
+            $html_msg['EMAIL_CUSTOMER_PHONE'] = $this->customer['telephone'];
+            $html_msg['EMAIL_TEXT_TELEPHONE'] = EMAIL_TEXT_TELEPHONE;
+        }
 
         //comments area
         $html_msg['ORDER_COMMENTS'] = '';
@@ -1434,7 +1440,10 @@ class order extends base
                 EMAIL_SEPARATOR . "\n" .
                 zen_address_label($_SESSION['customer_id'], $_SESSION['sendto'], false, '', "\n") . "\n";
         }
-        $email_order .= EMAIL_TEXT_TELEPHONE . $this->customer['telephone'] . "\n\n";
+
+        if (!empty($this->customer['telephone'])) {
+            $email_order .= EMAIL_TEXT_TELEPHONE . $this->customer['telephone'] . "\n\n";
+        }
 
         //addresses area: Billing
         $email_order .= "\n" . EMAIL_TEXT_BILLING_ADDRESS . "\n" .


### PR DESCRIPTION
If a site doesn't require a telephone number (i.e. Configuration :: Minimum Values :: Telephone Number is set to 0), empty telephone numbers are still displayed on an order's invoice or packingslip and are also included in the order's confirmation email.

This PR includes the telephone number in those 3 spots only if the value isn't "empty".