### PR TITLE
Developer tool missing POST data

### DIFF
--- a/admin/developers_tool_kit.php
+++ b/admin/developers_tool_kit.php
@@ -61,7 +61,7 @@ function getDirList($dirName, $filetypes = 1) {
 function zen_display_files($include_root = false, $filetypesincluded = 1) {
   global $check_directory, $found, $configuration_key_lookup, $outCount, $output;
   global $db;
-  $max_context_lines_before = $max_context_lines_after = !empty($_POST['context_lines']) ? abs((int)$_POST['context_lines']) : 0;
+  $max_context_lines_before = $max_context_lines_after = abs((int)($_POST['context_lines'] ?? 0));
 
   $directory_array = array();
   for ($i = 0, $n = count($check_directory); $i < $n; $i++) {

--- a/admin/developers_tool_kit.php
+++ b/admin/developers_tool_kit.php
@@ -61,7 +61,7 @@ function getDirList($dirName, $filetypes = 1) {
 function zen_display_files($include_root = false, $filetypesincluded = 1) {
   global $check_directory, $found, $configuration_key_lookup, $outCount, $output;
   global $db;
-  $max_context_lines_before = $max_context_lines_after = abs((int)$_POST['context_lines']);
+  $max_context_lines_before = $max_context_lines_after = !empty($_POST['context_lines']) ? abs((int)$_POST['context_lines']) : 0;
 
   $directory_array = array();
   for ($i = 0, $n = count($check_directory); $i < $n; $i++) {


### PR DESCRIPTION
Fixes #7105 
When coming back from Look Up Constant definition page to Developer Tool page, there is no POST data `context_lines`. Taking this in account avoids warning log.