### PR TITLE
Add missing storefront DATE_TIME_FORMAT definition

### DIFF
--- a/includes/languages/lang.english.php
+++ b/includes/languages/lang.english.php
@@ -94,6 +94,7 @@ $define = [
     'CHARSET' => 'utf-8',
     'DATE_FORMAT' => 'm/d/Y',
     'DATE_FORMAT_LONG' => '%A %d %B, %Y',
+    'DATE_TIME_FORMAT' => '%m/%d/%Y %H:%M:%S',
     'DATE_TIME_FORMAT_WITHOUT_SECONDS' => '%m/%d/%Y %H:%M',
     'DB_ERROR_NOT_CONNECTED' => 'Error - Could not connect to Database',
     'DOB_FORMAT_STRING' => 'mm/dd/yyyy',


### PR DESCRIPTION
Needed for storefront calls to `zen_datetime_short`; reported [here](https://www.zen-cart.com/showthread.php?230744-shipstation-error&p=1407656#post1407656) on the Zen Cart forums.