### PR TITLE
Coupon help, only active when a coupon's been applied

### DIFF
--- a/includes/modules/pages/popup_coupon_help/header_php.php
+++ b/includes/modules/pages/popup_coupon_help/header_php.php
@@ -7,6 +7,12 @@
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: DrByte 2020 Jul 10 Modified in v1.5.8-alpha $
  */
+if (!isset($_GET['cID'], $_SESSION['cc_id']) || (int)$_GET['cID'] !== (int)$_SESSION['cc_id']) {
+    $_SESSION['cart']->reset(true);
+    zen_session_destroy();
+
+    die('Illegal Access');
+}
+
 $_SESSION['navigation']->remove_current_page();
-require(DIR_WS_MODULES . zen_get_module_directory('require_languages.php'));
-?>
+require DIR_WS_MODULES . zen_get_module_directory('require_languages.php');


### PR DESCRIPTION
The `popup_coupon_help` page should only be displayed when a discount-coupon has been applied to an order.

This PR prevents unwanted accesses attempting to find coupon information.