### PR TITLE
Remove password-reset-tokens when customer deleted

### DIFF
--- a/includes/classes/Customer.php
+++ b/includes/classes/Customer.php
@@ -834,6 +834,11 @@ class Customer extends base
               WHERE customers_id = " . (int)$this->customer_id
         );
 
+        $db->Execute(
+            "DELETE FROM " . TABLE_CUSTOMER_PASSWORD_RESET_TOKENS . "
+              WHERE customer_id = " . (int)$this->customer_id
+        );
+
         $this->notify('NOTIFY_CUSTOMER_AFTER_RECORD_DELETED', (int)$this->customer_id);
 
         zen_record_admin_activity('Customer with customer ID ' . (int)$this->customer_id . ' deleted.', 'warning');


### PR DESCRIPTION
Remove any records in the `customer_password_reset_tokens` table when a customer is deleted.