### PR TITLE
Correct TEXT attributes form name

### DIFF
--- a/includes/modules/attributes.php
+++ b/includes/modules/attributes.php
@@ -586,7 +586,7 @@ foreach ($products_options_names as $next_option_name) {
 
         // text
         if ($products_options_type === PRODUCTS_OPTIONS_TYPE_TEXT) {
-            $option_form_name . '[' . TEXT_PREFIX . $products_options_id . ']';
+            $option_form_name = 'id[' . TEXT_PREFIX . $products_options_id . ']';
             if (!empty($_POST['id']) && is_array($_POST['id'])) {
                 foreach ($_POST['id'] as $key => $value) {
                     if (preg_replace('/txt_/', '', $key) == $products_options_id) {


### PR DESCRIPTION
Updates/fixes refactor in #7107 

... otherwise, various PHP warnings/deprecations are thrown because the shopping_cart class doesn't create the 'attributes_values' element of its `contents` array.

```
[25-Jun-2025 10:01:40 America/New_York] Request URI: /zc210/index.php?main_page=shopping_cart, IP address: 127.0.0.1, Language id 1
#0 C:\xampp\htdocs\zc210\includes\classes\shopping_cart.php(1064): zen_debug_error_handler()
#1 C:\xampp\htdocs\zc210\includes\classes\shopping_cart.php(1393): shoppingCart->attributes_price()
#2 C:\xampp\htdocs\zc210\includes\modules\pages\shopping_cart\header_php.php(22): shoppingCart->get_products()
#3 C:\xampp\htdocs\zc210\index.php(40): require('C:\\xampp\\htdocs...')
--> PHP Warning: Undefined array key "attributes_values" in C:\xampp\htdocs\zc210\includes\classes\shopping_cart.php on line 1064.

[25-Jun-2025 10:01:40 America/New_York] Request URI: /zc210/index.php?main_page=shopping_cart, IP address: 127.0.0.1, Language id 1
#0 C:\xampp\htdocs\zc210\includes\classes\shopping_cart.php(1064): zen_debug_error_handler()
#1 C:\xampp\htdocs\zc210\includes\classes\shopping_cart.php(1393): shoppingCart->attributes_price()
#2 C:\xampp\htdocs\zc210\includes\modules\pages\shopping_cart\header_php.php(22): shoppingCart->get_products()
#3 C:\xampp\htdocs\zc210\index.php(40): require('C:\\xampp\\htdocs...')
--> PHP Warning: Trying to access array offset on null in C:\xampp\htdocs\zc210\includes\classes\shopping_cart.php on line 1064.
```