### PR TITLE
Upload: Lowercase file-extension only

### DIFF
--- a/includes/classes/upload.php
+++ b/includes/classes/upload.php
@@ -262,14 +262,15 @@ class upload extends base
 
     protected function sanitizeFileName(string $filename): string
     {
-        // Convert to lowercase
-        $filename = strtolower($filename);
+        // Convert file-extension to lowercase
+        $file_pieces = pathinfo($filename);
+        $filename = $file_pieces['filename'] . '.' . strtolower($file_pieces['extension']);
 
         // Replace spaces with hyphens
         $filename = str_replace(' ', '-', $filename);
 
         // Remove special characters (keep alphanumerics, dashes, underscores, and dots)
-        $filename = preg_replace('/[^a-z0-9_\-\.]/', '', $filename);
+        $filename = preg_replace('/[^a-zA-Z0-9_\-\.]/', '', $filename);
 
         // Replace multiple dots with a single dot
         $filename = preg_replace('/\.+/', '.', $filename);


### PR DESCRIPTION
The filename sanitization for PR #6897 was a bit overreaching in its lower-casing of the entire filename, as the goal was to avoid issues with JPG vs jpg files.

This has caused problems in the DbIo plugin (https://github.com/lat9/dbio/issues/240) and possibly others that upload files as part of their processing.

This change updates the sanitization so that only the uploaded file's _extension_ is lowercased.