### PR TITLE
Prevent log during who's online

### DIFF
--- a/admin/includes/languages/lang.english.php
+++ b/admin/includes/languages/lang.english.php
@@ -235,6 +235,7 @@ $define = [
     'ERROR_PASSWORDS_NOT_MATCHING' => 'Password and confirmation must match',
     'ERROR_PASSWORD_RULES' => 'Passwords must contain both letters and numbers, must be at least %s characters long, and must not be the same as the last 4 passwords used. Passwords expire every 90 days, after which you will be prompted to choose a new password.',
     'ERROR_PAYMENT_MODULES_NOT_DEFINED' => 'NOTE: You have no payment modules activated. Please go to Modules->Payment to configure.',
+    'ERROR_PRODUCT_OPTION_SELECTION' => '<br> ... Invalid Option Values Selected ',
     'ERROR_SHIPPING_CONFIGURATION' => '<strong>Shipping Configuration errors!</strong>',
     'ERROR_SHIPPING_MODULES_NOT_DEFINED' => 'NOTE: You have no shipping modules activated. Please go to Modules->Shipping to configure.',
     'ERROR_SHIPPING_ORIGIN_ZIP' => '<strong>Warning:</strong> Store Zip Code is not defined. See Configuration | Shipping/Packaging to set it.',


### PR DESCRIPTION
```
[28-Jun-2025 12:06:18 UTC] PHP Fatal error:  Uncaught Error: Undefined constant "ERROR_PRODUCT_OPTION_SELECTION" in /Users/scott/Sites/gh_demo_200/includes/classes/shopping_cart.php:1098
Stack trace:
#0 /Users/scott/Sites/gh_demo_200/includes/classes/shopping_cart.php(1393): shoppingCart->attributes_price('1:edff669e5da95...')
#1 /Users/scott/Sites/gh_demo_200/admin/includes/classes/WhosOnline.php(361): shoppingCart->get_products()
#2 /Users/scott/Sites/gh_demo_200/admin/includes/classes/WhosOnline.php(249): WhosOnline->inspectSessionCart('', 'securityToken|s...')
#3 /Users/scott/Sites/gh_demo_200/admin/includes/classes/WhosOnline.php(157): WhosOnline->getStatusCode(Array)
#4 /Users/scott/Sites/gh_demo_200/admin/whos_online.php(52): WhosOnline->retrieve('', '423a3f87ea98313...', true, false)
#5 /Users/scott/Sites/gh_demo_200/admin/index.php(16): require('/Users/scott/Si...')
#6 {main}
  thrown in /Users/scott/Sites/gh_demo_200/includes/classes/shopping_cart.php on line 1098
```