### PR TITLE
Function zen_break_string use

### DIFF
--- a/admin/reviews.php
+++ b/admin/reviews.php
@@ -207,7 +207,7 @@ if (!empty($action)) {
                 <p class="control-label"><?php echo ENTRY_REVIEW; ?></p>
               </div>
               <div class="col-sm-9 col-md-6">
-                <span class="form-control" style="border:none; -webkit-box-shadow: none"><?php echo nl2br(zen_output_string_protected(zen_break_string($rInfo->reviews_text, 15))); ?></span>
+                <span class="form-control" style="border:none; -webkit-box-shadow: none"><?php echo nl2br(zen_output_string_protected(zen_trunc_string($rInfo->reviews_text, 15))); ?></span>
               </div>
             </div>
             <div class="form-group">

--- a/includes/templates/responsive_classic/templates/tpl_product_reviews_info_default.php
+++ b/includes/templates/responsive_classic/templates/tpl_product_reviews_info_default.php
@@ -12,7 +12,7 @@
 
 <?php
   if (!empty($products_image)) {
-   	/**
+    /**
      * require the image display code
      */
 ?>
@@ -50,7 +50,7 @@
 <div class="reviews-wrapper clearBoth">
 <h3 class="rating"><?php echo zen_image(DIR_WS_TEMPLATE_IMAGES . 'stars_' . $review_info->fields['reviews_rating'] . '.png', sprintf(TEXT_OF_5_STARS, $review_info->fields['reviews_rating'])), sprintf(TEXT_OF_5_STARS, $review_info->fields['reviews_rating']); ?></h3>
 
-<div id="reviewsInfoDefaultMainContent" class="content"><?php echo zen_break_string(nl2br(zen_output_string_protected(stripslashes($review_info->fields['reviews_text']))), 60); ?></div>
+<div id="reviewsInfoDefaultMainContent" class="content"><?php echo nl2br(zen_output_string_protected(stripslashes($review_info->fields['reviews_text']))); ?></div>
 <div id="reviewsInfoDefaultDate"><?php echo sprintf(TEXT_REVIEW_DATE_ADDED, zen_date_short($review_info->fields['date_added'])); ?>&nbsp;<?php echo sprintf(TEXT_REVIEW_BY, zen_output_string_protected($review_info->fields['customers_name'])); ?></div>
 
 </div>

--- a/includes/templates/template_default/templates/tpl_product_reviews_info_default.php
+++ b/includes/templates/template_default/templates/tpl_product_reviews_info_default.php
@@ -12,7 +12,7 @@
 
 <?php
   if (!empty($products_image)) {
-   	/**
+    /**
      * require the image display code
      */
 ?>
@@ -49,7 +49,7 @@
 
 <h3 class="rating"><?php echo zen_image(DIR_WS_TEMPLATE_IMAGES . 'stars_' . $review_info->fields['reviews_rating'] . '.gif', sprintf(TEXT_OF_5_STARS, $review_info->fields['reviews_rating'])), sprintf(TEXT_OF_5_STARS, $review_info->fields['reviews_rating']); ?></h3>
 
-<div id="reviewsInfoDefaultMainContent" class="content"><?php echo zen_break_string(nl2br(zen_output_string_protected(stripslashes($review_info->fields['reviews_text']))), 60, '-<br>'); ?></div>
+<div id="reviewsInfoDefaultMainContent" class="content"><?php echo nl2br(zen_output_string_protected(stripslashes($review_info->fields['reviews_text']))); ?></div>
 <div id="reviewsInfoDefaultDate" class="bold"><?php echo sprintf(TEXT_REVIEW_DATE_ADDED, zen_date_short($review_info->fields['date_added'])); ?>&nbsp;<?php echo sprintf(TEXT_REVIEW_BY, zen_output_string_protected($review_info->fields['customers_name'])); ?></div>
 
 </div>


### PR DESCRIPTION
Fixes #7113 
Removes use of function zen_break_string in templates reviews' display that leads to random line breaks when multibyte characters are used in languages with no spaces between words.