### PR TITLE
Initialize session language prior to `init_sanitize.php`

### DIFF
--- a/includes/auto_loaders/config.core.php
+++ b/includes/auto_loaders/config.core.php
@@ -190,6 +190,16 @@ $autoLoadConfig[90][] = [
     'objectName' => 'currencies',
 ];
 /**
+ * Breakpoint 95.
+ *
+ * require 'includes/init_includes/init_languages.php';
+ *
+ */
+$autoLoadConfig[95][] = [
+    'autoType' => 'init_script',
+    'loadFile' => 'init_languages.php',
+];
+/**
  * Breakpoint 96.
  *
  * require 'includes/init_includes/init_sanitize.php';
@@ -223,14 +233,9 @@ $autoLoadConfig[100][] = [
 /**
  * Breakpoint 110.
  *
- * require 'includes/init_includes/init_languages.php';
  * require 'includes/init_includes/init_templates.php';
  *
  */
-$autoLoadConfig[110][] = [
-    'autoType' => 'init_script',
-    'loadFile' => 'init_languages.php',
-];
 $autoLoadConfig[110][] = [
     'autoType' => 'init_script',
     'loadFile' => 'init_templates.php',


### PR DESCRIPTION
With the change in PR #7134, logs are now being seen
```
[29-Jun-2025 22:48:23 America/Chicago] Request URI:  /index.php?main_page=product_music_info&cPath=17&products_id=178,  IP address: 157.100.87.87, Language id not set
#0 /includes/classes/Product.php(251): zen_debug_error_handler()
#1 /includes/classes/Product.php(33): Product->loadProductDetails()
#2 /includes/functions/functions_products.php(419): Product->__construct()
#3 /includes/init_includes/init_sanitize.php(236): zen_products_id_valid()
#4 /includes/autoload_func.php(40): require_once('/home/haremark/...')
#5 /includes/application_top.php(329): require('/home/haremark/...')
#6 /index.php(27): require('/home/haremark/...')
--> PHP Warning: Undefined array key "languages_code" in /includes/classes/Product.php on line 251.

[29-Jun-2025 22:48:23 America/Chicago] Request URI:  /index.php?main_page=product_music_info&cPath=17&products_id=178,  IP address: 157.100.87.87, Language id not set
#0 /includes/classes/Product.php(252): zen_debug_error_handler()
#1 /includes/classes/Product.php(33): Product->loadProductDetails()
#2 /includes/functions/functions_products.php(419): Product->__construct()
#3 /includes/init_includes/init_sanitize.php(236): zen_products_id_valid()
#4 /includes/autoload_func.php(40): require_once('/home/haremark/...')
#5 /includes/application_top.php(329): require('/home/haremark/...')
#6 /index.php(27): require('/home/haremark/...')
--> PHP Warning: Undefined array key "languages_code" in /includes/classes/Product.php on line 252.

[29-Jun-2025 22:48:23 America/Chicago] Request URI:  /index.php?main_page=product_music_info&cPath=17&products_id=178,  IP address: 157.100.87.87, Language id not set
#0 /includes/classes/Product.php(253): zen_debug_error_handler()
#1 /includes/classes/Product.php(33): Product->loadProductDetails()
#2 /includes/functions/functions_products.php(419): Product->__construct()
#3 /includes/init_includes/init_sanitize.php(236): zen_products_id_valid()
#4 /includes/autoload_func.php(40): require_once('/home/haremark/...')
#5 /includes/application_top.php(329): require('/home/haremark/...')
#6 /index.php(27): require('/home/haremark/...')
--> PHP Warning: Undefined array key "languages_id" in /includes/classes/Product.php on line 253.
```

This is due to either a 'cold hit' or a page-refresh (after session timeout) of a page that includes a `products_id` $_GET variable.  Moving the language initialization (which sets those missing session variables) prior to the sanitization corrects that issue.