### PR TITLE
Customers::getOrderHistory, when order's status is missing

### DIFF
--- a/includes/classes/Customer.php
+++ b/includes/classes/Customer.php
@@ -696,10 +696,10 @@ class Customer extends base
               "SELECT o.orders_id, o.date_purchased, o.delivery_name,
                     o.order_total, o.currency, o.currency_value,
                     o.delivery_country, o.billing_name, o.billing_country,
-                    s.orders_status_name,
+                    o.orders_status, s.orders_status_name,
                     o.language_code
               FROM " . TABLE_ORDERS . " o
-                    INNER JOIN " . TABLE_ORDERS_STATUS . " s
+                    LEFT JOIN " . TABLE_ORDERS_STATUS . " s
                         ON s.orders_status_id = o.orders_status
                        AND s.language_id = :languagesID
               WHERE o.customers_id = :customersID
@@ -739,7 +739,7 @@ class Customer extends base
                 'order_type' => $order_type,
                 'order_name' => $order_name,
                 'order_country' => $order_country,
-                'orders_status_name' => $result['orders_status_name'],
+                'orders_status_name' => $result['orders_status_name'] ?? sprintf(TEXT_UNKNOWN_ORDERS_STATUS_NAME, (int)$result['orders_status']),
                 'order_total' => $currencies->format($result['order_total'], true, $result['currency'], $result['currency_value']),
                 'order_total_raw' => $result['order_total'],
                 'currency' => $result['currency'],

--- a/includes/languages/lang.english.php
+++ b/includes/languages/lang.english.php
@@ -521,6 +521,7 @@ $define = [
     'TEXT_TOTAL_AMOUNT' => '&nbsp;&nbsp;Amount: ',
     'TEXT_TOTAL_ITEMS' => 'Total Items: ',
     'TEXT_TOTAL_WEIGHT' => '&nbsp;&nbsp;Weight: ',
+    'TEXT_UNKNOWN_ORDERS_STATUS_NAME' => 'Unknown (%u)',   //- %u is filled in by the Customer class to contain the missing orders_status_id
     'TEXT_UNKNOWN_TAX_RATE' => 'Sales Tax',
     'TEXT_VALID_COUPON' => 'Congratulations you have redeemed the Discount Coupon',
     'TEXT_WORDS_FREE' => ' Word(s) free ',


### PR DESCRIPTION
Enables display of orders with missing `orders_status` records for the order's `orders_status` and/or the current language.