### PR TITLE
Unnecessary Multibyte function provoking bug

### DIFF
--- a/admin/define_pages_editor.php
+++ b/admin/define_pages_editor.php
@@ -69,7 +69,7 @@ switch ($_GET['action']) {
         @rename($file, 'bak' . $file);
         $new_file = fopen($file, 'w');
         $file_contents = stripslashes($_POST['file_contents']);
-        fwrite($new_file, $file_contents, mb_strlen($file_contents));
+        fwrite($new_file, $file_contents, strlen($file_contents));
         fclose($new_file);
       }
       zen_record_admin_activity('Define-Page-Editor was used to save changes to file ' . $file, 'info');


### PR DESCRIPTION
A bug was introduced in PR #7123 in file admin/define_page_editor.php line 72 where using mb_strlen() function gives wrong results as the variable is coming from POST data and is encoded differently from a standard PHP multibyte string.
Just replacing back `mb_strlen()` by `strlen()` function fixes the problem.