### PR TITLE
function zen_lookup_admin_menu_language_override update

### DIFF
--- a/includes/functions/functions_lookups.php
+++ b/includes/functions/functions_lookups.php
@@ -311,20 +311,20 @@ function zen_lookup_admin_menu_language_override(string $lookup_type, ?string $l
             break;
         case 'configuration_group_title':
             $str = $lookup_key;
-            $str = preg_replace('/[\s ]+/', '_', $str);
+            $str = preg_replace('/[\s -\/]+/', '_', $str);
             $str = preg_replace('/[^a-zA-Z0-9_\x80-\xff]/', '', $str);
             $lookup = strtoupper('CFG_GRP_TITLE_' . $str);
             break;
         case 'plugin_name':
             $str = $lookup_key;
-            $str = preg_replace('/[\s -]+/', '_', $str);
+            $str = preg_replace('/[\s -\/]+/', '_', $str);
             $str = preg_replace('/[^a-zA-Z0-9_\x80-\xff]/', '', $str);
             $str = preg_replace('/_+/', '_', $str);
             $lookup = strtoupper('ADMIN_PLUGIN_MANAGER_NAME_FOR_' . $str);
             break;
         case 'plugin_description':
             $str = $lookup_key;
-            $str = preg_replace('/[\s -]+/', '_', $str);
+            $str = preg_replace('/[\s -\/]+/', '_', $str);
             $str = preg_replace('/[^a-zA-Z0-9_\x80-\xff]/', '', $str);
             $str = preg_replace('/_+/', '_', $str);
             $lookup = strtoupper('ADMIN_PLUGIN_MANAGER_DESCRIPTION_FOR_' . $str);


### PR DESCRIPTION
Add slash character use in names for configuration groups titles and plugins title/description.
Actually, admin configuration::Shipping / Packaging menu is not translated because the language override constant name is not properly recognized due to the slash (/) character.

This PR updates function zen_lookup_admin_menu_language_override to recognize slashes in group titles and replace them by underscore in constants names.
To be coherent, characters space, hyphen and slash are replaced by underscore in language constants name for configuration groups titles, plugins names and description.
