### PR TITLE
Yearly sales report display bug when more than 5 years of reports

### DIFF
--- a/admin/stats_sales_report_graphs.php
+++ b/admin/stats_sales_report_graphs.php
@@ -111,7 +111,7 @@ for ($i = 0; $i < $report->size; $i++) {
   echo "           ['";
 
   if ($sales_report_view == statsSalesReportGraph::YEARLY_VIEW && $report->size > 5) {
-    echo substr($report->info[$i]['text'], 0, 1);
+    echo substr($report->info[$i]['text'], 2, 2);
   } elseif ($sales_report_view == statsSalesReportGraph::MONTHLY_VIEW) {
     echo substr($report->info[$i]['text'], 0, 3);
   } elseif ($sales_report_view == statsSalesReportGraph::WEEKLY_VIEW) {


### PR DESCRIPTION
Yearly sales report display bug fix to display year last 2 digits only when there are more than 5 years of reports.

When there are more than five years of report, year's first digit only (2 for 2025) is displayed instead of last 2 digits (25 for 2025).
This due to some bad `substring` parameter, '`0,1`' that should be '`2,2`'.
You need more than five years of data for testing. If not, you can change test on line 113 from '`> 5`' to a lower number.