### PR TITLE
tax_rates_description table update query failing

### DIFF
--- a/zc_install/sql/updates/mysql_upgrade_zencart_220.sql
+++ b/zc_install/sql/updates/mysql_upgrade_zencart_220.sql
@@ -68,7 +68,7 @@ CREATE TABLE tax_rates_description (
   UNIQUE KEY idx_rate_lang_zen (tax_rates_id,language_id),
   KEY idx_tax_rates_description_zen (tax_description(250))
 ) ENGINE=MyISAM;
-INSERT INTO tax_rates_description SELECT tr.tax_rates_id, lg.languages_id, tr.tax_description FROM tax_rates tr, languages lg;
+INSERT INTO tax_rates_description (tax_rates_id, language_id, tax_description) SELECT tr.tax_rates_id, lg.languages_id, tr.tax_description FROM tax_rates tr, languages lg;
 ALTER TABLE tax_rates DROP COLUMN tax_description;
 
 #PROGRESS_FEEDBACK:!TEXT=Finalizing ... Done!


### PR DESCRIPTION
When updating database to v2.2.0, the MySQL query to populate new tax_rates_description table after its creation is returning an error due to wrong number of column inserted.
This query needs to be adapted to the new auto increment index added after some modifications.