### PR TITLE
Hard coded decimal place in sales graphs reports

### DIFF
--- a/admin/stats_sales_report_graphs.php
+++ b/admin/stats_sales_report_graphs.php
@@ -128,11 +128,11 @@ for ($i = 0; $i < $report->size; $i++) {
 
   if ($j == 0) {
   // first value
-  echo round($report->info[$i]['sum'], 2);
+  echo round($report->info[$i]['sum'], $currencies->get_decimal_places(DEFAULT_CURRENCY));
   } else {
     // second value
     if ($sales_report_view < statsSalesReportGraph::YEARLY_VIEW) {
-      echo round($report->info[$i]['avg'], 2);
+      echo round($report->info[$i]['avg'], $currencies->get_decimal_places(DEFAULT_CURRENCY));
     }
   }
   echo ']';


### PR DESCRIPTION
Values when hovering sales graphs reports in admin are always displayed with 2 decimals, whatever the currency is. This PR uses default currency decimal place instead.