### PR TITLE
Message stack reformat and sync function signatures

### DIFF
--- a/admin/includes/classes/message_stack.php
+++ b/admin/includes/classes/message_stack.php
@@ -67,7 +67,7 @@ class messageStack extends boxTableBlock
         $this->size = 0;
     }
 
-    public function output(): string
+    public function output(string $class='')
     {
         $this->table_data_parameters = 'class="messageBox"';
         return $this->tableBlock($this->errors);

--- a/admin/includes/classes/table_block.php
+++ b/admin/includes/classes/table_block.php
@@ -6,69 +6,70 @@
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: brittainmark 2022 Aug 22 Modified in v1.5.8-alpha2 $
  */
-class boxTableBlock {
-    protected 
-        $table_row_parameters,
-        $table_data_parameters;
-     
-function tableBlock($contents) {
-    $tableBox_string = '';
+class boxTableBlock
+{
+    protected string $table_row_parameters;
+    protected string $table_data_parameters;
 
-    $form_set = false;
-    if (isset($contents['form'])) {
-      $tableBox_string .= $contents['form'] . "\n";
-      $form_set = true;
-      array_shift($contents);
-    }
+    public function tableBlock($contents): string
+    {
+        $tableBox_string = '';
 
-    for ($i = 0, $n = sizeof($contents); $i < $n; $i++) {
-      if (isset($contents[$i][0]) && is_array($contents[$i][0])) {
-        for ($x = 0, $y = sizeof($contents[$i]); $x < $y; $x++) {
-          if (isset($contents[$i][$x]['text']) && zen_not_null($contents[$i][$x]['text'])) {
-            $tableBox_string .= '<div class="row';
-            if (zen_not_null($this->table_row_parameters)) {
-              $tableBox_string .= ' ' . $this->table_row_parameters;
-            }
-            if (isset($contents[$i][$x]['align']) && zen_not_null($contents[$i][$x]['align'])) {
-              $tableBox_string .= ' ' . $contents[$i][$x]['align'];
-            }
-            if (isset($contents[$i][$x]['params']) && zen_not_null($contents[$i][$x]['params'])) {
-              $tableBox_string .= ' ' . $contents[$i][$x]['params'];
-            } elseif (zen_not_null($this->table_data_parameters)) {
-              $tableBox_string .= ' ' . $this->table_data_parameters;
-            }
-            $tableBox_string .= '"';
-            $tableBox_string .= '>';
-            if (isset($contents[$i][$x]['form']) && zen_not_null($contents[$i][$x]['form'])){
-              $tableBox_string .= $contents[$i][$x]['form'];
-            }
-            $tableBox_string .= $contents[$i][$x]['text'];
-            if (isset($contents[$i][$x]['form']) && zen_not_null($contents[$i][$x]['form'])){
-              $tableBox_string .= '</form>';
-            }
-            $tableBox_string .= '</div>' . "\n";
-          }
+        $form_set = false;
+        if (isset($contents['form'])) {
+            $tableBox_string .= $contents['form'] . "\n";
+            $form_set = true;
+            array_shift($contents);
         }
-      } else {
-        $tableBox_string .= '<div class="row';
-        if (isset($contents[$i]['align']) && zen_not_null($contents[$i]['align'])) {
-          $tableBox_string .= ' ' . $contents[$i]['align'];
-        }
-        if (isset($contents[$i]['params']) && zen_not_null($contents[$i]['params'])) {
-          $tableBox_string .= ' ' . $contents[$i]['params'];
-        } elseif (zen_not_null($this->table_data_parameters)) {
-          $tableBox_string .= ' ' . $this->table_data_parameters;
-        }
-        $tableBox_string .= '"';
-        $tableBox_string .= '>' . $contents[$i]['text'] . '</div>' . "\n";
-      }
-    }
 
-    if ($form_set == true) {
-      $tableBox_string .= '</form>' . "\n";
-    }
+        foreach ($contents as $rowKey => $row) {
+            if (isset($row[0]) && is_array($row[0])) {
+                foreach ($row as $cell => $content) {
+                    if (isset($content['text']) && zen_not_null($content['text'])) {
+                        $tableBox_string .= '<div class="row';
+                        if (zen_not_null($this->table_row_parameters)) {
+                            $tableBox_string .= ' ' . $this->table_row_parameters;
+                        }
+                        if (isset($content['align']) && zen_not_null($content['align'])) {
+                            $tableBox_string .= ' ' . $content['align'];
+                        }
+                        if (isset($content['params']) && zen_not_null($content['params'])) {
+                            $tableBox_string .= ' ' . $content['params'];
+                        } elseif (zen_not_null($this->table_data_parameters)) {
+                            $tableBox_string .= ' ' . $this->table_data_parameters;
+                        }
+                        $tableBox_string .= '"';
+                        $tableBox_string .= '>';
+                        if (isset($content['form']) && zen_not_null($content['form'])) {
+                            $tableBox_string .= $contents[$rowKey][$cell]['form'];
+                        }
+                        $tableBox_string .= $contents[$rowKey][$cell]['text'];
+                        if (isset($content['form']) && zen_not_null($content['form'])) {
+                            $tableBox_string .= '</form>';
+                        }
+                        $tableBox_string .= '</div>' . "\n";
+                    }
+                }
+            } else {
+                $tableBox_string .= '<div class="row';
+                if (isset($row['align']) && zen_not_null($row['align'])) {
+                    $tableBox_string .= ' ' . $row['align'];
+                }
+                if (isset($row['params']) && zen_not_null($row['params'])) {
+                    $tableBox_string .= ' ' . $row['params'];
+                } elseif (zen_not_null($this->table_data_parameters)) {
+                    $tableBox_string .= ' ' . $this->table_data_parameters;
+                }
+                $tableBox_string .= '"';
+                $tableBox_string .= '>' . $row['text'] . '</div>' . "\n";
+            }
+        }
 
-    return $tableBox_string;
-  }
+        if ($form_set === true) {
+            $tableBox_string .= '</form>' . "\n";
+        }
+
+        return $tableBox_string;
+    }
 
 }

--- a/includes/classes/message_stack.php
+++ b/includes/classes/message_stack.php
@@ -87,7 +87,7 @@ class messageStack extends base
         $this->messages = [];
     }
 
-    function output($class)
+    public function output(string $class = 'default')
     {
         global $template, $current_page_base;
 

--- a/includes/classes/message_stack.php
+++ b/includes/classes/message_stack.php
@@ -13,16 +13,15 @@ if (!defined('IS_ADMIN_FLAG')) {
 
 /**
  * Manage messageStack alerts
- *
  */
 class messageStack extends base
 {
     /** to override these, call setMessageFormatting() and pass it an array of the desired formats, similar to what getDefaultFormats() returns */
-    private $formats = [];
+    private array $formats = [];
     /** array of messages to be displayed */
-    public $messages = [];
+    public array $messages = [];
 
-    function __construct()
+    public function __construct()
     {
         $this->messages = [];
 
@@ -31,7 +30,7 @@ class messageStack extends base
         }
     }
 
-    function add($class, $message, $type = 'error')
+    public function add(string $class, string $message, string $type = 'error'): void
     {
         $message = trim($message);
         $duplicate = false;
@@ -66,7 +65,7 @@ class messageStack extends base
         }
     }
 
-    function add_session($class, $message, $type = 'error')
+    public function add_session(string $class, string $message, string $type = 'error'): void
     {
         if (empty($_SESSION['messageToStack'])) {
             $messageToStack = [];
@@ -83,7 +82,7 @@ class messageStack extends base
         $this->add($class, $message, $type);
     }
 
-    function reset()
+    public function reset(): void
     {
         $this->messages = [];
     }
@@ -106,7 +105,7 @@ class messageStack extends base
 
         $output = [];
         foreach ($this->messages as $next_message) {
-            if ($next_message['class'] == $class) {
+            if ($next_message['class'] === $class) {
                 $output[] = $next_message;
             }
         }
@@ -117,7 +116,7 @@ class messageStack extends base
         require $template->get_template_dir('tpl_message_stack_default.php', DIR_WS_TEMPLATE, $current_page_base, 'templates') . '/tpl_message_stack_default.php';
     }
 
-    function size($class)
+    public function size(string $class): int
     {
         if (!empty($_SESSION['messageToStack'])) {
             foreach ($_SESSION['messageToStack'] as $next_message) {
@@ -128,7 +127,7 @@ class messageStack extends base
         $count = 0;
 
         foreach ($this->messages as $next_message) {
-            if ($next_message['class'] == $class) {
+            if ($next_message['class'] === $class) {
                 $count++;
             }
         }
@@ -136,18 +135,15 @@ class messageStack extends base
         return $count;
     }
 
-    /**
-     * @param array $formattingArray
-     */
-    function setMessageFormatting($formattingArray = [])
+    public function setMessageFormatting(array $formattingArray = []): void
     {
         foreach ($formattingArray as $messageType => $keys) {
             foreach ($keys as $key => $value) {
-                if ($key == 'params') {
+                if ($key === 'params') {
                     $this->formats[$messageType]['params'] = $value;
                     continue;
                 }
-                if ($key == 'icon') {
+                if ($key === 'icon') {
                     $this->formats[$messageType]['icon'] = $value;
                 }
             }
@@ -157,7 +153,7 @@ class messageStack extends base
     /**
      * @return array
      */
-    function getDefaultFormats()
+    public function getDefaultFormats(): array
     {
         global $template, $current_page_base;
 


### PR DESCRIPTION
Upcoming updates for PayPal, which uses messageStack (by extending the class for visual control), needs the `output()` method to be compatible with both admin and catalog versions (because webhook handlers only have catalog awareness).

This update, apart from 2 reformatting/refactoring commits, has a commit that simply syncs the `output()` method signature for compatibility.

This is NOT bringing exact parity between the admin/catalog classes, because "use" of the messageStack features are quite different between catalog/admin implementations.
