### PR TITLE
Modifying currencies table to support four letter codes

### DIFF
--- a/zc_install/sql/install/mysql_zencart.sql
+++ b/zc_install/sql/install/mysql_zencart.sql
@@ -598,7 +598,7 @@ DROP TABLE IF EXISTS currencies;
 CREATE TABLE currencies (
   currencies_id int(11) NOT NULL auto_increment,
   title varchar(32) NOT NULL default '',
-  code char(3) NOT NULL default '',
+  code char(4) NOT NULL default '',
   symbol_left varchar(32) default NULL,
   symbol_right varchar(32) default NULL,
   decimal_point char(1) default NULL,
@@ -1204,7 +1204,7 @@ CREATE TABLE orders (
   date_purchased datetime default NULL,
   orders_status int(5) NOT NULL default 0,
   orders_date_finished datetime default NULL,
-  currency char(3) default NULL,
+  currency char(4) default NULL,
   currency_value decimal(14,6) default NULL,
   order_total decimal(15,4) default NULL,
   order_tax decimal(15,4) default NULL,

--- a/zc_install/sql/updates/mysql_upgrade_zencart_220.sql
+++ b/zc_install/sql/updates/mysql_upgrade_zencart_220.sql
@@ -47,7 +47,8 @@ CREATE TABLE customer_password_reset_tokens (
 ALTER TABLE orders_products_attributes MODIFY products_options varchar(191) NOT NULL default '';
 ALTER TABLE products_options MODIFY products_options_name varchar(191) NOT NULL default '';
 ALTER TABLE products_options_values MODIFY products_options_values_name varchar(191) NOT NULL default '';
-
+ALTER TABLE currencies MODIFY code char(4) NOT NULL default '';
+ALTER TABLE orders MODIFY currency char(4) default NULL;
 
 #PROGRESS_FEEDBACK:!TEXT=Updating configuration settings...
 DELETE FROM configuration WHERE configuration_key IN ('REPORT_ALL_ERRORS_ADMIN', 'REPORT_ALL_ERRORS_STORE', 'REPORT_ALL_ERRORS_NOTICE_BACKTRACE');


### PR DESCRIPTION
Some currency services (ie, OpenExchangeRates) have support for four-digit currency codes—namely CryptoCurrencies like DOGE (DogeCoin), DASH, others.

Some currencies are longer, but those are mostly "Black Market Rates" not widely in circulation or use.