### PR TITLE
Strftime_parameter_mismatch_in zcDate.php

### DIFF
--- a/admin/includes/languages/lang.english.php
+++ b/admin/includes/languages/lang.english.php
@@ -9,7 +9,7 @@
 @setlocale(LC_TIME, ['en_US', 'en_US.utf8', 'en', 'English_United States.1252']);
 
 $define = [
-    'ADMIN_NAV_DATE_TIME_FORMAT' => '%A %d %b %Y %X (%Z)',
+    'ADMIN_NAV_DATE_TIME_FORMAT' => '%A %d %b %Y %X (%z)',
     'ARIA_PAGINATION_' => '',
     'ARIA_PAGINATION_CURRENTLY_ON' => ', now on page %s',
     'ARIA_PAGINATION_CURRENT_PAGE' => 'Current Page',

--- a/includes/classes/zcDate.php
+++ b/includes/classes/zcDate.php
@@ -59,6 +59,7 @@ class zcDate extends base
             '%B' => 'F',
             '%d' => 'd',
             '%H' => 'H',
+            '%k' => 'G',
             '%m' => 'm',
             '%M' => 'i',
             '%S' => 's',
@@ -67,8 +68,8 @@ class zcDate extends base
             '%X' => 'H:i:s',
             '%y' => 'y',
             '%Y' => 'Y',
-            '%z' => 'ZZZZ',
-            '%Z' => 'ZZZZ',
+            '%z' => 'eP',
+            '%Z' => 'T',
         ];
         $this->strftime2date = [
             'from' => array_keys($strftime2date),
@@ -107,6 +108,7 @@ class zcDate extends base
                 '%B' => 'MMMM',
                 '%d' => 'dd',
                 '%H' => 'HH',
+                '%k' => 'H',
                 '%m' => 'MM',
                 '%M' => 'mm',
                 '%S' => 'ss',
@@ -116,7 +118,7 @@ class zcDate extends base
                 '%y' => 'yy',
                 '%Y' => 'y',
                 '%z' => 'ZZZZ',
-                '%Z' => 'ZZZZ',
+                '%Z' => 'zzzz',
             ];
             $this->strftime2intl = [
                 'from' => array_keys($strftime2intl),


### PR DESCRIPTION
Corrects conversion of some `strftime` parameters to date() and `intlDate` format parameters.
Fixes #6840  and adds parameter `%k` conversion, useful for some plugins.