### PR TITLE
zen_cfg_select_multioption - allow = separator for descriptive text

### DIFF
--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -609,14 +609,25 @@ function zen_get_master_categories_pulldown($product_id, $fullpath = false)
  * Alias function for Store configuration values in the Administration Tool
  * adapted from USPS-related contributions by Brad Waite and Fritz Clapp
  */
-function zen_cfg_select_multioption($select_array, $key_value, $key = '')
+function zen_cfg_select_multioption(array $choices_array, string $stored_value, string $config_key_name = ''): string
 {
     $string = '';
-    for ($i = 0, $n = count($select_array); $i < $n; $i++) {
-        $name = (($key) ? 'configuration[' . $key . '][]' : 'configuration_value');
-        $key_values = explode(", ", $key_value);
-        $string .= '<div class="checkbox"><label>' . zen_draw_checkbox_field($name, $select_array[$i], (in_array($select_array[$i], $key_values) ? true : false), 'id="' . strtolower($select_array[$i] . '-' . $name) . '"') . $select_array[$i] . '</label></div>' . "\n";
+    $name = (($config_key_name) ? 'configuration[' . $config_key_name . '][]' : 'configuration_value');
+    $chosen_already = explode(", ", $stored_value);
+
+    foreach ($choices_array as $value) {
+        // Account for cases where an = sign is used to allow key->value pairs where the value is friendly display text
+        $beforeEquals = strstr($value, '=', true);
+
+        // this entry's checkbox should be pre-selected if the key matches
+        $ticked = (in_array($value, $chosen_already, true) || in_array($beforeEquals, $chosen_already, true));
+
+        // determine the value to show (the part after the =; if no =, just the whole string)
+        $display_value = strpos($value, '=') !== false ? explode('=', $value, 2)[1] : $value;
+
+        $string .= '<div class="checkbox"><label>' . zen_draw_checkbox_field($name, $value, $ticked, 'id="' . strtolower($value . '-' . $name) . '"') . $display_value . '</label></div>' . "\n";
     }
+
     $string .= zen_draw_hidden_field($name, '--none--');
     return $string;
 }


### PR DESCRIPTION
`product=Product Page` can be parsed for key of `product` and display in checkboxes as `Product Page`

Before:
<img width="340" height="328" alt="Screen Shot 2025-08-12 at 12 56 13 AM" src="https://github.com/user-attachments/assets/811f658f-9240-4552-94fa-f80594d6542c" />

After:
<img width="376" height="340" alt="Screen Shot 2025-08-12 at 12 57 28 AM" src="https://github.com/user-attachments/assets/0ef5f588-e0f4-480c-9d63-823c8fc25779" />
