### PR TITLE
PayPal Admin notification, correcting missing constant whitescreen

### DIFF
--- a/includes/modules/payment/paypal/paypalwpp_admin_notification.php
+++ b/includes/modules/payment/paypal/paypalwpp_admin_notification.php
@@ -473,7 +473,9 @@ if (isset($response['RESPMSG']) /*|| defined('MODULE_PAYMENT_PAYFLOW_STATUS')*/)
             if (method_exists($this, '_doRefund') && ($response['PAYMENTTYPE'] != 'instant' || $module == 'paypaldp')) {
                 $output .= $outputRefund;
             }
-            if (MODULE_PAYMENT_PAYPALWPP_TRANSACTION_MODE == 'Auth Only' || MODULE_PAYMENT_PAYPALDP_TRANSACTION_MODE == 'Auth Only') {
+            zen_define_default('MODULE_PAYMENT_PAYPALWPP_TRANSACTION_MODE', '');
+            zen_define_default('MODULE_PAYMENT_PAYPALDP_TRANSACTION_MODE', '');
+            if (MODULE_PAYMENT_PAYPALWPP_TRANSACTION_MODE === 'Auth Only' || MODULE_PAYMENT_PAYPALDP_TRANSACTION_MODE === 'Auth Only') {
                 if (method_exists($this, '_doAuth')) {
                     $output .= $outputAuth;
                 }


### PR DESCRIPTION
Ensure that the two PayPal NVP configuration constants are defined, to prevent a whitescreen on the admin's Customers :: Orders page.