### PR TITLE
Order query: Enable observer to reuse gathered product info

### DIFF
--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -370,7 +370,7 @@ class order extends base
 
         $this->statuses = $this->getStatusHistory($this->orderId);
 
-        $this->notify('NOTIFY_ORDER_AFTER_QUERY', IS_ADMIN_FLAG, $this->orderId);
+        $this->notify('NOTIFY_ORDER_AFTER_QUERY', IS_ADMIN_FLAG, $this->orderId, $order->fields);
 
         /**
          * @deprecated since v1.5.6; use NOTIFY_ORDER_AFTER_QUERY instead

--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -362,7 +362,7 @@ class order extends base
 
             $this->info['tax_groups']["{$this->products[$index]['tax']}"] = '1';
 
-            $this->notify('NOTIFY_ORDER_QUERY_ADD_PRODUCT', $this->products[$index], $index);
+            $this->notify('NOTIFY_ORDER_QUERY_ADD_PRODUCT', $this->products[$index], $index, $orders_products->fields);
 
             $index++;
             $orders_products->MoveNext();


### PR DESCRIPTION
During the `order` class' `query` method (retrieving a previous order from the database), that method gathers **all** fields from the `orders` and `orders_products` tables, but there's no way for an observer watching 'NOTIFY_ORDER_AFTER_QUERY' or 'NOTIFY_ORDER_QUERY_ADD_PRODUCT' to make use of the information.

This PR adds the database fields to those notification.  An observer can determine whether that value's present by testing either notification's 3rd parameter for `null` and performing the database query for additional fields on its own.