### PR TITLE
Fixes #7174 Notifier bypassed in ot_group_pricing

### DIFF
--- a/includes/modules/order_total/ot_group_pricing.php
+++ b/includes/modules/order_total/ot_group_pricing.php
@@ -172,7 +172,7 @@ class ot_group_pricing {
             $ratio = 1;
           }
           $adjustedTax = $orderTotalTax * $ratio;
-          if ($order->info['tax'] == 0) return $od_amount;
+          if ($order->info['tax'] == 0) break;
           $ratioTax = ($orderTotalTax != 0 ) ? $adjustedTax/$orderTotalTax : 0;
           $tax_deduct = 0;
           foreach ($taxGroups as $key=>$value) {


### PR DESCRIPTION
Replaces return statement with break so notifier is reached if tax is zero and tax recalculate option is set to Standard (the default).

Fixes #7174 