### PR TITLE
Correct plugin sidebox path w/o full path

### DIFF
--- a/includes/classes/ResourceLoaders/SideboxFinder.php
+++ b/includes/classes/ResourceLoaders/SideboxFinder.php
@@ -42,7 +42,7 @@ class SideboxFinder
     {
         if (!empty($sideboxInfo['plugin_details'])) {
             $path = $this->sideboxPathInPlugin($sideboxInfo);
-            $path = ($withFullPath) ? DIR_FS_CATALOG . 'zc_plugins/' . $path . '/catalog/includes/modules/sideboxes/': $path;
+            $path = ($withFullPath) ? DIR_FS_CATALOG . 'zc_plugins/' . $path . '/catalog/includes/modules/sideboxes/': ($path . '/');
             return $path;
         }
         $baseDir = DIR_FS_CATALOG . DIR_WS_MODULES . 'sideboxes/';


### PR DESCRIPTION
When a plugin's sidebox path is requested **without** the full path (as it is in the admin's Layout Boxes Controller), that path is currently returned without a trailing slash (/), resulting in a wonky display on that admin tool.

<img width="562" height="45" alt="image" src="https://github.com/user-attachments/assets/bd2585cf-5e8e-43ec-8095-436d8a9c7bd9" />

This PR corrects that display issue:

<img width="571" height="43" alt="image" src="https://github.com/user-attachments/assets/6bc8c678-ce7e-4b10-96d9-286fd2e6529e" />


