### PR TITLE
Add plugin 'helper' to manage zc db changes on update/uninstall

### DIFF
--- a/includes/classes/PluginSupport/ScriptedInstallHelpers.php
+++ b/includes/classes/PluginSupport/ScriptedInstallHelpers.php
@@ -8,6 +8,7 @@
 
 namespace Zencart\PluginSupport;
 
+use App\Models\LayoutBox;
 use queryFactory;
 use queryFactoryResult;
 
@@ -131,7 +132,6 @@ trait ScriptedInstallHelpers
 
         return $rows;
     }
-
 
     protected function getOrCreateConfigGroupId(string $config_group_title, string $config_group_description, ?int $sort_order = 1): int
     {
@@ -313,5 +313,26 @@ trait ScriptedInstallHelpers
         }
         $this->dbConn->dieOnErrors = true;
         return true;
+    }
+
+    // -----
+    // This method provides the means to update various database fields
+    // that are managed by core Zen Cart processes on the update of an encapsulated
+    // plugin.
+    //
+    protected function updateZenCoreDbFields(string $pluginKey, string $version, string $oldVersion): void
+    {
+        LayoutBox::where('plugin_details', 'LIKE', $pluginKey . '/%')
+            ->update(['plugin_details' => $pluginKey . '/' . $version]);
+    }
+
+    // -----
+    // This method provides the means to update various database fields
+    // that are managed by core Zen Cart processes on the uninstall of an encapsulated
+    // plugin.
+    //
+    protected function uninstallZenCoreDbFields(string $pluginKey, string $version): void
+    {
+        LayoutBox::where('plugin_details', 'LIKE', $pluginKey . '/%')->delete();
     }
 }

--- a/includes/classes/PluginSupport/ScriptedInstaller.php
+++ b/includes/classes/PluginSupport/ScriptedInstaller.php
@@ -39,6 +39,7 @@ class ScriptedInstaller
      */
     protected function executeUninstall()
     {
+        $this->uninstallZenCoreDbFields($this->pluginKey, $this->version);
         return true;
     }
 
@@ -47,6 +48,7 @@ class ScriptedInstaller
      */
     protected function executeUpgrade($oldVersion)
     {
+        $this->updateZenCoreDbFields($this->pluginKey, $this->version, $oldVersion);
         return true;
     }
 


### PR DESCRIPTION
Fixes #7187

Note that encapsulated plugins that provide a `ScriptedInstaller.php` in their distribution should ensure that their last action in their `executeInstall`, `executeUpgrade` and `executeUninstall` methods should be a call to the parent class' method (passing any input parameters).

For example, an `executeUpgrade` method should end with
```php
parent::executeUpgrade($oldVersion);
```