### PR TITLE
Admin :: Plugin Manager: Refactor radio/checkbox input layout

### DIFF
--- a/includes/classes/ViewBuilders/PluginManagerController.php
+++ b/includes/classes/ViewBuilders/PluginManagerController.php
@@ -115,8 +115,8 @@ class PluginManagerController extends BaseController
         $firstKey = key($versions);
         if ($hasMultiple) {
             foreach ($versions as $version) {
-                $checked = ($version['version'] == $firstKey) ? true : false;
-                $this->setBoxContent('<br>' . zen_draw_label($version['version'], 'version', 'class="control-label"') . zen_draw_radio_field('version', $version['version'], $checked));
+                $checked = ($version['version'] == $firstKey);
+                $this->setBoxContent('<br><label class="radio-inline">' . zen_draw_radio_field('version', $version['version'], $checked) . $version['version']);
             }
         }
         if (!$hasMultiple) {
@@ -230,7 +230,7 @@ class PluginManagerController extends BaseController
         $firstKey = key($versions);
         foreach ($versions as $version) {
             $checked = ($version == $firstKey);
-            $this->setBoxContent('<br>' . zen_draw_label($version, 'version', 'class="control-label"') . zen_draw_radio_field('version', $version, $checked));
+            $this->setBoxContent('<br><label class="radio-inline">' . zen_draw_radio_field('version', $version, $checked) . $version);
         }
         $this->setBoxContent(
             '<br><button type="submit" class="btn btn-primary">'
@@ -248,7 +248,7 @@ class PluginManagerController extends BaseController
         if (!$this->pluginManager->isUpgradeAvailable($this->currentFieldValue('unique_key'), $this->currentFieldValue('version'))) {
             $error = true;
         }
-        if ((!$this->request->has('version'))) {
+        if (!$this->request->has('version')) {
             $error = true;
         }
         if (!in_array($this->request->input('version'), $versions)) {
@@ -333,16 +333,7 @@ class PluginManagerController extends BaseController
         );
         $this->setBoxContent('<br>' . TEXT_INFO_SELECT_CLEAN . '<br>');
         foreach ($versions as $version) {
-            $this->setBoxContent('<br>' . zen_draw_label
-                    (
-                        $version['version'],
-                        'version',
-                        'class="control-label"'
-                    ) . zen_draw_checkbox_field(
-                        'version[]',
-                        $version['version']
-                    )
-            );
+            $this->setBoxContent('<br>' . zen_draw_checkbox_field('version[]', $version['version']) . ' ' . $version['version']);
         }
         $this->setBoxContent(
             '<br><button type="submit" class="btn btn-danger">'
@@ -481,5 +472,4 @@ class PluginManagerController extends BaseController
         $this->messageStack->add_session(TEXT_DISABLE_SUCCESS, 'success');
         zen_redirect(zen_href_link(FILENAME_PLUGIN_MANAGER, $this->pageLink() . '&' . $this->colKeylink()));
     }
-
 }


### PR DESCRIPTION
Essentially, lining up the radio/checkbox inputs.

Without these changes:
<img width="333" height="266" alt="image" src="https://github.com/user-attachments/assets/b6854da0-f0a0-471e-8ffc-39c7158c31cd" /> <img width="364" height="229" alt="image" src="https://github.com/user-attachments/assets/2cc97f46-ea0a-4efc-90dd-c373d216b095" />

With these changes:
<img width="350" height="252" alt="image" src="https://github.com/user-attachments/assets/e1604de9-7beb-4d3e-ac6b-f8a6c722023a" /> <img width="360" height="227" alt="image" src="https://github.com/user-attachments/assets/e26525b7-8341-44b4-b6a3-6f9c5198296f" />

