### PR TITLE
Update plugin control version field to accommodate alpha/beta

### DIFF
--- a/zc_install/sql/install/mysql_zencart.sql
+++ b/zc_install/sql/install/mysql_zencart.sql
@@ -1559,7 +1559,7 @@ CREATE TABLE plugin_control (
   managed tinyint(1) NOT NULL default 0,
   status tinyint(1) NOT NULL default 0,
   author varchar(64) NOT NULL,
-  version varchar(10),
+  version varchar(20),
   zc_versions text NOT NULL,
   zc_contrib_id int(11),
   infs tinyint(1) NOT NULL default 0,
@@ -1575,7 +1575,7 @@ CREATE TABLE plugin_control (
 DROP TABLE IF EXISTS plugin_control_versions;
 CREATE TABLE plugin_control_versions (
   unique_key varchar(40) NOT NULL,
-  version varchar(10),
+  version varchar(20),
   author varchar(64) NOT NULL,
   zc_versions text NOT NULL,
   infs tinyint(1) NOT NULL default 0,

--- a/zc_install/sql/updates/mysql_upgrade_zencart_220.sql
+++ b/zc_install/sql/updates/mysql_upgrade_zencart_220.sql
@@ -49,6 +49,8 @@ ALTER TABLE products_options MODIFY products_options_name varchar(191) NOT NULL 
 ALTER TABLE products_options_values MODIFY products_options_values_name varchar(191) NOT NULL default '';
 ALTER TABLE currencies MODIFY code char(4) NOT NULL default '';
 ALTER TABLE orders MODIFY currency char(4) default NULL;
+ALTER TABLE plugin_control MODIFY `version` varchar(20);
+ALTER TABLE plugin_control_versions MODIFY `version` varchar(20); 
 
 #PROGRESS_FEEDBACK:!TEXT=Updating configuration settings...
 DELETE FROM configuration WHERE configuration_key IN ('REPORT_ALL_ERRORS_ADMIN', 'REPORT_ALL_ERRORS_STORE', 'REPORT_ALL_ERRORS_NOTICE_BACKTRACE');


### PR DESCRIPTION
With only 10 characters for a plugin's version, a plugin can't provide a `v1.1.1-alpha1` version since that requires 13 characters.