### PR TITLE
Add zen_get_buyable_product_type_handlers() function

### DIFF
--- a/includes/functions/functions_lookups.php
+++ b/includes/functions/functions_lookups.php
@@ -31,6 +31,22 @@ function zen_get_handler_from_type($product_type): string
     return $handler->fields['type_handler'];
 }
 
+/**
+ * Get a list of product page names that identify buyable products.
+ * This allows us to mark a page as containing a product which can
+ * be allowed to add-to-cart or buy-now with various modules.
+ */
+function zen_get_buyable_product_type_handlers(): array
+{
+    global $db;
+    $sql = "SELECT type_handler from " . TABLE_PRODUCT_TYPES . " WHERE allow_add_to_cart = 'Y'";
+    $results = $db->Execute($sql);
+    $retVal = [];
+    foreach ($results as $result) {
+        $retVal[] = $result['type_handler'] . '_info';
+    }
+    return $retVal;
+}
 
 /*
  * List manufacturers (returned in an array)


### PR DESCRIPTION
Retrieves an array of product page names that identify buyable products. This allows us to mark a page as containing a product which can be allowed to add-to-cart or buy-now with various modules.

**eg**: `product_info`, `product_free_shipping_info`, etc. 
This avoids hard-coding a list of product-types, and supports dynamic detection of custom product types.

**Use-Case:** Some payment modules (and other services) want to know what kind of page the shopper is on. Being able to indicate that the current page is one from which add-to-cart or buy-now should be offered, allows that ability.