### PR TITLE
Customer login/password-forgotten throttling

### DIFF
--- a/includes/extra_datafiles/dist-site_specific_overrides.php
+++ b/includes/extra_datafiles/dist-site_specific_overrides.php
@@ -99,3 +99,11 @@
 // false ... Do not show the link.
 //
 //$show_order_status_sidebox_link = true;
+
+// -----
+// Indicate the maximum number of times in a session an error during either a
+// login or forgotten-password attempt can fail.
+//
+// This value is an integer and defaults to 9.
+//
+//$max_login_attempts = 9;


### PR DESCRIPTION
Extend the `password_forgotten` throttling to the `login` page, using a common (and override-able) maximum number of failures value.

The session-based count increments each time either a `login` page error is detected or an unknown email_address is submitted to the `password_forgotten` page.  If that session-based count exceeds the maximum value above, both pages' form-processing respond with an HTTP 406 response code until the session times out.

The `password_forgotten` page is also updated to throttle the sending of the password-reset-link email.  If a password-reset email has been previously sent for an email address and the link's still valid, simply display the "check your email" message without resending that email.  This makes it more difficult for a site to reach its per-hour-email-limit in the presence of repeated bashing on the page.