### PR TITLE
add notifier in search class similar to default filter

### DIFF
--- a/includes/classes/class.search.php
+++ b/includes/classes/class.search.php
@@ -452,7 +452,10 @@ class Search extends \base
 
         $this->notify('NOTIFY_SEARCH_REAL_ORDERBY_STRING', $order_str, $order_str);
 
-        $listing_sql = $select_str . $from_str . $where_str . $order_str;
+        $listing_sql = $select_str . $from_str;
+        $this->notify('NOTIFY_SEARCH_LISTING_QUERY_STRING', ['default'], $listing_sql, $where_str, $order_str);
+        $listing_sql .= ' ' . $where_str . ' ' . $order_str;
+
         // Notifier Point
         $this->notify('NOTIFY_SEARCH_ORDERBY_STRING', $listing_sql);
 


### PR DESCRIPTION
we already have the `default_filter` script.  during a search, that script gets hit; why i do not know.  perhaps something for another day.

that script has a notifier here:

https://github.com/zencart/zencart/blob/17d3fcf12da531374812b5723e12f8e2f0a50404/includes/index_filters/default_filter.php#L148-L149

while this search class already has a number of notifiers, adding this new notifier here, mimics the notifier in the aforementioned script; allowing for an observer to reuse the same code for both notifiers.
