### PR TITLE
Skip empty attribute queries.

### DIFF
--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -651,6 +651,9 @@ class order extends base
                             AND poval.language_id = '" . (int)$_SESSION['languages_id'] . "'";
 
                     $attributes = $db->Execute($sql);
+                    if ($attributes->EOF) {
+                        continue;
+                    }
 
                     //clr 030714 Account for text attributes
                     if ($value == PRODUCTS_OPTIONS_VALUES_TEXT_ID) {
@@ -1451,7 +1454,7 @@ class order extends base
         }
         return null;
     }
-    
+
     private function getAddress(array $customerAddresses, int $arrayKey): array
     {
         $address = $customerAddresses[$arrayKey]['address'];

--- a/includes/modules/pages/shopping_cart/header_php.php
+++ b/includes/modules/pages/shopping_cart/header_php.php
@@ -75,6 +75,10 @@ for ($i = 0, $n = count($products); $i < $n; $i++) {
             $sql = $db->bindVars($sql, ':languageID', $_SESSION['languages_id'], 'integer');
             $attributes_values = $db->Execute($sql);
 
+            if ($attributes_values->EOF) {
+                continue;
+            }
+
             if ($value == PRODUCTS_OPTIONS_VALUES_TEXT_ID) {
                 $attributeHiddenField .= zen_draw_hidden_field('id[' . $products[$i]['id'] . '][' . TEXT_PREFIX . $option . ']', $products[$i]['attributes_values'][$option]);
                 $attr_value = htmlspecialchars($products[$i]['attributes_values'][$option], ENT_COMPAT, CHARSET, TRUE);


### PR DESCRIPTION
Fixes #7164

Potential issues: 
- in both cases a notifier will not fire, which previously was expected to fire; however, a PHP Fatal error due to EOF would have blocked the notifier as well
- in one case a counter doesn't get updated; not sure if that counter's value is essential in that it needs to match a count elsewhere, or if it's merely incrementing the array index.