### PR TITLE
Correct PHP warnings on `customers_authorization` page

### DIFF
--- a/includes/modules/pages/customers_authorization/header_php.php
+++ b/includes/modules/pages/customers_authorization/header_php.php
@@ -7,27 +7,31 @@
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: DrByte 2020 Jul 10 Modified in v1.5.8-alpha $
  */
+if (!zen_is_logged_in()) {
+    zen_redirect(zen_href_link(FILENAME_DEFAULT));
+}
 
-
-$sql = "SELECT customers_authorization 
-        FROM " . TABLE_CUSTOMERS . " 
-        WHERE customers_id = :customersID";
+$sql =
+    "SELECT customers_authorization
+       FROM " . TABLE_CUSTOMERS . "
+      WHERE customers_id = :customersID";
 
 $sql = $db->bindVars($sql, ':customersID', $_SESSION['customer_id'], 'integer');
-$check_customer = $db->Execute($sql);
+$check_customer = $db->Execute($sql, 1);
+if ($check_customer->EOF) {
+    zen_redirect(zen_href_link(FILENAME_DEFAULT));  //- Shouldn't happen, but for completeness ...
+}
 
 $_SESSION['customers_authorization'] = $check_customer->fields['customers_authorization'];
 
-if ($_SESSION['customers_authorization'] != '1') {
-  zen_redirect(zen_href_link(FILENAME_DEFAULT));
+if ($_SESSION['customers_authorization'] !== '1' && $_SESSION['customers_authorization'] !== '3') {
+    zen_redirect(zen_href_link(FILENAME_DEFAULT));
 }
 
-require(DIR_WS_MODULES . zen_get_module_directory('require_languages.php'));
+require DIR_WS_MODULES . zen_get_module_directory('require_languages.php');
 $breadcrumb->add(NAVBAR_TITLE);
 
-if (CUSTOMERS_AUTHORIZATION_COLUMN_RIGHT_OFF == 'true') $flag_disable_right = true;
-if (CUSTOMERS_AUTHORIZATION_COLUMN_LEFT_OFF == 'true') $flag_disable_left = true;
-if (CUSTOMERS_AUTHORIZATION_FOOTER_OFF == 'true') $flag_disable_footer = true;
-if (CUSTOMERS_AUTHORIZATION_HEADER_OFF == 'true') $flag_disable_header = true;
-
-?>
+$flag_disable_right = (CUSTOMERS_AUTHORIZATION_COLUMN_RIGHT_OFF === 'true');
+$flag_disable_left = (CUSTOMERS_AUTHORIZATION_COLUMN_LEFT_OFF === 'true');
+$flag_disable_footer = (CUSTOMERS_AUTHORIZATION_FOOTER_OFF === 'true');
+$flag_disable_header = (CUSTOMERS_AUTHORIZATION_HEADER_OFF === 'true');


### PR DESCRIPTION
Corrects PHP warnings on the `customers_authorization` page when the page is "hit" and a customer isn't logged in.

Also
- Correctly displays the page when the customer's current authorization status is '3' (Pending, can browse with prices but cannot purchase until authorized).
- Simplifies the header/footer/left/right enable/disable settings.
