### PR TITLE
Adding instructions to the `moneyorder` status history

### DIFF
--- a/includes/languages/english/modules/payment/lang.moneyorder.php
+++ b/includes/languages/english/modules/payment/lang.moneyorder.php
@@ -2,6 +2,7 @@
 $define = [
     'MODULE_PAYMENT_MONEYORDER_TEXT_TITLE' => 'Check/Money Order',
     'MODULE_PAYMENT_MONEYORDER_TEXT_DESCRIPTION' => 'Customers can mail in their payment. Their order confirmation email will ask them to: <br><br>Please make your check or money order payable to:<br>' . (defined('MODULE_PAYMENT_MONEYORDER_PAYTO') ? MODULE_PAYMENT_MONEYORDER_PAYTO : '<br>(your store name)') . '<br><br>Mail your payment to:<br>' . nl2br(STORE_NAME_ADDRESS) . '<br><br>' . 'Your order will not ship until we receive payment.',
+    'MODULE_PAYMENT_MONEYORDER_REMINDER' => 'Please be sure to write your order number on the front of your check or money order.',
 ];
 if (defined('MODULE_PAYMENT_MONEYORDER_STATUS')) {
     $define['MODULE_PAYMENT_MONEYORDER_TEXT_EMAIL_FOOTER'] = 'Please make your check or money order payable to:' . "\n\n" . MODULE_PAYMENT_MONEYORDER_PAYTO . "\n\n" . 'Mail your payment to:' . "\n" . STORE_NAME_ADDRESS . "\n\n" . 'Your order will not ship until we receive payment.';

--- a/includes/modules/payment/moneyorder.php
+++ b/includes/modules/payment/moneyorder.php
@@ -154,6 +154,12 @@
 
         function after_process()
         {
+            // Adding the instructions to the Order Status History, will be visible but will not generate a new email.
+            global $insert_id;
+
+            $comments = MODULE_PAYMENT_MONEYORDER_TEXT_EMAIL_FOOTER . " " . MODULE_PAYMENT_MONEYORDER_REMINDER;
+            zen_update_orders_history($insert_id, $comments, null, -1, 0);
+
             return false;
         }
 


### PR DESCRIPTION
When a customer completes a payment using `moneyorder`, it will add a note in the `order_status_history` table providing instructions to the customer where and how to prepare payment. (Done by tacking the EMAIL_FOOTER note and one additional define.)