### PR TITLE
Correcting 'undefined array key' log thrown by the cache.php class

### DIFF
--- a/includes/classes/cache.php
+++ b/includes/classes/cache.php
@@ -8,212 +8,206 @@
  * @version $Id: DrByte 2024 Oct 16 Modified in v2.1.0 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
-  die('Illegal Access');
+    die('Illegal Access');
 }
+
 /**
  * cache Class.
  * handles query caching
  *
  */
-class cache extends base {
-
-  function sql_cache_exists($zf_query, $zf_cachetime=null) {
-    global $db;
-    $zp_cache_name = $this->cache_generate_cache_name($zf_query);
-    switch (SQL_CACHE_METHOD) {
-      case 'file':
-      // where using a single directory at the moment. Need to look at splitting into subdirectories
-      // like adodb
-      if (file_exists(DIR_FS_SQL_CACHE . '/' . $zp_cache_name . '.sql') && (is_null($zf_cachetime) || !$this->sql_cache_is_expired($zf_query, $zf_cachetime))) {
-        return true;
-      } else {
-        return false;
-      }
-      break;
-      case 'database':
-      $sql = "select * from " . TABLE_DB_CACHE . " where cache_entry_name = '" . $zp_cache_name . "'";
-      $zp_cache_exists = $db->Execute($sql);
-      if ($zp_cache_exists->RecordCount() > 0 && (is_null($zf_cachetime) || !$this->sql_cache_is_expired($zf_query, $zf_cachetime))) {
-        return true;
-      } else {
-        return false;
-      }
-      break;
-      case 'memory':
-      return false;
-      break;
-      case 'none':
-      default:
-      return false;
-      break;
-    }
-  }
-
-  function sql_cache_is_expired($zf_query, $zf_cachetime) {
-    global $db;
-    $zp_cache_name = $this->cache_generate_cache_name($zf_query);
-    switch (SQL_CACHE_METHOD) {
-      case 'file':
-      if (@filemtime(DIR_FS_SQL_CACHE . '/' . $zp_cache_name . '.sql') > (time() - $zf_cachetime)) {
-        return false;
-      } else {
-        return true;
-      }
-      break;
-      case 'database':
-      $sql = "select * from " . TABLE_DB_CACHE . " where cache_entry_name = '" . $zp_cache_name ."'";
-      $cache_result = $db->Execute($sql);
-      if ($cache_result->RecordCount() > 0) {
-        $start_time = $cache_result->fields['cache_entry_created'];
-        if (time() - $start_time > $zf_cachetime) return true;
-        return false;
-      } else {
-        return true;
-      }
-      break;
-      case 'memory':
-      return true;
-      break;
-      case 'none':
-      default:
-      return true;
-      break;
-    }
-  }
-
-  function sql_cache_expire_now($zf_query) {
-    global $db;
-    $zp_cache_name = $this->cache_generate_cache_name($zf_query);
-      if ($this->sql_cache_exists($zf_query)) {
-          switch (SQL_CACHE_METHOD) {
-              case 'file':
-                  @unlink(DIR_FS_SQL_CACHE . '/' . $zp_cache_name . '.sql');
-                  return true;
-                  break;
-              case 'database':
-                  $sql = "delete from " . TABLE_DB_CACHE . " where cache_entry_name = '" . $zp_cache_name . "'";
-                  $db->Execute($sql);
-                  return true;
-                  break;
-              case 'memory':
-                  unset($this->cache_array[$zp_cache_name]);
-                  return true;
-                  break;
-              case 'none':
-              default:
-                  return true;
-                  break;
-          }
-      }
-  }
-
-  function sql_cache_store($zf_query, $zf_result_array) {
-    global $db;
-    $zp_cache_name = $this->cache_generate_cache_name($zf_query);
-    switch (SQL_CACHE_METHOD) {
-      case 'file':
-      $OUTPUT = serialize($zf_result_array);
-      $fp = fopen(DIR_FS_SQL_CACHE . '/' . $zp_cache_name . '.sql',"w");
-      fputs($fp, $OUTPUT);
-      fclose($fp);
-      return true;
-      break;
-      case 'database':
-      $sql = "select * from " . TABLE_DB_CACHE . " where cache_entry_name = '" . $zp_cache_name . "'";
-      $zp_cache_exists = $db->Execute($sql);
-      if ($zp_cache_exists->RecordCount() > 0) {
-        return true;
-      }
-      $result_serialize = $db->prepare_input(base64_encode(serialize($zf_result_array)));
-      $sql = "insert ignore into " . TABLE_DB_CACHE . " (cache_entry_name, cache_data, cache_entry_created) VALUES (:cachename, :cachedata, unix_timestamp() )";
-      $sql = $db->bindVars($sql, ':cachename', $zp_cache_name, 'string');
-      $sql = $db->bindVars($sql, ':cachedata', $result_serialize, 'string');
-      $db->Execute($sql);
-      return true;
-      break;
-      case 'memory':
-      return true;
-      break;
-      case 'none':
-      default:
-      return true;
-      break;
-    }
-  }
-
-  function sql_cache_read($zf_query) {
-    global $db;
-    $zp_cache_name = $this->cache_generate_cache_name($zf_query);
-    switch (SQL_CACHE_METHOD) {
-      case 'file':
-      $zp_fa = file(DIR_FS_SQL_CACHE . '/' . $zp_cache_name . '.sql');
-      if ($zp_fa === false) return false;
-      $zp_result_array = unserialize(implode('', $zp_fa));
-      return $zp_result_array;
-      break;
-      case 'database':
-      $sql = "select * from " . TABLE_DB_CACHE . " where cache_entry_name = '" . $zp_cache_name . "'";
-      $zp_cache_result = $db->Execute($sql);
-      if ($zp_cache_result->EOF) {
-          return false;
-      }
-      $zp_result_array = unserialize(base64_decode($zp_cache_result->fields['cache_data']));
-      return $zp_result_array;
-      break;
-      case 'memory':
-      return true;
-      break;
-      case 'none':
-      default:
-      return true;
-      break;
-    }
-  }
-
-  function sql_cache_flush_cache() {
-    global $db;
-    switch (SQL_CACHE_METHOD) {
-      case 'file':
-      if ($za_dir = @dir(DIR_FS_SQL_CACHE)) {
-        while ($zv_file = $za_dir->read()) {
-          if (strstr($zv_file, '.sql') && strstr($zv_file, 'zc_')) {
-            @unlink(DIR_FS_SQL_CACHE . '/' . $zv_file);
-          }
+class cache
+{
+    public function sql_cache_exists($zf_query, $zf_cachetime = null): bool
+    {
+        global $db;
+        $zp_cache_name = $this->cache_generate_cache_name($zf_query);
+        switch (SQL_CACHE_METHOD) {
+            case 'file':
+                // where using a single directory at the moment. Need to look at splitting into subdirectories
+                // like adodb
+                if (file_exists(DIR_FS_SQL_CACHE . '/' . $zp_cache_name . '.sql') && (is_null($zf_cachetime) || !$this->sql_cache_is_expired($zf_query, $zf_cachetime))) {
+                    return true;
+                } else {
+                    return false;
+                }
+                break;
+            case 'database':
+                $sql = "SELECT * FROM " . TABLE_DB_CACHE . " WHERE cache_entry_name = '" . $zp_cache_name . "'";
+                $zp_cache_exists = $db->Execute($sql);
+                if (!$zp_cache_exists->EOF && (is_null($zf_cachetime) || !$this->sql_cache_is_expired($zf_query, $zf_cachetime))) {
+                    return true;
+                } else {
+                    return false;
+                }
+                break;
+            case 'memory':
+                return false;
+                break;
+            case 'none':
+            default:
+                return false;
+                break;
         }
-        $za_dir->close();
-      }
-      return true;
-      break;
-      case 'database':
-      $sql = "delete from " . TABLE_DB_CACHE;
-      $db->Execute($sql);
-      return true;
-      break;
-      case 'memory':
-      return true;
-      break;
-      case 'none':
-      default:
-      return true;
-      break;
     }
-  }
 
-  function cache_generate_cache_name($zf_query) {
-    switch (SQL_CACHE_METHOD) {
-      case 'file':
-      return 'zc_' . hash('md5', $zf_query);
-      break;
-      case 'database':
-      return 'zc_' . hash('md5', $zf_query);
-      break;
-      case 'memory':
-      return 'zc_' . hash('md5', $zf_query);
-      break;
-      case 'none':
-      default:
-      return true;
-      break;
+    public function sql_cache_is_expired($zf_query, $zf_cachetime): bool
+    {
+        global $db;
+        $zp_cache_name = $this->cache_generate_cache_name($zf_query);
+        switch (SQL_CACHE_METHOD) {
+            case 'file':
+                if (@filemtime(DIR_FS_SQL_CACHE . '/' . $zp_cache_name . '.sql') > (time() - $zf_cachetime)) {
+                    return false;
+                } else {
+                    return true;
+                }
+                break;
+            case 'database':
+                $sql = "SELECT * FROM " . TABLE_DB_CACHE . " WHERE cache_entry_name = '" . $zp_cache_name ."'";
+                $cache_result = $db->Execute($sql);
+                if (!$cache_result->EOF) {
+                    $start_time = $cache_result->fields['cache_entry_created'];
+                    if (time() - $start_time > $zf_cachetime) {
+                        return true;
+                    }
+                    return false;
+                } else {
+                    return true;
+                }
+                break;
+            case 'memory':
+                return true;
+                break;
+            case 'none':
+            default:
+                return true;
+                break;
+        }
     }
-  }
+
+    public function sql_cache_expire_now($zf_query): void
+    {
+        global $db;
+        $zp_cache_name = $this->cache_generate_cache_name($zf_query);
+        if ($this->sql_cache_exists($zf_query)) {
+            switch (SQL_CACHE_METHOD) {
+                case 'file':
+                    @unlink(DIR_FS_SQL_CACHE . '/' . $zp_cache_name . '.sql');
+                    break;
+                case 'database':
+                    $sql = "DELETE FROM " . TABLE_DB_CACHE . " WHERE cache_entry_name = '" . $zp_cache_name . "'";
+                    $db->Execute($sql);
+                    break;
+                case 'memory':
+                case 'none':
+                default:
+                    break;
+            }
+        }
+    }
+
+    public function sql_cache_store($zf_query, $zf_result_array): void
+    {
+        global $db;
+        $zp_cache_name = $this->cache_generate_cache_name($zf_query);
+        switch (SQL_CACHE_METHOD) {
+            case 'file':
+                $OUTPUT = serialize($zf_result_array);
+                $fp = fopen(DIR_FS_SQL_CACHE . '/' . $zp_cache_name . '.sql',"w");
+                fputs($fp, $OUTPUT);
+                fclose($fp);
+                break;
+            case 'database':
+                $sql = "SELECT * FROM " . TABLE_DB_CACHE . " WHERE cache_entry_name = '" . $zp_cache_name . "'";
+                $zp_cache_exists = $db->Execute($sql);
+                if (!$zp_cache_exists->EOF) {
+                    break;
+                }
+                $result_serialize = $db->prepare_input(base64_encode(serialize($zf_result_array)));
+                $sql = "INSERT IGNORE INTO " . TABLE_DB_CACHE . " (cache_entry_name, cache_data, cache_entry_created) VALUES (:cachename, :cachedata, unix_timestamp() )";
+                $sql = $db->bindVars($sql, ':cachename', $zp_cache_name, 'string');
+                $sql = $db->bindVars($sql, ':cachedata', $result_serialize, 'string');
+                $db->Execute($sql);
+                break;
+            case 'memory':
+            case 'none':
+            default:
+                break;
+        }
+    }
+
+    public function sql_cache_read($zf_query): bool|array
+    {
+        global $db;
+        $zp_cache_name = $this->cache_generate_cache_name($zf_query);
+        switch (SQL_CACHE_METHOD) {
+            case 'file':
+                $zp_fa = file(DIR_FS_SQL_CACHE . '/' . $zp_cache_name . '.sql');
+                if ($zp_fa === false) {
+                    return false;
+                }
+                $zp_result_array = unserialize(implode('', $zp_fa));
+                return $zp_result_array;
+                break;
+            case 'database':
+                $sql = "SELECT * FROM " . TABLE_DB_CACHE . " WHERE cache_entry_name = '" . $zp_cache_name . "'";
+                $zp_cache_result = $db->Execute($sql);
+                if ($zp_cache_result->EOF) {
+                    return false;
+                }
+                $zp_result_array = unserialize(base64_decode($zp_cache_result->fields['cache_data']));
+                return $zp_result_array;
+                break;
+            case 'memory':
+            case 'none':
+            default:
+                return true;
+                break;
+        }
+    }
+
+    public function sql_cache_flush_cache(): void
+    {
+        global $db;
+        switch (SQL_CACHE_METHOD) {
+            case 'file':
+                if ($za_dir = @dir(DIR_FS_SQL_CACHE)) {
+                    while ($zv_file = $za_dir->read()) {
+                        if (strstr($zv_file, '.sql') && strstr($zv_file, 'zc_')) {
+                            @unlink(DIR_FS_SQL_CACHE . '/' . $zv_file);
+                        }
+                    }
+                    $za_dir->close();
+                }
+                break;
+            case 'database':
+                $sql = "DELETE FROM " . TABLE_DB_CACHE;
+                $db->Execute($sql);
+                break;
+            case 'memory':
+            case 'none':
+            default:
+                break;
+        }
+    }
+
+    public function cache_generate_cache_name($zf_query): bool|string
+    {
+        switch (SQL_CACHE_METHOD) {
+            case 'file':
+                return 'zc_' . hash('md5', $zf_query);
+                break;
+            case 'database':
+                return 'zc_' . hash('md5', $zf_query);
+                break;
+            case 'memory':
+                return 'zc_' . hash('md5', $zf_query);
+                break;
+            case 'none':
+            default:
+                return true;
+                break;
+        }
+    }
 }

--- a/includes/classes/cache.php
+++ b/includes/classes/cache.php
@@ -58,7 +58,7 @@ class cache
         switch (SQL_CACHE_METHOD) {
             case 'file':
                 $filename = DIR_FS_SQL_CACHE . '/' . $zp_cache_name . '.sql';
-                if (file_exists($filename) && filemtime($filename) > (time() - $zf_cachetime)) {
+                if (file_exists($filename) && @filemtime($filename) > (time() - $zf_cachetime)) {
                     return false;
                 } else {
                     return true;

--- a/includes/classes/cache.php
+++ b/includes/classes/cache.php
@@ -57,7 +57,8 @@ class cache
         $zp_cache_name = $this->cache_generate_cache_name($zf_query);
         switch (SQL_CACHE_METHOD) {
             case 'file':
-                if (@filemtime(DIR_FS_SQL_CACHE . '/' . $zp_cache_name . '.sql') > (time() - $zf_cachetime)) {
+                $filename = DIR_FS_SQL_CACHE . '/' . $zp_cache_name . '.sql';
+                if (file_exists($filename) && filemtime($filename) > (time() - $zf_cachetime)) {
                     return false;
                 } else {
                     return true;
@@ -93,7 +94,10 @@ class cache
         if ($this->sql_cache_exists($zf_query)) {
             switch (SQL_CACHE_METHOD) {
                 case 'file':
-                    @unlink(DIR_FS_SQL_CACHE . '/' . $zp_cache_name . '.sql');
+                    $filename = DIR_FS_SQL_CACHE . '/' . $zp_cache_name . '.sql';
+                    if (file_exists($filename)) {
+                        unlink($filename);
+                    }
                     break;
                 case 'database':
                     $sql = "DELETE FROM " . TABLE_DB_CACHE . " WHERE cache_entry_name = '" . $zp_cache_name . "'";
@@ -113,10 +117,7 @@ class cache
         $zp_cache_name = $this->cache_generate_cache_name($zf_query);
         switch (SQL_CACHE_METHOD) {
             case 'file':
-                $OUTPUT = serialize($zf_result_array);
-                $fp = fopen(DIR_FS_SQL_CACHE . '/' . $zp_cache_name . '.sql',"w");
-                fputs($fp, $OUTPUT);
-                fclose($fp);
+                file_put_contents(DIR_FS_SQL_CACHE . '/' . $zp_cache_name . '.sql', serialize($zf_result_array));
                 break;
             case 'database':
                 $sql = "SELECT * FROM " . TABLE_DB_CACHE . " WHERE cache_entry_name = '" . $zp_cache_name . "'";
@@ -174,8 +175,8 @@ class cache
             case 'file':
                 if ($za_dir = @dir(DIR_FS_SQL_CACHE)) {
                     while ($zv_file = $za_dir->read()) {
-                        if (strstr($zv_file, '.sql') && strstr($zv_file, 'zc_')) {
-                            @unlink(DIR_FS_SQL_CACHE . '/' . $zv_file);
+                        if (str_ends_with($zv_file, '.sql') && str_starts_with($zv_file, 'zc_')) {
+                            unlink(DIR_FS_SQL_CACHE . '/' . $zv_file);
                         }
                     }
                     $za_dir->close();

--- a/includes/classes/cache.php
+++ b/includes/classes/cache.php
@@ -154,6 +154,9 @@ class cache extends base {
       case 'database':
       $sql = "select * from " . TABLE_DB_CACHE . " where cache_entry_name = '" . $zp_cache_name . "'";
       $zp_cache_result = $db->Execute($sql);
+      if ($zp_cache_result->EOF) {
+          return false;
+      }
       $zp_result_array = unserialize(base64_decode($zp_cache_result->fields['cache_data']));
       return $zp_result_array;
       break;


### PR DESCRIPTION
... as reported [here](https://www.zen-cart.com/showthread.php/230855-quot-Undefined-array-key-quot-warning-in-includes-classes-cache-php) on the Zen Cart forums.

Also 'refreshes' the class' processing.