### PR TITLE
`password_forgotten`: email body variables missing '$'

### DIFF
--- a/includes/languages/english/lang.password_forgotten.php
+++ b/includes/languages/english/lang.password_forgotten.php
@@ -6,7 +6,7 @@ $define = [
     'TEXT_MAIN' => "Enter your email address below and we'll send you instructions on how to reset your password.",
 
     'EMAIL_PASSWORD_RESET_SUBJECT' => STORE_NAME . ' - Password Reset',
-    'EMAIL_PASSWORD_RESET_BODY' => "A password reset was requested from %1s. \n\nTo reset your password for '%2s' please visit the following URL:\n\n%3s \n\n",
+    'EMAIL_PASSWORD_RESET_BODY' => "A password reset was requested from %1\$s.\n\nTo reset your password for '%2\$s', please visit the following URL:\n\n%3\$s\n\n",
 
     'SUCCESS_PASSWORD_RESET_SENT' => 'Thank you. If that email address is in our system, we will send password recovery instructions to that email address (remember to check your Spam folder)',
 ];


### PR DESCRIPTION
The `password_forgotten` page's email body is missing the '$' that identifies a sprintf argument number.  Without that '$', the formatted string interprets the number (e.g. `%1s`) as a character length.