### PR TITLE
Re-Repairing the logic tests for invoking `deleteconfirm` in the admin area

### DIFF
--- a/admin/orders.php
+++ b/admin/orders.php
@@ -320,7 +320,7 @@ if (!empty($action) && $order_exists === true) {
             break;
 
         case 'deleteconfirm':
-            $order->delete(!empty($_POST['restock']) && $_POST['restock'] === true);
+            $order->delete(!empty($_POST['restock']) && $_POST['restock'] === '1');
             zen_redirect(zen_href_link(FILENAME_ORDERS, zen_get_all_get_params(['oID', 'action']), 'NONSSL'));
             break;
         case 'delete_cvv':
@@ -1549,7 +1549,7 @@ if ($show_orders_weights === true) {
                                     $contents = ['form' => zen_draw_form('orders', FILENAME_ORDERS, zen_get_all_get_params(['oID', 'action']) . '&action=deleteconfirm', 'post', 'class="form-horizontal"', true) . zen_draw_hidden_field('oID', $oInfo->orders_id)];
 //            $contents[] = array('text' => TEXT_INFO_DELETE_INTRO . '<br><br><strong>' . $cInfo->customers_firstname . ' ' . $cInfo->customers_lastname . '</strong>');
                                     $contents[] = ['text' => TEXT_INFO_DELETE_INTRO . '<br><br><strong>' . ENTRY_ORDER_ID . $oInfo->orders_id . '<br>' . $oInfo->order_total . '<br>' . $oInfo->customers_name . ($oInfo->customers_company !== '' ? '<br>' . zen_output_string_protected($oInfo->customers_company) : '') . '</strong>'];
-                                    $contents[] = ['text' => '<br><label>' . zen_draw_checkbox_field('restock', true) . ' ' . TEXT_INFO_RESTOCK_PRODUCT_QUANTITY . '</label>'];
+                                    $contents[] = ['text' => '<br><label>' . zen_draw_checkbox_field('restock', '1') . ' ' . TEXT_INFO_RESTOCK_PRODUCT_QUANTITY . '</label>'];
                                     $contents[] = ['align' => 'text-center', 'text' => '<br><button type="submit" class="btn btn-danger">' . IMAGE_DELETE . '</button> <a href="' . zen_href_link(FILENAME_ORDERS, zen_get_all_get_params(['oID', 'action']) . 'oID=' . $oInfo->orders_id, 'NONSSL') . '" class="btn btn-default" role="button">' . IMAGE_CANCEL . '</a>'];
                                     break;
                                 default:


### PR DESCRIPTION
As the browser sends `true` as '1' (string), now the logic test for `deleteconfirm` is "Is $_POST['restock'] set? And if it is, is it '1' as a string? If so, call the `delete` method of the order class.