### PR TITLE
attribute_controller:  product select, auto submit

### DIFF
--- a/admin/attributes_controller.php
+++ b/admin/attributes_controller.php
@@ -902,9 +902,8 @@ function zen_js_option_values_list($selectedName, $fieldName)
                   echo zen_get_products_quantity_min_units_display($_GET['products_filter'], $include_break = true);
                   ?>
                 </div>
-                <div class="col-xs-8 col-sm-8 col-md-6 col-lg-4 text-center"><?= zen_draw_pulldown_products('products_filter', 'class="form-control"', '', true, $_GET['products_filter'], true, true) ?></div>
-                <div class="col-xs-2 col-sm-3 col-md-5 col-lg-7">
-                  <button type="submit" class="btn btn-primary"><?= IMAGE_DISPLAY ?></button>
+                <div class="col-xs-10"><?= zen_draw_pulldown_products('products_filter', 'class="form-control" size="10" onchange="this.form.submit()"', '', true, $_GET['products_filter'], true, true, 'products_model'); ?>
+                    <noscript><button type="submit" class="btn btn-primary"><?= IMAGE_DISPLAY ?></button></noscript>
                 </div>
               </div>
             <?php } // product dropdown


### PR DESCRIPTION
The category select dropdown autosubmits.

This PR does the same for the product select (the "Display" button shows on noscript).
![attribute_controller-no_display](https://github.com/user-attachments/assets/64b2bad8-fa94-482e-9fe5-7b62ad234d5f)

I have a few formatting improvements for this top section, which is a bit ugly.

