### PR TITLE
Changing tooltip for edit order

### DIFF
--- a/admin/includes/functions/html_output.php
+++ b/admin/includes/functions/html_output.php
@@ -234,7 +234,8 @@ $iconMap = [
   'star-shadow' => 'fa-star txt-gold star-shadow',
   'locked' => 'fa-lock',
   'unlocked' => 'fa-lock-open',
-  'loading' => 'fa-gear fa-spin'
+  'loading' => 'fa-gear fa-spin',
+  'clipboard' => 'fa-solid fa-clipboard-list',
 ];
 
 /**

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -1493,7 +1493,7 @@ if ($show_orders_weights === true) {
                                 <td class="dataTableContent noprint text-right actions dataTableButtonCell">
                                     <div class="btn-group">
                                         <?php
-                                        echo '<a href="' . zen_href_link(FILENAME_ORDERS, zen_get_all_get_params(['oID', 'action']) . 'oID=' . $orders->fields['orders_id'] . '&action=edit', 'NONSSL') . '" class="btn btn-sm btn-default btn-edit" data-toggle="tooltip" title="' . ICON_EDIT . '">' .
+                                        echo '<a href="' . zen_href_link(FILENAME_ORDERS, zen_get_all_get_params(['oID', 'action']) . 'oID=' . $orders->fields['orders_id'] . '&action=edit', 'NONSSL') . '" class="btn btn-sm btn-default btn-edit" data-toggle="tooltip" title="' . IMAGE_DETAILS . '">' .
                                             zen_icon('pencil', hidden: true) .
                                         '</a>' . $extra_action_icons;
                                         ?>

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -1494,7 +1494,7 @@ if ($show_orders_weights === true) {
                                     <div class="btn-group">
                                         <?php
                                         echo '<a href="' . zen_href_link(FILENAME_ORDERS, zen_get_all_get_params(['oID', 'action']) . 'oID=' . $orders->fields['orders_id'] . '&action=edit', 'NONSSL') . '" class="btn btn-sm btn-default btn-edit" data-toggle="tooltip" title="' . IMAGE_DETAILS . '">' .
-                                            zen_icon('pencil', hidden: true) .
+                                            zen_icon('clipboard', hidden: true) .
                                         '</a>' . $extra_action_icons;
                                         ?>
                                         </div>


### PR DESCRIPTION
Could be confusing having two "edit" references (one from innate ZenCart and the other from something like Edit Orders) next to each other. Changing the link to the order itself to read as "Details" using an already existing define.