### PR TITLE
checkout_payment: add optional text element for payment method info

### DIFF
--- a/includes/templates/template_default/templates/tpl_checkout_payment_default.php
+++ b/includes/templates/template_default/templates/tpl_checkout_payment_default.php
@@ -147,9 +147,13 @@
 ?>
 <?php
     }
+?>
+<?php
     if (!empty(($selection[$i]['text']))) { ?>
         <div class="ccinfoText"><?= $selection[$i]['text'] ?></div>
-    <?php } ?>
+<?php
+    }
+?>
 <br class="clearBoth">
 
 <?php


### PR DESCRIPTION
as discussed here: https://github.com/zencart/zencart/issues/7240

This PR is for a single text element after the module name and before the fields array.

The fields element-array set is currently parsed to produce a hard-coded label + input and would require reworking to produce a  single element and/or a label+ input pair....could be done if preferred...

I note that the matching area in checkout_confirmation uses an element confusingly named title. I decided to not match that.
