### PR TITLE
function zen_get_products_manufacturers_id: cast return value (string) to int as per hint

### DIFF
--- a/includes/functions/functions_products.php
+++ b/includes/functions/functions_products.php
@@ -545,7 +545,7 @@ function zen_get_products_manufacturers_image($product_id): string
  */
 function zen_get_products_manufacturers_id($product_id): int
 {
-    return (new Product((int)$product_id))->get('manufacturers_id') ?? 0;
+    return (int)(new Product((int)$product_id))->get('manufacturers_id') ?? 0;
 }
 
 /**


### PR DESCRIPTION
have to cast here as Product->get method is generic/can return multiple values.