### PR TITLE
POSM observer: do not return quantity as string

### DIFF
--- a/zc_plugins/POSM/v6.1.1/catalog/includes/classes/observers/class.products_options_stock_observer.php
+++ b/zc_plugins/POSM/v6.1.1/catalog/includes/classes/observers/class.products_options_stock_observer.php
@@ -377,7 +377,7 @@ class products_options_stock_observer extends base
         }
         $pos_record = $this->getOptionsStockRecord($products_id, $posm_options);
         if ($pos_record !== false) {
-            $products_quantity = ($pos_record->EOF) ? 0 : $pos_record->fields['products_quantity'];
+            $products_quantity = $pos_record->EOF ? 0 : zen_str_to_numeric((string)$pos_record->fields['products_quantity']);
             $quantity_handled = true;
         }
     }


### PR DESCRIPTION

This functions returns int or float
https://github.com/zencart/zencart/blob/28e44ef618cc9e81e49f5661e7dfa4f41107962a/includes/functions/functions_products.php#L471-L489

but the observer may return a string.

Fix copied from here
https://github.com/zencart/zencart/blob/28e44ef618cc9e81e49f5661e7dfa4f41107962a/includes/classes/Product.php#L159

Or maybe the observer should watch this method?