### PR TITLE
Adding function to display the group comment

### DIFF
--- a/includes/functions/functions_customer_groups.php
+++ b/includes/functions/functions_customer_groups.php
@@ -269,8 +269,8 @@ function zen_get_customer_group_comment(string $group_name): string
 
     $sql = "SELECT group_comment FROM " .
             TABLE_CUSTOMER_GROUPS . "
-            WHERE group_name = ':group_name:'";
-    $sql = $db->bindVars($sql, ':group_name:', $group_name, 'string');
+            WHERE group_name = :group_name:";
+    $sql = $db->bindVars($sql, ':group_name:', $group_name, 'stringIgnoreNull');
 
     $results = $db->Execute($sql, 1);
 

--- a/includes/functions/functions_customer_groups.php
+++ b/includes/functions/functions_customer_groups.php
@@ -260,3 +260,17 @@ function zen_delete_customer_group($group_id, $also_unassign_customers = true)
     return true;
 }
 
+/**
+  * @param string $group_name The name of the group to be retrieved (ie. the value from the group_name column of the DB)
+ */
+function zen_get_customer_group_comment(string $group_name) {
+    global $db;
+
+    $sql = "SELECT group_comment FROM " .
+            TABLE_CUSTOMER_GROUPS . "
+            WHERE group_name = '" . $group_name ."'";
+
+    $results = $db->Execute($sql);
+
+    return $results->fields['group_comment'] ?? '';
+}

--- a/includes/functions/functions_customer_groups.php
+++ b/includes/functions/functions_customer_groups.php
@@ -263,7 +263,8 @@ function zen_delete_customer_group($group_id, $also_unassign_customers = true)
 /**
   * @param string $group_name The name of the group to be retrieved (ie. the value from the group_name column of the DB)
  */
-function zen_get_customer_group_comment(string $group_name) {
+function zen_get_customer_group_comment(string $group_name)
+{
     global $db;
 
     $sql = "SELECT group_comment FROM " .

--- a/includes/functions/functions_customer_groups.php
+++ b/includes/functions/functions_customer_groups.php
@@ -263,7 +263,7 @@ function zen_delete_customer_group($group_id, $also_unassign_customers = true)
 /**
   * @param string $group_name The name of the group to be retrieved (ie. the value from the group_name column of the DB)
  */
-function zen_get_customer_group_comment(string $group_name)
+function zen_get_customer_group_comment(string $group_name): string
 {
     global $db;
 
@@ -272,7 +272,7 @@ function zen_get_customer_group_comment(string $group_name)
             WHERE group_name = ':group_name:'";
     $sql = $db->bindVars($sql, ':group_name:', $group_name, 'string');
 
-    $results = $db->Execute($sql);
+    $results = $db->Execute($sql, 1);
 
     return $results->fields['group_comment'] ?? '';
 }

--- a/includes/functions/functions_customer_groups.php
+++ b/includes/functions/functions_customer_groups.php
@@ -269,7 +269,8 @@ function zen_get_customer_group_comment(string $group_name)
 
     $sql = "SELECT group_comment FROM " .
             TABLE_CUSTOMER_GROUPS . "
-            WHERE group_name = '" . $group_name ."'";
+            WHERE group_name = ':group_name:'";
+    $sql = $db->bindVars($sql, ':group_name:', $group_name, 'string');
 
     $results = $db->Execute($sql);
 


### PR DESCRIPTION
Simply adding a function to display the Group Comment field from the DB. This can be handy if you want a "friendly" display of what groups a customer belongs to rather than a potentially cryptic `group_name` field.