### PR TITLE
Update to Whos Online User Agent string filter

### DIFF
--- a/includes/functions/whos_online.php
+++ b/includes/functions/whos_online.php
@@ -31,7 +31,7 @@ function zen_update_whos_online()
 
     $wo_session_id = zen_session_id();
     $wo_ip_address = substr(isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : 'Unknown', 0, 45);
-    $wo_user_agent = preg_replace('#[a-zA-Z0-9/\.;:\(\)]#', '~', preg_quote($_SERVER['HTTP_USER_AGENT'] ?? '', '#'));
+    $wo_user_agent = preg_replace('/\W+/u', '~', $_SERVER['HTTP_USER_AGENT'] ?? '');
     $wo_user_agent = substr(zen_db_prepare_input($wo_user_agent), 0, 254);
 
     $_SERVER['QUERY_STRING'] = (isset($_SERVER['QUERY_STRING']) && $_SERVER['QUERY_STRING'] != '') ? $_SERVER['QUERY_STRING'] : zen_get_all_get_params();


### PR DESCRIPTION
After filtering, the actual user agent displayed in Who's Online page is just a series of `~` with sometimes some special characters.
The new filtering will let all _word type_ characters plus few commonly used specials characters, and this in any language/character set of UTF8.

Example with MSN search bot:
Original user agent:
`Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm) Chrome/116.0.1938.76 Safari/537.36`
Before PR:
`~~~~~~~~~~~ ~~~~~~~~~~~~~~~~~~ ~~~~~~, ~~~~ ~~~~~~ ~~~~~~~~~~~ ~~~~~~~~~~~~ +~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~~~~`
After PR:
`Mozilla~5~0~AppleWebKit~537~36~KHTML~like~Gecko~compatible~bingbot~2~0~http~www~bing~com~bingbot~htm~Chrome~116~0~1938~76~Safari~537~36`