### PR TITLE
Enable notifier-tracing to limit events monitored

### DIFF
--- a/includes/classes/traits/NotifierManager.php
+++ b/includes/classes/traits/NotifierManager.php
@@ -119,6 +119,9 @@ trait NotifierManager
         if (!defined('NOTIFIER_TRACE') || empty(NOTIFIER_TRACE) || NOTIFIER_TRACE === 'false' || NOTIFIER_TRACE === 'Off') {
             return;
         }
+        if (defined('NOTIFIER_TRACE_EVENTS') && is_array(NOTIFIER_TRACE_EVENTS) && !in_array($eventID, NOTIFIER_TRACE_EVENTS)) {
+            return;
+        }
         global $zcDate;
 
         $file = DIR_FS_LOGS . '/notifier_trace.log';


### PR DESCRIPTION
Usage:
```php
define('NOTIFIER_TRACE_EVENTS', [comma-separated-list-of-events]);
```

Using the above definition, the `notifier_trace.log` file can be limited to the selected events.  Requires also that the `NOTIFIER_TRACE` definition is defined and 'enabled'.