### PR TITLE
Change to see if first comment is not empty

### DIFF
--- a/admin/orders.php
+++ b/admin/orders.php
@@ -1592,17 +1592,18 @@ if ($show_orders_weights === true) {
                                             $contents[] = ['align' => 'text-center', 'text' => $goto_gv];
                                         }
 
-                                        // indicate if comments exist
+                                        // -----
+                                        // Indicate if comments exist and retrieve the first comment only.
+                                        // (The first comment should only be the customer/admin's comment)
                                         $orders_history_query = $db->Execute(
                                                 "SELECT comments, updated_by
                                                      FROM " . TABLE_ORDERS_STATUS_HISTORY . "
                                                     WHERE orders_id = " . (int)$oInfo->orders_id . "
-                                                        AND comments != ''
                                                     ORDER BY date_added ASC
                                                     LIMIT 1"
                                         );
 
-                                        if (!$orders_history_query->EOF) {
+                                        if (!$orders_history_query->EOF && zen_not_null($orders_history_query->fields['comments'])) {
                                             $contents[] = ['text' => '<br>' . TABLE_HEADING_COMMENTS];
 
                                             // -----


### PR DESCRIPTION
If the customer or admin checks out without placing an order note, it still creates an empty row in Order Status History before any other module adds their note from payment (or observer). 

So, this changes from pulling the first non-empty comment to the first comment row period. If the check passes, it will print that comment in the area. (This way, you avoid showing payment module notes in the admin area in the orders sidebar.)