### PR TITLE
Avoiding possible warning about unset array key

### DIFF
--- a/includes/functions/whos_online.php
+++ b/includes/functions/whos_online.php
@@ -10,7 +10,7 @@
 function zen_update_whos_online()
 {
     // exclude ajax pages from whos-online updates
-    if (preg_match('|ajax\.php$|', $_SERVER['SCRIPT_NAME']) && (isset($_GET['act']) && $_GET['act'] !== '')) return;
+    if (preg_match('|ajax\.php$|', $_SERVER['SCRIPT_NAME']) && !empty($_GET['act'])) return;
 
     global $db;
 

--- a/includes/functions/whos_online.php
+++ b/includes/functions/whos_online.php
@@ -10,7 +10,7 @@
 function zen_update_whos_online()
 {
     // exclude ajax pages from whos-online updates
-    if (preg_match('|ajax\.php$|', $_SERVER['SCRIPT_NAME']) && $_GET['act'] != '') return;
+    if (preg_match('|ajax\.php$|', $_SERVER['SCRIPT_NAME']) && (isset($_GET['act']) && $_GET['act'] !== '')) return;
 
     global $db;
 


### PR DESCRIPTION
Discovered the following warning using 2.2.0:

``` shell
[23-Sep-2025 18:46:26 America/New_York] Request URI: /ajax/api/content_infraction/getIndexableContent, IP address: 5.79.66.133, Language id 1
#0 /includes/classes/navigation_history.php(38): zen_debug_error_handler()
#1 /includes/autoload_func.php(62): navigationHistory->add_current_page()
#2 /includes/application_top.php(329): require('...')
#3 /ajax.php(24): require('...')
--> PHP Warning: Undefined array key "act" in /includes/classes/navigation_history.php on line 38.

[23-Sep-2025 18:46:26 America/New_York] Request URI: /ajax/api/content_infraction/getIndexableContent, IP address: 5.79.66.133, Language id 1
#0 /includes/functions/whos_online.php(13): zen_debug_error_handler()
#1 /includes/init_includes/init_special_funcs.php(18): zen_update_whos_online()
#2 /includes/autoload_func.php(40): require_once('...')
#3 /includes/application_top.php(329): require('...')
#4 /ajax.php(24): require('...')
--> PHP Warning: Undefined array key "act" in /includes/functions/whos_online.php on line 13.
```

So I'm short-circuiting the lookup at the array key "act" by check if it's set first. (Not sure if it's appropriate to `act` could equal zero so I'm using the isset instead.