### PR TITLE
Whos Online multibyte characters in User Agent

### DIFF
--- a/includes/functions/whos_online.php
+++ b/includes/functions/whos_online.php
@@ -32,7 +32,7 @@ function zen_update_whos_online()
     $wo_session_id = zen_session_id();
     $wo_ip_address = substr(isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : 'Unknown', 0, 45);
     $wo_user_agent = preg_replace('/\W+/u', '~', $_SERVER['HTTP_USER_AGENT'] ?? '');
-    $wo_user_agent = substr(zen_db_prepare_input($wo_user_agent), 0, 254);
+    $wo_user_agent = mb_substr(zen_db_prepare_input($wo_user_agent), 0, 254);
 
     $_SERVER['QUERY_STRING'] = (isset($_SERVER['QUERY_STRING']) && $_SERVER['QUERY_STRING'] != '') ? $_SERVER['QUERY_STRING'] : zen_get_all_get_params();
     if (isset($_SERVER['REQUEST_URI'])) {


### PR DESCRIPTION
Replacing `substr()` by `mb_substr()` will avoid invalid characters when user agent contains multibyte characters and is long enough, which leads to an SQL fatal error. See forum thread [here](https://www.zen-cart.com/showthread.php/230872-Fatal-Error-Incorrect-string-value).