### PR TITLE
PluginStatus class, provides common 'status' values

### DIFF
--- a/admin/includes/templates/plugin_manager.php
+++ b/admin/includes/templates/plugin_manager.php
@@ -8,19 +8,18 @@
  * @var \Zencart\TableViewControllers\BaseController $tableController
  * @var string $PHP_SELF
  */
-
-
+use Zencart\PluginSupport\PluginStatus;
 ?>
 <div class="container-fluid">
     <h1><?php echo HEADING_TITLE; ?></h1>
     <div class="row">
         <div class="col-xs-12 col-sm-12 col-md-9 col-lg-9 configurationColumnLeft">
         <?php
-            foreach ([1, 2, 0] as $i) {
+            foreach ([PluginStatus::ENABLED, PluginStatus::DISABLED, PluginStatus::NOT_INSTALLED] as $i) {
                 $firstheader = 0;
                 $skip = 1;
                 foreach ($formatter->getTableData() as $tableData) {
-                    if ($tableData ["status"] ["original"] === $i) {
+                    if ($tableData["status"]["original"] === $i) {
                         $skip = 0;
                         break;
                     }
@@ -44,9 +43,9 @@
                         <th class="<?php echo $colHeader['headerClass'] . $colwidth; ?>">
                         <?php if ($firstheader === 0) {
                             $tabletitle = match($i) {
-                                0 => TEXT_NOT_INSTALLED,
-                                1 => TEXT_INSTALLED_ENABLED,
-                                2 => TEXT_INSTALLED_DISABLED,
+                                PluginStatus::NOT_INSTALLED => TEXT_NOT_INSTALLED,
+                                PluginStatus::ENABLED => TEXT_INSTALLED_ENABLED,
+                                PluginStatus::DISABLED => TEXT_INSTALLED_DISABLED,
                             };
                             echo $tabletitle;
                             $firstheader = 1;
@@ -61,7 +60,7 @@
                 </thead>
                 <tbody>
                 <?php foreach ($formatter->getTableData() as $tableData) { ?>
-                    <?php if ($tableData ["status"] ["original"] === $i) {
+                    <?php if ($tableData["status"]["original"] === $i) {
                               if ($formatter->isRowSelected($tableData)) { ?>
                         <tr id="defaultSelected" class="dataTableRowSelected" onclick="document.location.href='<?php echo $formatter->getSelectedRowLink(
                             $tableData); ?>'" role="button">

--- a/admin/plugin_manager.php
+++ b/admin/plugin_manager.php
@@ -12,6 +12,7 @@ use Zencart\PluginManager\PluginManager;
 use Zencart\PluginSupport\Installer;
 use Zencart\PluginSupport\InstallerFactory;
 use Zencart\PluginSupport\PluginErrorContainer;
+use Zencart\PluginSupport\PluginStatus;
 use Zencart\PluginSupport\ScriptedInstallerFactory;
 use Zencart\PluginSupport\SqlPatchInstaller;
 use Zencart\ViewBuilders\DerivedItemsManager;
@@ -58,7 +59,11 @@ $tableDefinition = [
             'derivedItem' => [
                 'type' => 'local',
                 'method' => 'arrayReplace',
-                'params' => ['0' => zen_icon('status-red'), '1' => zen_icon('status-green'), '2' => zen_icon('status-yellow')],
+                'params' => [
+                    (string)PluginStatus::NOT_INSTALLED => zen_icon('status-red'),
+                    (string)PluginStatus::ENABLED => zen_icon('status-green'),
+                    (string)PluginStatus::DISABLED => zen_icon('status-yellow'),
+                ],
             ],
         ],
     ],
@@ -80,7 +85,12 @@ $filterDefinitions = [
         'source' => 'options',
         'selectName' => 'plugin_status',
         'auto' => true,
-        'options' => ['*' => TEXT_ALL_STATUSES, '0' => TEXT_NOT_INSTALLED, '1' => TEXT_INSTALLED_ENABLED, '2' => TEXT_INSTALLED_DISABLED],
+        'options' => [
+            '*' => TEXT_ALL_STATUSES,
+            (string)PluginStatus::NOT_INSTALLED => TEXT_NOT_INSTALLED,
+            (string)PluginStatus::ENABLED => TEXT_INSTALLED_ENABLED,
+            (string)PluginStatus::DISABLED => TEXT_INSTALLED_DISABLED,
+        ],
     ],
 ];
 

--- a/includes/classes/PluginManager.php
+++ b/includes/classes/PluginManager.php
@@ -8,6 +8,8 @@
 
 namespace Zencart\PluginManager;
 
+use Zencart\PluginSupport\PluginStatus;
+
 class PluginManager
 {
     private
@@ -28,7 +30,7 @@ class PluginManager
 
     public function getInstalledPlugins()
     {
-        $results = $this->pluginControl->where(['status' => 1])->orderBy('name')->orderBy('unique_key')->get();
+        $results = $this->pluginControl->where(['status' => PluginStatus::ENABLED])->orderBy('name')->orderBy('unique_key')->get();
         $pluginList = [];
         foreach ($results as $result) {
             $pluginList[$result['unique_key']] = $result;
@@ -229,7 +231,7 @@ class PluginManager
                     'name' => $plugin[$pluginVersion]['pluginName'],
                     'description' => $plugin[$pluginVersion]['pluginDescription'],
                     'type' => '',
-                    'status' => 0,
+                    'status' => PluginStatus::NOT_INSTALLED,
                     'author' => $plugin[$pluginVersion]['pluginAuthor'],
                     'version' => '',
                     'zc_versions' => '',

--- a/includes/classes/PluginSupport/BasePluginInstaller.php
+++ b/includes/classes/PluginSupport/BasePluginInstaller.php
@@ -8,6 +8,7 @@
 namespace Zencart\PluginSupport;
 
 use queryFactory;
+use Zencart\PluginSupport\PluginStatus;
 
 class BasePluginInstaller
 {
@@ -30,7 +31,7 @@ class BasePluginInstaller
         if ($this->errorContainer->hasErrors()) {
             return false;
         }
-        $this->setPluginVersionStatus($pluginKey, $version, 1);
+        $this->setPluginVersionStatus($pluginKey, $version, PluginStatus::ENABLED);
         return true;
     }
 
@@ -38,7 +39,7 @@ class BasePluginInstaller
     {
         $this->pluginDir = DIR_FS_CATALOG . 'zc_plugins/' . $pluginKey . '/' . $version;
         $this->loadInstallerLanguageFile('main.php', $this->pluginDir);
-        $this->setPluginVersionStatus($pluginKey, '', 0);
+        $this->setPluginVersionStatus($pluginKey, '', PluginStatus::NOT_INSTALLED);
         $this->pluginInstaller->setVersions($this->pluginDir, $pluginKey, $version);
         $this->pluginInstaller->executeUninstallers($this->pluginDir);
         if ($this->errorContainer->hasErrors()) {
@@ -56,19 +57,19 @@ class BasePluginInstaller
         if ($this->errorContainer->hasErrors()) {
             return false;
         }
-        $this->setPluginVersionStatus($pluginKey, $oldVersion, 0);
-        $this->setPluginVersionStatus($pluginKey, $version, 1);
+        $this->setPluginVersionStatus($pluginKey, $oldVersion, PluginStatus::NOT_INSTALLED);
+        $this->setPluginVersionStatus($pluginKey, $version, PluginStatus::ENABLED);
         return true;
     }
 
     public function processDisable($pluginKey, $version): void
     {
-        $this->setPluginVersionStatus($pluginKey, $version, 2);
+        $this->setPluginVersionStatus($pluginKey, $version, PluginStatus::DISABLED);
     }
 
     public function processEnable($pluginKey, $version): void
     {
-        $this->setPluginVersionStatus($pluginKey, $version, 1);
+        $this->setPluginVersionStatus($pluginKey, $version, PluginStatus::ENABLED);
     }
 
     protected function setPluginVersionStatus($pluginKey, $version, $status): void

--- a/includes/classes/PluginSupport/PluginStatus.php
+++ b/includes/classes/PluginSupport/PluginStatus.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @copyright Copyright 2003-2024 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: DrByte 2024 Sep 20 Modified in v2.1.0-beta1 $
+ *
+ * @since ZC v2.2.0
+ */
+namespace Zencart\PluginSupport;
+
+class PluginStatus
+{
+    public const NOT_INSTALLED = 0;
+    public const ENABLED = 1;
+    public const DISABLED = 2;
+}

--- a/includes/classes/ViewBuilders/PluginManagerController.php
+++ b/includes/classes/ViewBuilders/PluginManagerController.php
@@ -10,6 +10,7 @@ namespace Zencart\ViewBuilders;
 use Zencart\FileSystem\FileSystem;
 use Zencart\PluginManager\PluginManager;
 use Zencart\PluginSupport\InstallerFactory;
+use Zencart\PluginSupport\PluginStatus;
 
 class PluginManagerController extends BaseController
 {
@@ -37,7 +38,7 @@ class PluginManagerController extends BaseController
             );
         }
 
-        if ($this->currentFieldValue('status') == 0) {
+        if ((int)$this->currentFieldValue('status') === PluginStatus::NOT_INSTALLED) {
             $this->setBoxContent(
                 '<a href="' . zen_href_link(
                     FILENAME_PLUGIN_MANAGER,
@@ -64,7 +65,7 @@ class PluginManagerController extends BaseController
                 ) . '" class="btn btn-primary" role="button">' . TEXT_UPGRADE_AVAILABLE . '</a>'
             );
         }
-        if ($this->currentFieldValue('status') == 1) {
+        if ((int)$this->currentFieldValue('status') === PluginStatus::ENABLED) {
             $this->setBoxContent(
                 '<a href="' . zen_href_link(
                     FILENAME_PLUGIN_MANAGER,
@@ -77,8 +78,7 @@ class PluginManagerController extends BaseController
                     $this->pageLink() . '&' . $this->colKeylink() . '&action=uninstall'
                 ) . '" class="btn btn-primary" role="button">' . TEXT_UNINSTALL . '</a>'
             );
-        }
-        if ($this->currentFieldValue('status')== 2) {
+        } elseif ((int)$this->currentFieldValue('status') === PluginStatus::DISABLED) {
             $this->setBoxContent(
                 '<a href="' . zen_href_link(
                     FILENAME_PLUGIN_MANAGER,

--- a/includes/classes/ViewBuilders/PluginManagerDataSource.php
+++ b/includes/classes/ViewBuilders/PluginManagerDataSource.php
@@ -9,15 +9,16 @@ namespace Zencart\ViewBuilders;
 
 use App\Models\PluginControl;
 use Illuminate\Database\Eloquent\Builder;
+use Zencart\PluginSupport\PluginStatus;
 
 class PluginManagerDataSource extends DataTableDataSource
 {
     protected function buildInitialQuery(): Builder
     {
         $statusSort = [
-            1, // enabled
-            2, // disabled
-            0, // not installed
+            PluginStatus::ENABLED, // enabled
+            PluginStatus::DISABLED, // disabled
+            PluginStatus::NOT_INSTALLED, // not installed
         ];
         return PluginControl::query()
             ->orderByRaw(


### PR DESCRIPTION
A corollary to PR #7303, this PR adds a `PluginStatus` class where the various plugin-status constants are defined for common use.

It's a bit easier to 'understand'
```php
$this->setPluginVersionStatus($pluginKey, '', PluginStatus::NOT_INSTALLED);
```
than
```
$this->setPluginVersionStatus($pluginKey, '', 0);
```