### PR TITLE
Configuration-values-cannot-be-saved-as-HTML-character-codes

### DIFF
--- a/admin/configuration.php
+++ b/admin/configuration.php
@@ -210,7 +210,7 @@ echo zen_draw_form('configuration', FILENAME_CONFIGURATION, 'gID=' . $_GET['gID'
 <?php
 foreach ($configuration as $item) {
     $fieldName = 'cfg_' . $item['configuration_id'];
-    $cfgValue = $item['configuration_value'];
+    $cfgValue = htmlspecialchars($item['configuration_value']);
 
     if (defined('CFGTITLE_' . $item['configuration_key'])) {
         $item['configuration_title'] = constant('CFGTITLE_' . $item['configuration_key']);


### PR DESCRIPTION
Any character saved as an HTML character code for a configuration value in table configuration is automatically replaced by the actual character at first edit of the corresponding configuration setting page. Then HTML character codes cannot be saved anymore, they will be saved as the actual character representing the HTML code.
For example:
In `Configuration -> Emails -> Convert currencies for Text emails`, the value `&pound;,£:&euro;,€:&reg;,®:&trade;,™` becomes `£,£:€,€:®,®:™,™` as soon as any setting on this page is edited and saved.

The solution is to use `htmlspecialchars` online 213 of `admin/configuration.php` to avoid that these codes to be interpreted when populating the form field.