### PR TITLE
Remove curl_close() calls

### DIFF
--- a/extras/curltester.php
+++ b/extras/curltester.php
@@ -39,7 +39,6 @@ $goodMessage = '<span style="color:green;font-weight:bold">GOOD: </span>';
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
         $data = curl_exec($ch);
-        curl_close($ch);
         $json = json_decode($data, false);
         echo (stripos($json->rating, 'Okay') !== false ? $goodMessage : $errorMessage) . ' Rating: ' . $json->rating;
         echo "<br>\n";
@@ -243,7 +242,6 @@ function doCurlTest($url = 'http://s3.amazonaws.com/zencart-curltest/endpoint', 
         $errnum = curl_errno($ch);
     }
     $commInfo = @curl_getinfo($ch);
-    curl_close($ch);
 
     // enclose URL in quotes so it doesn't get converted to a clickable link if posted on the forum
     if (isset($commInfo['url'])) {

--- a/extras/ipncheck.php
+++ b/extras/ipncheck.php
@@ -221,7 +221,6 @@ function doPayPalIPNCurlPostback($web, $vars, $verboseMode = false, $headerMode 
         $commErrNo = curl_errno($ch);
     }
     //$commInfo = @curl_getinfo($ch);
-    curl_close($ch);
     //die("\n\n".'data:'.$response);
 
     if ($verboseMode) {

--- a/includes/functions/functions_communications.php
+++ b/includes/functions/functions_communications.php
@@ -89,8 +89,6 @@ use http\Exception\BadQueryStringException;
       $info = curl_getinfo($ch);
       $httpCode = curl_getinfo($ch, $proxy ? CURLINFO_HTTP_CONNECTCODE : CURLINFO_RESPONSE_CODE);
 
-      curl_close($ch);
-
       if (!empty($error)) {
           // only give messageStack responses on admin-side
           if (IS_ADMIN_FLAG === true) {

--- a/includes/modules/payment/authorizenet_aim.php
+++ b/includes/modules/payment/authorizenet_aim.php
@@ -711,7 +711,6 @@ class authorizenet_aim extends base {
     }
 
     $this->commInfo = @curl_getinfo($ch);
-    curl_close ($ch);
 
     // if in 'echo' mode, dump the returned data to the browser and stop execution
     if ((defined('AUTHORIZENET_DEVELOPER_MODE') && AUTHORIZENET_DEVELOPER_MODE == 'echo') || MODULE_PAYMENT_AUTHORIZENET_AIM_DEBUGGING == 'echo') {

--- a/includes/modules/payment/paypal/paypal_curl.php
+++ b/includes/modules/payment/paypal/paypal_curl.php
@@ -482,7 +482,6 @@ class paypal_curl extends base {
     }
 
     $commInfo = @curl_getinfo($ch);
-    curl_close($ch);
 
     $rawdata = "CURL raw data:\n" . $response . "CURL RESULTS: (" . $commErrNo . ') ' . $commError . "\n" . print_r($commInfo, true) . "\nEOF";
 

--- a/includes/modules/payment/paypal/paypal_functions.php
+++ b/includes/modules/payment/paypal/paypal_functions.php
@@ -657,7 +657,6 @@ function ipn_create_order_history_array($insert_id)
       $commErrNo = curl_errno($ch);
     }
     $commInfo = @curl_getinfo($ch);
-    curl_close($ch);
 
     $errors = ($commErrNo != 0 ? "CURL communication ERROR: (" . $commErrNo . ') ' . $commError : '');
     $response .= ($commErrNo != 0 ? '&CURL_ERRORS=' . urlencode('(' . $commErrNo . ') ' . $commError) : '') ;
@@ -686,7 +685,6 @@ function ipn_create_order_history_array($insert_id)
       $commError = curl_error($ch);
       $commErrNo = curl_errno($ch);
       $commInfo = @curl_getinfo($ch);
-      curl_close($ch);
       ipn_debug_email('CURL OPTS: ' . print_r($curlOpts, true));
       ipn_debug_email('CURL response: ' . $response);
       $errors = ($commErrNo != 0 ? "\n(" . $commErrNo . ') ' . $commError : '');

--- a/includes/modules/payment/paypaldp.php
+++ b/includes/modules/payment/paypaldp.php
@@ -2548,9 +2548,6 @@ class paypaldp extends base {
       $succeeded  = curl_errno($ch) == 0 ? true : false;
       $error = curl_errno($ch) . '-' . curl_error($ch);
 
-      // close cURL resource, and free up system resources
-      curl_close($ch);
-
       // If Communication was not successful set error result
       if (!$succeeded) {
         $this->zcLog('Cardinal Send 1', '[' . zen_session_id() . '] Cardinal Centinel - ' . CENTINEL_ERROR_CODE_8030_DESC);

--- a/zc_install/includes/classes/class.systemChecker.php
+++ b/zc_install/includes/classes/class.systemChecker.php
@@ -539,7 +539,6 @@ class systemChecker
         $err = curl_errno($ch);
         $errmsg = curl_error($ch);
         $header = curl_getinfo($ch);
-        curl_close($ch);
 
         if ($header === false) {
             $header = [];
@@ -660,7 +659,6 @@ class systemChecker
         $commInfo = @curl_getinfo($ch);
 // error_log('CURL Connect: ' . $errnum . ' ' . $errtext . "\n" . print_r($commInfo, TRUE));
 // error_log('CURL Response: ' . $result);
-        curl_close($ch);
 
         return $errnum === 0 && trim($result) === 'PASS';
     }


### PR DESCRIPTION
`PHP Deprecated: Function curl_close() is deprecated since 8.5, as it has no effect since PHP 8.0`