### PR TITLE
Deprecated: The __wakeup() serialization magic method has been deprecated. Implement __unserialize() instead

### DIFF
--- a/includes/classes/traits/Singleton.php
+++ b/includes/classes/traits/Singleton.php
@@ -13,12 +13,23 @@ namespace Zencart\Traits;
  */
 trait Singleton
 {
-    private static $instances = array();
-    protected function __construct() {}
+    private static array $instances = [];
+
+    protected function __construct() { }
+
     /**
      * @since ZC v1.5.7
      */
-    protected function __clone() {}
+    protected function __clone() { }
+
+    /**
+     * @since ZC v2.2.0
+     */
+    public function __unserialize(array $data): void
+    {
+        throw new \BadMethodCallException("Cannot unserialize singleton");
+    }
+
     /**
      * @since ZC v1.5.7
      */


### PR DESCRIPTION
```
#0 /includes/classes/vendors/AuraAutoload/src/Loader.php(361): zen_debug_error_handler()
#1 /includes/classes/vendors/AuraAutoload/src/Loader.php(361): require()
#2 /includes/classes/vendors/AuraAutoload/src/Loader.php(336): Aura\Autoload\Loader->requireFile()
#3 /includes/classes/vendors/AuraAutoload/src/Loader.php(288): Aura\Autoload\Loader->loadFile()
#4 /includes/classes/ResourceLoaders/PageLoader.php(16): Aura\Autoload\Loader->loadClass()
#5 /includes/classes/vendors/AuraAutoload/src/Loader.php(361): require('/Users/chris/CO...')
#6 /includes/classes/vendors/AuraAutoload/src/Loader.php(336): Aura\Autoload\Loader->requireFile()
#7 /includes/classes/vendors/AuraAutoload/src/Loader.php(288): Aura\Autoload\Loader->loadFile()
#8 /admin/includes/application_bootstrap.php(181): Aura\Autoload\Loader->loadClass()

--> PHP Deprecated: The __wakeup() serialization magic method has been deprecated. Implement __unserialize() instead (or in addition, if support for old PHP versions is necessary) in /includes/classes/traits/Singleton.php on line 14.
```