### PR TITLE
System Inspection: Updating built-in tables

### DIFF
--- a/zc_plugins/SystemInspection/1.6.0/admin/includes/extra_configures/system_inspection_base.php
+++ b/zc_plugins/SystemInspection/1.6.0/admin/includes/extra_configures/system_inspection_base.php
@@ -189,6 +189,7 @@ define('BUILT_IN_TABLES', [
     'coupon_referrers',
     'currencies',
     'customers',
+    'customers_auth_tokens',
     'customers_basket',
     'customers_basket_attributes',
     'customers_info',
@@ -228,7 +229,6 @@ define('BUILT_IN_TABLES', [
     'paypal_payment_status',
     'paypal_payment_status_history',
     'paypal_session',
-    'paypal_webhooks',
     'plugin_control',
     'plugin_control_versions',
     'plugin_groups',
@@ -340,5 +340,3 @@ define('REPLACEMENTS', [
     'usps.php' => 'USPS Shipping RESTful',
     'fedex.php' => 'FedEx Shipping REST',
 ]);
-
-


### PR DESCRIPTION
- Adding `customers_auth_tokens`, added for [this](https://github.com/zencart/zencart/issues/7235) issue.
- Removing `paypal_webhooks`, mistakenly added via [this](https://github.com/zencart/zencart/commit/b36771915bb8680dc3501288e6568d26da6da8b0) commit.