### PR TITLE
Display Logs: `pluginId` refers to obsolete plugin

### DIFF
--- a/zc_plugins/DisplayLogs/v3.0.3/manifest.php
+++ b/zc_plugins/DisplayLogs/v3.0.3/manifest.php
@@ -4,7 +4,7 @@ return [
     'pluginName' => 'Display Logs',
     'pluginDescription' => 'Display and manage Zen Cart log files.',
     'pluginAuthor' => 'Vinos de Frutas Tropicales (lat9)',
-    'pluginId' => 1583, // ID from Zen Cart forum
+    'pluginId' => 0, // ID from Zen Cart forum
     'zcVersions' => [],
     'changelog' => '', // online URL (eg github release tag page, or changelog file there) or local filename only, ie: changelog.txt (in same dir as this manifest file)
     'github_repo' => '', // url


### PR DESCRIPTION
The `pluginId` provided in the Display Logs encapsulated manifest refers to an obsolete version of the plugin as the encapsulated version's been in-core since zc157.