### PR TITLE
PHP 8.5 must use 'int' not integer; and case statements require closing colon

### DIFF
--- a/admin/includes/functions/configuration_checks.php
+++ b/admin/includes/functions/configuration_checks.php
@@ -32,7 +32,7 @@ function zen_validate_configuration_entry($variable, $check_string, $config_name
             case (strpos($data['error'], 'TEXT_MIN_ADMIN') === 0):
                 $error_msg = TEXT_MIN_GENERAL_ADMIN;
                 break;
-            case (strpos($data['error'], 'TEXT_MAX_ADMIN') === 0);
+            case (strpos($data['error'], 'TEXT_MAX_ADMIN') === 0):
                 $error_msg = TEXT_MAX_GENERAL_ADMIN;
                 break;
             default:

--- a/includes/functions/functions_dates.php
+++ b/includes/functions/functions_dates.php
@@ -272,7 +272,7 @@ function zen_checkdate($date_to_check, $format_string, &$date_array)
         return false;
     }
 
-    if (!settype($year, 'integer') || !settype($month, 'integer') || !settype($day, 'integer')) {
+    if (!settype($year, 'int') || !settype($month, 'int') || !settype($day, 'int')) {
         return false;
     }
 


### PR DESCRIPTION
In PHP 8.5 must now use `int` not `integer` 
and `case` statements require closing **colon** (not **semicolon**, which was rare, but supported since longtime.)