### PR TITLE
use large image in modal, relying on fallbacks if not exist

### DIFF
--- a/includes/templates/responsive_classic/modalboxes/tpl_image.php
+++ b/includes/templates/responsive_classic/modalboxes/tpl_image.php
@@ -13,7 +13,7 @@ require DIR_WS_MODULES . zen_get_module_directory(FILENAME_MAIN_PRODUCT_IMAGE);
 <div id="imageModalPrimary" class="imgmodal">
     <div class="imgmodal-content">
         <span onclick="closeModal('imageModalPrimary')">
-        <?php echo zen_image($products_image_medium, $products_name, '', '', 'class="centered-image"'); ?>
+        <?php echo zen_image($products_image_large, $products_name, '', '', 'class="centered-image"'); ?>
         <div class="imgmodal-close"><i class="fa-solid fa-circle-xmark"></i></div>
         <div class="center"><?php echo $products_name; ?></div>
 <!--        <div class="imgLink center">--><?php //echo TEXT_CLOSE_WINDOW_IMAGE; ?><!--</div>-->

--- a/includes/templates/template_default/modalboxes/tpl_image.php
+++ b/includes/templates/template_default/modalboxes/tpl_image.php
@@ -13,7 +13,7 @@ require DIR_WS_MODULES . zen_get_module_directory(FILENAME_MAIN_PRODUCT_IMAGE);
 <div id="imageModalPrimary" class="imgmodal">
     <div class="imgmodal-content">
         <span onclick="closeModal('imageModalPrimary')">
-        <?php echo zen_image($products_image_medium, $products_name, '', '', 'class="centered-image"'); ?>
+        <?php echo zen_image($products_image_large, $products_name, '', '', 'class="centered-image"'); ?>
         <div class="imgmodal-close"><i class="fa-solid fa-circle-xmark"></i></div>
         <div class="center"><?php echo $products_name; ?></div>
 <!--        <div class="imgLink center">--><?php //echo TEXT_CLOSE_WINDOW_IMAGE; ?><!--</div>-->

--- a/includes/templates/template_default/templates/tpl_modules_main_product_image.php
+++ b/includes/templates/template_default/templates/tpl_modules_main_product_image.php
@@ -14,7 +14,7 @@ require DIR_WS_MODULES . zen_get_module_directory(FILENAME_MAIN_PRODUCT_IMAGE);
 <div id="imageModalPrimary" class="imgmodal">
     <div class="imgmodal-content">
         <span onclick="closeModal('imageModalPrimary')">
-        <?php echo zen_image($products_image_medium, $products_name, '', '', 'class="centered-image"'); ?>
+        <?php echo zen_image($products_image_large, $products_name, '', '', 'class="centered-image"'); ?>
         <div class="imgmodal-close"><i class="fa-solid fa-circle-xmark"></i></div>
         <div class="center"><?php echo $products_name; ?></div>
 <!--        <div class="imgLink center">--><?php //echo TEXT_CLOSE_WINDOW_IMAGE; ?><!--</div>-->


### PR DESCRIPTION
The modal for "click to view larger" should show the large image if it exists, not the smallest.
(The variable for "large" is already assigned to the best available image size if a matching file is found. This PR just actually uses that variable.)

Updates https://github.com/zencart/zencart/pull/6176