### PR TITLE
Added language constant for payment modules 'already installed message'

### DIFF
--- a/admin/includes/languages/english/lang.modules.php
+++ b/admin/includes/languages/english/lang.modules.php
@@ -22,6 +22,7 @@ $define = [
     'TEXT_WARNING_SSL_INSTALL' => 'ALERT: <a href="https://docs.zen-cart.com/user/installing/enable_ssl/" rel="noopener" target="_blank">For security reasons, Installation of this module is disabled until your Admin is configured for SSL</a>.',
     'TEXT_POSITIVE_INT' => '%s must be an integer greater than or equal to 0',
     'TEXT_POSITIVE_FLOAT' => '%s must be a decimal greater than or equal to 0',
+    'TEXT_ERROR_MODULE_ALREADY_INSTALLED' => '%s module already installed!',
 ];
 
 return $define;

--- a/includes/modules/payment/authorizenet.php
+++ b/includes/modules/payment/authorizenet.php
@@ -506,7 +506,7 @@ class authorizenet extends base {
   function install() {
     global $db, $messageStack;
     if (defined('MODULE_PAYMENT_AUTHORIZENET_STATUS')) {
-      $messageStack->add_session('Authorize.net (SIM) module already installed.', 'error');
+      $messageStack->add_session(sprintf(TEXT_ERROR_MODULE_ALREADY_INSTALLED, $this->title), 'error');
       zen_redirect(zen_href_link(FILENAME_MODULES, 'set=payment&module=authorizenet', 'SSL'));
       return 'failed';
     }

--- a/includes/modules/payment/authorizenet_aim.php
+++ b/includes/modules/payment/authorizenet_aim.php
@@ -565,7 +565,7 @@ class authorizenet_aim extends base {
   function install() {
     global $db, $messageStack;
     if (defined('MODULE_PAYMENT_AUTHORIZENET_AIM_STATUS')) {
-      $messageStack->add_session('Authorize.net (AIM) module already installed.', 'error');
+      $messageStack->add_session(sprintf(TEXT_ERROR_MODULE_ALREADY_INSTALLED, $this->title), 'error');
       zen_redirect(zen_href_link(FILENAME_MODULES, 'set=payment&module=authorizenet_aim', 'NONSSL'));
       return 'failed';
     }

--- a/includes/modules/payment/cod.php
+++ b/includes/modules/payment/cod.php
@@ -180,7 +180,7 @@ class cod
     function install() {
       global $db, $messageStack;
       if (defined('MODULE_PAYMENT_COD_STATUS')) {
-        $messageStack->add_session('COD module already installed.', 'error');
+        $messageStack->add_session(sprintf(TEXT_ERROR_MODULE_ALREADY_INSTALLED, $this->title), 'error');
         zen_redirect(zen_href_link(FILENAME_MODULES, 'set=payment&module=cod', 'NONSSL'));
         return 'failed';
       }

--- a/includes/modules/payment/freecharger.php
+++ b/includes/modules/payment/freecharger.php
@@ -179,7 +179,7 @@
     function install() {
       global $db, $messageStack;
       if (defined('MODULE_PAYMENT_FREECHARGER_STATUS')) {
-        $messageStack->add_session('FreeCharger module already installed.', 'error');
+        $messageStack->add_session(sprintf(TEXT_ERROR_MODULE_ALREADY_INSTALLED, $this->title), 'error');
         zen_redirect(zen_href_link(FILENAME_MODULES, 'set=payment&module=freecharger', 'SSL'));
         return 'failed';
       }

--- a/includes/modules/payment/moneyorder.php
+++ b/includes/modules/payment/moneyorder.php
@@ -219,7 +219,7 @@ class moneyorder extends base
         {
             global $db, $messageStack;
             if (defined('MODULE_PAYMENT_MONEYORDER_STATUS')) {
-                $messageStack->add_session('MoneyOrder module already installed.', 'error');
+                $messageStack->add_session(sprintf(TEXT_ERROR_MODULE_ALREADY_INSTALLED, $this->title), 'error');
                 zen_redirect(zen_href_link(FILENAME_MODULES, 'set=payment&module=moneyorder', 'NONSSL'));
                 return 'failed';
             }

--- a/includes/modules/payment/paypal.php
+++ b/includes/modules/payment/paypal.php
@@ -564,7 +564,7 @@ class paypal extends base {
   function install() {
     global $db, $messageStack;
     if (defined('MODULE_PAYMENT_PAYPAL_STATUS')) {
-      $messageStack->add_session('PayPal Payments Standard module already installed.', 'error');
+      $messageStack->add_session(sprintf(TEXT_ERROR_MODULE_ALREADY_INSTALLED, $this->title), 'error');
       zen_redirect(zen_href_link(FILENAME_MODULES, 'set=payment&module=paypal', 'NONSSL'));
       return 'failed';
     }

--- a/includes/modules/payment/paypaldp.php
+++ b/includes/modules/payment/paypaldp.php
@@ -1211,7 +1211,7 @@ class paypaldp extends base {
   function install() {
     global $db, $messageStack;
     if (defined('MODULE_PAYMENT_PAYPALDP_STATUS')) {
-      $messageStack->add_session('Website Payments Pro module already installed.', 'error');
+      $messageStack->add_session(sprintf(TEXT_ERROR_MODULE_ALREADY_INSTALLED, $this->title), 'error');
       zen_redirect(zen_href_link(FILENAME_MODULES, 'set=payment&module=paypaldp', 'NONSSL'));
       return 'failed';
     }

--- a/includes/modules/payment/paypalwpp.php
+++ b/includes/modules/payment/paypalwpp.php
@@ -716,7 +716,7 @@ if (false) { // disabled until clarification is received about coupons in PayPal
   function install() {
     global $db, $messageStack;
     if (defined('MODULE_PAYMENT_PAYPALWPP_STATUS')) {
-      $messageStack->add_session('Express Checkout module already installed.', 'error');
+      $messageStack->add_session(sprintf(TEXT_ERROR_MODULE_ALREADY_INSTALLED, $this->title), 'error');
       zen_redirect(zen_href_link(FILENAME_MODULES, 'set=payment&module=paypalwpp', 'NONSSL'));
       return 'failed';
     }


### PR DESCRIPTION
Fixes #7358 
Replaces a hardcoded message in payment modules' install function by a language constant.