### PR TITLE
Handle soft-deprecation of sleep/wakeup

### DIFF
--- a/laravel/vendor/illuminate/database/Eloquent/Model.php
+++ b/laravel/vendor/illuminate/database/Eloquent/Model.php
@@ -2393,4 +2393,36 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         $this->initializeTraits();
     }
+    /**
+     * Prepare the object for serialization.
+     *
+     * @return array
+     */
+    public function __serialize()
+    {
+        $this->mergeAttributesFromCachedCasts();
+
+        $this->classCastCache = [];
+        $this->attributeCastCache = [];
+
+        return get_object_vars($this);
+    }
+
+    /**
+     * When a model is being unserialized, check if it needs to be booted.
+     *
+     * @return void
+     */
+    public function __unserialize($data)
+    {
+        foreach ($data as $property => $value) {
+            if (property_exists($this, $property)) {
+                $this->{$property} = $value;
+            }
+        }
+
+        $this->bootIfNotBooted();
+
+        $this->initializeTraits();
+    }
 }


### PR DESCRIPTION
While the PHP 8.5 RFC has been updated to only a soft-deprecation for RC2 onward, this accommodates the matter to avoid false reports of deprecation in PHP 8.5-RC1.

These links are intentionally left broken here:
Ref https://github.com/php/php-src/ pull/19966
Ref https://github.com/laravel/framework/ pull/57032