### PR TITLE
paypalwpp: Correct deprecation when TAXAMT isn't present

### DIFF
--- a/includes/modules/payment/paypalwpp.php
+++ b/includes/modules/payment/paypalwpp.php
@@ -526,7 +526,7 @@ if (false) { // disabled until clarification is received about coupons in PayPal
       $this->transactiontype = $response[$this->infoPrefix . 'TRANSACTIONTYPE'];
       $this->payment_time = urldecode($response[$this->infoPrefix . 'ORDERTIME']);
       $this->feeamt = empty($response[$this->infoPrefix . 'FEEAMT']) ? 0 : urldecode($response[$this->infoPrefix . 'FEEAMT']);
-      $this->taxamt = urldecode($response[$this->infoPrefix . 'TAXAMT']);
+      $this->taxamt = urldecode($response[$this->infoPrefix . 'TAXAMT'] ?? '');
       $this->pendingreason = $response[$this->infoPrefix . 'PENDINGREASON'];
       $this->reasoncode = $response[$this->infoPrefix . 'REASONCODE'];
       $this->numitems = count($order->products);


### PR DESCRIPTION
Seeing logs like:
```
[17-Oct-2025 11:39:10 America/Regina] Request URI: /shop/index.php?main_page=checkout_process, IP address: xx.xx.xx.xx, Language id 1
#0 [internal function]: zen_debug_error_handler()
#1 /home/mysite/public_html/shop/includes/modules/payment/paypalwpp.php(514): urldecode()
#2 /home/mysite/public_html/shop/includes/classes/payment.php(350): paypalwpp->before_process()
#3 /home/mysite/public_html/shop/includes/modules/checkout_process.php(98): payment->before_process()
#4 /home/mysite/public_html/shop/includes/modules/pages/checkout_process/header_php.php(13): require('...')
#5 /home/mysite/public_html/shop/index.php(35): require('...')
--> PHP Deprecated: urldecode(): Passing null to parameter #1 ($string) of type string is deprecated in /home/mysite/public_html/shop/includes/modules/payment/paypalwpp.php on line 514.
```