### PR TITLE
 SetLocale() no longer accepts int 0 since PHP 8.5. Use string '0' instead.

### DIFF
--- a/admin/includes/application_bootstrap.php
+++ b/admin/includes/application_bootstrap.php
@@ -43,7 +43,7 @@ date_default_timezone_set(date_default_timezone_get());
  * Check for a valid system locale, and override if invalid or set to 'C' which means 'unconfigured'
  * It will be overridden later via language-selection operations anyway, but a valid default must be set for zcDate class methods to work
  */
-$detected_locale = setlocale(LC_TIME, 0);
+$detected_locale = setlocale(LC_TIME, '0');
 if ($detected_locale === false || $detected_locale === 'C') {
     setlocale(LC_TIME, ['en_US', 'en_US.UTF-8', 'en-US', 'en']);
 }

--- a/admin/includes/header.php
+++ b/admin/includes/header.php
@@ -219,7 +219,7 @@ if (defined('MODULE_ORDER_TOTAL_GV_SHOW_QUEUE_IN_ADMIN') && MODULE_ORDER_TOTAL_G
         echo '<br>';
         echo gethostname();
         echo ' - ' . date_default_timezone_get(); //what is the PHP timezone set to?
-        $loc = setlocale(LC_TIME, 0);
+        $loc = setlocale(LC_TIME, '0');
         if ($loc !== FALSE) echo ' - ' . $loc; //what is the locale in use?
         ?>
     </div>

--- a/includes/application_top.php
+++ b/includes/application_top.php
@@ -191,7 +191,7 @@ date_default_timezone_set(date_default_timezone_get());
  * Check for a valid system locale, and override if invalid or set to 'C' which means 'unconfigured'
  * It will be overridden later via language-selection operations anyway, but a valid default must be set for zcDate class methods to work
  */
-$detected_locale = setlocale(LC_TIME, 0);
+$detected_locale = setlocale(LC_TIME, '0');
 if ($detected_locale === false || $detected_locale === 'C') {
     setlocale(LC_TIME, ['en_US', 'en_US.UTF-8', 'en-US', 'en']);
 }

--- a/includes/classes/zcDate.php
+++ b/includes/classes/zcDate.php
@@ -89,7 +89,7 @@ class zcDate extends base
             // First, save the current locale; it's set by the main language file's (presumed) call to the
             // setlocale function.
             //
-            $this->locale = setlocale(LC_TIME, 0);
+            $this->locale = setlocale(LC_TIME, '0');
 
             // -----
             // Using the current locale, retrieve the locale-specific 'short' date and time
@@ -189,7 +189,7 @@ class zcDate extends base
             // If the locale has changes (as it might between the class construction and
             // this method, re-initialize the conversion arrays for the current locale.
             //
-            if ($this->locale !== setlocale(LC_TIME, 0)) {
+            if ($this->locale !== setlocale(LC_TIME, '0')) {
                 $this->initializeConversionArrays();
             }
 

--- a/laravel/vendor/symfony/var-dumper/Dumper/AbstractDumper.php
+++ b/laravel/vendor/symfony/var-dumper/Dumper/AbstractDumper.php
@@ -118,7 +118,7 @@ abstract class AbstractDumper implements DataDumperInterface, DumperInterface
      */
     public function dump(Data $data, $output = null): ?string
     {
-        if ($locale = $this->flags & (self::DUMP_COMMA_SEPARATOR | self::DUMP_TRAILING_COMMA) ? setlocale(\LC_NUMERIC, 0) : null) {
+        if ($locale = $this->flags & (self::DUMP_COMMA_SEPARATOR | self::DUMP_TRAILING_COMMA) ? setlocale(\LC_NUMERIC, '0') : null) {
             setlocale(\LC_NUMERIC, 'C');
         }
 

--- a/zc_install/includes/application_top.php
+++ b/zc_install/includes/application_top.php
@@ -12,7 +12,7 @@
 /*
  * Check for a valid system locale, and override if invalid or set to 'C' which means 'unconfigured'
  */
-$detected_locale = setlocale(LC_TIME, 0);
+$detected_locale = setlocale(LC_TIME, '0');
 if ($detected_locale === false || $detected_locale === 'C') {
     setlocale(LC_TIME, ['en_US', 'en_US.UTF-8', 'en-US', 'en']);
 }


### PR DESCRIPTION
Param 2 cannot be int anymore, must be string.
Formerly we passed `0` to "retrieve current locale". To do the same, use string `'0'` instead.

Fixes #7399 