### PR TITLE
Allow null string parameter in zen_output_string_protected

### DIFF
--- a/includes/functions/functions_strings.php
+++ b/includes/functions/functions_strings.php
@@ -52,7 +52,7 @@ function zen_preserve_search_quotes(?string $search_string): string
  * @param  string  $string  The string to be parsed
  * @since ZC v1.0.3
  */
-function zen_output_string_protected(string $string): string
+function zen_output_string_protected(?string $string): string
 {
     return zen_output_string($string, false, true);
 }


### PR DESCRIPTION
Without the null, attempting to view details for an order results in a partial blank screen with the following log.

[22-Oct-2025 18:17:09 UTC] PHP Fatal error: Uncaught TypeError: zen_output_string_protected(): Argument #1 ($string) must be of type string, null given, called in /includes/modules/payment/square_support/square_admin_notification.php on line 43 and defined in /includes/functions/functions_strings.php:55 Stack trace:
#0 /includes/modules/payment/square_support/square_admin_notification.php(43): zen_output_string_protected(NULL) #1 /includes/modules/payment/square_webPay.php(589): require('/home/******/...') #2 /******/orders.php(808): square_webPay->admin_notification(5020) #3 /******/index.php(16): require('/home/******/...') #4 {main}
thrown in /includes/functions/functions_strings.php on line 55

[22-Oct-2025 18:17:09 UTC] Request URI: /******/index.php?cmd=orders&origin=index&page=1&oID=5020&action=edit, IP address: 177.216.186.199 --> PHP Fatal error: Uncaught TypeError: zen_output_string_protected(): Argument #1 ($string) must be of type string, null given, called in /includes/modules/payment/square_support/square_admin_notification.php on line 43 and defined in /includes/functions/functions_strings.php:55 Stack trace:
#0 /includes/modules/payment/square_support/square_admin_notification.php(43): zen_output_string_protected(NULL) #1 /includes/modules/payment/square_webPay.php(589): require('/home/******/...') #2 /******/orders.php(808): square_webPay->admin_notification(5020) #3 /******/index.php(16): require('/home/******/...') #4 {main}
thrown in /includes/functions/functions_strings.php on line 55.

[22-Oct-2025 18:17:09 UTC] Request URI: /******/index.php?cmd=orders&origin=index&page=1&oID=5020&action=edit, IP address: 177.216.186.199 --> PHP Fatal error: Uncaught TypeError: zen_output_string_protected(): Argument #1 ($string) must be of type string, null given, called in /includes/modules/payment/square_support/square_admin_notification.php on line 43 and defined in /includes/functions/functions_strings.php:55 Stack trace:
#0 /includes/modules/payment/square_support/square_admin_notification.php(43): zen_output_string_protected(NULL) #1 /includes/modules/payment/square_webPay.php(589): require('/home/******/...') #2 /******/orders.php(808): square_webPay->admin_notification(5020) #3 /******/index.php(16): require('/home/******/...') #4 {main}
thrown in /includes/functions/functions_strings.php on line 55.