### PR TITLE
`brands`: Correct divide-by-0

### DIFF
--- a/includes/modules/pages/brands/header_php.php
+++ b/includes/modules/pages/brands/header_php.php
@@ -59,7 +59,11 @@ if (!defined('BRANDS_IMAGE_HEIGHT')) {
     define('BRANDS_IMAGE_HEIGHT', IMAGE_PRODUCT_LISTING_HEIGHT);
 }
 if (!defined('BRANDS_MAX_COLUMNS')) {
-    define('BRANDS_MAX_COLUMNS', PRODUCT_LISTING_COLUMNS_PER_ROW);
+    $product_listing_columns_per_row = (int)PRODUCT_LISTING_COLUMNS_PER_ROW;
+    if ($product_listing_columns_per_row < 1) {
+        $product_listing_columns_per_row = 1;
+    }
+    define('BRANDS_MAX_COLUMNS', $product_listing_columns_per_row);
 }
 
 // This should be last line of the script:


### PR DESCRIPTION
If you're switching back and forth between responsive_classic and bootstrap, displaying the `brands` page can result in a divide-by-0 error if the current configuration for PRODUCT_LISTING_COLUMNS_PER row is set to 0 ... as it is for bootstrap's grid layout.

```
[25-Oct-2025 11:16:56 America/New_York] Request URI: /zc210/index.php?main_page=brands, IP address: 127.0.0.1
--> PHP Fatal error: Uncaught DivisionByZeroError: Division by zero in C:\xampp\htdocs\zc210\includes\templates\template_default\templates\tpl_brands_default.php:71
Stack trace:
#0 C:\xampp\htdocs\zc210\includes\templates\responsive_classic\common\tpl_main_page.php(181): require()
#1 C:\xampp\htdocs\zc210\index.php(109): require('C:\\xampp\\htdocs...')
#2 {main}
  thrown in C:\xampp\htdocs\zc210\includes\templates\template_default\templates\tpl_brands_default.php on line 71.
```