### PR TITLE
Cast int prid to string for urlencode wrapper

### DIFF
--- a/includes/modules/checkout_process.php
+++ b/includes/modules/checkout_process.php
@@ -165,7 +165,7 @@ $_SESSION['order_summary']['tax'] = $otax;
 $_SESSION['order_summary']['shipping'] = $oshipping;
 $products_array = [];
 foreach ($order->products as $key => $val) {
-    $products_array[urlencode($val['id'])] = urlencode($val['model']);
+    $products_array[urlencode((string)$val['id'])] = urlencode($val['model']);
 }
 $_SESSION['order_summary']['products_ordered_ids'] = implode('|', array_keys($products_array));
 $_SESSION['order_summary']['products_ordered_models'] = implode('|', array_values($products_array));

--- a/ipn_main_handler.php
+++ b/ipn_main_handler.php
@@ -451,7 +451,7 @@ if (isset($_GET['type']) && $_GET['type'] === 'ec') {
                 $_SESSION['order_summary']['shipping'] = $oshipping ?? 0;
                 $products_array = [];
                 foreach ($order->products as $key => $val) {
-                    $products_array[urlencode($val['id'])] = urlencode($val['model']);
+                    $products_array[urlencode((string)$val['id'])] = urlencode($val['model']);
                 }
                 $_SESSION['order_summary']['products_ordered_ids'] = implode('|', array_keys($products_array));
                 $_SESSION['order_summary']['products_ordered_models'] = implode('|', array_values($products_array));


### PR DESCRIPTION
`urlencode()` can't accommodate integers with strict_types=1, and this array supports both prid (string) and integer (product ID). So here we force the type change instead of allowing php to coerce it naturally, when strict-types=1. 

Fixes #7393