### PR TITLE
products_to_categories: add Button to hide/show Linked Categories

### DIFF
--- a/admin/includes/languages/english/lang.products_to_categories.php
+++ b/admin/includes/languages/english/lang.products_to_categories.php
@@ -22,6 +22,8 @@ $define = [
     'TEXT_HEADING_LINKED_CATEGORIES' => 'Linked Categories',
     'TEXT_SET_MASTER_CATEGORIES_ID' => '<strong>WARNING:</strong> a MASTER CATEGORIES ID must be assigned',
     'BUTTON_UPDATE_CATEGORY_LINKS' => 'Update Category Links for',
+    'BUTTON_HIDE_LINKED_CATEGORIES' => 'Hide Linked Categories',
+    'BUTTON_SHOW_LINKED_CATEGORIES' => 'Show Linked Categories',
     'TEXT_INFO_PRODUCTS_TO_CATEGORIES_LINKER_INTRO' => '<p>This product is currently linked to the categories selected below (you may change the number of columns displayed on <a target="_blank" href="configuration.php?&amp;gID=3">this page</a>).<br>To add/remove links, select/deselect the checkboxes as required and then click on the Update Category Links button.</p><p>Note that additional product/category actions are available using the Global Tools below.</p>',
     'TEXT_LABEL_CATEGORY_DISPLAY_ROOT' => 'Display the SubCategories under:',
     'BUTTON_SET_DEFAULT_TARGET_CATEGORY' => 'Set as Default',


### PR DESCRIPTION
Useful for working with the Global Tools and preventing unwanted loading/display of (a massive list of) linked categories.

<img width="751" height="268" alt="Hide" src="https://github.com/user-attachments/assets/c42d6ea5-5379-4868-8488-1de0772e0f1c" />  

To

<img width="551" height="214" alt="show" src="https://github.com/user-attachments/assets/cff7e662-2689-4794-b2c9-d95f135f3af8" />  

Note that for the huge "changed" block as shown in the diff display, the only change is 614-620 for the extra code for the button/form.
All the rest is unmodified/original code indented and a correction of the location of the final closing divs. The page seems to have given up trying to make a match.