### PR TITLE
Revised load-order of language defines to before error-handling functions are fired

### DIFF
--- a/includes/auto_loaders/config.core.php
+++ b/includes/auto_loaders/config.core.php
@@ -158,6 +158,17 @@ $autoLoadConfig[70][] = [
     'loadFile' => 'init_sessions.php',
 ];
 /**
+ * Breakpoint 75.
+ *
+ * require 'includes/init_includes/init_languages.php';
+ *
+ */
+$autoLoadConfig[75][] = [
+    'autoType' => 'init_script',
+    'loadFile' => 'init_languages.php',
+];
+
+/**
  * Breakpoint 80.
  *
  * if (!$_SESSION['cart']) $_SESSION['cart'] = new shoppingCart();
@@ -188,16 +199,6 @@ $autoLoadConfig[90][] = [
     'autoType' => 'classInstantiate',
     'className' => 'currencies',
     'objectName' => 'currencies',
-];
-/**
- * Breakpoint 95.
- *
- * require 'includes/init_includes/init_languages.php';
- *
- */
-$autoLoadConfig[95][] = [
-    'autoType' => 'init_script',
-    'loadFile' => 'init_languages.php',
 ];
 /**
  * Breakpoint 96.

--- a/includes/auto_loaders/paypal_ipn.core.php
+++ b/includes/auto_loaders/paypal_ipn.core.php
@@ -111,7 +111,20 @@ $autoLoadConfig[70][] = [
     'autoType' => 'init_script',
     'loadFile' => 'init_sessions.php',
 ];
-$autoLoadConfig[71][] = [
+
+/**
+ * Breakpoint 75 (not 95)
+ *
+ * require('includes/init_includes/init_languages.php');
+ * Note: loading here after session started, but before PayPal IPN session handling (which may use language defines if it needs to send email)
+ */
+$autoLoadConfig[75][] = [
+    'autoType' => 'init_script',
+    'loadFile' => 'init_languages.php',
+];
+
+// Loads just before shoppingCart is instantiated
+$autoLoadConfig[79][] = [
     'autoType' => 'init_script',
     'loadFile' => 'init_paypal_ipn_sessions.php',
 ];
@@ -140,15 +153,6 @@ $autoLoadConfig[90][] = [
     'autoType' => 'classInstantiate',
     'className' => 'currencies',
     'objectName' => 'currencies',
-];
-/**
- * Breakpoint 95
- *
- * require('includes/init_includes/init_languages.php');
- */
-$autoLoadConfig[95][] = [
-    'autoType' => 'init_script',
-    'loadFile' => 'init_languages.php',
 ];
 /**
  * Breakpoint 100.

--- a/includes/init_includes/init_paypal_ipn_sessions.php
+++ b/includes/init_includes/init_paypal_ipn_sessions.php
@@ -11,6 +11,8 @@ if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
 }
 
+// NOTE: Depends on language subsystem being initialized already
+
 /**
  * Begin processing. Add notice to log if logging enabled.
  */


### PR DESCRIPTION
Load language strings before the Cart gets instantiated (and before IPN session inspection loads, since it depends on language strings in order to send any error/debug/warning emails/alerts).

Should fix #6547 