### PR TITLE
Plugin-Manager: gracefully accommodate missing plugins in list

### DIFF
--- a/includes/classes/ViewBuilders/BaseController.php
+++ b/includes/classes/ViewBuilders/BaseController.php
@@ -117,6 +117,9 @@ class BaseController
     public function currentFieldValue($field)
     {
         $currentRow = $this->formatter->currentRowFromRequest();
+        if (is_null($currentRow)) {
+            return null;
+        }
         return $currentRow->$field;
     }
 

--- a/includes/classes/ViewBuilders/PluginManagerController.php
+++ b/includes/classes/ViewBuilders/PluginManagerController.php
@@ -35,6 +35,10 @@ class PluginManagerController extends BaseController
      */
     protected function processDefaultAction()
     {
+        if ($this->currentFieldValue('unique_key') === null) {
+            zen_redirect(zen_href_link(FILENAME_PLUGIN_MANAGER));
+        }
+
         $this->setBoxHeader('<h4>' . zen_lookup_admin_menu_language_override('plugin_name', $this->currentFieldValue('unique_key'), $this->currentFieldValue('name')) . '</h4>');
         if ($this->currentFieldValue('status') == 1) {
             $this->setBoxContent('<br>' . sprintf(TEXT_VERSION_INSTALLED, $this->currentFieldValue('version')) . '<br>');


### PR DESCRIPTION
When accessing a plugin-manager entry that no longer exists, or malformed URL, redirect back to Plugin Manager main page.

Indirectly resolves #6459 which appears to already be partially resolved.