### PR TITLE
Use non-break hyphen when displaying discounts

### DIFF
--- a/includes/modules/order_total/ot_coupon.php
+++ b/includes/modules/order_total/ot_coupon.php
@@ -175,7 +175,8 @@ class ot_coupon extends base
 
             $this->output[] = [
                 'title' => $this->title . ': ' . $this->coupon_code . ' :',
-                'text' => '-' . $currencies->format($od_amount['total']),
+                // &#8209; is a non-break-hyphen so displays with number
+                'text' => '&#8209;' . $currencies->format($od_amount['total']),
                 'value' => $od_amount['total']
             ];
         }

--- a/includes/modules/order_total/ot_group_pricing.php
+++ b/includes/modules/order_total/ot_group_pricing.php
@@ -110,10 +110,12 @@ class ot_group_pricing {
       if ($this->calculate_tax == "Standard") $order->info['total'] -= $tax;
       if ($order->info['total'] < 0) $order->info['total'] = 0;
       $order->info['tax'] = $order->info['tax'] - $tax;
-      $this->output[] = array('title' => $this->title . ':',
-      'text' => '-' . $currencies->format($od_amount['total'], true, $order->info['currency'], $order->info['currency_value']),
-      'value' => $od_amount['total']);
-
+        $this->output[] = [
+            'title' => $this->title . ':',
+            // &#8209; is a non-break-hyphen so displays with number
+            'text' => '&#8209;' . $currencies->format($od_amount['total'], true, $order->info['currency'], $order->info['currency_value']),
+            'value' => $od_amount['total'],
+        ];
     }
   }
   /**

--- a/includes/modules/order_total/ot_gv.php
+++ b/includes/modules/order_total/ot_gv.php
@@ -155,9 +155,12 @@ class ot_gv {
         if ($order->info['total'] < 0) $order->info['total'] = 0;
         $order->info['tax'] = $order->info['tax'] - $od_amount['tax'];
         // prepare order-total output for display and storing to invoice
-        $this->output[] = array('title' => $this->title . ':',
-                                'text' => '-' . $currencies->format($od_amount['total']),
-                                'value' => $od_amount['total']);
+          $this->output[] = [
+              'title' => $this->title . ':',
+              // &#8209; is a non-break-hyphen so displays with number
+              'text' => '&#8209;' . $currencies->format($od_amount['total']),
+              'value' => $od_amount['total'],
+          ];
       }
     }
   }

--- a/not_for_release/testFramework/FeatureStore/GVCoupons/GiftVoucherRedeemTest.php
+++ b/not_for_release/testFramework/FeatureStore/GVCoupons/GiftVoucherRedeemTest.php
@@ -53,7 +53,7 @@ class GiftVoucherRedeemTest extends zcFeatureTestCaseStore
         $this->browser->submitForm('Continue', []);
         $this->browser->submitForm('Continue', ['cot_gv' => 100.00, 'payment' => '']);
         $response = $this->browser->getResponse();
-        $this->assertStringContainsString('-$45.29', (string)$response->getContent() );
+        $this->assertStringContainsString('&#8209;$45.29', (string)$response->getContent() );
     }
 
     /**

--- a/not_for_release/testFramework/FeatureStore/GroupDiscounts/GroupDiscountTest.php
+++ b/not_for_release/testFramework/FeatureStore/GroupDiscounts/GroupDiscountTest.php
@@ -23,7 +23,7 @@ class GroupDiscountTest extends zcFeatureTestCaseStore
         $this->browser->submitForm('Continue', []);
         $response = $this->browser->getResponse();
         $this->assertStringContainsString('39.99', (string)$response->getContent());
-        $this->assertStringContainsString('-$4.00', (string)$response->getContent());
+        $this->assertStringContainsString('&#8209;$4.00', (string)$response->getContent());
         $this->assertStringContainsString('2.52', (string)$response->getContent());
         $this->assertStringContainsString('41.01', (string)$response->getContent());
         $this->setCustomerGroupDiscount($profile['email_address'], 0);
@@ -46,8 +46,8 @@ class GroupDiscountTest extends zcFeatureTestCaseStore
         $this->browser->submitForm('Continue', ['dc_redeem_code' => 'test10percent']);
         $response = $this->browser->getResponse();
         $this->assertStringContainsString('39.99', (string)$response->getContent());
-        $this->assertStringContainsString('-$4.00', (string)$response->getContent());
-        $this->assertStringContainsString('-$3.60', (string)$response->getContent());
+        $this->assertStringContainsString('&#8209;$4.00', (string)$response->getContent());
+        $this->assertStringContainsString('&#8209;$3.60', (string)$response->getContent());
         $this->assertStringContainsString('2.27', (string)$response->getContent());
         $this->assertStringContainsString('37.16', (string)$response->getContent());
         $this->setCustomerGroupDiscount($profile['email_address'], 0);
@@ -70,7 +70,7 @@ class GroupDiscountTest extends zcFeatureTestCaseStore
         $this->browser->submitForm('Continue', []);
         $response = $this->browser->getResponse();
         $this->assertStringContainsString('42.79', (string)$response->getContent());
-        $this->assertStringContainsString('-$4.28', (string)$response->getContent());
+        $this->assertStringContainsString('&#8209;$4.28', (string)$response->getContent());
         $this->assertStringContainsString('2.52', (string)$response->getContent());
         $this->assertStringContainsString('41.01', (string)$response->getContent());
         $this->setCustomerGroupDiscount($profile['email_address'], 0);
@@ -95,7 +95,7 @@ class GroupDiscountTest extends zcFeatureTestCaseStore
         $this->browser->submitForm('Continue', []);
         $response = $this->browser->getResponse();
         $this->assertStringContainsString('42.79', (string)$response->getContent());
-        $this->assertStringContainsString('-$4.28', (string)$response->getContent());
+        $this->assertStringContainsString('&#8209;$4.28', (string)$response->getContent());
         $this->assertStringContainsString('2.77', (string)$response->getContent());
         $this->assertStringContainsString('41.26', (string)$response->getContent());
         $this->setCustomerGroupDiscount($profile['email_address'], 0);
@@ -123,7 +123,7 @@ class GroupDiscountTest extends zcFeatureTestCaseStore
         $response = $this->browser->getResponse();
         $this->assertStringContainsString('42.79', (string)$response->getContent());
         $this->assertStringContainsString('2.75', (string)$response->getContent());
-        $this->assertStringContainsString('-$4.28', (string)$response->getContent());
+        $this->assertStringContainsString('&#8209;$4.28', (string)$response->getContent());
         $this->assertStringContainsString('2.52', (string)$response->getContent());
         $this->assertStringContainsString('0.25', (string)$response->getContent());
         $this->assertStringContainsString('41.26', (string)$response->getContent());

--- a/not_for_release/testFramework/FeatureStore/LowOrderFees/LowOrderFeeTest.php
+++ b/not_for_release/testFramework/FeatureStore/LowOrderFees/LowOrderFeeTest.php
@@ -142,7 +142,7 @@ class LowOrderFeeTest extends zcFeatureTestCaseStore
         $this->assertStringContainsString('2.50', $lookup_section); // shipping item
         $this->assertStringContainsString('3.05', $lookup_section); // Tax
         $this->assertStringContainsString('5.00', $lookup_section); // low order fee
-        $this->assertStringContainsString('-$50.54', $lookup_section); // gv used
+        $this->assertStringContainsString('&#8209;$50.54', $lookup_section); // gv used
         $this->assertStringContainsString('0.00', $lookup_section); // balance
         $this->switchLowOrderFee('off');
         $this->switchItemShippingTax('off');
@@ -171,7 +171,7 @@ class LowOrderFeeTest extends zcFeatureTestCaseStore
         $this->assertStringContainsString('2.75', $lookup_section);
         $this->assertStringContainsString('3.05', $lookup_section);
         $this->assertStringContainsString('5.00', $lookup_section);
-        $this->assertStringContainsString('-$50.54', $lookup_section);
+        $this->assertStringContainsString('&#8209;$50.54', $lookup_section);
         $this->assertStringContainsString('0.00', $lookup_section);
         $this->switchLowOrderFee('off');
         $this->switchItemShippingTax('off');
@@ -198,7 +198,7 @@ class LowOrderFeeTest extends zcFeatureTestCaseStore
         $lookup_section = self::locateElementInPageSource('id="orderTotals"', $response);
         $this->assertStringContainsString('39.99', $lookup_section);
         $this->assertStringContainsString('2.50', $lookup_section);
-        $this->assertStringContainsString('-$4.00', $lookup_section);
+        $this->assertStringContainsString('&#8209;$4.00', $lookup_section);
         $this->assertStringContainsString('2.52', $lookup_section);
         $this->assertStringContainsString('5.00', $lookup_section);
         $this->assertStringContainsString('46.01', $lookup_section);
@@ -225,7 +225,7 @@ class LowOrderFeeTest extends zcFeatureTestCaseStore
         $lookup_section = self::locateElementInPageSource('id="orderTotals"', $response);
         $this->assertStringContainsString('39.99', $lookup_section);
         $this->assertStringContainsString('2.50', $lookup_section);
-        $this->assertStringContainsString('-$4.00', $lookup_section);
+        $this->assertStringContainsString('&#8209;$4.00', $lookup_section);
         $this->assertStringContainsString('2.52', $lookup_section);
         $this->assertStringContainsString('5.00', $lookup_section);
         $this->assertStringContainsString('46.01', $lookup_section);
@@ -258,10 +258,10 @@ class LowOrderFeeTest extends zcFeatureTestCaseStore
         $lookup_section = self::locateElementInPageSource('id="orderTotals"', $response);
         $this->assertStringContainsString('39.99', $lookup_section);
         $this->assertStringContainsString('2.50', $lookup_section);
-        $this->assertStringContainsString('-$4.00', $lookup_section);
+        $this->assertStringContainsString('&#8209;$4.00', $lookup_section);
         $this->assertStringContainsString('2.52', $lookup_section);
         $this->assertStringContainsString('5.00', $lookup_section);
-        $this->assertStringContainsString('-$46.01', $lookup_section);
+        $this->assertStringContainsString('&#8209;$46.01', $lookup_section);
         $this->setCustomerGroupDiscount($profile['email_address'], 0);
         $this->switchLowOrderFee('off');
     }


### PR DESCRIPTION
Otherwise, on narrow screens sometimes the hyphen will get separated from the number it's negating, which brings confusion to the viewer.

Fixes #7432 