### PR TITLE
Add notifier hooks to invoice, orders, and packing slip pages for Sup…

### DIFF
--- a/admin/invoice.php
+++ b/admin/invoice.php
@@ -22,11 +22,22 @@ $oID = zen_db_prepare_input($_GET['oID']);
 include DIR_FS_CATALOG . DIR_WS_CLASSES . 'order.php';
 $order = new order($oID);
 
-// bof Super Orders batch mode support
-$super_order_data = ['order_currency' => $order->info['currency'] ?? ''];
+// -----
+//
+// Give observers an opportunity to participate in invoice pre-initialization.
+//
+// Observers may:
+// - Inspect the order ID
+// - Populate or augment the $invoice_context array with invoice-related data
+// - Control whether the HTML head/body structure should be rendered
+//
+// Observer note:
+// - Use the provided references to add or modify data
+// - Be mindful that multiple observers may act on this notifier
+//
+$invoice_context = ['order_currency' => $order->info['currency'] ?? ''];
 $render_html_head = true;
-$zco_notifier->notify('NOTIFY_ADMIN_INVOICE_PRE_INITIALIZATION', $oID, $super_order_data, $render_html_head);
-// eof Super Orders batch mode support
+$zco_notifier->notify('NOTIFY_ADMIN_INVOICE_PRE_INITIALIZATION', $oID, $invoice_context, $render_html_head);
 ?>
 <!doctype html>
 <html <?= HTML_PARAMS ?>>
@@ -419,13 +430,22 @@ if (empty($order->info)) {
         }
         ?>
         <?php
-        // bof Super Orders custom totals
-        $custom_totals_html = '';
-        $zco_notifier->notify('NOTIFY_ADMIN_INVOICE_TOTALS_CUSTOM', $oID, $custom_totals_html);
-        if (!empty($custom_totals_html)) {
-            echo $custom_totals_html;
+        // -----
+        //
+        // Give observers an opportunity to inject additional invoice totals rows.
+        //
+        // Observers may append HTML output (e.g. additional totals or summary rows)
+        // to be displayed within the invoice totals section.
+        //
+        // Observer note:
+        // - Append to the provided string rather than overwriting where possible
+        // - Multiple observers may contribute output
+        //
+        $extra_totals_html = '';
+        $zco_notifier->notify('NOTIFY_ADMIN_INVOICE_TOTALS_CUSTOM', $oID, $extra_totals_html);
+        if (!empty($extra_totals_html)) {
+          echo $extra_totals_html;
         }
-        // eof Super Orders custom totals
         ?>
         </table>
         <?php if (ORDER_COMMENTS_INVOICE > 0) { ?>

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -383,12 +383,16 @@ if (!empty($action) && $order_exists === true) {
         <link rel="stylesheet" media="print" href="includes/css/stylesheet_print.css">
         <?php
         // -----
-        // Give an observer the chance to inject additional <head> resources on the admin orders page.
         //
-        // Notes:
-        // - The observer should append <link>, <style>, or <script> tags to the $extra_head variable.
-        // - This notifier fires during the <head> section, so resources will be loaded before page render.
-        // - Available for use by Super Orders, plugins, or other modules.
+        // Give observers an opportunity to inject additional resources into the
+        // <head> section of the admin orders page.
+        //
+        // Observers may append <link>, <style>, or <script> tags to the $extra_head
+        // variable to load page-specific resources.
+        //
+        // Observer note:
+        // - Append content rather than overwrite existing output
+        // - Multiple observers may contribute resources
         //
         $extra_head = '';
         $zco_notifier->notify('NOTIFY_ADMIN_ORDERS_HEAD', [], $extra_head);
@@ -490,12 +494,19 @@ if (!empty($action) && $order_exists === true) {
                 </div>
                 <?php
                 // -----
-                // Give an observer the chance to inject additional content or buttons into the orders listing view.
                 //
-                // Notes:
-                // - The 'oID' value is (bool)false since this is the listing view, not order edit.
-                // - The observer should append HTML content to the $extra_listing_content variable.
-                // - This is typically used for action buttons or filtering controls.
+                // Give observers an opportunity to inject additional content into the
+                // admin orders listing view.
+                //
+                // The $oID parameter is passed as (bool)false, since this notifier fires
+                // in the listing context rather than for a specific order.
+                //
+                // Observers may append HTML output (e.g. action controls or informational
+                // elements) to the $extra_listing_content variable for display.
+                //
+                // Observer note:
+                // - Append content rather than overwrite existing output
+                // - Multiple observers may contribute content
                 //
                 $extra_listing_content = '';
                 $zco_notifier->notify('NOTIFY_ADMIN_ORDERS_LISTING_BUTTONS', false, $extra_listing_content);
@@ -842,13 +853,21 @@ if (is_array($address_footer_suffix)) {
                 ?>
                 <?php
                 // -----
-                // Notifier to inject split order UI elements into the order edit view.
-                // Observers should append HTML to $super_orders_split_order for display.
                 //
-                $super_orders_split_order = '';
-                $zco_notifier->notify('NOTIFY_ADMIN_ORDER_SPLIT_ORDER', $oID, $super_orders_split_order);
-                if (!empty($super_orders_split_order)) {
-                    echo $super_orders_split_order;
+                // Give observers an opportunity to inject additional UI elements into the
+                // admin order edit view.
+                //
+                // Observers may append HTML output (e.g. buttons, informational blocks,
+                // or action controls) to the $extra_order_actions variable for display.
+                //
+                // Observer note:
+                // - Append content rather than overwrite existing output
+                // - Multiple observers may contribute content
+                //
+                $extra_order_actions = '';
+                $zco_notifier->notify('NOTIFY_ADMIN_ORDER_SPLIT_ORDER', $oID, $extra_order_actions);
+                if (!empty($extra_order_actions)) {
+                    echo $extra_order_actions;
                 }
                 ?>
 


### PR DESCRIPTION
…er Orders integration

This PR adds observer notifier hooks to admin pages (invoice, orders, and packing slip) to support the Super Orders plugin without modifying core functionality.

## Changes

### invoice.php
- `NOTIFY_ADMIN_INVOICE_PRE_INITIALIZATION`: Enables batch mode setup
- `NOTIFY_ADMIN_INVOICE_TOTALS_CUSTOM`: Allows custom totals injection

### orders.php
- `NOTIFY_ADMIN_ORDERS_HEAD`: Inject head resources (stylesheets, scripts)
- `NOTIFY_ADMIN_ORDERS_LISTING_BUTTONS`: Add buttons to orders listing
- `NOTIFY_ADMIN_ORDER_SPLIT_ORDER`: Display split order UI elements

### packingslip.php
- `NOTIFY_ADMIN_PACKINGSLIP_PRE_INITIALIZATION`: Batch mode initialization
- `NOTIFY_ADMIN_PACKINGSLIP_LOAD_PARENT_ORDER`: Load parent/child order data
- `NOTIFY_ADMIN_PACKINGSLIP_SPLIT_PRODUCTS`: Display related order products

These hooks follow Zen Cart's observer pattern, enabling plugins to extend core functionality without requiring core file modifications.