### PR TITLE
Guard legacy mt_srand() call in installer

### DIFF
--- a/zc_install/includes/functions/general.php
+++ b/zc_install/includes/functions/general.php
@@ -42,7 +42,9 @@ function zen_rand(?int $min = null, ?int $max = null): int
     static $seeded;
 
     if (!isset($seeded)) {
-        mt_srand((int)(microtime(true) * 1000000));
+        if (function_exists('mt_srand')) {
+            mt_srand((int)(microtime(true) * 1000000));
+        }
         $seeded = true;
     }
 


### PR DESCRIPTION
Some hardened PHP 8.x builds disable or remove mt_srand(), which causes a fatal error during installation.

Guarding the call preserves existing behavior where mt_srand() is available, while allowing the installer to run on environments where PHP auto-seeds the RNG.