### PR TITLE
Move multi-use language constant

### DIFF
--- a/admin/includes/languages/english/lang.users.php
+++ b/admin/includes/languages/english/lang.users.php
@@ -25,7 +25,6 @@ $define = [
     'ERROR_ADMIN_NAME_TOO_SHORT' => 'Admin user names must have at least %s characters.',
     'ERROR_PASSWORD_TOO_SHORT' => 'Passwords must contain at least %s characters.',
     'SUCCESS_NEW_USER_ADDED' => 'New Admin User "%s" created.',
-    'SUCCESS_USER_DETAILS_UPDATED' => 'User details updated.',
     'SUCCESS_PASSWORD_UPDATED' => 'Password updated.',
     'ERROR_ADMIN_INVALID_EMAIL_ADDRESS' => 'The email address you provided seems to be invalid.',
     'ERROR_ADMIN_INVALID_CHARS_IN_USERNAME' => 'The admin username you entered contains invalid characters.',

--- a/admin/includes/languages/lang.english.php
+++ b/admin/includes/languages/lang.english.php
@@ -388,6 +388,7 @@ $define = [
     'SUCCESS_CATEGORY_MOVED' => 'Success! Category has successfully been moved ...',
     'SUCCESS_FILE_SAVED_SUCCESSFULLY' => 'Success: File upload saved successfully %s',
     'SUCCESS_PRODUCT_UPDATE_SORT' => 'Successful Attribute Sort Order Update for ID# ',
+    'SUCCESS_USER_DETAILS_UPDATED' => 'User details updated.',
     'TABLE_ATTRIBUTES_QTY_PRICE_PRICE' => 'PRICE',
     'TABLE_ATTRIBUTES_QTY_PRICE_QTY' => 'QTY',
     'TABLE_HEADING_ACTION' => 'Action',


### PR DESCRIPTION
As identified in issue 2 of [this](https://www.zen-cart.com/showthread.php/231045-Two-errors-involving-the-quot-Admin-Users-quot-and-(admin)-quot-Account-quot-in-the-back-end) Zen Cart forum bug report, the language constant 'SUCCESS_USER_DETAILS_UPDATED' is used by both the `/admin/users.php` and `/admin/admin_account.php`.  Unfortunately, the constant is currently defined only in `lang.users.php`.

Moving the language constant from that page-specific file to `lang.english.php` so that it's available for both scripts.