### PR TITLE
Make zen_array_to_string able to support GET parameters that are arrays.

### DIFF
--- a/includes/functions/functions_strings.php
+++ b/includes/functions/functions_strings.php
@@ -234,8 +234,8 @@ function zen_array_to_string(array $array, array|string $exclude = '', string $e
     if (count($array) > 0) {
         foreach ($array as $key => $value) {
             if (!in_array($key, $exclude)) {
-                if(is_array($value)) {
-                    foreach($value as $k => $v) {
+                if (is_array($value)) {
+                    foreach ($value as $k => $v) {
                         $get_string .= $key . "[$k]" . $equals . $v . $separator;
                     }
                 } else {


### PR DESCRIPTION
I created this improvement for for my advanced search customization that allows multiple categories and manufacturers and some custom attributes to be searched. Submitting to core because it may be useful.