### PR TITLE
Code-optimization-in-functions_strings.php

### DIFF
--- a/includes/functions/functions_strings.php
+++ b/includes/functions/functions_strings.php
@@ -385,11 +385,7 @@ function zen_clean_html(string $clean_it, array|string $extraTags = ''): string
     // remove any embedded javascript
     $clean_it = preg_replace('#<script(.*?)>(.*?)</script>#is', '', $clean_it ?? '');
 
-    $clean_it = preg_replace('/\r/', ' ', $clean_it);
-    $clean_it = preg_replace('/\t/', ' ', $clean_it);
-    $clean_it = preg_replace('/\n/', ' ', $clean_it);
-
-    $clean_it = nl2br($clean_it);
+    $clean_it = str_replace(["\r", "\t", "\n"], ' ', $clean_it);
 
     // update breaks with a space for text displays in all listings with descriptions
     $clean_it = preg_replace('~(<br ?/?>|</?p>)~', ' ', $clean_it);


### PR DESCRIPTION
Fixes #7533
Replaced 3 `preg_replace` by 1 `str_replace` (as per @lat9 suggestion) in function `zen_clean_html` of file `functions_strings.php`. Although removed a useless call to `nl2br` function.