### PR TITLE
`paypalr` storefront observer needs `\base`

### DIFF
--- a/zc_plugins/PayPalRestful/v2.0.0/catalog/includes/classes/observers/auto.paypalrestful.php
+++ b/zc_plugins/PayPalRestful/v2.0.0/catalog/includes/classes/observers/auto.paypalrestful.php
@@ -14,12 +14,10 @@ use PayPalRestful\Api\Data\CountryCodes;
 use PayPalRestful\Api\PayPalRestfulApi;
 use PayPalRestful\Zc2Pp\Amount;
 use Zencart\Traits\InteractsWithPlugins;
-use Zencart\Traits\ObserverManager;
 
-class zcObserverPaypalrestful
+class zcObserverPaypalrestful extends \base
 {
     use InteractsWithPlugins;
-    use ObserverManager;
 
     protected array $lastOrderValues = [];
     protected array $orderTotalChanges = [];


### PR DESCRIPTION
... since the class both observes and notifies.

Seeing logs like
```
[19-Mar-2026 18:11:54 America/New_York] PHP Fatal error:  Uncaught Error: Call to undefined method zcObserverPaypalrestful::notify() in C:\xampp\htdocs\zc210\zc_plugins\PayPalRestful\v2.0.0\catalog\includes\classes\observers\auto.paypalrestful.php:352
Stack trace:
#0 C:\xampp\htdocs\zc210\zc_plugins\PayPalRestful\v2.0.0\catalog\includes\classes\observers\auto.paypalrestful.php(156): zcObserverPaypalrestful->outputJsFooter('shopping_cart')
#1 C:\xampp\htdocs\zc210\includes\classes\traits\NotifierManager.php(112): zcObserverPaypalrestful->updateNotifyFooterEnd(Object(notifier), 'NOTIFY_FOOTER_E...', 'shopping_cart', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
#2 C:\xampp\htdocs\zc210\includes\templates\bootstrap\common\tpl_main_page.php(326): base->notify('NOTIFY_FOOTER_E...', 'shopping_cart')
#3 C:\xampp\htdocs\zc210\index.php(109): require('C:\\xampp\\htdocs...')
#4 {main}
  thrown in C:\xampp\htdocs\zc210\zc_plugins\PayPalRestful\v2.0.0\catalog\includes\classes\observers\auto.paypalrestful.php on line 352
```