### PR TITLE
Fix PHP opening tag in version.php

### DIFF
--- a/zc_install/includes/version.php
+++ b/zc_install/includes/version.php
@@ -1,4 +1,4 @@
- <?php
+<?php
 /**
  * version.php
  * Defines the project version details


### PR DESCRIPTION
There is a space in the opening PHP tag that makes installation fail with a session problem.