### PR TITLE
Add ScriptedInstaller methods to remove files/dirs

### DIFF
--- a/admin/includes/languages/english/lang.plugin_manager.php
+++ b/admin/includes/languages/english/lang.plugin_manager.php
@@ -47,9 +47,14 @@ $define = [
     'TEXT_INFO_UPGRADE_WARNING' => '',
     'TEXT_INFO_CONFIRM_CLEAN' => 'Confirm version directories to clean/remove',
     'TEXT_LABEL_STATUS' => 'Status: ',
-    'ERROR_NOT_FOUND_IN_SQL_FUNCTIONS_MAP' => 'Check your SQL statement. A SQL function map cannot be found for : ',
+
+    'ERROR_CANT_REMOVE_DIR' => 'Unable to remove  directory: %s',
     'ERROR_INVALID_SYNTAX' => 'The table cannot be identified as syntax is invalid in: ',
+    'ERROR_NOT_FOUND_IN_SQL_FUNCTIONS_MAP' => 'Check your SQL statement. A SQL function map cannot be found for : ',
+    'ERROR_REMOVE_FILES_CANT_DELETE' => 'Unable to remove file: %s',
+    'ERROR_REMOVE_FILES_CONTEXT' => 'Invalid context supplied (%s), it must be either "catalog" or "admin".',
     'ERROR_SQL_PATCH' => 'Error while processing SQL install. ',
+
     'WARNING_NONENCAPSULATED_REMOVAL' => '<b>Note:</b> Installing this plugin will result in files provided by a non-encapsulated version (if present) being <b>permanently</b> removed!',
 ];
 

--- a/includes/classes/PluginSupport/ScriptedInstaller.php
+++ b/includes/classes/PluginSupport/ScriptedInstaller.php
@@ -111,4 +111,115 @@ class ScriptedInstaller
         $this->dbConn->dieOnErrors = true;
         return true;
     }
+
+    /**
+     * Removes, if they exist, a list of files from either the 'admin' or
+     * 'catalog' side.
+     *
+     * The $files_to_remove input is an associative array with each key being
+     * an admin/catalog sub-directory and the value(s) being an array of files
+     * to be removed from the key directory.
+     *
+     * If a file-name is identified as '*.*', then **ALL** files and sub-directories
+     * as well as the upper, keyed, directory are removed.
+     *
+     * @since ZC v3.0.0
+     */
+    protected function removeFiles(array $files_to_remove, string $context): bool
+    {
+        if (!in_array($context, ['admin', 'catalog'])) {
+            $error_message = sprintf(ERROR_REMOVE_FILES_CONTEXT, $context);
+            $this->errorContainer->addError(0, $error_message, true, $error_message);
+            return false;
+        }
+
+        $base_dir = ($context === 'admin') ? DIR_FS_ADMIN : DIR_FS_CATALOG;
+        foreach ($files_to_remove as $dir => $files) {
+            $current_dir = $base_dir . $dir;
+            foreach ($files as $next_file) {
+                $current_file = $current_dir . $next_file;
+                if (str_ends_with($current_file, '*.*')) {
+                    if ($this->removeDirectoryAndFiles(str_replace('/*.*', '', $current_file)) === false) {
+                        $errorOccurred = true;
+                    }
+                    continue;
+                }
+
+                if (file_exists($current_file)) {
+                    unlink($current_file);
+                    if (file_exists($current_file)) {
+                        $errorOccurred = true;
+                        $this->errorContainer->addError(
+                            0,
+                            sprintf(ERROR_REMOVE_FILES_CANT_DELETE, $current_file),
+                            false,
+                            // this str_replace has to do DIR_FS_ADMIN before CATALOG because catalog is contained within admin, so results are wrong.
+                            // also, '[admin_directory]' is used to obfuscate the admin dir name, in case the user copy/pastes output to a public forum for help.
+                            sprintf(ERROR_REMOVE_FILES_CANT_DELETE, str_replace([DIR_FS_ADMIN, DIR_FS_CATALOG], ['[admin_directory]/', ''], $current_file))
+                        );
+                    }
+                }
+            }
+        }
+
+        return !$errorOccurred;
+    }
+
+    /**
+     * Removes all files from the specified directory and its sub-directories, recursively.
+     *
+     * Returns a boolean indication as to whether (true) or not (false) all files
+     * and sub-directories were removed.
+     * 
+     * @since ZC v3.0.0
+     */
+    protected function removeDirectoryAndFilesRecursive(string $dir_name): bool
+    {
+        $errorOccurred = false;
+        if ($dir_name === '.' || $dir_name === '..' || !is_dir($dir_name)) {
+            return true;
+        }
+
+        $dir_files = scandir($dir_name);
+        foreach ($dir_files as $next_file) {
+            if ($next_file === '.' || $next_file === '..') {
+                continue;
+            }
+
+            $next_entry = $dir_name . '/' . $next_file;
+            if (is_file($next_entry)) {
+                unlink($next_entry);
+                if (file_exists($next_entry)) {
+                    $errorOccurred = true;
+                    $this->errorContainer->addError(
+                        0,
+                        sprintf(ERROR_REMOVE_FILES_CANT_DELETE, $next_entry),
+                        false,
+                        // this str_replace has to do DIR_FS_ADMIN before CATALOG because catalog is contained within admin, so results are wrong.
+                        // also, '[admin_directory]' is used to obfuscate the admin dir name, in case the user copy/pastes output to a public forum for help.
+                        sprintf(ERROR_REMOVE_FILES_CANT_DELETE, str_replace([DIR_FS_ADMIN, DIR_FS_CATALOG], ['[admin_directory]/', ''], $next_entry))
+                    );
+                }
+            } elseif ($this->removeDirectoryAndFiles($next_entry) === false) {
+                $errorOccurred = true;
+            }
+        }
+
+        if (is_dir($dir_name)) {
+            rmdir($dir_name);
+            if (is_dir($dir_name)) {
+                $errorOccurred = true;
+                $this->errorContainer->addError(
+                    0,
+                    sprintf(ERROR_CANT_REMOVE_DIR, $dir_name),
+                    false,
+                    // this str_replace has to do DIR_FS_ADMIN before CATALOG because catalog is contained within admin, so results are wrong.
+                    // also, '[admin_directory]' is used to obfuscate the admin dir name, in case the user copy/pastes output to a public forum for help.
+                    sprintf(ERROR_CANT_REMOVE_DIR, str_replace([DIR_FS_ADMIN, DIR_FS_CATALOG], ['[admin_directory]/', ''], $dir_name))
+                );
+            }
+        }
+
+        return !$errorOccurred;
+    }
 }


### PR DESCRIPTION
As an aid to encapsulated plugins that remove their unencapsulated version upon "Install".

Modeled after similarly-named methods in the PayPalRestful plugin's `ScriptedInstaller`: https://github.com/zencart/zencart/blob/59a101c64ca27f0dca514d28e03d113adbaf2a09/zc_plugins/PayPalRestful/v2.0.0/Installer/ScriptedInstaller.php#L46-L191