### PR TITLE
Correct `contact_us` name conflict.

### DIFF
--- a/includes/application_top.php
+++ b/includes/application_top.php
@@ -173,7 +173,7 @@ if (!empty($_SERVER['QUERY_STRING'])) {
 
     // count occurrences of each key
     $counts = array_count_values($keys);
-    foreach ($counts as $name => $count) {
+    foreach ($counts as $key => $count) {
         // allow one duplication (possibly accidental), more than 2 is not accidental
         if ($count > 2) {
             $contaminated = true;


### PR DESCRIPTION
Corrects the behavior identified in [this](https://www.zen-cart.com/showthread.php/231072-zencart-2-2-1-upgrade-contact-page) Zen Cart forum-posting on the contact_us page.