### PR TITLE
Enable `ScriptedInstaller` some control over the various "Plugin Manager" actions

### DIFF
--- a/admin/includes/languages/english/lang.plugin_manager.php
+++ b/admin/includes/languages/english/lang.plugin_manager.php
@@ -54,6 +54,12 @@ $define = [
     'ERROR_REMOVE_FILES_CANT_DELETE' => 'Unable to remove file: %s',
     'ERROR_REMOVE_FILES_CONTEXT' => 'Invalid context supplied (%s), it must be either "catalog" or "admin".',
     'ERROR_SQL_PATCH' => 'Error while processing SQL install. ',
+    'ERROR_UNKNOWN_FAILURE' => 'The plugin denied the %s action, but did not provide a message indicating the reason.',
+        'ERROR_UNKNOWN_FAILURE_DISABLE' => 'disable',
+        'ERROR_UNKNOWN_FAILURE_ENABLE' => 'enable',
+        'ERROR_UNKNOWN_FAILURE_INSTALL' => 'install',
+        'ERROR_UNKNOWN_FAILURE_UNINSTALL' => 'un-install',
+        'ERROR_UNKNOWN_FAILURE_UPGRADE' => 'upgrade',
 
     'WARNING_NONENCAPSULATED_REMOVAL' => '<b>Note:</b> Installing this plugin will result in files provided by a non-encapsulated version (if present) being <b>permanently</b> removed!',
 ];

--- a/includes/classes/PluginSupport/BasePluginInstaller.php
+++ b/includes/classes/PluginSupport/BasePluginInstaller.php
@@ -34,8 +34,8 @@ class BasePluginInstaller
             return false;
         }
         $this->processSetup($pluginKey, $version);
-        $this->pluginInstaller->executeInstallers($this->pluginDir);
-        if ($this->errorContainer->hasErrors()) {
+        $plugin_return = $this->pluginInstaller->executeInstallers($this->pluginDir);
+        if ($this->checkPluginReturn($plugin_return, ERROR_UNKNOWN_FAILURE_INSTALL) === false) {
             return false;
         }
         $this->setPluginVersionStatus($pluginKey, $version, PluginStatus::ENABLED);
@@ -51,8 +51,8 @@ class BasePluginInstaller
             return false;
         }
         $this->processSetup($pluginKey, $version);
-        $this->pluginInstaller->executeUninstallers($this->pluginDir);
-        if ($this->errorContainer->hasErrors()) {
+        $plugin_return = $this->pluginInstaller->executeUninstallers($this->pluginDir);
+        if ($this->checkPluginReturn($plugin_return, ERROR_UNKNOWN_FAILURE_UNINSTALL) === false) {
             return false;
         }
         $this->setPluginVersionStatus($pluginKey, '', PluginStatus::NOT_INSTALLED);
@@ -79,11 +79,9 @@ class BasePluginInstaller
         if (empty($pluginKey) || empty($version) || empty($oldVersion)) {
             return false;
         }
-        $this->pluginDir = DIR_FS_CATALOG . 'zc_plugins/' . $pluginKey . '/' . $version;
-        $this->loadInstallerLanguageFile('main.php');
-        $this->pluginInstaller->setVersions($this->pluginDir, $pluginKey, $version, $oldVersion);
-        $this->pluginInstaller->executeUpgraders($this->pluginDir, $oldVersion);
-        if ($this->errorContainer->hasErrors()) {
+        $this->processSetup($pluginKey, $version, $oldVersion);
+        $plugin_return = $this->pluginInstaller->executeUpgraders($this->pluginDir, $oldVersion);
+        if ($this->checkPluginReturn($plugin_return, ERROR_UNKNOWN_FAILURE_UPGRADE) === false) {
             return false;
         }
         $this->setPluginVersionStatus($pluginKey, $oldVersion, PluginStatus::NOT_INSTALLED);
@@ -124,8 +122,8 @@ class BasePluginInstaller
             return false;
         }
         $this->processSetup($pluginKey, $version);
-        $this->pluginInstaller->executeDisablers($this->pluginDir);
-        if ($this->errorContainer->hasErrors()) {
+        $plugin_return = $this->pluginInstaller->executeDisablers($this->pluginDir);
+        if ($this->checkPluginReturn($plugin_return, ERROR_UNKNOWN_FAILURE_DISABLE) === false) {
             return false;
         }
         $this->setPluginVersionStatus($pluginKey, $version, PluginStatus::DISABLED);
@@ -153,8 +151,8 @@ class BasePluginInstaller
             return false;
         }
         $this->processSetup($pluginKey, $version);
-        $this->pluginInstaller->executeEnablers($this->pluginDir);
-        if ($this->errorContainer->hasErrors()) {
+        $plugin_return = $this->pluginInstaller->executeEnablers($this->pluginDir);
+        if ($this->checkPluginReturn($plugin_return, ERROR_UNKNOWN_FAILURE_ENABLE) === false) {
             return false;
         }
         $this->setPluginVersionStatus($pluginKey, $version, PluginStatus::ENABLED);
@@ -164,11 +162,26 @@ class BasePluginInstaller
     /**
      * @since ZC v3.0.0
      */
-    public function processSetup(string $pluginKey, string $version, ?string $oldVersion = null): void
+    protected function processSetup(string $pluginKey, string $version, ?string $oldVersion = null): void
     {
         $this->pluginDir = DIR_FS_CATALOG . 'zc_plugins/' . $pluginKey . '/' . $version;
         $this->loadInstallerLanguageFile('main.php');
         $this->pluginInstaller->setVersions($this->pluginDir, $pluginKey, $version, $oldVersion);
+    }
+
+    /**
+     * @since ZC v3.0.0
+     */
+    protected function checkPluginReturn(?bool $plugin_return, string $plugin_action): bool
+    {
+        if ($plugin_return !== false) {
+            return true;
+        }
+        if (!$this->errorContainer->hasErrors()) {
+            $default_message = sprintf(ERROR_UNKNOWN_FAILURE, $plugin_action);
+            $this->errorContainer->addError(0, $default_message, false, $default_message);
+        }
+        return false;
     }
 
     /**

--- a/includes/classes/PluginSupport/BasePluginInstaller.php
+++ b/includes/classes/PluginSupport/BasePluginInstaller.php
@@ -60,6 +60,18 @@ class BasePluginInstaller
     }
 
     /**
+     * @since ZC v3.0.0
+     */
+    public function processPreUninstall($pluginKey, $version): array
+    {
+        if (empty($pluginKey) || empty($version)) {
+            return [];
+        }
+        $this->processSetup($pluginKey, $version);
+        return $this->pluginInstaller->executePreUninstallers($this->pluginDir);
+    }
+
+    /**
      * @since ZC v1.5.8
      */
     public function processUpgrade($pluginKey, $version, $oldVersion): bool

--- a/includes/classes/PluginSupport/BasePluginInstaller.php
+++ b/includes/classes/PluginSupport/BasePluginInstaller.php
@@ -124,7 +124,7 @@ class BasePluginInstaller
             return [];
         }
         $this->processSetup($pluginKey, $version);
-        return $this->pluginInstaller->executePreDisablers($this->pluginDir, $version);
+        return $this->pluginInstaller->executePreDisablers($this->pluginDir);
     }
 
     /**
@@ -153,7 +153,7 @@ class BasePluginInstaller
             return [];
         }
         $this->processSetup($pluginKey, $version);
-        return $this->pluginInstaller->executePreEnablers($this->pluginDir, $version);
+        return $this->pluginInstaller->executePreEnablers($this->pluginDir);
     }
 
     /**

--- a/includes/classes/PluginSupport/BasePluginInstaller.php
+++ b/includes/classes/PluginSupport/BasePluginInstaller.php
@@ -33,15 +33,28 @@ class BasePluginInstaller
         if (empty($pluginKey) || empty($version)) {
             return false;
         }
-        $this->pluginDir = DIR_FS_CATALOG . 'zc_plugins/' . $pluginKey . '/' . $version;
-        $this->loadInstallerLanguageFile('main.php');
-        $this->pluginInstaller->setVersions($this->pluginDir, $pluginKey, $version);
+        $this->processSetup($pluginKey, $version);
         $this->pluginInstaller->executeInstallers($this->pluginDir);
         if ($this->errorContainer->hasErrors()) {
             return false;
         }
         $this->setPluginVersionStatus($pluginKey, $version, PluginStatus::ENABLED);
         return true;
+    }
+
+    /**
+     * @param string $pluginKey
+     * @param string $version
+     * @return array
+     * @since ZC v3.0.0
+     */
+    public function processPreInstall($pluginKey, $version): array
+    {
+        if (empty($pluginKey) || empty($version)) {
+            return [];
+        }
+        $this->processSetup($pluginKey, $version);
+        return $this->pluginInstaller->executePreInstallers($this->pluginDir);
     }
 
     /**
@@ -52,15 +65,28 @@ class BasePluginInstaller
         if (empty($pluginKey) || empty($version)) {
             return false;
         }
-        $this->pluginDir = DIR_FS_CATALOG . 'zc_plugins/' . $pluginKey . '/' . $version;
-        $this->loadInstallerLanguageFile('main.php');
-        $this->setPluginVersionStatus($pluginKey, '', PluginStatus::NOT_INSTALLED);
-        $this->pluginInstaller->setVersions($this->pluginDir, $pluginKey, $version);
+        $this->processSetup($pluginKey, $version);
         $this->pluginInstaller->executeUninstallers($this->pluginDir);
         if ($this->errorContainer->hasErrors()) {
             return false;
         }
+        $this->setPluginVersionStatus($pluginKey, '', PluginStatus::NOT_INSTALLED);
         return true;
+    }
+
+    /**
+     * @param string $pluginKey
+     * @param string $version
+     * @return array
+     * @since ZC v3.0.0
+     */
+    public function processPreUninstall($pluginKey, $version): array
+    {
+        if (empty($pluginKey) || empty($version)) {
+            return [];
+        }
+        $this->processSetup($pluginKey, $version);
+        return $this->pluginInstaller->executePreUninstallers($this->pluginDir);
     }
 
     /**
@@ -84,19 +110,110 @@ class BasePluginInstaller
     }
 
     /**
-     * @since ZC v1.5.7
+     * @param string $pluginKey
+     * @param string $version
+     * @return array
+     * @since ZC v3.0.0
      */
-    public function processDisable($pluginKey, $version): void
+    public function processPreUpgrade(string $pluginKey, string $version): array
     {
-        $this->setPluginVersionStatus($pluginKey, $version, PluginStatus::DISABLED);
+        if (empty($pluginKey) || empty($version)) {
+            return [];
+        }
+        $this->processSetup($pluginKey, $version);
+        return $this->pluginInstaller->executePreUpgraders($this->pluginDir, $version);
     }
 
     /**
-     * @since ZC v1.5.7
+     * @param string $pluginKey
+     * @param string $version
+     * @return array
+     * @since ZC v3.0.0
      */
-    public function processEnable($pluginKey, $version): void
+    public function processPreConfirmUpgrade(string $pluginKey, string $version): array
     {
+        if (empty($pluginKey) || empty($version)) {
+            return [];
+        }
+        $this->processSetup($pluginKey, $version);
+        return $this->pluginInstaller->executePreConfirmUpgraders($this->pluginDir, $version);
+    }
+
+    /**
+     * @param string $pluginKey
+     * @param string $version
+     * @return array
+     * @since ZC v3.0.0
+     */
+    public function processPreDisable(string $pluginKey, string $version): array
+    {
+        if (empty($pluginKey) || empty($version)) {
+            return [];
+        }
+        $this->processSetup($pluginKey, $version);
+        return $this->pluginInstaller->executePreDisablers($this->pluginDir, $version);
+    }
+
+    /**
+     * @since ZC v3.0.0
+     */
+    public function processDisable($pluginKey, $version): bool
+    {
+        if (empty($pluginKey) || empty($version)) {
+            return false;
+        }
+        $this->processSetup($pluginKey, $version);
+        $this->pluginInstaller->executeDisablers($this->pluginDir);
+        if ($this->errorContainer->hasErrors()) {
+            return false;
+        }
+        $this->setPluginVersionStatus($pluginKey, $version, PluginStatus::DISABLED);
+        return true;
+    }
+
+    /**
+     * @param string $pluginKey
+     * @param string $version
+     * @return array
+     * @since ZC v3.0.0
+     */
+    public function processPreEnable(string $pluginKey, string $version): array
+    {
+        if (empty($pluginKey) || empty($version)) {
+            return [];
+        }
+        $this->processSetup($pluginKey, $version);
+        return $this->pluginInstaller->executePreEnablers($this->pluginDir, $version);
+    }
+
+    /**
+     * @since ZC v3.0.0
+     */
+    public function processEnable($pluginKey, $version): bool
+    {
+        if (empty($pluginKey) || empty($version)) {
+            return false;
+        }
+        $this->processSetup($pluginKey, $version);
+        $this->pluginInstaller->executeEnablers($this->pluginDir);
+        if ($this->errorContainer->hasErrors()) {
+            return false;
+        }
         $this->setPluginVersionStatus($pluginKey, $version, PluginStatus::ENABLED);
+        return true;
+    }
+
+    /**
+     * @param string $pluginKey
+     * @param string $version
+     * @return void
+     * @since ZC v3.0.0
+     */
+    public function processSetup(string $pluginKey, string $version): void
+    {
+        $this->pluginDir = DIR_FS_CATALOG . 'zc_plugins/' . $pluginKey . '/' . $version;
+        $this->loadInstallerLanguageFile('main.php');
+        $this->pluginInstaller->setVersions($this->pluginDir, $pluginKey, $version);
     }
 
     /**

--- a/includes/classes/PluginSupport/BasePluginInstaller.php
+++ b/includes/classes/PluginSupport/BasePluginInstaller.php
@@ -43,9 +43,6 @@ class BasePluginInstaller
     }
 
     /**
-     * @param string $pluginKey
-     * @param string $version
-     * @return array
      * @since ZC v3.0.0
      */
     public function processPreInstall($pluginKey, $version): array
@@ -75,9 +72,6 @@ class BasePluginInstaller
     }
 
     /**
-     * @param string $pluginKey
-     * @param string $version
-     * @return array
      * @since ZC v3.0.0
      */
     public function processPreUninstall($pluginKey, $version): array
@@ -110,24 +104,18 @@ class BasePluginInstaller
     }
 
     /**
-     * @param string $pluginKey
-     * @param string $version
-     * @return array
      * @since ZC v3.0.0
      */
-    public function processPreConfirmUpgrade(string $pluginKey, string $version): array
+    public function processPreConfirmUpgrade(string $pluginKey, string $version, string $oldVersion): array
     {
         if (empty($pluginKey) || empty($version)) {
             return [];
         }
-        $this->processSetup($pluginKey, $version);
-        return $this->pluginInstaller->executePreConfirmUpgraders($this->pluginDir, $version);
+        $this->processSetup($pluginKey, $version, $oldVersion);
+        return $this->pluginInstaller->executePreConfirmUpgraders($this->pluginDir, $version, $oldVersion);
     }
 
     /**
-     * @param string $pluginKey
-     * @param string $version
-     * @return array
      * @since ZC v3.0.0
      */
     public function processPreDisable(string $pluginKey, string $version): array
@@ -157,9 +145,6 @@ class BasePluginInstaller
     }
 
     /**
-     * @param string $pluginKey
-     * @param string $version
-     * @return array
      * @since ZC v3.0.0
      */
     public function processPreEnable(string $pluginKey, string $version): array
@@ -189,16 +174,13 @@ class BasePluginInstaller
     }
 
     /**
-     * @param string $pluginKey
-     * @param string $version
-     * @return void
      * @since ZC v3.0.0
      */
-    public function processSetup(string $pluginKey, string $version): void
+    public function processSetup(string $pluginKey, string $version, ?string $oldVersion = null): void
     {
         $this->pluginDir = DIR_FS_CATALOG . 'zc_plugins/' . $pluginKey . '/' . $version;
         $this->loadInstallerLanguageFile('main.php');
-        $this->pluginInstaller->setVersions($this->pluginDir, $pluginKey, $version);
+        $this->pluginInstaller->setVersions($this->pluginDir, $pluginKey, $version, $oldVersion);
     }
 
     /**

--- a/includes/classes/PluginSupport/BasePluginInstaller.php
+++ b/includes/classes/PluginSupport/BasePluginInstaller.php
@@ -43,18 +43,6 @@ class BasePluginInstaller
     }
 
     /**
-     * @since ZC v3.0.0
-     */
-    public function processPreInstall($pluginKey, $version): array
-    {
-        if (empty($pluginKey) || empty($version)) {
-            return [];
-        }
-        $this->processSetup($pluginKey, $version);
-        return $this->pluginInstaller->executePreInstallers($this->pluginDir);
-    }
-
-    /**
      * @since ZC v1.5.7
      */
     public function processUninstall($pluginKey, $version): bool
@@ -69,18 +57,6 @@ class BasePluginInstaller
         }
         $this->setPluginVersionStatus($pluginKey, '', PluginStatus::NOT_INSTALLED);
         return true;
-    }
-
-    /**
-     * @since ZC v3.0.0
-     */
-    public function processPreUninstall($pluginKey, $version): array
-    {
-        if (empty($pluginKey) || empty($version)) {
-            return [];
-        }
-        $this->processSetup($pluginKey, $version);
-        return $this->pluginInstaller->executePreUninstallers($this->pluginDir);
     }
 
     /**

--- a/includes/classes/PluginSupport/BasePluginInstaller.php
+++ b/includes/classes/PluginSupport/BasePluginInstaller.php
@@ -115,21 +115,6 @@ class BasePluginInstaller
      * @return array
      * @since ZC v3.0.0
      */
-    public function processPreUpgrade(string $pluginKey, string $version): array
-    {
-        if (empty($pluginKey) || empty($version)) {
-            return [];
-        }
-        $this->processSetup($pluginKey, $version);
-        return $this->pluginInstaller->executePreUpgraders($this->pluginDir, $version);
-    }
-
-    /**
-     * @param string $pluginKey
-     * @param string $version
-     * @return array
-     * @since ZC v3.0.0
-     */
     public function processPreConfirmUpgrade(string $pluginKey, string $version): array
     {
         if (empty($pluginKey) || empty($version)) {

--- a/includes/classes/PluginSupport/Installer.php
+++ b/includes/classes/PluginSupport/Installer.php
@@ -58,8 +58,6 @@ class Installer
     }
 
     /**
-     * @param string $pluginDir
-     * @return array
      * @since ZC v3.0.0
      */
     public function executePreInstallers(string $pluginDir): array
@@ -80,8 +78,6 @@ class Installer
     }
 
     /**
-     * @param string $pluginDir
-     * @return array
      * @since ZC v3.0.0
      */
     public function executePreUninstallers(string $pluginDir): array
@@ -98,30 +94,14 @@ class Installer
     }
 
     /**
-     * @param string $pluginDir
-     * @param string $oldVersion
-     * @return array
      * @since ZC v3.0.0
      */
-    public function executePreUpgraders(string $pluginDir, string $oldVersion): array
+    public function executePreConfirmUpgraders(string $pluginDir, string $version, string $oldVersion): array
     {
-        return $this->executeScriptedPreUpgrader($pluginDir, $oldVersion);
+        return $this->executeScriptedPreConfirmUpgrader($pluginDir, $version, $oldVersion);
     }
 
     /**
-     * @param string $pluginDir
-     * @param string $oldVersion
-     * @return array
-     * @since ZC v3.0.0
-     */
-    public function executePreConfirmUpgraders(string $pluginDir, string $oldVersion): array
-    {
-        return $this->executeScriptedPreConfirmUpgrader($pluginDir, $oldVersion);
-    }
-
-    /**
-     * @param string $pluginDir
-     * @return array
      * @since ZC v3.0.0
      */
     public function executePreDisablers(string $pluginDir): array
@@ -130,8 +110,6 @@ class Installer
     }
 
     /**
-     * @param string $pluginDir
-     * @return void
      * @since ZC v3.0.0
      */
     public function executeDisablers(string $pluginDir): void
@@ -140,8 +118,6 @@ class Installer
     }
 
     /**
-     * @param string $pluginDir
-     * @return array
      * @since ZC v3.0.0
      */
     public function executePreEnablers(string $pluginDir): array
@@ -150,8 +126,6 @@ class Installer
     }
 
     /**
-     * @param string $pluginDir
-     * @return void
      * @since ZC v3.0.0
      */
     public function executeEnablers(string $pluginDir): void
@@ -256,13 +230,13 @@ class Installer
     /**
      * @since ZC v3.0.0
      */
-    protected function executeScriptedPreConfirmUpgrader(string $pluginDir, string $oldVersion): array
+    protected function executeScriptedPreConfirmUpgrader(string $pluginDir, string $version, string $oldVersion): array
     {
         $scriptedInstaller = $this->scriptedSetup($pluginDir);
         if (empty($scriptedInstaller)) {
             return [];
         }
-        return $scriptedInstaller->doPreConfirmUpgrade($oldVersion);
+        return $scriptedInstaller->doPreConfirmUpgrade($version, $oldVersion);
     }
 
     /**
@@ -294,11 +268,10 @@ class Installer
      */
     protected function executeScriptedEnabler(string $pluginDir): void
     {
-        if (!file_exists($pluginDir . '/Installer/ScriptedInstaller.php')) {
+        $scriptedInstaller = $this->scriptedSetup($pluginDir);
+        if (empty($scriptedInstaller)) {
             return;
         }
-        $scriptedInstaller = $this->scriptedInstallerFactory->make($pluginDir);
-        $scriptedInstaller->setVersionDetails($this->getVersionInformation());
         $scriptedInstaller->doEnable();
     }
 
@@ -307,11 +280,10 @@ class Installer
      */
     protected function executeScriptedPreEnabler(string $pluginDir): array
     {
-        if (!file_exists($pluginDir . '/Installer/ScriptedInstaller.php')) {
+        $scriptedInstaller = $this->scriptedSetup($pluginDir);
+        if (empty($scriptedInstaller)) {
             return [];
         }
-        $scriptedInstaller = $this->scriptedInstallerFactory->make($pluginDir);
-        $scriptedInstaller->setVersionDetails($this->getVersionInformation());
         return $scriptedInstaller->doPreEnable();
     }
 

--- a/includes/classes/PluginSupport/Installer.php
+++ b/includes/classes/PluginSupport/Installer.php
@@ -50,9 +50,9 @@ class Installer
      */
     public function executeInstallers($pluginDir): ?bool
     {
-        $this->executePatchInstaller($pluginDir);
-        if ($this->errorContainer->hasErrors()) {
-            return null;
+        $patch_status = $this->executePatchInstaller($pluginDir);
+        if ($patch_status !== null) {
+            return $patch_status;
         }
         return $this->executeScriptedInstaller($pluginDir);
     }
@@ -62,9 +62,9 @@ class Installer
      */
     public function executeUninstallers($pluginDir): ?bool
     {
-        $this->executePatchUninstaller($pluginDir);
-        if ($this->errorContainer->hasErrors()) {
-            return null;
+        $patch_status = $this->executePatchUninstaller($pluginDir);
+        if ($patch_status !== null) {
+            return $patch_status;
         }
         return $this->executeScriptedUninstaller($pluginDir);
     }
@@ -80,7 +80,7 @@ class Installer
     /**
      * @since ZC v1.5.8
      */
-public function executeUpgraders($pluginDir, $oldVersion): ?bool
+    public function executeUpgraders($pluginDir, $oldVersion): ?bool
     {
         return $this->executeScriptedUpgrader($pluginDir, $oldVersion);
     }
@@ -128,35 +128,36 @@ public function executeUpgraders($pluginDir, $oldVersion): ?bool
     /**
      * @since ZC v1.5.7
      */
-    protected function executePatchInstaller($pluginDir): void
+    protected function executePatchInstaller($pluginDir): ?bool
     {
         $patchFile = 'install.sql';
-        $this->executePatchFile($pluginDir, $patchFile);
+        return $this->executePatchFile($pluginDir, $patchFile);
     }
 
     /**
      * @since ZC v1.5.7
      */
-    protected function executePatchUninstaller($pluginDir): void
+    protected function executePatchUninstaller($pluginDir): ?bool
     {
         $patchFile = 'uninstall.sql';
-        $this->executePatchFile($pluginDir, $patchFile);
+        return $this->executePatchFile($pluginDir, $patchFile);
     }
 
     /**
      * @since ZC v1.5.7
      */
-    protected function executePatchFile($pluginDir, $patchFile): void
+    protected function executePatchFile($pluginDir, $patchFile): ?bool
     {
         if (!file_exists($pluginDir . '/Installer/' . $patchFile)) {
-            return;
+            return null;
         }
         $lines = file($pluginDir . '/Installer/' . $patchFile);
         $paramLines = $this->patchInstaller->parse($lines);
         if ($this->errorContainer->hasErrors()) {
-            return;
+            return false;
         }
         $this->patchInstaller->executePatchSql($paramLines);
+        return true;
     }
 
     /**

--- a/includes/classes/PluginSupport/Installer.php
+++ b/includes/classes/PluginSupport/Installer.php
@@ -48,25 +48,25 @@ class Installer
     /**
      * @since ZC v1.5.7
      */
-    public function executeInstallers($pluginDir): void
+    public function executeInstallers($pluginDir): ?bool
     {
         $this->executePatchInstaller($pluginDir);
         if ($this->errorContainer->hasErrors()) {
-            return;
+            return null;
         }
-        $this->executeScriptedInstaller($pluginDir);
+        return $this->executeScriptedInstaller($pluginDir);
     }
 
     /**
      * @since ZC v1.5.7
      */
-    public function executeUninstallers($pluginDir): void
+    public function executeUninstallers($pluginDir): ?bool
     {
         $this->executePatchUninstaller($pluginDir);
         if ($this->errorContainer->hasErrors()) {
-            return;
+            return null;
         }
-        $this->executeScriptedUninstaller($pluginDir);
+        return $this->executeScriptedUninstaller($pluginDir);
     }
 
     /**
@@ -80,9 +80,9 @@ class Installer
     /**
      * @since ZC v1.5.8
      */
-    public function executeUpgraders($pluginDir, $oldVersion): void
+public function executeUpgraders($pluginDir, $oldVersion): ?bool
     {
-        $this->executeScriptedUpgrader($pluginDir, $oldVersion);
+        return $this->executeScriptedUpgrader($pluginDir, $oldVersion);
     }
 
     /**
@@ -104,9 +104,9 @@ class Installer
     /**
      * @since ZC v3.0.0
      */
-    public function executeDisablers(string $pluginDir): void
+    public function executeDisablers(string $pluginDir): ?bool
     {
-        $this->executeScriptedDisabler($pluginDir);
+        return $this->executeScriptedDisabler($pluginDir);
     }
 
     /**
@@ -120,9 +120,9 @@ class Installer
     /**
      * @since ZC v3.0.0
      */
-    public function executeEnablers(string $pluginDir): void
+    public function executeEnablers(string $pluginDir): ?bool
     {
-        $this->executeScriptedEnabler($pluginDir);
+        return $this->executeScriptedEnabler($pluginDir);
     }
 
     /**
@@ -162,25 +162,25 @@ class Installer
     /**
      * @since ZC v1.5.7
      */
-    protected function executeScriptedInstaller($pluginDir): void
+    protected function executeScriptedInstaller($pluginDir): ?bool
     {
         $scriptedInstaller = $this->scriptedSetup($pluginDir);
         if (empty($scriptedInstaller)) {
-            return;
+            return null;
         }
-        $scriptedInstaller->doInstall();
+        return $scriptedInstaller->doInstall();
     }
 
     /**
      * @since ZC v1.5.7
      */
-    protected function executeScriptedUninstaller($pluginDir): void
+    protected function executeScriptedUninstaller($pluginDir): ?bool
     {
         $scriptedInstaller = $this->scriptedSetup($pluginDir);
         if (empty($scriptedInstaller)) {
-            return;
+            return null;
         }
-        $scriptedInstaller->doUninstall();
+        return $scriptedInstaller->doUninstall();
     }
 
     /**
@@ -198,13 +198,13 @@ class Installer
     /**
      * @since ZC v1.5.8
      */
-    protected function executeScriptedUpgrader($pluginDir, $oldVersion): void
+    protected function executeScriptedUpgrader($pluginDir, $oldVersion): ?bool
     {
         $scriptedInstaller = $this->scriptedSetup($pluginDir);
         if (empty($scriptedInstaller)) {
-            return;
+            return null;
         }
-        $scriptedInstaller->doUpgrade($oldVersion);
+        return $scriptedInstaller->doUpgrade($oldVersion);
     }
 
     /**
@@ -222,13 +222,13 @@ class Installer
     /**
      * @since ZC v3.0.0
      */
-    protected function executeScriptedDisabler(string $pluginDir): void
+    protected function executeScriptedDisabler(string $pluginDir): ?bool
     {
         $scriptedInstaller = $this->scriptedSetup($pluginDir);
         if (empty($scriptedInstaller)) {
-            return;
+            return null;
         }
-        $scriptedInstaller->doDisable();
+        return $scriptedInstaller->doDisable();
     }
 
     /**
@@ -246,13 +246,13 @@ class Installer
     /**
      * @since ZC v3.0.0
      */
-    protected function executeScriptedEnabler(string $pluginDir): void
+    protected function executeScriptedEnabler(string $pluginDir): ?bool
     {
         $scriptedInstaller = $this->scriptedSetup($pluginDir);
         if (empty($scriptedInstaller)) {
-            return;
+            return null;
         }
-        $scriptedInstaller->doEnable();
+        return $scriptedInstaller->doEnable();
     }
 
     /**

--- a/includes/classes/PluginSupport/Installer.php
+++ b/includes/classes/PluginSupport/Installer.php
@@ -58,6 +58,16 @@ class Installer
     }
 
     /**
+     * @param string $pluginDir
+     * @return array
+     * @since ZC v3.0.0
+     */
+    public function executePreInstallers(string $pluginDir): array
+    {
+        return $this->executeScriptedPreInstaller($pluginDir);
+    }
+
+    /**
      * @since ZC v1.5.7
      */
     public function executeUninstallers($pluginDir): void
@@ -70,11 +80,83 @@ class Installer
     }
 
     /**
+     * @param string $pluginDir
+     * @return array
+     * @since ZC v3.0.0
+     */
+    public function executePreUninstallers(string $pluginDir): array
+    {
+        return $this->executeScriptedPreUninstaller($pluginDir);
+    }
+
+    /**
      * @since ZC v1.5.8
      */
     public function executeUpgraders($pluginDir, $oldVersion): void
     {
         $this->executeScriptedUpgrader($pluginDir, $oldVersion);
+    }
+
+    /**
+     * @param string $pluginDir
+     * @param string $oldVersion
+     * @return array
+     * @since ZC v3.0.0
+     */
+    public function executePreUpgraders(string $pluginDir, string $oldVersion): array
+    {
+        return $this->executeScriptedPreUpgrader($pluginDir, $oldVersion);
+    }
+
+    /**
+     * @param string $pluginDir
+     * @param string $oldVersion
+     * @return array
+     * @since ZC v3.0.0
+     */
+    public function executePreConfirmUpgraders(string $pluginDir, string $oldVersion): array
+    {
+        return $this->executeScriptedPreConfirmUpgrader($pluginDir, $oldVersion);
+    }
+
+    /**
+     * @param string $pluginDir
+     * @return array
+     * @since ZC v3.0.0
+     */
+    public function executePreDisablers(string $pluginDir): array
+    {
+        return $this->executeScriptedPreDisabler($pluginDir);
+    }
+
+    /**
+     * @param string $pluginDir
+     * @return void
+     * @since ZC v3.0.0
+     */
+    public function executeDisablers(string $pluginDir): void
+    {
+        $this->executeScriptedDisabler($pluginDir);
+    }
+
+    /**
+     * @param string $pluginDir
+     * @return array
+     * @since ZC v3.0.0
+     */
+    public function executePreEnablers(string $pluginDir): array
+    {
+        return $this->executeScriptedPreEnabler($pluginDir);
+    }
+
+    /**
+     * @param string $pluginDir
+     * @return void
+     * @since ZC v3.0.0
+     */
+    public function executeEnablers(string $pluginDir): void
+    {
+        $this->executeScriptedEnabler($pluginDir);
     }
 
     /**
@@ -125,6 +207,19 @@ class Installer
     }
 
     /**
+     * @since ZC v3.0.0
+     */
+    protected function executeScriptedPreInstaller(string $pluginDir): array
+    {
+        if (!file_exists($pluginDir . '/Installer/ScriptedInstaller.php')) {
+            return [];
+        }
+        $scriptedInstaller = $this->scriptedInstallerFactory->make($pluginDir);
+        $scriptedInstaller->setVersionDetails($this->getVersionInformation());
+        return $scriptedInstaller->doPreInstall();
+    }
+
+    /**
      * @since ZC v1.5.7
      */
     protected function executeScriptedUninstaller($pluginDir): void
@@ -138,6 +233,19 @@ class Installer
     }
 
     /**
+     * @since ZC v3.0.0
+     */
+    protected function executeScriptedPreUninstaller(string $pluginDir): array
+    {
+        if (!file_exists($pluginDir . '/Installer/ScriptedInstaller.php')) {
+            return [];
+        }
+        $scriptedInstaller = $this->scriptedInstallerFactory->make($pluginDir);
+        $scriptedInstaller->setVersionDetails($this->getVersionInformation());
+        return $scriptedInstaller->doPreUninstall();
+    }
+
+    /**
      * @since ZC v1.5.8
      */
     protected function executeScriptedUpgrader($pluginDir, $oldVersion): void
@@ -148,6 +256,84 @@ class Installer
         $scriptedInstaller = $this->scriptedInstallerFactory->make($pluginDir);
         $scriptedInstaller->setVersionDetails($this->getVersionInformation());
         $scriptedInstaller->doUpgrade($oldVersion);
+    }
+
+    /**
+     * @since ZC v3.0.0
+     */
+    protected function executeScriptedPreUpgrader(string $pluginDir, string $oldVersion): array
+    {
+        if (!file_exists($pluginDir . '/Installer/ScriptedInstaller.php')) {
+            return [];
+        }
+        $scriptedInstaller = $this->scriptedInstallerFactory->make($pluginDir);
+        $scriptedInstaller->setVersionDetails($this->getVersionInformation());
+        return $scriptedInstaller->doPreUpgrade($oldVersion);
+    }
+
+    /**
+     * @since ZC v3.0.0
+     */
+    protected function executeScriptedPreConfirmUpgrader(string $pluginDir, string $oldVersion): array
+    {
+        if (!file_exists($pluginDir . '/Installer/ScriptedInstaller.php')) {
+            return [];
+        }
+        $scriptedInstaller = $this->scriptedInstallerFactory->make($pluginDir);
+        $scriptedInstaller->setVersionDetails($this->getVersionInformation());
+        return $scriptedInstaller->doPreUpgrade($oldVersion);
+    }
+
+    /**
+     * @since ZC v3.0.0
+     */
+    protected function executeScriptedDisabler(string $pluginDir): void
+    {
+        if (!file_exists($pluginDir . '/Installer/ScriptedInstaller.php')) {
+            return;
+        }
+        $scriptedInstaller = $this->scriptedInstallerFactory->make($pluginDir);
+        $scriptedInstaller->setVersionDetails($this->getVersionInformation());
+        $scriptedInstaller->doDisable();
+    }
+
+    /**
+     * @since ZC v3.0.0
+     */
+    protected function executeScriptedPreDisabler(string $pluginDir): array
+    {
+        if (!file_exists($pluginDir . '/Installer/ScriptedInstaller.php')) {
+            return [];
+        }
+        $scriptedInstaller = $this->scriptedInstallerFactory->make($pluginDir);
+        $scriptedInstaller->setVersionDetails($this->getVersionInformation());
+        return $scriptedInstaller->doPreDisable();
+    }
+
+    /**
+     * @since ZC v3.0.0
+     */
+    protected function executeScriptedEnabler(string $pluginDir): void
+    {
+        if (!file_exists($pluginDir . '/Installer/ScriptedInstaller.php')) {
+            return;
+        }
+        $scriptedInstaller = $this->scriptedInstallerFactory->make($pluginDir);
+        $scriptedInstaller->setVersionDetails($this->getVersionInformation());
+        $scriptedInstaller->doEnable();
+    }
+
+    /**
+     * @since ZC v3.0.0
+     */
+    protected function executeScriptedPreEnabler(string $pluginDir): array
+    {
+        if (!file_exists($pluginDir . '/Installer/ScriptedInstaller.php')) {
+            return [];
+        }
+        $scriptedInstaller = $this->scriptedInstallerFactory->make($pluginDir);
+        $scriptedInstaller->setVersionDetails($this->getVersionInformation());
+        return $scriptedInstaller->doPreEnable();
     }
 
     /**

--- a/includes/classes/PluginSupport/Installer.php
+++ b/includes/classes/PluginSupport/Installer.php
@@ -58,14 +58,6 @@ class Installer
     }
 
     /**
-     * @since ZC v3.0.0
-     */
-    public function executePreInstallers(string $pluginDir): array
-    {
-        return $this->executeScriptedPreInstaller($pluginDir);
-    }
-
-    /**
      * @since ZC v1.5.7
      */
     public function executeUninstallers($pluginDir): void
@@ -177,18 +169,6 @@ class Installer
             return;
         }
         $scriptedInstaller->doInstall();
-    }
-
-    /**
-     * @since ZC v3.0.0
-     */
-    protected function executeScriptedPreInstaller(string $pluginDir): array
-    {
-        $scriptedInstaller = $this->scriptedSetup($pluginDir);
-        if (empty($scriptedInstaller)) {
-            return [];
-        }
-        return $scriptedInstaller->doPreInstall();
     }
 
     /**

--- a/includes/classes/PluginSupport/Installer.php
+++ b/includes/classes/PluginSupport/Installer.php
@@ -198,11 +198,10 @@ class Installer
      */
     protected function executeScriptedInstaller($pluginDir): void
     {
-        if (!file_exists($pluginDir . '/Installer/ScriptedInstaller.php')) {
+        $scriptedInstaller = $this->scriptedSetup($pluginDir);
+        if (empty($scriptedInstaller)) {
             return;
         }
-        $scriptedInstaller = $this->scriptedInstallerFactory->make($pluginDir);
-        $scriptedInstaller->setVersionDetails($this->getVersionInformation());
         $scriptedInstaller->doInstall();
     }
 
@@ -211,11 +210,10 @@ class Installer
      */
     protected function executeScriptedPreInstaller(string $pluginDir): array
     {
-        if (!file_exists($pluginDir . '/Installer/ScriptedInstaller.php')) {
+        $scriptedInstaller = $this->scriptedSetup($pluginDir);
+        if (empty($scriptedInstaller)) {
             return [];
         }
-        $scriptedInstaller = $this->scriptedInstallerFactory->make($pluginDir);
-        $scriptedInstaller->setVersionDetails($this->getVersionInformation());
         return $scriptedInstaller->doPreInstall();
     }
 
@@ -224,11 +222,10 @@ class Installer
      */
     protected function executeScriptedUninstaller($pluginDir): void
     {
-        if (!file_exists($pluginDir . '/Installer/ScriptedInstaller.php')) {
+        $scriptedInstaller = $this->scriptedSetup($pluginDir);
+        if (empty($scriptedInstaller)) {
             return;
         }
-        $scriptedInstaller = $this->scriptedInstallerFactory->make($pluginDir);
-        $scriptedInstaller->setVersionDetails($this->getVersionInformation());
         $scriptedInstaller->doUninstall();
     }
 
@@ -237,11 +234,10 @@ class Installer
      */
     protected function executeScriptedPreUninstaller(string $pluginDir): array
     {
-        if (!file_exists($pluginDir . '/Installer/ScriptedInstaller.php')) {
+        $scriptedInstaller = $this->scriptedSetup($pluginDir);
+        if (empty($scriptedInstaller)) {
             return [];
         }
-        $scriptedInstaller = $this->scriptedInstallerFactory->make($pluginDir);
-        $scriptedInstaller->setVersionDetails($this->getVersionInformation());
         return $scriptedInstaller->doPreUninstall();
     }
 
@@ -250,25 +246,11 @@ class Installer
      */
     protected function executeScriptedUpgrader($pluginDir, $oldVersion): void
     {
-        if (!file_exists($pluginDir . '/Installer/ScriptedInstaller.php')) {
+        $scriptedInstaller = $this->scriptedSetup($pluginDir);
+        if (empty($scriptedInstaller)) {
             return;
         }
-        $scriptedInstaller = $this->scriptedInstallerFactory->make($pluginDir);
-        $scriptedInstaller->setVersionDetails($this->getVersionInformation());
         $scriptedInstaller->doUpgrade($oldVersion);
-    }
-
-    /**
-     * @since ZC v3.0.0
-     */
-    protected function executeScriptedPreUpgrader(string $pluginDir, string $oldVersion): array
-    {
-        if (!file_exists($pluginDir . '/Installer/ScriptedInstaller.php')) {
-            return [];
-        }
-        $scriptedInstaller = $this->scriptedInstallerFactory->make($pluginDir);
-        $scriptedInstaller->setVersionDetails($this->getVersionInformation());
-        return $scriptedInstaller->doPreUpgrade($oldVersion);
     }
 
     /**
@@ -276,12 +258,11 @@ class Installer
      */
     protected function executeScriptedPreConfirmUpgrader(string $pluginDir, string $oldVersion): array
     {
-        if (!file_exists($pluginDir . '/Installer/ScriptedInstaller.php')) {
+        $scriptedInstaller = $this->scriptedSetup($pluginDir);
+        if (empty($scriptedInstaller)) {
             return [];
         }
-        $scriptedInstaller = $this->scriptedInstallerFactory->make($pluginDir);
-        $scriptedInstaller->setVersionDetails($this->getVersionInformation());
-        return $scriptedInstaller->doPreUpgrade($oldVersion);
+        return $scriptedInstaller->doPreConfirmUpgrade($oldVersion);
     }
 
     /**
@@ -289,11 +270,10 @@ class Installer
      */
     protected function executeScriptedDisabler(string $pluginDir): void
     {
-        if (!file_exists($pluginDir . '/Installer/ScriptedInstaller.php')) {
+        $scriptedInstaller = $this->scriptedSetup($pluginDir);
+        if (empty($scriptedInstaller)) {
             return;
         }
-        $scriptedInstaller = $this->scriptedInstallerFactory->make($pluginDir);
-        $scriptedInstaller->setVersionDetails($this->getVersionInformation());
         $scriptedInstaller->doDisable();
     }
 
@@ -302,11 +282,10 @@ class Installer
      */
     protected function executeScriptedPreDisabler(string $pluginDir): array
     {
-        if (!file_exists($pluginDir . '/Installer/ScriptedInstaller.php')) {
+        $scriptedInstaller = $this->scriptedSetup($pluginDir);
+        if (empty($scriptedInstaller)) {
             return [];
         }
-        $scriptedInstaller = $this->scriptedInstallerFactory->make($pluginDir);
-        $scriptedInstaller->setVersionDetails($this->getVersionInformation());
         return $scriptedInstaller->doPreDisable();
     }
 
@@ -334,6 +313,19 @@ class Installer
         $scriptedInstaller = $this->scriptedInstallerFactory->make($pluginDir);
         $scriptedInstaller->setVersionDetails($this->getVersionInformation());
         return $scriptedInstaller->doPreEnable();
+    }
+
+    /**
+     * @since ZC v3.0.0
+     */
+    protected function scriptedSetup(string $pluginDir): ?ScriptedInstaller
+    {
+        if (!file_exists($pluginDir . '/Installer/ScriptedInstaller.php')) {
+            return null;
+        }
+        $scriptedInstaller = $this->scriptedInstallerFactory->make($pluginDir);
+        $scriptedInstaller->setVersionDetails($this->getVersionInformation());
+        return $scriptedInstaller;
     }
 
     /**

--- a/includes/classes/PluginSupport/ScriptedInstaller.php
+++ b/includes/classes/PluginSupport/ScriptedInstaller.php
@@ -39,18 +39,6 @@ class ScriptedInstaller
     }
 
     /**
-     * Optionally, return an array of additional messages and/or
-     * form-fields to be added to the Plugin Manager's "Install"
-     * verification form.
-     *
-     * @since ZC v3.0.0
-     */
-    protected function preInstall(): array
-    {
-        return [];
-    }
-
-    /**
      * Optionally, check any form-fields supplied by the preInstall
      * method.  Gives the installer a means to disallow the installation.
      * Returns a boolean indication whether (true) or not (false) the plugin's
@@ -206,14 +194,6 @@ class ScriptedInstaller
         }
         return $this->executeInstall();
      }
-
-    /**
-     * @since ZC v3.0.0
-     */
-    public function doPreInstall(): array
-    {
-        return $this->preInstall();
-    }
 
     /**
      * @since ZC v1.5.7

--- a/includes/classes/PluginSupport/ScriptedInstaller.php
+++ b/includes/classes/PluginSupport/ScriptedInstaller.php
@@ -112,20 +112,20 @@ class ScriptedInstaller
 
     /**
      * Optionally, return an array of additional messages and/or
-     * form-fields to be added to the Plugin Manager's "Upgrade"
+     * form-fields to be added to the Plugin Manager's "Confirm Upgrade"
      * verification form.
      *
      * @param string $oldVersion
      * @return array
      * @since ZC v3.0.0
      */
-    protected function preUpgrade(string $oldVersion): array
+    protected function preConfirmUpgrade(string $oldVersion): array
     {
         return [];
     }
 
     /**
-     * Optionally, check any form-fields supplied by the preUpgrade
+     * Optionally, check any form-fields supplied by the preConfirmUpgrade
      * method.  Gives the installer a means to disallow the upgrade.
      * Returns a boolean indication whether (true) or not (false) the plugin's
      * upgrade should proceed.
@@ -134,7 +134,7 @@ class ScriptedInstaller
      * @return bool
      * @since ZC v3.0.0
      */
-    protected function validateUpgrade(string $oldVersion): bool
+    protected function validateConfirmUpgrade(string $oldVersion): bool
     {
         return true;
     }
@@ -272,9 +272,9 @@ class ScriptedInstaller
      * @return array
      * @since ZC v3.0.0
      */
-    public function doPreUpgrade(string $oldVersion): array
+    public function doPreConfirmUpgrade(string $oldVersion): array
     {
-        return $this->preUpgrade($oldVersion);
+        return $this->preConfirmUpgrade($oldVersion);
     }
 
     /**

--- a/includes/classes/PluginSupport/ScriptedInstaller.php
+++ b/includes/classes/PluginSupport/ScriptedInstaller.php
@@ -26,7 +26,7 @@ class ScriptedInstaller
     {
     }
 
-    /***** THESE ARE THE 3 METHODS FOR IMPLEMENTATION IN EXTENDED CLASSES *********/
+    /***** START: METHODS FOR IMPLEMENTATION IN EXTENDED CLASSES *********/
     /***** There is no need to implement any other methods in extended classes ****/
 
     /**
@@ -34,6 +34,33 @@ class ScriptedInstaller
      * @since ZC v1.5.7
      */
     protected function executeInstall()
+    {
+        return true;
+    }
+
+    /**
+     * Optionally, return an array of additional messages and/or
+     * form-fields to be added to the Plugin Manager's "Install"
+     * verification form.
+     *
+     * @return array
+     * @since ZC v3.0.0
+     */
+    protected function preInstall(): array
+    {
+        return [];
+    }
+
+    /**
+     * Optionally, check any form-fields supplied by the preInstall
+     * method.  Gives the installer a means to disallow the installation.
+     * Returns a boolean indication whether (true) or not (false) the plugin's
+     * installation should proceed.
+     *
+     * @return bool
+     * @since ZC v3.0.0
+     */
+    protected function validateInstall(): bool
     {
         return true;
     }
@@ -48,6 +75,33 @@ class ScriptedInstaller
     }
 
     /**
+     * Optionally, return an array of additional messages and/or
+     * form-fields to be added to the Plugin Manager's "UnInstall"
+     * verification form.
+     *
+     * @return array
+     * @since ZC v3.0.0
+     */
+    protected function preUninstall(): array
+    {
+        return [];
+    }
+
+    /**
+     * Optionally, check any form-fields supplied by the preUninstall
+     * method.  Gives the installer a means to disallow the un-installation.
+     * Returns a boolean indication whether (true) or not (false) the plugin's
+     * un-installation should proceed.
+     *
+     * @return bool
+     * @since ZC v3.0.0
+     */
+    protected function validateUninstall(): bool
+    {
+        return true;
+    }
+
+    /**
      * @return bool
      * @since ZC v1.5.8
      */
@@ -56,8 +110,94 @@ class ScriptedInstaller
         return true;
     }
 
+    /**
+     * Optionally, return an array of additional messages and/or
+     * form-fields to be added to the Plugin Manager's "Upgrade"
+     * verification form.
+     *
+     * @param string $oldVersion
+     * @return array
+     * @since ZC v3.0.0
+     */
+    protected function preUpgrade(string $oldVersion): array
+    {
+        return [];
+    }
+
+    /**
+     * Optionally, check any form-fields supplied by the preUpgrade
+     * method.  Gives the installer a means to disallow the upgrade.
+     * Returns a boolean indication whether (true) or not (false) the plugin's
+     * upgrade should proceed.
+     *
+     * @param string $oldVersion
+     * @return bool
+     * @since ZC v3.0.0
+     */
+    protected function validateUpgrade(string $oldVersion): bool
+    {
+        return true;
+    }
+
+    /**
+     * Optionally, return an array of additional messages and/or
+     * form-fields to be added to the Plugin Manager's "Enable"
+     * verification form.
+     *
+     * @return array
+     * @since ZC v3.0.0
+     */
+    protected function preEnable(): array
+    {
+        return [];
+    }
+
+    /**
+     * Optionally, check any form-fields supplied by the preEnable
+     * method.  Gives the installer a means to disallow the enablement.
+     * Returns a boolean indication whether (true) or not (false) the plugin's
+     * enablement should proceed.
+     *
+     * @return bool
+     * @since ZC v3.0.0
+     */
+    protected function validateEnable(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Optionally, return an array of additional messages and/or
+     * form-fields to be added to the Plugin Manager's "Disable"
+     * verification form.
+     *
+     * @return array
+     * @since ZC v3.0.0
+     */
+    protected function preDisable(): array
+    {
+        return [];
+    }
+
+    /**
+     * Optionally, check any form-fields supplied by the preDisable
+     * method.  Gives the installer a means to disallow the disabling of the plugin.
+     * Returns a boolean indication whether (true) or not (false) the plugin's
+     * disable-action should proceed.
+     *
+     * @return bool
+     * @since ZC v3.0.0
+     */
+    protected function validateDisable(): bool
+    {
+        return true;
+    }
+
+    /***** END: METHODS FOR IMPLEMENTATION IN EXTENDED CLASSES *********/
+
     /******** Internal methods ***********/
     /**
+     * @param array $versionDetails
      * @since ZC v2.1.0
      */
     public function setVersionDetails(array $versionDetails): void
@@ -73,8 +213,19 @@ class ScriptedInstaller
      */
     public function doInstall(): ?bool
     {
-        $installed = $this->executeInstall();
-        return $installed;
+        if ($this->validateInstall() === false) {
+            return false;
+        }
+        return $this->executeInstall();
+     }
+
+    /**
+     * @return array
+     * @since ZC v3.0.0
+     */
+    public function doPreInstall(): array
+    {
+        return $this->preInstall();
     }
 
     /**
@@ -82,9 +233,23 @@ class ScriptedInstaller
      */
     public function doUninstall(): ?bool
     {
+        if ($this->validateUninstall() === false) {
+            return false;
+        }
         $uninstalled = $this->executeUninstall();
-        $this->uninstallZenCoreDbFields();
+        if ($uninstalled === true) {
+            $this->uninstallZenCoreDbFields();
+        }
         return $uninstalled;
+    }
+
+    /**
+     * @return array
+     * @since ZC v3.0.0
+     */
+    public function doPreUninstall(): array
+    {
+        return $this->preUninstall();
     }
 
     /**
@@ -92,12 +257,65 @@ class ScriptedInstaller
      */
     public function doUpgrade($oldVersion): ?bool
     {
+        if ($this->validateUpgrade($oldVersion) === false) {
+            return false;
+        }
         $upgraded = $this->executeUpgrade($oldVersion);
-        $this->updateZenCoreDbFields($oldVersion);
+        if ($upgraded === true) {
+            $this->updateZenCoreDbFields($oldVersion);
+        }
         return $upgraded;
     }
 
     /**
+     * @param string $oldVersion
+     * @return array
+     * @since ZC v3.0.0
+     */
+    public function doPreUpgrade(string $oldVersion): array
+    {
+        return $this->preUpgrade($oldVersion);
+    }
+
+    /**
+     * @return bool
+     * @since ZC v3.0.0
+     */
+    public function doEnable(): bool
+    {
+        return $this->validateEnable();
+    }
+
+    /**
+     * @return array
+     * @since ZC v3.0.0
+     */
+    public function doPreEnable(): array
+    {
+        return $this->preEnable();
+    }
+
+    /**
+     * @return bool
+     * @since ZC v3.0.0
+     */
+    public function doDisable(): bool
+    {
+        return $this->validateDisable();
+    }
+
+    /**
+     * @return array
+     * @since ZC v3.0.0
+     */
+    public function doPreDisable(): array
+    {
+        return $this->preDisable();
+    }
+
+    /**
+     * @param string $sql
+     * @return bool
      * @since ZC v1.5.7
      */
     protected function executeInstallerSql($sql): bool
@@ -123,6 +341,9 @@ class ScriptedInstaller
      * If a file-name is identified as '*.*', then **ALL** files and sub-directories
      * as well as the upper, keyed, directory are removed.
      *
+     * @param array $files_to_remove
+     * @param string $context
+     * @return bool
      * @since ZC v3.0.0
      */
     protected function removeFiles(array $files_to_remove, string $context): bool
@@ -170,7 +391,9 @@ class ScriptedInstaller
      *
      * Returns a boolean indication as to whether (true) or not (false) all files
      * and sub-directories were removed.
-     * 
+     *
+     * @param string $dir_name
+     * @return bool
      * @since ZC v3.0.0
      */
     protected function removeDirectoryAndFilesRecursive(string $dir_name): bool

--- a/includes/classes/PluginSupport/ScriptedInstaller.php
+++ b/includes/classes/PluginSupport/ScriptedInstaller.php
@@ -134,7 +134,7 @@ class ScriptedInstaller
      * @return bool
      * @since ZC v3.0.0
      */
-    protected function validateConfirmUpgrade(string $oldVersion): bool
+    protected function validateUpgrade(string $oldVersion): bool
     {
         return true;
     }

--- a/includes/classes/PluginSupport/ScriptedInstaller.php
+++ b/includes/classes/PluginSupport/ScriptedInstaller.php
@@ -43,7 +43,6 @@ class ScriptedInstaller
      * form-fields to be added to the Plugin Manager's "Install"
      * verification form.
      *
-     * @return array
      * @since ZC v3.0.0
      */
     protected function preInstall(): array
@@ -57,7 +56,6 @@ class ScriptedInstaller
      * Returns a boolean indication whether (true) or not (false) the plugin's
      * installation should proceed.
      *
-     * @return bool
      * @since ZC v3.0.0
      */
     protected function validateInstall(): bool
@@ -79,7 +77,6 @@ class ScriptedInstaller
      * form-fields to be added to the Plugin Manager's "UnInstall"
      * verification form.
      *
-     * @return array
      * @since ZC v3.0.0
      */
     protected function preUninstall(): array
@@ -93,7 +90,6 @@ class ScriptedInstaller
      * Returns a boolean indication whether (true) or not (false) the plugin's
      * un-installation should proceed.
      *
-     * @return bool
      * @since ZC v3.0.0
      */
     protected function validateUninstall(): bool
@@ -115,11 +111,9 @@ class ScriptedInstaller
      * form-fields to be added to the Plugin Manager's "Confirm Upgrade"
      * verification form.
      *
-     * @param string $oldVersion
-     * @return array
      * @since ZC v3.0.0
      */
-    protected function preConfirmUpgrade(string $oldVersion): array
+    protected function preConfirmUpgrade(string $version, string $oldVersion): array
     {
         return [];
     }
@@ -130,8 +124,6 @@ class ScriptedInstaller
      * Returns a boolean indication whether (true) or not (false) the plugin's
      * upgrade should proceed.
      *
-     * @param string $oldVersion
-     * @return bool
      * @since ZC v3.0.0
      */
     protected function validateUpgrade(string $oldVersion): bool
@@ -144,7 +136,6 @@ class ScriptedInstaller
      * form-fields to be added to the Plugin Manager's "Enable"
      * verification form.
      *
-     * @return array
      * @since ZC v3.0.0
      */
     protected function preEnable(): array
@@ -158,7 +149,6 @@ class ScriptedInstaller
      * Returns a boolean indication whether (true) or not (false) the plugin's
      * enablement should proceed.
      *
-     * @return bool
      * @since ZC v3.0.0
      */
     protected function validateEnable(): bool
@@ -171,7 +161,6 @@ class ScriptedInstaller
      * form-fields to be added to the Plugin Manager's "Disable"
      * verification form.
      *
-     * @return array
      * @since ZC v3.0.0
      */
     protected function preDisable(): array
@@ -185,7 +174,6 @@ class ScriptedInstaller
      * Returns a boolean indication whether (true) or not (false) the plugin's
      * disable-action should proceed.
      *
-     * @return bool
      * @since ZC v3.0.0
      */
     protected function validateDisable(): bool
@@ -220,7 +208,6 @@ class ScriptedInstaller
      }
 
     /**
-     * @return array
      * @since ZC v3.0.0
      */
     public function doPreInstall(): array
@@ -244,7 +231,6 @@ class ScriptedInstaller
     }
 
     /**
-     * @return array
      * @since ZC v3.0.0
      */
     public function doPreUninstall(): array
@@ -268,17 +254,14 @@ class ScriptedInstaller
     }
 
     /**
-     * @param string $oldVersion
-     * @return array
      * @since ZC v3.0.0
      */
-    public function doPreConfirmUpgrade(string $oldVersion): array
+    public function doPreConfirmUpgrade(string $version, string $oldVersion): array
     {
-        return $this->preConfirmUpgrade($oldVersion);
+        return $this->preConfirmUpgrade($version, $oldVersion);
     }
 
     /**
-     * @return bool
      * @since ZC v3.0.0
      */
     public function doEnable(): bool
@@ -287,7 +270,6 @@ class ScriptedInstaller
     }
 
     /**
-     * @return array
      * @since ZC v3.0.0
      */
     public function doPreEnable(): array
@@ -296,7 +278,6 @@ class ScriptedInstaller
     }
 
     /**
-     * @return bool
      * @since ZC v3.0.0
      */
     public function doDisable(): bool
@@ -305,7 +286,6 @@ class ScriptedInstaller
     }
 
     /**
-     * @return array
      * @since ZC v3.0.0
      */
     public function doPreDisable(): array
@@ -341,9 +321,6 @@ class ScriptedInstaller
      * If a file-name is identified as '*.*', then **ALL** files and sub-directories
      * as well as the upper, keyed, directory are removed.
      *
-     * @param array $files_to_remove
-     * @param string $context
-     * @return bool
      * @since ZC v3.0.0
      */
     protected function removeFiles(array $files_to_remove, string $context): bool
@@ -392,8 +369,6 @@ class ScriptedInstaller
      * Returns a boolean indication as to whether (true) or not (false) all files
      * and sub-directories were removed.
      *
-     * @param string $dir_name
-     * @return bool
      * @since ZC v3.0.0
      */
     protected function removeDirectoryAndFilesRecursive(string $dir_name): bool

--- a/includes/classes/PluginSupport/ScriptedInstaller.php
+++ b/includes/classes/PluginSupport/ScriptedInstaller.php
@@ -39,8 +39,7 @@ class ScriptedInstaller
     }
 
     /**
-     * Optionally, check any form-fields supplied by the preInstall
-     * method.  Gives the installer a means to disallow the installation.
+     * Optional, gives the installer a means to disallow the installation.
      * Returns a boolean indication whether (true) or not (false) the plugin's
      * installation should proceed.
      *

--- a/includes/classes/ViewBuilders/PluginManagerController.php
+++ b/includes/classes/ViewBuilders/PluginManagerController.php
@@ -369,7 +369,7 @@ class PluginManagerController extends BaseController
         );
 
         $installer = $this->installerFactory->make($this->currentFieldValue('unique_key'), $this->request->input('version'));
-        $additional_content = $installer->processPreConfirmUpgrade($this->currentFieldValue('unique_key'), $this->request->input('version'));
+        $additional_content = $installer->processPreConfirmUpgrade($this->currentFieldValue('unique_key'), $this->request->input('version'), $this->currentFieldValue('version'));
         foreach ($additional_content as $content) {
             $this->setBoxContent($content);
         }

--- a/includes/classes/ViewBuilders/PluginManagerController.php
+++ b/includes/classes/ViewBuilders/PluginManagerController.php
@@ -179,6 +179,12 @@ class PluginManagerController extends BaseController
             );
         }
 
+        $installer = $this->installerFactory->make($unique_key, $firstKey);
+        $additional_content = $installer->processPreInstall($unique_key, $firstKey);
+        foreach ($additional_content as $content) {
+            $this->setBoxContent($content);
+        }
+
         $this->setBoxContent(
             '<br><button type="submit" class="btn btn-primary">'
             . TEXT_INSTALL . '</button> <a href="' . zen_href_link(
@@ -201,8 +207,11 @@ class PluginManagerController extends BaseController
                 )
             );
         }
-        $installer = $this->installerFactory->make($this->currentFieldValue('unique_key'), $this->request->input('version'));
-        $installed = $installer->processInstall($this->currentFieldValue('unique_key'), $this->request->input('version'));
+
+        $unique_key = $this->currentFieldValue('unique_key');
+        $version = $this->request->input('version');
+        $installer = $this->installerFactory->make($unique_key, $version);
+        $installed = $installer->processInstall($unique_key, $version);
         if (!$installed) {
             $this->outputMessageList($installer->getErrorContainer()->getFriendlyErrors(), 'error');
             zen_redirect(
@@ -226,7 +235,9 @@ class PluginManagerController extends BaseController
      */
     protected function processActionUninstall(): void
     {
-        $this->setBoxHeader('<h4>' . zen_lookup_admin_menu_language_override('plugin_name', $this->currentFieldValue('unique_key'), $this->currentFieldValue('name')) . '</h4>');
+        $unique_key = $this->currentFieldValue('unique_key');
+        $version = $this->currentFieldValue('version');
+        $this->setBoxHeader('<h4>' . zen_lookup_admin_menu_language_override('plugin_name', $unique_key, $this->currentFieldValue('name')) . '</h4>');
         $this->setBoxForm(
             zen_draw_form(
                 'pluginuninstall',
@@ -234,9 +245,16 @@ class PluginManagerController extends BaseController
                 $this->pageLink() . '&' . $this->colKeyLink() . '&action=doUninstall',
                 'post',
                 'class="form-horizontal"'
-            ) . zen_draw_hidden_field('version', $this->currentFieldValue('version'))
+            ) . zen_draw_hidden_field('version', $version)
         );
         $this->setBoxContent('<br>' . TEXT_CONFIRM_UNINSTALL . '<br>');
+
+        $installer = $this->installerFactory->make($unique_key, $version);
+        $additional_content = $installer->processPreUninstall($unique_key, $version);
+        foreach ($additional_content as $content) {
+            $this->setBoxContent($content);
+        }
+
         $this->setBoxContent(
             '<br><button type="submit" class="btn btn-danger">'
             . TEXT_UNINSTALL . '</button> <a href="' . zen_href_link(
@@ -294,8 +312,9 @@ class PluginManagerController extends BaseController
                 )
             );
         }
+        $unique_key = $this->currentFieldValue('unique_key');
         $versions = $this->pluginManager->getVersionsForUpgrade($this->currentFieldValue('unique_key'), $this->currentFieldValue('version'));
-        $this->setBoxHeader('<h4>' . zen_lookup_admin_menu_language_override('plugin_name', $this->currentFieldValue('unique_key'), $this->currentFieldValue('name')) . '</h4>');
+        $this->setBoxHeader('<h4>' . zen_lookup_admin_menu_language_override('plugin_name', $unique_key, $this->currentFieldValue('name')) . '</h4>');
         $this->setBoxForm(zen_draw_form('pluginupgrade', FILENAME_PLUGIN_MANAGER, $this->pageLink() . '&' . $this->colKeyLink() . '&action=confirmUpgrade', 'post', 'class="form-horizontal"'));
         $this->setBoxContent('<br>' . TEXT_INFO_UPGRADE . '<br>');
         $firstKey = key($versions);
@@ -303,6 +322,13 @@ class PluginManagerController extends BaseController
             $checked = ($version == $firstKey);
             $this->setBoxContent('<br><label class="radio-inline">' . zen_draw_radio_field('version', $version, $checked) . $version);
         }
+
+        $installer = $this->installerFactory->make($unique_key, $firstKey);
+        $additional_content = $installer->processPreUpgrade($unique_key, $firstKey);
+        foreach ($additional_content as $content) {
+            $this->setBoxContent($content);
+        }
+
         $this->setBoxContent(
             '<br><button type="submit" class="btn btn-primary">'
             . TEXT_UPGRADE . '</button> <a href="' . zen_href_link(
@@ -347,6 +373,13 @@ class PluginManagerController extends BaseController
         $this->setBoxContent(
             '<br>' . TEXT_CONFIRM_UPGRADE . '<br>' . sprintf(TEXT_INFO_UPGRADE_CONFIRM, $this->request->input('version')) . '<br><br>' . TEXT_INFO_UPGRADE_WARNING
         );
+
+        $installer = $this->installerFactory->make($this->currentFieldValue('unique_key'), $this->request->input('version'));
+        $additional_content = $installer->processPreConfirmUpgrade($this->currentFieldValue('unique_key'), $this->request->input('version'));
+        foreach ($additional_content as $content) {
+            $this->setBoxContent($content);
+        }
+
         $this->setBoxContent(
             '<br><button type="submit" class="btn btn-primary">'
             . TEXT_UPGRADE . '</button> <a href="' . zen_href_link(
@@ -473,7 +506,7 @@ class PluginManagerController extends BaseController
                 )
             );
         }
-        $error = "";
+        $error = '';
         foreach ($this->request->input('version') as $version) {
             $path = DIR_FS_CATALOG . 'zc_plugins/' . $this->currentFieldValue('unique_key') . '/' . $version;
             (new FileSystem())->deleteDirectory($path);
@@ -481,7 +514,7 @@ class PluginManagerController extends BaseController
                 $error .= " :" . $path;
             }
         }
-        if ($error === "") {
+        if ($error === '') {
             $this->messageStack->add_session(TEXT_CLEANUP_SUCCESS, 'success');
         } else {
             $this->messageStack->add_session(TEXT_CLEANUP_ERROR . $error, 'error');
@@ -505,6 +538,13 @@ class PluginManagerController extends BaseController
                 'class="form-horizontal"'
             ) . zen_draw_hidden_field('version', $this->currentFieldValue('version')));
         $this->setBoxContent('<br>' . TEXT_CONFIRM_ENABLE . '<br>');
+
+        $installer = $this->installerFactory->make($this->currentFieldValue('unique_key'), $this->currentFieldValue('version'));
+        $additional_content = $installer->processPreEnable($this->currentFieldValue('unique_key'), $this->currentFieldValue('version'));
+        foreach ($additional_content as $content) {
+            $this->setBoxContent($content);
+        }
+
         $this->setBoxContent(
             '<br><button type="submit" class="btn btn-primary">'
             . TEXT_ENABLE . '</button> <a href="' . zen_href_link(
@@ -528,7 +568,17 @@ class PluginManagerController extends BaseController
             );
         }
         $installer = $this->installerFactory->make($this->currentFieldValue('unique_key'), $this->request->input('version'));
-        $installer->processEnable($this->currentFieldValue('unique_key'), $this->request->input('version'));
+        $enabled = $installer->processEnable($this->currentFieldValue('unique_key'), $this->request->input('version'));
+        if (!$enabled) {
+            $this->outputMessageList($installer->getErrorContainer()->getFriendlyErrors(), 'error');
+            zen_redirect(
+                zen_href_link(
+                    FILENAME_PLUGIN_MANAGER,
+                    $this->pageLink() . '&' . $this->colKeyLink()
+                )
+            );
+        }
+
         $this->notify('NOTIFY_PLUGINMANAGER_DO_ENABLE', ['plugin_key' => $this->currentFieldValue('unique_key'), 'version' => $this->request->input('version')]);
 
         $this->messageStack->add_session(TEXT_ENABLE_SUCCESS, 'success');
@@ -554,6 +604,13 @@ class PluginManagerController extends BaseController
                 'class="form-horizontal"'
             ) . zen_draw_hidden_field('version', $this->currentFieldValue('version')));
         $this->setBoxContent('<br>' . TEXT_CONFIRM_DISABLE . '<br>');
+
+        $installer = $this->installerFactory->make($this->currentFieldValue('unique_key'), $this->currentFieldValue('version'));
+        $additional_content = $installer->processPreDisable($this->currentFieldValue('unique_key'), $this->currentFieldValue('version'));
+        foreach ($additional_content as $content) {
+            $this->setBoxContent($content);
+        }
+
         $this->setBoxContent(
             '<br><button type="submit" class="btn btn-danger">'
             . TEXT_DISABLE . '</button> <a href="' . zen_href_link(
@@ -572,7 +629,17 @@ class PluginManagerController extends BaseController
             zen_redirect(zen_href_link(FILENAME_PLUGIN_MANAGER, $this->pageLink() . '&' . $this->colKeyLink()));
         }
         $installer = $this->installerFactory->make($this->currentFieldValue('unique_key'), $this->request->input('version'));
-        $installer->processDisable($this->currentFieldValue('unique_key'), $this->request->input('version'));
+        $disabled = $installer->processDisable($this->currentFieldValue('unique_key'), $this->request->input('version'));
+        if (!$disabled) {
+            $this->outputMessageList($installer->getErrorContainer()->getFriendlyErrors(), 'error');
+            zen_redirect(
+                zen_href_link(
+                    FILENAME_PLUGIN_MANAGER,
+                    $this->pageLink() . '&' . $this->colKeyLink()
+                )
+            );
+        }
+
         $this->notify('NOTIFY_PLUGINMANAGER_DO_DISABLE', ['plugin_key' => $this->currentFieldValue('unique_key'), 'version' => $this->request->input('version')]);
 
         $this->messageStack->add_session(TEXT_DISABLE_SUCCESS, 'success');

--- a/includes/classes/ViewBuilders/PluginManagerController.php
+++ b/includes/classes/ViewBuilders/PluginManagerController.php
@@ -323,12 +323,6 @@ class PluginManagerController extends BaseController
             $this->setBoxContent('<br><label class="radio-inline">' . zen_draw_radio_field('version', $version, $checked) . $version);
         }
 
-        $installer = $this->installerFactory->make($unique_key, $firstKey);
-        $additional_content = $installer->processPreUpgrade($unique_key, $firstKey);
-        foreach ($additional_content as $content) {
-            $this->setBoxContent($content);
-        }
-
         $this->setBoxContent(
             '<br><button type="submit" class="btn btn-primary">'
             . TEXT_UPGRADE . '</button> <a href="' . zen_href_link(

--- a/includes/classes/ViewBuilders/PluginManagerController.php
+++ b/includes/classes/ViewBuilders/PluginManagerController.php
@@ -179,12 +179,6 @@ class PluginManagerController extends BaseController
             );
         }
 
-        $installer = $this->installerFactory->make($unique_key, $firstKey);
-        $additional_content = $installer->processPreInstall($unique_key, $firstKey);
-        foreach ($additional_content as $content) {
-            $this->setBoxContent($content);
-        }
-
         $this->setBoxContent(
             '<br><button type="submit" class="btn btn-primary">'
             . TEXT_INSTALL . '</button> <a href="' . zen_href_link(


### PR DESCRIPTION
Enable an encapsulated plugin's `ScriptedInstaller.php` to have some control (and additional checking) on the install, uninstall, upgrade, disable and enable actions provided by the admin's "Plugin Manager.

Updated, including the zip-file that contains the `zc_plugins` directory/files used to validate the flow and actions.

[TestPluginAdditions.zip](https://github.com/user-attachments/files/26570217/TestPluginAdditions.zip)

