### PR TITLE
fix checks on modern header

### DIFF
--- a/admin/includes/header.php
+++ b/admin/includes/header.php
@@ -132,7 +132,7 @@ foreach ($upperMenuArray as $menuItem) {
                     </li>
                     <?php } ?>
 
-                    <?php if (false && zen_is_superuser() || check_page(FILENAME_CUSTOMERS, '')) { ?>
+                    <?php if (zen_is_superuser() || check_page(FILENAME_CUSTOMERS, '')) { ?>
                     <li class="hidden-xs">
                         <?= zen_draw_form('customer_search', FILENAME_CUSTOMERS, '', 'get', 'class="navbar-form"', true); ?>
                         <div class="form-group header-search">
@@ -142,7 +142,7 @@ foreach ($upperMenuArray as $menuItem) {
                     </li>
                     <?php } ?>
 
-                    <?php if (false && zen_is_superuser() || check_page(FILENAME_CATEGORY_PRODUCT_LISTING, '')) { ?>
+                    <?php if (zen_is_superuser() || check_page(FILENAME_CATEGORY_PRODUCT_LISTING, '')) { ?>
                     <li class="hidden-xs">
                         <?= zen_draw_form('goto', FILENAME_CATEGORY_PRODUCT_LISTING, '', 'get', 'class="navbar-form"') ?>
                         <div class="form-group header-search goto-category">
@@ -227,7 +227,8 @@ foreach ($upperMenuArray as $menuItem) {
                             <?php if (!empty($plugin_menu_items)) { ?>
                                 <li class="divider"></li>
                                 <?php foreach ($plugin_menu_items as $item) { ?>
-                                <li <?= $item['id'] ? 'id="' . $item['id'] . '"' : '' ?>  <?= $item['li-class'] ? 'class="' . $item['li-class'] . '"' : '' ?>><a href="<?= $item['a'] ?>" <?= $item['params'] ?? '' ?>><i class="fa <?= $item['icon'] ?? 'fa-plug' ?>"></i> <?= $item['title'] ?></a></li>
+                                <li <?= !empty($item['id']) ? 'id="' . $item['id'] . '"' : '' ?>  <?= !empty($item['li-class']) ? 'class="' . $item['li-class'] . '"' : '' ?>><a href="<?= $item['a'] ?>"
+                                        <?= $item['params'] ?? '' ?>><i class="fa <?= $item['icon'] ?? 'fa-plug' ?>"></i> <?= $item['title'] ?></a></li>
                                 <?php } ?>
                             <?php } ?>
 


### PR DESCRIPTION
`li-class` and `id` were previously not required in the override.  the current checks result in an error.

i do not know why the `false` check was there.  i can only assume it was for testing purposes, as being logged in as a superuser also results in an error.

```
#0 [internal function]: zen_debug_error_handler()
#1 /var/www/zcdev/admin/includes/functions/admin_access.php(63): preg_replace()
#2 /var/www/zcdev/admin/includes/header.php(135): check_page()
#3 /var/www/zcdev/admin/index_dashboard.php(179): require('...')
#4 /var/www/zcdev/admin/home.php(27): require('...')
#5 /var/www/zcdev/admin/index.php(16): require('...')
--> PHP Deprecated: preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /var/www/zcdev/admin/includes/functions/admin_access.php on line 63.
```

```
[08-Apr-2026 22:47:48 UTC] Request URI: /admin/, IP address: 192.168.14.72, Language id 1
#0 /var/www/zcdev/admin/includes/header.php(230): zen_debug_error_handler()
#1 /var/www/zcdev/admin/index_dashboard.php(179): require('...')
#2 /var/www/zcdev/admin/home.php(27): require('...')
#3 /var/www/zcdev/admin/index.php(16): require('...')
--> PHP Warning: Undefined array key "id" in /var/www/zcdev/admin/includes/header.php on line 230.

[08-Apr-2026 22:47:48 UTC] Request URI: /admin/, IP address: 192.168.14.72, Language id 1
#0 /var/www/zcdev/admin/includes/header.php(230): zen_debug_error_handler()
#1 /var/www/zcdev/admin/index_dashboard.php(179): require('...')
#2 /var/www/zcdev/admin/home.php(27): require('...')
#3 /var/www/zcdev/admin/index.php(16): require('...')
--> PHP Warning: Undefined array key "li-class" in /var/www/zcdev/admin/includes/header.php on line 230.
``` 