### PR TITLE
Correct missing directory-separator ...

### DIFF
--- a/includes/classes/ResourceLoaders/LanguageLoader.php
+++ b/includes/classes/ResourceLoaders/LanguageLoader.php
@@ -135,7 +135,7 @@ class LanguageLoader
             $moduleType .= '/';
         }
         $match_string = 'modules/' . $moduleType . 'lang.' . $fileName;
-        $match_string_template = 'modules/' . $moduleType . $this->arrayLoader->getTemplateDir() . 'lang.' . $fileName;
+        $match_string_template = 'modules/' . $moduleType . $this->arrayLoader->getTemplateDir() . '/lang.' . $fileName;
         foreach ($language_files_loaded as $next_file) {
             if (str_contains($next_file, $match_string) || str_contains($next_file, $match_string_template)) {
                 return true;


### PR DESCRIPTION
The `getTemplateDir` method's return doesn't end in a directory-separator, so add one!

The issue is only exposed if (for some reason) a 'module' language file is present **only** in the template override directory.