### PR TITLE
Correct missing var on modal addl images

### DIFF
--- a/includes/templates/responsive_classic/modalboxes/tpl_image_additional.php
+++ b/includes/templates/responsive_classic/modalboxes/tpl_image_additional.php
@@ -28,11 +28,11 @@
 <!-- Thumbnail for additional image -->
 <div class="back">
     <a id="<?= $modal_link_id ?>"
-       href="<?= htmlspecialchars($large_image, ENT_QUOTES, 'UTF-8'); ?>"
+       href="<?= htmlspecialchars($image['products_image_large'], ENT_QUOTES, 'UTF-8'); ?>"
        onclick="openModal('<?= $modal_id ?>'); return false;"
        title="<?= htmlspecialchars(TEXT_CLICK_TO_ENLARGE . ' ' . $image['products_name'], ENT_QUOTES, 'UTF-8'); ?>">
-       
+
         <?= $modal_link_img; ?>
-        
+
     </a>
 </div>

--- a/includes/templates/template_default/modalboxes/tpl_image_additional.php
+++ b/includes/templates/template_default/modalboxes/tpl_image_additional.php
@@ -28,11 +28,11 @@
 <!-- Thumbnail for additional image -->
 <div class="back">
     <a id="<?= $modal_link_id ?>"
-       href="<?= htmlspecialchars($large_image, ENT_QUOTES, 'UTF-8'); ?>"
+       href="<?= htmlspecialchars($image['products_image_large'], ENT_QUOTES, 'UTF-8'); ?>"
        onclick="openModal('<?= $modal_id ?>'); return false;"
        title="<?= htmlspecialchars(TEXT_CLICK_TO_ENLARGE . ' ' . $image['products_name'], ENT_QUOTES, 'UTF-8'); ?>">
-       
+
         <?= $modal_link_img; ?>
-        
+
     </a>
 </div>


### PR DESCRIPTION
Fixes #7624 which is a bug introduced in https://github.com/zencart/zencart/pull/7567

Noting, also, that the `responsive_classic/modalboxes` files are an exact copy of those in `template_default/modalboxes`.