### PR TITLE
Drop unused PROJECT_VERSION_PATCH constants

### DIFF
--- a/admin/home.php
+++ b/admin/home.php
@@ -50,7 +50,7 @@ if (!empty($new_version)) { ?>
     <script>
         jQuery(function($){
             let newVersion = <?php echo json_encode($new_version); ?>;
-            let versionInfo = <?php echo json_encode('(' . TEXT_CURRENT_VER_IS . ' v' . PROJECT_VERSION_MAJOR . '.' . PROJECT_VERSION_MINOR . (PROJECT_VERSION_PATCH1 != '' ? 'p' . PROJECT_VERSION_PATCH1 : '') . ')'); ?>;
+            let versionInfo = <?php echo json_encode('(' . TEXT_CURRENT_VER_IS . ' v' . PROJECT_VERSION_MAJOR . '.' . PROJECT_VERSION_MINOR . ')'); ?>;
             let $target1 = $('#versionCheckAlert');
             if ($target1.length) {
                 $target1.html(newVersion);

--- a/admin/includes/classes/VersionServer.php
+++ b/admin/includes/classes/VersionServer.php
@@ -108,6 +108,14 @@ class VersionServer
     }
 
     /**
+     * This method checks the major and minor version numbers to determine if the project is current.
+     *
+     * Since v2.0.0, Zen Cart follows semantic versioning.
+     * But the version number is split across 2 constants: PROJECT_VERSION_MAJOR and PROJECT_VERSION_MINOR.
+     * PROJECT_VERSION_MAJOR is always the first digit(s) of the version number.
+     * PROJECT_VERSION_MINOR is the second digit(s) of the version number.
+     * The 2 segments must always be paired together for thorough comparison.
+     *
      * @since ZC v1.5.5f
      */
     public function isProjectCurrent(?array $newVersionInfo = null): bool
@@ -116,11 +124,17 @@ class VersionServer
             $newVersionInfo = $this->getProjectVersion();
         }
 
+        // If major version is higher on the server than the present major version, then this site is not current. So return false immediately.
         if (trim($newVersionInfo['versionMajor'] ?? 0) > PROJECT_VERSION_MAJOR) {
             return false;
         }
 
-        if ((int)trim($newVersionInfo['versionMajor'] ?? 0) === (int)PROJECT_VERSION_MAJOR && trim($newVersionInfo['versionMinor'] ?? 0) > PROJECT_VERSION_MINOR) {
+        // Note: If the formula used here for `PROJECT_VERSION_MAJOR . '.' . PROJECT_VERSION_MINOR` changes, be sure to also update zen_get_zcversion() in functions_general_shared.php.
+
+        // Now use version_compare for a more thorough comparison with major/minor, including semantic-versioning support for pre-release identifiers such as -dev, -alpha, -beta, -rc, -pl.
+        $currentVersion = PROJECT_VERSION_MAJOR . '.' . PROJECT_VERSION_MINOR;
+        $newVersion = trim($newVersionInfo['versionMajor'] ?? 0) . '.' . trim($newVersionInfo['versionMinor'] ?? 0);
+        if (version_compare($newVersion, $currentVersion, '>')) {
             return false;
         }
 
@@ -128,23 +142,15 @@ class VersionServer
     }
 
     /**
-     * @since ZC v1.5.5f
+     * Deprecated.
+     * Note: Since semantic versioning already accommodates "pl" or "p" as a patch-level indicator, we no longer use the patch-level constants (PROJECT_VERSION_PATCH1 and PROJECT_VERSION_PATCH2).
+     *
+     * @deprecated in v3.0.0. This method is no longer used since v2.0.0, and will be removed in a future major release.
+     * @since was added to this class in ZC v1.5.5f
      */
     public function hasProjectPatches(?array $newVersionInfo = null): int
     {
-        if (empty($newVersionInfo)) {
-            $newVersionInfo = $this->getProjectVersion();
-        }
-
-        $result = 0;
-        if (isset($newVersionInfo['versionPatch1']) && trim($newVersionInfo['versionPatch1'] ?? 0) > (int)PROJECT_VERSION_PATCH1) {
-            $result++;
-        }
-        if (isset($newVersionInfo['versionPatch2']) && trim($newVersionInfo['versionPatch2'] ?? 0) > (int)PROJECT_VERSION_PATCH2) {
-            $result++;
-            $result++;
-        }
-        return $result;
+        return 0;
     }
 
     /**

--- a/admin/includes/footer.php
+++ b/admin/includes/footer.php
@@ -14,7 +14,6 @@
   $check_hist_details = $db->Execute($check_hist_query);
   if (!$check_hist_details->EOF) {
     $current_sinfo .=  'v' . $check_hist_details->fields['project_version_major'] . '.' . $check_hist_details->fields['project_version_minor'];
-    if (!empty($check_hist_details->fields['project_version_patch1'])) $current_sinfo .= '&nbsp;&nbsp;Patch: ' . $check_hist_details->fields['project_version_patch1'];
   }
 ?>
 <footer>
@@ -36,7 +35,7 @@ if (!empty($new_version)) { ?>
 <script>
     jQuery(function($){
       let newVersion = <?php echo json_encode($new_version); ?>;
-      let versionInfo = <?php echo json_encode('(' . TEXT_CURRENT_VER_IS . ' v' . PROJECT_VERSION_MAJOR . '.' . PROJECT_VERSION_MINOR . (PROJECT_VERSION_PATCH1 != '' ? 'p' . PROJECT_VERSION_PATCH1 : '') . ')'); ?>;
+      let versionInfo = <?php echo json_encode('(' . TEXT_CURRENT_VER_IS . ' v' . PROJECT_VERSION_MAJOR . '.' . PROJECT_VERSION_MINOR . ')'); ?>;
 
       let $target1 = $('#versionCheckAlert');
       if ($target1.length) {

--- a/admin/includes/header.php
+++ b/admin/includes/header.php
@@ -239,7 +239,7 @@ if (!empty($upperMenuOverrideArray) && is_array($upperMenuOverrideArray)) {
                                     <div id="versionCheckAlert"></div>
                                 </div>
                                 <div class="version-dropdown-footer" id="versionCheckFooter">
-                                    <?= TEXT_CURRENT_VER_IS . ' v' . PROJECT_VERSION_MAJOR . '.' . PROJECT_VERSION_MINOR . (PROJECT_VERSION_PATCH1 != '' ? 'p' . PROJECT_VERSION_PATCH1 : '') ?>
+                                    <?= TEXT_CURRENT_VER_IS . ' v' . PROJECT_VERSION_MAJOR . '.' . PROJECT_VERSION_MINOR ?>
                                 </div>
                             </li>
                         </ul>

--- a/admin/includes/init_includes/init_db_config_read.php
+++ b/admin/includes/init_includes/init_db_config_read.php
@@ -30,10 +30,6 @@ $projectVersionRepository = new ProjectVersionRepository($db);
 $versionInfo = $projectVersionRepository->getByKey('Zen-Cart Database');
 define('PROJECT_DB_VERSION_MAJOR', $versionInfo['project_version_major']);
 define('PROJECT_DB_VERSION_MINOR', $versionInfo['project_version_minor']);
-define('PROJECT_DB_VERSION_PATCH1', $versionInfo['project_version_patch1']);
-define('PROJECT_DB_VERSION_PATCH2', $versionInfo['project_version_patch2']);
-define('PROJECT_DB_VERSION_PATCH1_SOURCE', $versionInfo['project_version_patch1_source']);
-define('PROJECT_DB_VERSION_PATCH2_SOURCE', $versionInfo['project_version_patch2_source']);
 
 $productTypeLayoutRepository = new ProductTypeLayoutRepository($db);
 $productTypeLayoutRepository->loadConfigSettings();

--- a/admin/includes/versioncheck.php
+++ b/admin/includes/versioncheck.php
@@ -44,7 +44,6 @@ if (file_exists($skip_file) && $lines = @file($skip_file)) {
 
 $doVersionCheck = false;
 $versionCheckError = false;
-$hasPatches = 0;
 
 // ignore version check if not enabled or if not on main page or sysinfo page
 if ((SHOW_VERSION_UPDATE_IN_HEADER === 'true'
@@ -68,20 +67,9 @@ if ((SHOW_VERSION_UPDATE_IN_HEADER === 'true'
     if (!$isCurrent) {
         $new_version = TEXT_VERSION_CHECK_NEW_VER . trim($newinfo['versionMajor']) . '.' . trim($newinfo['versionMinor']) . ' :: ' . $newinfo['versionDetail'];
     }
-    if ($isCurrent) {
-        $hasPatches = $versionServer->hasProjectPatches($newinfo);
-    }
 
-    if ($isCurrent && $hasPatches && $new_version === TEXT_VERSION_CHECK_CURRENT) {
+    if ($isCurrent && $new_version === TEXT_VERSION_CHECK_CURRENT) {
         $new_version = '';
-    }
-
-    // Handle patch notices
-    if ($isCurrent && $hasPatches !== 2 && $hasPatches) {
-        $new_version .= (($new_version !== '') ? '<br>' : '') . '<span class="alert">' . TEXT_VERSION_CHECK_NEW_PATCH . trim($newinfo['versionMajor']) . '.' . trim($newinfo['versionMinor']) . ' - ' . TEXT_VERSION_CHECK_PATCH . ': [' . trim($newinfo['versionPatch1']) . '] :: ' . $newinfo['versionPatchDetail'] . '</span>';
-    }
-    if ($isCurrent && $hasPatches > 1) {
-        $new_version .= (($new_version !== '') ? '<br>' : '') . '<span class="alert">' . TEXT_VERSION_CHECK_NEW_PATCH . trim($newinfo['versionMajor']) . '.' . trim($newinfo['versionMinor']) . ' - ' . TEXT_VERSION_CHECK_PATCH . ': [' . trim($newinfo['versionPatch2']) . '] :: ' . $newinfo['versionPatchDetail'] . '</span>';
     }
 
     // Prepare download link
@@ -111,7 +99,7 @@ if (!$doVersionCheck || $versionCheckError) {
 //if ($new_version) {
 //    echo $new_version;
 //    echo '<br>';
-//    echo '(' . TEXT_CURRENT_VER_IS . ' v' . PROJECT_VERSION_MAJOR . '.' . PROJECT_VERSION_MINOR . (PROJECT_VERSION_PATCH1 != '' ? 'p' . PROJECT_VERSION_PATCH1 : '') . ')';
+//    echo '(' . TEXT_CURRENT_VER_IS . ' v' . PROJECT_VERSION_MAJOR . '.' . PROJECT_VERSION_MINOR;
 //}
 //
 // In footer.php we place it into a jQuery snippet to insert into the #versionCheckAlert placeholder in the admin header.

--- a/admin/server_info.php
+++ b/admin/server_info.php
@@ -15,16 +15,11 @@
   $sinfo =  '<div class="sysinfo wrapper">' .
          '  <div class="center"><a href="https://www.zen-cart.com"><img src="images/small_zen_logo.gif" alt=" Zen Cart "></a></div>' .
          '  <div class="center"><h2> ' . PROJECT_VERSION_NAME . ' ' . PROJECT_VERSION_MAJOR . '.' . PROJECT_VERSION_MINOR . '</h2>' .
-               ((PROJECT_VERSION_PATCH1 =='') ? '' : '<h3>Patch: ' . PROJECT_VERSION_PATCH1 . '::' . PROJECT_VERSION_PATCH1_SOURCE . '</h3>') .
-               ((PROJECT_VERSION_PATCH2 =='') ? '' : '<h3>Patch: ' . PROJECT_VERSION_PATCH2 . '::' . PROJECT_VERSION_PATCH2_SOURCE . '</h3>') .
-         '     <h2> ' . PROJECT_DATABASE_LABEL . ' ' . PROJECT_DB_VERSION_MAJOR . '.' . PROJECT_DB_VERSION_MINOR . '</h2>' .
-               ((PROJECT_DB_VERSION_PATCH1 =='') ? '' : '<h3>Patch: ' . PROJECT_DB_VERSION_PATCH1 . '::' . PROJECT_DB_VERSION_PATCH1_SOURCE . '</h3>') .
-               ((PROJECT_DB_VERSION_PATCH2 =='') ? '' : '<h3>Patch: ' . PROJECT_DB_VERSION_PATCH2 . '::' . PROJECT_DB_VERSION_PATCH2_SOURCE . '</h3>') ;
+         '     <h2> ' . PROJECT_DATABASE_LABEL . ' ' . PROJECT_DB_VERSION_MAJOR . '.' . PROJECT_DB_VERSION_MINOR . '</h2>';
   $sinfo .= '  </div><div class="center">';
   $hist_query = "SELECT * from " . TABLE_PROJECT_VERSION . " WHERE project_version_key = 'Zen-Cart Main' ORDER BY project_version_date_applied DESC, project_version_major DESC, project_version_minor DESC";
   $hist_details = $db->Execute($hist_query);
       $sinfo .=  'v' . $hist_details->fields['project_version_major'] . '.' . $hist_details->fields['project_version_minor'];
-      if (isset($hist_details->fields['project_version_patch']) && zen_not_null($hist_details->fields['project_version_patch'])) $sinfo .= '&nbsp;&nbsp;Patch: ' . $hist_details->fields['project_version_patch'];
       if (isset($hist_details->fields['project_version_date_applied']) && zen_not_null($hist_details->fields['project_version_date_applied'])) $sinfo .= ' &nbsp;&nbsp;[' . $hist_details->fields['project_version_date_applied'] . '] ';
       if (isset($hist_details->fields['project_version_comment']) && !empty($hist_details->fields['project_version_comment'])) $sinfo .= ' &nbsp;&nbsp;(' . $hist_details->fields['project_version_comment'] . ')';
       $sinfo .=  '<br>';
@@ -32,7 +27,6 @@
   $hist_details = $db->Execute($hist_query);
     while (!$hist_details->EOF) {
       $sinfo .=  'v' . $hist_details->fields['project_version_major'] . '.' . $hist_details->fields['project_version_minor'];
-      if (zen_not_null($hist_details->fields['project_version_patch'])) $sinfo .= '&nbsp;&nbsp;Patch: ' . $hist_details->fields['project_version_patch'];
       if (zen_not_null($hist_details->fields['project_version_date_applied'])) $sinfo .= ' &nbsp;&nbsp;[' . $hist_details->fields['project_version_date_applied'] . '] ';
       if (!empty($hist_details->fields['project_version_comment'])) $sinfo .= ' &nbsp;&nbsp;(' . $hist_details->fields['project_version_comment'] . ')';
       $sinfo .=  '<br>';

--- a/includes/classes/DbRepositories/ProjectVersionRepository.php
+++ b/includes/classes/DbRepositories/ProjectVersionRepository.php
@@ -26,8 +26,7 @@ class ProjectVersionRepository
     {
         $projectVersionKey = $this->db->prepare_input($projectVersionKey);
         $result = $this->db->Execute(
-            "SELECT project_version_major, project_version_minor, project_version_patch1, project_version_patch2," .
-            " project_version_patch1_source, project_version_patch2_source" .
+            "SELECT project_version_major, project_version_minor" .
             " FROM " . TABLE_PROJECT_VERSION .
             " WHERE project_version_key = '" . $projectVersionKey . "' LIMIT 1"
         );

--- a/includes/functions/functions_general_shared.php
+++ b/includes/functions/functions_general_shared.php
@@ -4,12 +4,13 @@
  * @copyright Portions Copyright 2003 osCommerce
  * @license https://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: DrByte 2026 Feb 26 Modified in v2.2.1 $
- * @since ZC v1.5.7
  */
 
 /**
  * Determine the Zen Cart version currently installed.
  * @return string in format "major.minor" (eg: "2.0.0", "3.1.0")
+ *
+ * @since ZC v1.5.7
  */
 function zen_get_zcversion(): string
 {

--- a/includes/functions/functions_general_shared.php
+++ b/includes/functions/functions_general_shared.php
@@ -7,7 +7,11 @@
  * @since ZC v1.5.7
  */
 
-function zen_get_zcversion()
+/**
+ * Determine the Zen Cart version currently installed.
+ * @return string in format "major.minor" (eg: "2.0.0", "3.1.0")
+ */
+function zen_get_zcversion(): string
 {
     return PROJECT_VERSION_MAJOR . '.' . PROJECT_VERSION_MINOR;
 }

--- a/includes/version.php
+++ b/includes/version.php
@@ -16,10 +16,6 @@
 define('PROJECT_VERSION_NAME', 'Zen Cart');
 define('PROJECT_VERSION_MAJOR', '3');
 define('PROJECT_VERSION_MINOR', '0.0-dev');
-define('PROJECT_VERSION_PATCH1', '');
-define('PROJECT_VERSION_PATCH2', '');
-define('PROJECT_VERSION_PATCH1_SOURCE', '');
-define('PROJECT_VERSION_PATCH2_SOURCE', '');
 define('NEW_VERSION_CHECKUP_URL','https://ping.zen-cart.com/version_id.txt');
 define('PROJECT_VERSIONSERVER_URL', 'https://ping.zen-cart.com/zcversioncheck');
 define('PLUGIN_VERSIONSERVER_URL', 'https://ping.zen-cart.com/plugincheck');

--- a/zc_install/includes/classes/class.systemChecker.php
+++ b/zc_install/includes/classes/class.systemChecker.php
@@ -792,30 +792,6 @@ class systemChecker
         if ((trim($lines[0]) > PROJECT_VERSION_MAJOR) || (trim($lines[0]) === PROJECT_VERSION_MAJOR && trim($lines[1]) > PROJECT_VERSION_MINOR)) {
             $new_version = TEXT_VERSION_CHECK_NEW_VER . trim($lines[0]) . '.' . trim($lines[1]) . ' :: ' . $lines[2];
         }
-        //check for patch version info
-        // first confirm that we're at latest major/minor -- otherwise no need to check patches:
-        if (trim($lines[0]) === PROJECT_VERSION_MAJOR && trim($lines[1]) === PROJECT_VERSION_MINOR) {
-            //check to see if either patch needs to be applied
-            if (trim($lines[3]) > (int)PROJECT_VERSION_PATCH1 || trim($lines[4]) > (int)PROJECT_VERSION_PATCH2) {
-                // reset update message, since we WILL be advising of an available upgrade
-                if ($new_version === TEXT_VERSION_CHECK_CURRENT) {
-                    $new_version = '';
-                }
-                //check for patch #1
-                if (trim($lines[3]) > (int)PROJECT_VERSION_PATCH1) {
-                    // if ($new_version != '') $new_version .= '<br>';
-                    $new_version .= (($new_version !== '') ? '<br>' : '') .
-                        '<span class="alert">' . TEXT_VERSION_CHECK_NEW_PATCH . trim($lines[0]) . '.' . trim($lines[1]) .
-                        ' - ' . TEXT_VERSION_CHECK_PATCH . ': [' . trim($lines[3]) . '] :: ' . $lines[5] . '</span>';
-                }
-                if (trim($lines[4]) > (int)PROJECT_VERSION_PATCH2) {
-                    // if ($new_version != '') $new_version .= '<br>';
-                    $new_version .= (($new_version !== '') ? '<br>' : '') .
-                        '<span class="alert">' . TEXT_VERSION_CHECK_NEW_PATCH . trim($lines[0]) . '.' . trim($lines[1]) .
-                        ' - ' . TEXT_VERSION_CHECK_PATCH . ': [' . trim($lines[4]) . '] :: ' . $lines[5] . '</span>';
-                }
-            }
-        }
 
         $this->log('Present: ' . PROJECT_VERSION_MAJOR . '.' . PROJECT_VERSION_MINOR . '; Latest release online: ' . trim($lines[0]) . '.' . trim($lines[1]), __METHOD__, []);
 

--- a/zc_install/includes/version.php
+++ b/zc_install/includes/version.php
@@ -16,10 +16,6 @@
 define('PROJECT_VERSION_NAME', 'Zen Cart');
 define('PROJECT_VERSION_MAJOR', '3');
 define('PROJECT_VERSION_MINOR', '0.0');
-define('PROJECT_VERSION_PATCH1', '');
-define('PROJECT_VERSION_PATCH2', '');
-define('PROJECT_VERSION_PATCH1_SOURCE', '');
-define('PROJECT_VERSION_PATCH2_SOURCE', '');
 define('NEW_VERSION_CHECKUP_URL','https://ping.zen-cart.com/version_id.txt');
 define('PROJECT_VERSIONSERVER_URL', 'https://ping.zen-cart.com/zcversioncheck');
 define('PLUGIN_VERSIONSERVER_URL', 'https://ping.zen-cart.com/plugincheck');


### PR DESCRIPTION
Given that semantic versioning in PHP already accommodates suffixes such as `-dev`, `-alpha`, `-beta`, `-rc`, `-pl` (patch level), and we can release a patch version easily via Github, we don't need these constants anymore.

Just note: use `version_compare()` instead of `<` or `>` or `==` for comparing the PROJECT_VERSION_MAJOR+MINOR string returned by `zen_get_zcversion()`.

Plus, we haven't used these `PROJECT_VERSION_PATCH1`, etc constants since around v1.5.5 or so.