### PR TITLE
Add echo of current_master_categories_id on update_product link form

### DIFF
--- a/admin/products_to_categories.php
+++ b/admin/products_to_categories.php
@@ -673,9 +673,8 @@ if (empty($_SESSION['hide_linked_categories'])) {
                             }
                         </script>
                     </div>
-                    <?php
-                    echo zen_draw_form('update', FILENAME_PRODUCTS_TO_CATEGORIES, 'action=update_product&products_filter=' . $products_filter . '&current_category_id=' . $current_category_id . '&target_category_id=' . $target_category_id, 'post');
-                    zen_draw_hidden_field('current_master_categories_id', $product_to_copy->fields['master_categories_id']); ?>
+                    <?= zen_draw_form('update', FILENAME_PRODUCTS_TO_CATEGORIES, 'action=update_product&products_filter=' . $products_filter . '&current_category_id=' . $current_category_id . '&target_category_id=' . $target_category_id, 'post') ?>
+                    <?= zen_draw_hidden_field('current_master_categories_id', $product_to_copy->fields['master_categories_id']) ?>
                     <table class="table-bordered">
                         <thead>
                         <?php $cnt_columns = 0; ?>


### PR DESCRIPTION
There was a missing `echo` statement when this code was updated in v1.5.7, where this field was relocated from a position later down in the form.

REQUIRES TESTING, but I'm pretty sure it's rendering the same net difference but saves a lookup query this way.

Refs:
https://github.com/zencart/zencart/pull/7434#pullrequestreview-3531773888
https://github.com/zencart/zencart/commit/e4fecea48cb9b63d5209795e428b0a222dbb8f22#comments