### PR TITLE
Improve password reset email HTML formatting

### DIFF
--- a/includes/languages/english/lang.password_forgotten.php
+++ b/includes/languages/english/lang.password_forgotten.php
@@ -1,6 +1,11 @@
 <?php
 
-$password_reset_button_colour = '#00BCE4';//change to stores theme colour
+// change this to match your store's theme colour
+// You can define this in your /includes/extra_datafiles/site_specific_overrides.php file to avoid editing this file directly.
+$password_reset_email_button_colour ??= '#00BCE4'; 
+
+// Simple sanitization
+$password_reset_email_button_colour = htmlspecialchars(substr($password_reset_email_button_colour, 0, 32), ENT_QUOTES);
 
 $define = [
     'NAVBAR_TITLE_1' => 'Login',
@@ -25,12 +30,12 @@ $define = [
         '<p>Hello,</p>' .
         '<p>We received a request to reset the password for your %2$s account.</p>' .
         '<p>To choose a new password, please click the button below:</p>' .
-        '<p><a href="%3$s" style="display:inline-block;padding:10px 16px;background:' . $password_reset_button_colour . ';color:#ffffff;text-decoration:none;border-radius:4px;font-weight:bold;">Reset your password</a></p>' .
+        '<p><a href="%3$s" style="display:inline-block;padding:10px 16px;background:' . $password_reset_email_button_colour . ';color:#ffffff;text-decoration:none;border-radius:4px;font-weight:bold;">Reset your password</a></p>' .
         '<p>Or copy and paste this link into your browser:<br><a href="%3$s">%3$s</a></p>' .
         '<p>This link is for password reset only. If you did not request this, you can safely ignore this email and your password will not be changed.</p>' .
         '<p>For your security, this request was made from IP address: %1$s</p>' .
         '<p>Kind regards,<br>' .
-        STORE_NAME .
+        '%2$s' .
         '</p>',
 
     'SUCCESS_PASSWORD_RESET_SENT' =>

--- a/includes/languages/english/lang.password_forgotten.php
+++ b/includes/languages/english/lang.password_forgotten.php
@@ -1,14 +1,40 @@
 <?php
+
+$password_reset_button_colour = '#00BCE4';//change to stores theme colour
+
 $define = [
     'NAVBAR_TITLE_1' => 'Login',
     'NAVBAR_TITLE_2' => 'Password Forgotten',
     'HEADING_TITLE' => 'Forgotten Password',
+
     'TEXT_MAIN' => "Enter your email address below and we'll send you instructions on how to reset your password.",
 
     'EMAIL_PASSWORD_RESET_SUBJECT' => STORE_NAME . ' - Password Reset',
-    'EMAIL_PASSWORD_RESET_BODY' => "A password reset was requested from %1\$s.\n\nTo reset your password for '%2\$s', please visit the following URL:\n\n%3\$s\n\n",
 
-    'SUCCESS_PASSWORD_RESET_SENT' => 'Thank you. If that email address is in our system, we will send password recovery instructions to that email address (remember to check your Spam folder)',
+    'EMAIL_PASSWORD_RESET_BODY' =>
+        "Hello,\n\n" .
+        "We received a request to reset the password for your %2\$s account.\n\n" .
+        "To choose a new password, please click the link below:\n\n" .
+        "%3\$s\n\n" .
+        "This link is for password reset only. If you did not request this, you can safely ignore this email and your password will not be changed.\n\n" .
+        "For your security, this request was made from IP address: %1\$s\n\n" .
+        "Kind regards,\n" .
+        STORE_NAME . "\n",
+
+    'EMAIL_PASSWORD_RESET_HTML' =>
+        '<p>Hello,</p>' .
+        '<p>We received a request to reset the password for your %2$s account.</p>' .
+        '<p>To choose a new password, please click the button below:</p>' .
+        '<p><a href="%3$s" style="display:inline-block;padding:10px 16px;background:' . $password_reset_button_colour . ';color:#ffffff;text-decoration:none;border-radius:4px;font-weight:bold;">Reset your password</a></p>' .
+        '<p>Or copy and paste this link into your browser:<br><a href="%3$s">%3$s</a></p>' .
+        '<p>This link is for password reset only. If you did not request this, you can safely ignore this email and your password will not be changed.</p>' .
+        '<p>For your security, this request was made from IP address: %1$s</p>' .
+        '<p>Kind regards,<br>' .
+        STORE_NAME .
+        '</p>',
+
+    'SUCCESS_PASSWORD_RESET_SENT' =>
+        'Thank you. If that email address is in our system, we will send password recovery instructions to that email address. Please check your Spam folder if it does not arrive shortly.',
 ];
 
 return $define;

--- a/includes/modules/pages/password_forgotten/header_php.php
+++ b/includes/modules/pages/password_forgotten/header_php.php
@@ -11,8 +11,7 @@
  * @var messageStack $messageStack
  * @var breadcrumb $breadcrumb
  * @var notifier $zco_notifier
- * 
- * TC changed improved password reset   
+ *
  */
 
 // This should be first line of the script:

--- a/includes/modules/pages/password_forgotten/header_php.php
+++ b/includes/modules/pages/password_forgotten/header_php.php
@@ -11,6 +11,8 @@
  * @var messageStack $messageStack
  * @var breadcrumb $breadcrumb
  * @var notifier $zco_notifier
+ * 
+ * TC changed improved password reset   
  */
 
 // This should be first line of the script:
@@ -36,11 +38,11 @@ if (($_GET['action'] ?? '') === 'process') {
         header('HTTP/1.1 406 Not Acceptable');
         exit(0);
     }
+
     // BEGIN SLAM PREVENTION
     if (!empty($_POST['email_address'])) {
         $_SESSION['login_attempt']++;
     } // END SLAM PREVENTION
-
 
     if (empty($_POST['email_address'])) {
         $messageStack->add_session('password_forgotten', ENTRY_EMAIL_ADDRESS_ERROR, 'error');
@@ -81,16 +83,30 @@ if (($_GET['action'] ?? '') === 'process') {
 
         $token = $check_customer['token'];
         $reset_url = zen_href_link(FILENAME_PASSWORD_RESET, "reset_token=$token");
+        $reset_url_text = html_entity_decode($reset_url, ENT_QUOTES, CHARSET);
 
         $name = $check_customer['customers_firstname'] . ' ' . $check_customer['customers_lastname'];
-        $body = sprintf(EMAIL_PASSWORD_RESET_BODY, zen_get_ip_address(), STORE_NAME, $reset_url);
+
+        $body = sprintf(
+            EMAIL_PASSWORD_RESET_BODY,
+            zen_get_ip_address(),
+            STORE_NAME,
+            $reset_url_text
+        );
 
         $html_msg = [];
-        $html_msg['EMAIL_CUSTOMERS_NAME'] = $name;
-        $html_msg['EMAIL_MESSAGE_HTML'] = $body;
+        $html_msg['EMAIL_CUSTOMERS_NAME'] = htmlspecialchars($name, ENT_QUOTES, CHARSET);
 
-        // Note: If this mail frequently winds up in spam folders, try replacing $html_msg with 'none' below.
-        // $html_msg = 'none';
+        if (defined('EMAIL_PASSWORD_RESET_HTML')) {
+            $html_msg['EMAIL_MESSAGE_HTML'] = sprintf(
+                EMAIL_PASSWORD_RESET_HTML,
+                htmlspecialchars(zen_get_ip_address(), ENT_QUOTES, CHARSET),
+                htmlspecialchars(STORE_NAME, ENT_QUOTES, CHARSET),
+                htmlspecialchars($reset_url, ENT_QUOTES, CHARSET)
+            );
+        } else {
+            $html_msg['EMAIL_MESSAGE_HTML'] = nl2br(htmlspecialchars($body, ENT_QUOTES, CHARSET));
+        }
 
         // Send the email
         zen_mail($name, $email_address, EMAIL_PASSWORD_RESET_SUBJECT, $body, STORE_NAME, EMAIL_FROM, $html_msg, 'password_forgotten');


### PR DESCRIPTION
This update improves the password reset email generated by the password_forgotten page.

Changes included:
- Adds a separate HTML version of the password reset message.
- Preserves the existing plain-text message for non-HTML emails.
- Converts the reset URL for plain-text output so &amp; is not displayed.
- Adds a clickable reset link/button for HTML email clients.
- Falls back to nl2br/htmlspecialchars formatting if the HTML language constant is not present.

This makes the password reset email more readable in HTML email clients while retaining the existing plain-text fallback.