### PR TITLE
allow for symlinked and bind mounted directories for plugins

### DIFF
--- a/includes/classes/FileSystem.php
+++ b/includes/classes/FileSystem.php
@@ -86,10 +86,13 @@ class FileSystem
         $found = null;
         foreach ($installedPlugins as $plugin) {
             $pluginDir = DIR_FS_CATALOG . 'zc_plugins/' . $plugin['unique_key'] . '/' . $plugin['version'];
+            $resolvedPluginDir = $this->realpath($pluginDir);
+            if ($resolvedPluginDir === false) {
+                continue;
+            }
             $adminFile = $pluginDir . '/admin/' . $page . '.php';
-            $adminFile = $this->realpath($adminFile);
             $realPath = $this->realpath($adminFile);
-            if ($realPath === false || strpos($realPath, $pluginDir) !== 0) {
+            if ($realPath === false || strpos($realPath, $resolvedPluginDir) !== 0) {
                 continue; // Skip this file if it's not under the intended directory
             }
             if (!file_exists($realPath)) {


### PR DESCRIPTION


when developing plugins it's nice to symlink the plugin under zc_plugin to a git repo checkout

however findPluginAdminPage() used to build the plugin path from DIR_FS_CATALOG . 'zc_plugins/... and then compare the resolved admin file path against that original string. That works for normal directories, but it fails for symlinked plugins especially if using docker/ddev

The change resolves the plugin directory first:

and then checks the admin page against that resolved directory:

So the safety check still prevents loading files outside the plugin directory, but now it also accepts valid symlinked or bind-mounted plugin paths
