### PR TITLE
Moving towards class-based access of config settings

### DIFF
--- a/includes/classes/Coupon.php
+++ b/includes/classes/Coupon.php
@@ -60,7 +60,7 @@ class Coupon extends base
         $sql = "SELECT coupon_id
                 FROM " . TABLE_COUPONS . "
                 WHERE coupon_code LIKE ':original_code:%'
-                AND coupon_id = " . (int)zen_get_config_value('NEW_SIGNUP_DISCOUNT_COUPON');
+                AND coupon_id = " . (int)zen_config('NEW_SIGNUP_DISCOUNT_COUPON');
         $sql = $db->bindVars($sql, ':original_code:', $origin_prefix, 'noquotestring');
         $delete_duplicate_coupons_check = $db->Execute($sql);
         if ($delete_duplicate_coupons_check->RecordCount() > 0) {
@@ -72,7 +72,7 @@ class Coupon extends base
                 FROM " . TABLE_COUPONS . "
                 WHERE coupon_code LIKE ':original_code:%'
                 AND coupon_active = 'Y'
-                AND coupon_id !=  " . (int)zen_get_config_value('NEW_SIGNUP_DISCOUNT_COUPON') . "
+                AND coupon_id !=  " . (int)zen_config('NEW_SIGNUP_DISCOUNT_COUPON') . "
                 AND coupon_type != 'G'";
         $sql = $db->bindVars($sql, ':original_code:', $origin_prefix, 'noquotestring');
         $delete_duplicate_coupons = $db->Execute($sql);
@@ -94,7 +94,7 @@ class Coupon extends base
         for ($i = 1; $i <= $quantity; $i++) {
             $old_code_length = strlen($new_code);
             $minimum_extra_chars = 7;
-            $delta_calculation = zen_get_config_value('SECURITY_CODE_LENGTH') - ($old_code_length + $minimum_extra_chars);
+            $delta_calculation = zen_config('SECURITY_CODE_LENGTH') - ($old_code_length + $minimum_extra_chars);
             $new_code_length = ($delta_calculation > 0) ? $minimum_extra_chars + $delta_calculation : $minimum_extra_chars;
 
             $generated_code = static::generateRandomCouponCode((string)$original_id, $new_code_length, $new_code);
@@ -190,7 +190,7 @@ class Coupon extends base
      * @return string (new coupon code) (will be blank if the function failed)
      * @since ZC v2.0.0
      */
-    //- TODO: SECURITY_CODE_LENGTH is a configuration setting, needs to be accessed by zen_get_config_value
+    //- TODO: SECURITY_CODE_LENGTH is a configuration setting, needs to be accessed by zen_config
     public static function generateRandomCouponCode(string $salt = "secret", $length = SECURITY_CODE_LENGTH, string $prefix = ''): string
     {
         $length = (int)$length;

--- a/includes/classes/Coupon.php
+++ b/includes/classes/Coupon.php
@@ -60,7 +60,7 @@ class Coupon extends base
         $sql = "SELECT coupon_id
                 FROM " . TABLE_COUPONS . "
                 WHERE coupon_code LIKE ':original_code:%'
-                AND coupon_id = " . (int)NEW_SIGNUP_DISCOUNT_COUPON;
+                AND coupon_id = " . (int)zen_get_config_value('NEW_SIGNUP_DISCOUNT_COUPON');
         $sql = $db->bindVars($sql, ':original_code:', $origin_prefix, 'noquotestring');
         $delete_duplicate_coupons_check = $db->Execute($sql);
         if ($delete_duplicate_coupons_check->RecordCount() > 0) {
@@ -72,7 +72,7 @@ class Coupon extends base
                 FROM " . TABLE_COUPONS . "
                 WHERE coupon_code LIKE ':original_code:%'
                 AND coupon_active = 'Y'
-                AND coupon_id !=  " . (int)NEW_SIGNUP_DISCOUNT_COUPON . "
+                AND coupon_id !=  " . (int)zen_get_config_value('NEW_SIGNUP_DISCOUNT_COUPON') . "
                 AND coupon_type != 'G'";
         $sql = $db->bindVars($sql, ':original_code:', $origin_prefix, 'noquotestring');
         $delete_duplicate_coupons = $db->Execute($sql);
@@ -94,7 +94,7 @@ class Coupon extends base
         for ($i = 1; $i <= $quantity; $i++) {
             $old_code_length = strlen($new_code);
             $minimum_extra_chars = 7;
-            $delta_calculation = SECURITY_CODE_LENGTH - ($old_code_length + $minimum_extra_chars);
+            $delta_calculation = zen_get_config_value('SECURITY_CODE_LENGTH') - ($old_code_length + $minimum_extra_chars);
             $new_code_length = ($delta_calculation > 0) ? $minimum_extra_chars + $delta_calculation : $minimum_extra_chars;
 
             $generated_code = static::generateRandomCouponCode((string)$original_id, $new_code_length, $new_code);
@@ -190,6 +190,7 @@ class Coupon extends base
      * @return string (new coupon code) (will be blank if the function failed)
      * @since ZC v2.0.0
      */
+    //- TODO: SECURITY_CODE_LENGTH is a configuration setting, needs to be accessed by zen_get_config_value
     public static function generateRandomCouponCode(string $salt = "secret", $length = SECURITY_CODE_LENGTH, string $prefix = ''): string
     {
         $length = (int)$length;

--- a/includes/classes/Customer.php
+++ b/includes/classes/Customer.php
@@ -55,7 +55,7 @@ class Customer extends base
                 'wholesale_tier' => 0,
                 'is_tax_exempt' => false,
             ];
-            if (zen_get_config_value('WHOLESALE_PRICING_CONFIG') !== 'false' && zen_is_logged_in() && !zen_in_guest_checkout()) {
+            if (zen_config('WHOLESALE_PRICING_CONFIG') !== 'false' && zen_is_logged_in() && !zen_in_guest_checkout()) {
                 global $db;
                 $wholesale = $db->Execute(
                     "SELECT customers_whole
@@ -67,7 +67,7 @@ class Customer extends base
                     $wholesaleInfo = [
                         'is_wholesale' => true,
                         'wholesale_tier' => (int)$wholesale->fields['customers_whole'],
-                        'is_tax_exempt' => (zen_get_config_value('WHOLESALE_PRICING_CONFIG') === 'Tax Exempt'),
+                        'is_tax_exempt' => (zen_config('WHOLESALE_PRICING_CONFIG') === 'Tax Exempt'),
                     ];
                 }
             }
@@ -499,13 +499,13 @@ class Customer extends base
      */
     public function createAuthToken(): string|false
     {
-        if (empty($this->data) || zen_get_config_value('CUSTOMERS_ACTIVATION_REQUIRED') === 'false') {
+        if (empty($this->data) || zen_config('CUSTOMERS_ACTIVATION_REQUIRED') === 'false') {
             return false;
         }
 
         global $db;
 
-        $length = (int)zen_get_config_value('CUSTOMERS_ACTIVATION_TOKEN_LENGTH');
+        $length = (int)zen_config('CUSTOMERS_ACTIVATION_TOKEN_LENGTH');
         if ($length < 12 || $length > 100) { // under 12 is impractical; over 100 is too large for db field
             $length = 24;
         }
@@ -838,7 +838,7 @@ class Customer extends base
         global $db;
 
         $activation_required = 0;
-        if ($status !== self::AUTH_OK && zen_get_config_value('CUSTOMERS_ACTIVATION_REQUIRED') === 'true') {
+        if ($status !== self::AUTH_OK && zen_config('CUSTOMERS_ACTIVATION_REQUIRED') === 'true') {
             $activation_required = (int)($status === self::AUTH_NO_PURCHASE);
         }
 
@@ -1273,7 +1273,7 @@ class Customer extends base
 
         $this->notify('NOTIFY_MODULE_CREATE_ACCOUNT_ADDING_CUSTOMER_RECORD', null, $data);
 
-        $activation_required = (int)(zen_get_config_value('CUSTOMERS_ACTIVATION_REQUIRED') === 'true');
+        $activation_required = (int)(zen_config('CUSTOMERS_ACTIVATION_REQUIRED') === 'true');
 
         $sql_data_array = [
             ['fieldName' => 'customers_firstname', 'value' => $data['firstname'], 'type' => 'stringIgnoreNull'],
@@ -1293,13 +1293,13 @@ class Customer extends base
             ['fieldName' => 'last_login_ip', 'value' => $data['ip_address'], 'type' => 'string'],
         ];
 
-        if (zen_get_config_value('CUSTOMERS_REFERRAL_STATUS') === '2' && !empty($data['customers_referral'])) {
+        if (zen_config('CUSTOMERS_REFERRAL_STATUS') === '2' && !empty($data['customers_referral'])) {
             $sql_data_array[] = ['fieldName' => 'customers_referral', 'value' => $data['customers_referral'], 'type' => 'stringIgnoreNull'];
         }
-        if (zen_get_config_value('ACCOUNT_GENDER') === 'true') {
+        if (zen_config('ACCOUNT_GENDER') === 'true') {
             $sql_data_array[] = ['fieldName' => 'customers_gender', 'value' => $data['gender'], 'type' => 'stringIgnoreNull'];
         }
-        if (zen_get_config_value('ACCOUNT_DOB') === 'true') {
+        if (zen_config('ACCOUNT_DOB') === 'true') {
             $dob = (empty($data['dob']) || $data['dob'] === '0001-01-01 00:00:00') ? '0001-01-01 00:00:00' : zen_date_raw($data['dob']);
             $sql_data_array[] = ['fieldName' => 'customers_dob', 'value' => $dob, 'type' => 'date'];
         }
@@ -1325,17 +1325,17 @@ class Customer extends base
             ['fieldName' => 'entry_country_id', 'value' => $data['country'], 'type' => 'integer'],
         ];
 
-        if (zen_get_config_value('ACCOUNT_GENDER') === 'true') {
+        if (zen_config('ACCOUNT_GENDER') === 'true') {
             $sql_data_array[] = ['fieldName' => 'entry_gender', 'value' => $data['gender'], 'type' => 'stringIgnoreNull'];
         }
-        if (zen_get_config_value('ACCOUNT_COMPANY') === 'true') {
+        if (zen_config('ACCOUNT_COMPANY') === 'true') {
             $sql_data_array[] = ['fieldName' => 'entry_company', 'value' => $data['company'], 'type' => 'stringIgnoreNull'];
         }
-        if (zen_get_config_value('ACCOUNT_SUBURB') === 'true') {
+        if (zen_config('ACCOUNT_SUBURB') === 'true') {
             $sql_data_array[] = ['fieldName' => 'entry_suburb', 'value' => $data['suburb'], 'type' => 'stringIgnoreNull'];
         }
 
-        if (zen_get_config_value('ACCOUNT_STATE') === 'true') {
+        if (zen_config('ACCOUNT_STATE') === 'true') {
             if ($data['zone_id'] > 0) {
                 $sql_data_array[] = ['fieldName' => 'entry_zone_id', 'value' => $data['zone_id'], 'type' => 'integer'];
                 $sql_data_array[] = ['fieldName' => 'entry_state', 'value' => '', 'type' => 'stringIgnoreNull'];

--- a/includes/classes/Customer.php
+++ b/includes/classes/Customer.php
@@ -55,7 +55,7 @@ class Customer extends base
                 'wholesale_tier' => 0,
                 'is_tax_exempt' => false,
             ];
-            if (WHOLESALE_PRICING_CONFIG !== 'false' && zen_is_logged_in() && !zen_in_guest_checkout()) {
+            if (zen_get_config_value('WHOLESALE_PRICING_CONFIG') !== 'false' && zen_is_logged_in() && !zen_in_guest_checkout()) {
                 global $db;
                 $wholesale = $db->Execute(
                     "SELECT customers_whole
@@ -67,7 +67,7 @@ class Customer extends base
                     $wholesaleInfo = [
                         'is_wholesale' => true,
                         'wholesale_tier' => (int)$wholesale->fields['customers_whole'],
-                        'is_tax_exempt' => (WHOLESALE_PRICING_CONFIG === 'Tax Exempt'),
+                        'is_tax_exempt' => (zen_get_config_value('WHOLESALE_PRICING_CONFIG') === 'Tax Exempt'),
                     ];
                 }
             }
@@ -499,13 +499,13 @@ class Customer extends base
      */
     public function createAuthToken(): string|false
     {
-        if (empty($this->data) || CUSTOMERS_ACTIVATION_REQUIRED === 'false') {
+        if (empty($this->data) || zen_get_config_value('CUSTOMERS_ACTIVATION_REQUIRED') === 'false') {
             return false;
         }
 
         global $db;
 
-        $length = (int)CUSTOMERS_ACTIVATION_TOKEN_LENGTH;
+        $length = (int)zen_get_config_value('CUSTOMERS_ACTIVATION_TOKEN_LENGTH');
         if ($length < 12 || $length > 100) { // under 12 is impractical; over 100 is too large for db field
             $length = 24;
         }
@@ -838,7 +838,7 @@ class Customer extends base
         global $db;
 
         $activation_required = 0;
-        if ($status !== self::AUTH_OK && CUSTOMERS_ACTIVATION_REQUIRED === 'true') {
+        if ($status !== self::AUTH_OK && zen_get_config_value('CUSTOMERS_ACTIVATION_REQUIRED') === 'true') {
             $activation_required = (int)($status === self::AUTH_NO_PURCHASE);
         }
 
@@ -1273,7 +1273,7 @@ class Customer extends base
 
         $this->notify('NOTIFY_MODULE_CREATE_ACCOUNT_ADDING_CUSTOMER_RECORD', null, $data);
 
-        $activation_required = (int)(CUSTOMERS_ACTIVATION_REQUIRED === 'true');
+        $activation_required = (int)(zen_get_config_value('CUSTOMERS_ACTIVATION_REQUIRED') === 'true');
 
         $sql_data_array = [
             ['fieldName' => 'customers_firstname', 'value' => $data['firstname'], 'type' => 'stringIgnoreNull'],
@@ -1293,13 +1293,13 @@ class Customer extends base
             ['fieldName' => 'last_login_ip', 'value' => $data['ip_address'], 'type' => 'string'],
         ];
 
-        if (CUSTOMERS_REFERRAL_STATUS === '2' && !empty($data['customers_referral'])) {
+        if (zen_get_config_value('CUSTOMERS_REFERRAL_STATUS') === '2' && !empty($data['customers_referral'])) {
             $sql_data_array[] = ['fieldName' => 'customers_referral', 'value' => $data['customers_referral'], 'type' => 'stringIgnoreNull'];
         }
-        if (ACCOUNT_GENDER === 'true') {
+        if (zen_get_config_value('ACCOUNT_GENDER') === 'true') {
             $sql_data_array[] = ['fieldName' => 'customers_gender', 'value' => $data['gender'], 'type' => 'stringIgnoreNull'];
         }
-        if (ACCOUNT_DOB === 'true') {
+        if (zen_get_config_value('ACCOUNT_DOB') === 'true') {
             $dob = (empty($data['dob']) || $data['dob'] === '0001-01-01 00:00:00') ? '0001-01-01 00:00:00' : zen_date_raw($data['dob']);
             $sql_data_array[] = ['fieldName' => 'customers_dob', 'value' => $dob, 'type' => 'date'];
         }
@@ -1325,17 +1325,17 @@ class Customer extends base
             ['fieldName' => 'entry_country_id', 'value' => $data['country'], 'type' => 'integer'],
         ];
 
-        if (ACCOUNT_GENDER === 'true') {
+        if (zen_get_config_value('ACCOUNT_GENDER') === 'true') {
             $sql_data_array[] = ['fieldName' => 'entry_gender', 'value' => $data['gender'], 'type' => 'stringIgnoreNull'];
         }
-        if (ACCOUNT_COMPANY === 'true') {
+        if (zen_get_config_value('ACCOUNT_COMPANY') === 'true') {
             $sql_data_array[] = ['fieldName' => 'entry_company', 'value' => $data['company'], 'type' => 'stringIgnoreNull'];
         }
-        if (ACCOUNT_SUBURB === 'true') {
+        if (zen_get_config_value('ACCOUNT_SUBURB') === 'true') {
             $sql_data_array[] = ['fieldName' => 'entry_suburb', 'value' => $data['suburb'], 'type' => 'stringIgnoreNull'];
         }
 
-        if (ACCOUNT_STATE === 'true') {
+        if (zen_get_config_value('ACCOUNT_STATE') === 'true') {
             if ($data['zone_id'] > 0) {
                 $sql_data_array[] = ['fieldName' => 'entry_zone_id', 'value' => $data['zone_id'], 'type' => 'integer'];
                 $sql_data_array[] = ['fieldName' => 'entry_state', 'value' => '', 'type' => 'stringIgnoreNull'];

--- a/includes/classes/DbRepositories/ConfigurationRepository.php
+++ b/includes/classes/DbRepositories/ConfigurationRepository.php
@@ -96,6 +96,7 @@ class ConfigurationRepository
         if (defined($configurationKey)) {
             return constant($configurationKey);
         }
-        return null;
+
+        return $this->getByKey($configurationKey);
     }
 }

--- a/includes/classes/DbRepositories/ConfigurationRepository.php
+++ b/includes/classes/DbRepositories/ConfigurationRepository.php
@@ -87,4 +87,15 @@ class ConfigurationRepository
 
         return $this->db->affectedRows();
     }
+
+    /**
+     * @since ZC v3.0.0
+     */
+    public function get(string $configurationKey): mixed
+    {
+        if (defined($configurationKey)) {
+            return constant($configurationKey);
+        }
+        return null;
+    }
 }

--- a/includes/classes/category_tree.php
+++ b/includes/classes/category_tree.php
@@ -165,7 +165,7 @@ class category_tree extends base {
 
     for ($i=0; $i<$this->tree[$counter]['level']; $i++) {
       if ($this->tree[$counter]['parent'] != TOPMOST_CATEGORY_PARENT_ID) {
-        $this->categories_string .= CATEGORIES_SUBCATEGORIES_INDENT;
+        $this->categories_string .= zen_get_config_value('CATEGORIES_SUBCATEGORIES_INDENT');
       }
     }
 
@@ -176,7 +176,7 @@ class category_tree extends base {
     } else {
       $this->box_categories_array[$ii]['top'] = 'false';
       $cPath_new = 'cPath=' . $this->tree[$counter]['path'];
-      $this->categories_string .= CATEGORIES_SEPARATOR_SUBS;
+      $this->categories_string .= zen_get_config_value('CATEGORIES_SEPARATOR_SUBS');
     }
     $this->box_categories_array[$ii]['path'] = $cPath_new;
 
@@ -198,7 +198,7 @@ class category_tree extends base {
       $this->box_categories_array[$ii]['has_sub_cat'] = false;
     }
 
-    if (SHOW_COUNTS == 'true') {
+    if (zen_get_config_value('SHOW_COUNTS') === 'true') {
       $products_in_category = zen_count_products_in_category($counter);
       if ($products_in_category > 0) {
         $this->box_categories_array[$ii]['count'] = $products_in_category;

--- a/includes/classes/category_tree.php
+++ b/includes/classes/category_tree.php
@@ -165,7 +165,7 @@ class category_tree extends base {
 
     for ($i=0; $i<$this->tree[$counter]['level']; $i++) {
       if ($this->tree[$counter]['parent'] != TOPMOST_CATEGORY_PARENT_ID) {
-        $this->categories_string .= zen_get_config_value('CATEGORIES_SUBCATEGORIES_INDENT');
+        $this->categories_string .= zen_config('CATEGORIES_SUBCATEGORIES_INDENT');
       }
     }
 
@@ -176,7 +176,7 @@ class category_tree extends base {
     } else {
       $this->box_categories_array[$ii]['top'] = 'false';
       $cPath_new = 'cPath=' . $this->tree[$counter]['path'];
-      $this->categories_string .= zen_get_config_value('CATEGORIES_SEPARATOR_SUBS');
+      $this->categories_string .= zen_config('CATEGORIES_SEPARATOR_SUBS');
     }
     $this->box_categories_array[$ii]['path'] = $cPath_new;
 
@@ -198,7 +198,7 @@ class category_tree extends base {
       $this->box_categories_array[$ii]['has_sub_cat'] = false;
     }
 
-    if (zen_get_config_value('SHOW_COUNTS') === 'true') {
+    if (zen_config('SHOW_COUNTS') === 'true') {
       $products_in_category = zen_count_products_in_category($counter);
       if ($products_in_category > 0) {
         $this->box_categories_array[$ii]['count'] = $products_in_category;

--- a/includes/classes/cc_validation.php
+++ b/includes/classes/cc_validation.php
@@ -29,34 +29,34 @@ class cc_validation
         
         // NOTE: We check Solo before Maestro, and Maestro/Switch *before* we check Visa/Mastercard, so we don't have to rule-out numerous types from V/MC matching rules.
         switch (true) {
-            case preg_match('/^(6334[5-9][0-9]|6767[0-9]{2})[0-9]{10}([0-9]{2,3}?)?$/', $this->cc_number) && zen_get_config_value('CC_ENABLED_SOLO') === '1':
+            case preg_match('/^(6334[5-9][0-9]|6767[0-9]{2})[0-9]{10}([0-9]{2,3}?)?$/', $this->cc_number) && zen_config('CC_ENABLED_SOLO') === '1':
                 $this->cc_type = "Solo"; // is also a Maestro product
                 break;
-            case preg_match('/^(49369[8-9]|490303|6333[0-4][0-9]|6759[0-9]{2}|5[0678][0-9]{4}|6[0-9][02-9][02-9][0-9]{2})[0-9]{6,13}?$/', $this->cc_number) && zen_get_config_value('CC_ENABLED_MAESTRO') === '1':
+            case preg_match('/^(49369[8-9]|490303|6333[0-4][0-9]|6759[0-9]{2}|5[0678][0-9]{4}|6[0-9][02-9][02-9][0-9]{2})[0-9]{6,13}?$/', $this->cc_number) && zen_config('CC_ENABLED_MAESTRO') === '1':
                 $this->cc_type = "Maestro";
                 break;
-            case preg_match('/^(49030[2-9]|49033[5-9]|4905[0-9]{2}|49110[1-2]|49117[4-9]|49918[0-2]|4936[0-9]{2}|564182|6333[0-4][0-9])[0-9]{10}([0-9]{2,3}?)?$/', $this->cc_number) && zen_get_config_value('CC_ENABLED_MAESTRO') == '1':
+            case preg_match('/^(49030[2-9]|49033[5-9]|4905[0-9]{2}|49110[1-2]|49117[4-9]|49918[0-2]|4936[0-9]{2}|564182|6333[0-4][0-9])[0-9]{10}([0-9]{2,3}?)?$/', $this->cc_number) && zen_config('CC_ENABLED_MAESTRO') == '1':
                 $this->cc_type = "Maestro"; // SWITCH is now Maestro
                 break;
-            case preg_match('/^4[0-9]{12}([0-9]{3})?$/', $this->cc_number) && zen_get_config_value('CC_ENABLED_VISA') === '1':
+            case preg_match('/^4[0-9]{12}([0-9]{3})?$/', $this->cc_number) && zen_config('CC_ENABLED_VISA') === '1':
                 $this->cc_type = 'Visa';
                 break;
-            case preg_match('/^(5[1-5][0-9]{2}|222[1-9]|22[3-9][0-9]|2[3-6][0-9]{2}|27[01][0-9]|2720)[0-9]{12}$/', $this->cc_number) && zen_get_config_value('CC_ENABLED_MC') === '1':
+            case preg_match('/^(5[1-5][0-9]{2}|222[1-9]|22[3-9][0-9]|2[3-6][0-9]{2}|27[01][0-9]|2720)[0-9]{12}$/', $this->cc_number) && zen_config('CC_ENABLED_MC') === '1':
                 $this->cc_type = 'MasterCard'; // 510000-550000, 222100-272099
                 break;
-            case preg_match('/^3[47][0-9]{13}$/', $this->cc_number) && zen_get_config_value('CC_ENABLED_AMEX') === '1':
+            case preg_match('/^3[47][0-9]{13}$/', $this->cc_number) && zen_config('CC_ENABLED_AMEX') === '1':
                 $this->cc_type = 'American Express';
                 break;
-            case preg_match('/^3(0[0-5]|[68][0-9])[0-9]{11}$/', $this->cc_number) && zen_get_config_value('CC_ENABLED_DINERS_CLUB') === '1':
+            case preg_match('/^3(0[0-5]|[68][0-9])[0-9]{11}$/', $this->cc_number) && zen_config('CC_ENABLED_DINERS_CLUB') === '1':
                 $this->cc_type = 'Diners Club';
                 break;
-            case preg_match('/^(6011[0-9]{12}|622[1-9][0-9]{12}|64[4-9][0-9]{13}|65[0-9]{14})$/', $this->cc_number) && zen_get_config_value('CC_ENABLED_DISCOVER') === '1':
+            case preg_match('/^(6011[0-9]{12}|622[1-9][0-9]{12}|64[4-9][0-9]{13}|65[0-9]{14})$/', $this->cc_number) && zen_config('CC_ENABLED_DISCOVER') === '1':
                 $this->cc_type = 'Discover';
                 break;
-            case preg_match('/^(35(28|29|[3-8][0-9])[0-9]{12}|2131[0-9]{11}|1800[0-9]{11})$/', $this->cc_number) && zen_get_config_value('CC_ENABLED_JCB') === '1':
+            case preg_match('/^(35(28|29|[3-8][0-9])[0-9]{12}|2131[0-9]{11}|1800[0-9]{11})$/', $this->cc_number) && zen_config('CC_ENABLED_JCB') === '1':
                 $this->cc_type = "JCB";
                 break;
-            case preg_match('/^5610[0-9]{12}$/', $this->cc_number) && zen_get_config_value('CC_ENABLED_AUSTRALIAN_BANKCARD') === '1':
+            case preg_match('/^5610[0-9]{12}$/', $this->cc_number) && zen_config('CC_ENABLED_AUSTRALIAN_BANKCARD') === '1':
                 $this->cc_type = 'Australian BankCard'; // NOTE: is now obsolete
                 break;
             default:

--- a/includes/classes/cc_validation.php
+++ b/includes/classes/cc_validation.php
@@ -16,109 +16,127 @@ if (!defined('IS_ADMIN_FLAG')) {
  *
  * @since ZC v1.0.3
  */
-class cc_validation extends base {
-  public $cc_type, $cc_number, $cc_expiry_month, $cc_expiry_year;
+class cc_validation
+{
+    public $cc_type, $cc_number, $cc_expiry_month, $cc_expiry_year;
 
-  /**
-   * @since ZC v1.0.3
-   */
-  function validate($number, $expiry_m, $expiry_y, $start_m = null, $start_y = null) {
-    $this->cc_number = preg_replace('/[^0-9]/', '', $number);
-    // NOTE: We check Solo before Maestro, and Maestro/Switch *before* we check Visa/Mastercard, so we don't have to rule-out numerous types from V/MC matching rules.
-    if (preg_match('/^(6334[5-9][0-9]|6767[0-9]{2})[0-9]{10}([0-9]{2,3}?)?$/', $this->cc_number) && CC_ENABLED_SOLO=='1') {
-      $this->cc_type = "Solo"; // is also a Maestro product
-    } else if (preg_match('/^(49369[8-9]|490303|6333[0-4][0-9]|6759[0-9]{2}|5[0678][0-9]{4}|6[0-9][02-9][02-9][0-9]{2})[0-9]{6,13}?$/', $this->cc_number) && CC_ENABLED_MAESTRO=='1') {
-      $this->cc_type = "Maestro";
-    } else if (preg_match('/^(49030[2-9]|49033[5-9]|4905[0-9]{2}|49110[1-2]|49117[4-9]|49918[0-2]|4936[0-9]{2}|564182|6333[0-4][0-9])[0-9]{10}([0-9]{2,3}?)?$/', $this->cc_number) && CC_ENABLED_MAESTRO=='1') {
-      $this->cc_type = "Maestro"; // SWITCH is now Maestro
-    } elseif (preg_match('/^4[0-9]{12}([0-9]{3})?$/', $this->cc_number) && CC_ENABLED_VISA=='1') {
-      $this->cc_type = 'Visa';
-	} elseif (preg_match('/^(5[1-5][0-9]{2}|222[1-9]|22[3-9][0-9]|2[3-6][0-9]{2}|27[01][0-9]|2720)[0-9]{12}$/', $this->cc_number) && CC_ENABLED_MC=='1') {
-      $this->cc_type = 'MasterCard'; // 510000-550000, 222100-272099
-    } elseif (preg_match('/^3[47][0-9]{13}$/', $this->cc_number) && CC_ENABLED_AMEX=='1') {
-      $this->cc_type = 'American Express';
-    } elseif (preg_match('/^3(0[0-5]|[68][0-9])[0-9]{11}$/', $this->cc_number) && CC_ENABLED_DINERS_CLUB=='1') {
-      $this->cc_type = 'Diners Club';
-    } elseif (preg_match('/^(6011[0-9]{12}|622[1-9][0-9]{12}|64[4-9][0-9]{13}|65[0-9]{14})$/', $this->cc_number) && CC_ENABLED_DISCOVER=='1') {
-      $this->cc_type = 'Discover';
-    } elseif (preg_match('/^(35(28|29|[3-8][0-9])[0-9]{12}|2131[0-9]{11}|1800[0-9]{11})$/', $this->cc_number) && CC_ENABLED_JCB=='1') {
-      $this->cc_type = "JCB";
-    } elseif (preg_match('/^5610[0-9]{12}$/', $this->cc_number) && CC_ENABLED_AUSTRALIAN_BANKCARD=='1') {
-      $this->cc_type = 'Australian BankCard'; // NOTE: is now obsolete
-    } else {
-      return -1;
-    }
-
-    if (is_numeric($expiry_m) && ($expiry_m > 0) && ($expiry_m < 13)) {
-      $this->cc_expiry_month = $expiry_m;
-    } else {
-      return -2;
-    }
-
-    $current_year = date('Y');
-    if (strlen($expiry_y) == 2) $expiry_y = intval(substr($current_year, 0, 2) . $expiry_y);
-    if (is_numeric($expiry_y) && ($expiry_y >= $current_year) && ($expiry_y <= ($current_year + 10))) {
-      $this->cc_expiry_year = $expiry_y;
-    } else {
-      return -3;
-    }
-
-    if ($expiry_y == $current_year) {
-      if ($expiry_m < date('n')) {
-        return -4;
-      }
-    }
-
-    // check the issue month & year but only for Switch/Solo cards
-    if (($start_m || $start_y) && in_array($this->cc_type, array('Switch', 'Solo'))) {
-      if (!(is_numeric($start_m) && ($start_m > 0) && ($start_m < 13))) {
-        return -2;
-      }
-
-      if (strlen($start_y) == 2) {
-        if ($start_y > 80) {
-          $start_y = intval('19' . $start_y);
-        } else {
-          $start_y = intval('20' . $start_y);
+    /**
+    * @since ZC v1.0.3
+    */
+    public function validate($number, $expiry_m, $expiry_y, $start_m = null, $start_y = null): int
+    {
+        $this->cc_number = preg_replace('/[^0-9]/', '', $number);
+        
+        // NOTE: We check Solo before Maestro, and Maestro/Switch *before* we check Visa/Mastercard, so we don't have to rule-out numerous types from V/MC matching rules.
+        switch (true) {
+            case preg_match('/^(6334[5-9][0-9]|6767[0-9]{2})[0-9]{10}([0-9]{2,3}?)?$/', $this->cc_number) && zen_get_config_value('CC_ENABLED_SOLO') === '1':
+                $this->cc_type = "Solo"; // is also a Maestro product
+                break;
+            case preg_match('/^(49369[8-9]|490303|6333[0-4][0-9]|6759[0-9]{2}|5[0678][0-9]{4}|6[0-9][02-9][02-9][0-9]{2})[0-9]{6,13}?$/', $this->cc_number) && zen_get_config_value('CC_ENABLED_MAESTRO') === '1':
+                $this->cc_type = "Maestro";
+                break;
+            case preg_match('/^(49030[2-9]|49033[5-9]|4905[0-9]{2}|49110[1-2]|49117[4-9]|49918[0-2]|4936[0-9]{2}|564182|6333[0-4][0-9])[0-9]{10}([0-9]{2,3}?)?$/', $this->cc_number) && zen_get_config_value('CC_ENABLED_MAESTRO') == '1':
+                $this->cc_type = "Maestro"; // SWITCH is now Maestro
+                break;
+            case preg_match('/^4[0-9]{12}([0-9]{3})?$/', $this->cc_number) && zen_get_config_value('CC_ENABLED_VISA') === '1':
+                $this->cc_type = 'Visa';
+                break;
+            case preg_match('/^(5[1-5][0-9]{2}|222[1-9]|22[3-9][0-9]|2[3-6][0-9]{2}|27[01][0-9]|2720)[0-9]{12}$/', $this->cc_number) && zen_get_config_value('CC_ENABLED_MC') === '1':
+                $this->cc_type = 'MasterCard'; // 510000-550000, 222100-272099
+                break;
+            case preg_match('/^3[47][0-9]{13}$/', $this->cc_number) && zen_get_config_value('CC_ENABLED_AMEX') === '1':
+                $this->cc_type = 'American Express';
+                break;
+            case preg_match('/^3(0[0-5]|[68][0-9])[0-9]{11}$/', $this->cc_number) && zen_get_config_value('CC_ENABLED_DINERS_CLUB') === '1':
+                $this->cc_type = 'Diners Club';
+                break;
+            case preg_match('/^(6011[0-9]{12}|622[1-9][0-9]{12}|64[4-9][0-9]{13}|65[0-9]{14})$/', $this->cc_number) && zen_get_config_value('CC_ENABLED_DISCOVER') === '1':
+                $this->cc_type = 'Discover';
+                break;
+            case preg_match('/^(35(28|29|[3-8][0-9])[0-9]{12}|2131[0-9]{11}|1800[0-9]{11})$/', $this->cc_number) && zen_get_config_value('CC_ENABLED_JCB') === '1':
+                $this->cc_type = "JCB";
+                break;
+            case preg_match('/^5610[0-9]{12}$/', $this->cc_number) && zen_get_config_value('CC_ENABLED_AUSTRALIAN_BANKCARD') === '1':
+                $this->cc_type = 'Australian BankCard'; // NOTE: is now obsolete
+                break;
+            default:
+                return -1;
+                break;  //- Redundant, but semantically correct
         }
-      }
 
-      if (!is_numeric($start_y) || ($start_y > $current_year)) {
-        return -3;
-      }
-      if (!($start_y >= ($current_year - 10))) {
-        return -3;
-      }
+        if (is_numeric($expiry_m) && $expiry_m > 0 && $expiry_m < 13) {
+            $this->cc_expiry_month = $expiry_m;
+        } else {
+            return -2;
+        }
+
+        $current_year = date('Y');
+        if (strlen($expiry_y) === 2) {
+            $expiry_y = intval(substr($current_year, 0, 2) . $expiry_y);
+        }
+        if (is_numeric($expiry_y) && $expiry_y >= $current_year && $expiry_y <= ($current_year + 10)) {
+            $this->cc_expiry_year = $expiry_y;
+        } else {
+            return -3;
+        }
+
+        if ($expiry_y == $current_year) {
+            if ($expiry_m < date('n')) {
+                return -4;
+            }
+        }
+
+        // check the issue month & year but only for Switch/Solo cards
+        if (($start_m || $start_y) && in_array($this->cc_type, ['Switch', 'Solo'])) {
+            if (!(is_numeric($start_m) && $start_m > 0 && $start_m < 13)) {
+                return -2;
+            }
+
+            if (strlen($start_y) === 2) {
+                if ($start_y > 80) {
+                    $start_y = intval('19' . $start_y);
+                } else {
+                    $start_y = intval('20' . $start_y);
+                }
+            }
+
+            if (!is_numeric($start_y) || $start_y > $current_year) {
+                return -3;
+            }
+            if (!($start_y >= ($current_year - 10))) {
+                return -3;
+            }
+        }
+        return (int)$this->is_valid();
     }
-    return $this->is_valid();
-  }
 
-  /**
-   * @since ZC v1.1.0
-   */
-  function is_valid() {
-    $cardNumber = strrev($this->cc_number);
-    $numSum = 0;
+    /**
+     * @since ZC v1.1.0
+     */
+    public function is_valid(): bool
+    {
+        $cardNumber = strrev($this->cc_number);
+        $numSum = 0;
 
-    for ($i=0; $i<strlen($cardNumber); $i++) {
-      $currentNum = substr($cardNumber, $i, 1);
+        for ($i = 0; $ i< strlen($cardNumber); $i++) {
+            $currentNum = substr($cardNumber, $i, 1);
 
-      // Double every second digit
-      if ($i % 2 == 1) {
-        $currentNum *= 2;
-      }
+            // Double every second digit
+            if ($i % 2 == 1) {
+                $currentNum *= 2;
+            }
 
-      // Add digits of 2-digit numbers together
-      if ($currentNum > 9) {
-        $firstNum = $currentNum % 10;
-        $secondNum = ($currentNum - $firstNum) / 10;
-        $currentNum = $firstNum + $secondNum;
-      }
+            // Add digits of 2-digit numbers together
+            if ($currentNum > 9) {
+                $firstNum = $currentNum % 10;
+                $secondNum = ($currentNum - $firstNum) / 10;
+                $currentNum = $firstNum + $secondNum;
+            }
 
-      $numSum += $currentNum;
+            $numSum += $currentNum;
+        }
+
+        // If the total has no remainder it's OK
+        return ($numSum % 10 === 0);
     }
-
-    // If the total has no remainder it's OK
-    return ($numSum % 10 == 0);
-  }
 }

--- a/includes/classes/class.search.php
+++ b/includes/classes/class.search.php
@@ -169,13 +169,13 @@ class Search extends \base
         }
 
         $define_list = [
-            'PRODUCT_LIST_MODEL' => PRODUCT_LIST_MODEL,
-            'PRODUCT_LIST_NAME' => PRODUCT_LIST_NAME,
-            'PRODUCT_LIST_MANUFACTURER' => PRODUCT_LIST_MANUFACTURER,
-            'PRODUCT_LIST_PRICE' => PRODUCT_LIST_PRICE,
-            'PRODUCT_LIST_QUANTITY' => PRODUCT_LIST_QUANTITY,
-            'PRODUCT_LIST_WEIGHT' => PRODUCT_LIST_WEIGHT,
-            'PRODUCT_LIST_IMAGE' => PRODUCT_LIST_IMAGE
+            'PRODUCT_LIST_MODEL' => zen_get_config_value('PRODUCT_LIST_MODEL'),
+            'PRODUCT_LIST_NAME' => zen_get_config_value('PRODUCT_LIST_NAME'),
+            'PRODUCT_LIST_MANUFACTURER' => zen_get_config_value('PRODUCT_LIST_MANUFACTURER'),
+            'PRODUCT_LIST_PRICE' => zen_get_config_value('PRODUCT_LIST_PRICE'),
+            'PRODUCT_LIST_QUANTITY' => zen_get_config_value('PRODUCT_LIST_QUANTITY'),
+            'PRODUCT_LIST_WEIGHT' => zen_get_config_value('PRODUCT_LIST_WEIGHT'),
+            'PRODUCT_LIST_IMAGE' => zen_get_config_value('PRODUCT_LIST_IMAGE')
         ];
 
         asort($define_list);
@@ -224,7 +224,7 @@ class Search extends \base
         */
 
         // always add quantity regardless of whether or not it is in the listing for add to cart buttons
-        if (PRODUCT_LIST_QUANTITY < 1) {
+        if (zen_get_config_value('PRODUCT_LIST_QUANTITY') < 1) {
             if (empty($select_column_list)) {
                 $select_column_list .= ' p.products_quantity ';
             } else {
@@ -244,7 +244,7 @@ class Search extends \base
             p.products_price, p.products_tax_class_id, p.products_price_sorter,
             p.products_qty_box_status, p.master_categories_id, p.product_is_call ";
 
-        if (DISPLAY_PRICE_WITH_TAX === 'true' && (!empty($this->searchOptions->pfrom) || !empty($this->searchOptions->pto))) {
+        if (zen_get_config_value('DISPLAY_PRICE_WITH_TAX') === 'true' && (!empty($this->searchOptions->pfrom) || !empty($this->searchOptions->pto))) {
             $select_str .= ", SUM(tr.tax_rate) AS tax_rate ";
         }
 
@@ -255,14 +255,14 @@ class Search extends \base
                     LEFT JOIN " . TABLE_MANUFACTURERS . " m
                     USING(manufacturers_id), " . TABLE_PRODUCTS_DESCRIPTION . " pd, " . TABLE_CATEGORIES . " c, " . TABLE_PRODUCTS_TO_CATEGORIES . " p2c )";
 
-        if (ADVANCED_SEARCH_INCLUDE_METATAGS === 'true') {
+        if (zen_get_config_value('ADVANCED_SEARCH_INCLUDE_METATAGS') === 'true') {
             $from_str .=
                 " LEFT JOIN " . TABLE_META_TAGS_PRODUCTS_DESCRIPTION . " mtpd
                     ON (mtpd.products_id= p2c.products_id AND mtpd.language_id = :languagesID)";
             $from_str = $db->bindVars($from_str, ':languagesID', $_SESSION['languages_id'], 'integer');
         }
 
-        if (DISPLAY_PRICE_WITH_TAX === 'true' && (!empty($this->searchOptions->pfrom) || !empty($this->searchOptions->pto))) {
+        if (zen_get_config_value('DISPLAY_PRICE_WITH_TAX') === 'true' && (!empty($this->searchOptions->pfrom) || !empty($this->searchOptions->pto))) {
             if (empty($_SESSION['customer_country_id'])) {
                 $_SESSION['customer_country_id'] = STORE_COUNTRY;
                 $_SESSION['customer_zone_id'] = STORE_ZONE;
@@ -336,7 +336,7 @@ class Search extends \base
                 'm.manufacturers_name',
             ];
 
-            if (ADVANCED_SEARCH_INCLUDE_METATAGS === 'true') {
+            if (zen_get_config_value('ADVANCED_SEARCH_INCLUDE_METATAGS') === 'true') {
                 $keyword_search_fields[] = 'mtpd.metatags_keywords';
                 $keyword_search_fields[] = 'mtpd.metatags_description';
             }
@@ -379,7 +379,7 @@ class Search extends \base
             }
         }
 
-        if (DISPLAY_PRICE_WITH_TAX === 'true') {
+        if (zen_get_config_value('DISPLAY_PRICE_WITH_TAX') === 'true') {
             if (!empty($this->searchOptions->pfrom)) {
                 $where_str .= " AND (p.products_price_sorter * IF(gz.geo_zone_id IS NULL, 1, 1 + (tr.tax_rate / 100)) >= :price)";
                 $where_str = $db->bindVars($where_str, ':price', $this->searchOptions->pfrom, 'float');
@@ -405,7 +405,7 @@ class Search extends \base
         $this->notify('NOTIFY_SEARCH_WHERE_STRING', $this->searchOptions->keywords, $where_str, $keyword_search_fields);
 
 
-        if (DISPLAY_PRICE_WITH_TAX === 'true' && (!empty($this->searchOptions->pfrom) || !empty($this->searchOptions->pto))) {
+        if (zen_get_config_value('DISPLAY_PRICE_WITH_TAX') === 'true' && (!empty($this->searchOptions->pfrom) || !empty($this->searchOptions->pto))) {
             $where_str .= " GROUP BY p.products_id, tr.tax_priority";
         }
 
@@ -422,8 +422,8 @@ class Search extends \base
         //
         } else {
             // set the default sort order setting from the Admin when not defined by customer
-            if (empty($this->searchOptions->sort) && PRODUCT_LISTING_DEFAULT_SORT_ORDER != '') {
-                $this->searchOptions->sort = PRODUCT_LISTING_DEFAULT_SORT_ORDER;
+            if (empty($this->searchOptions->sort) && zen_get_config_value('PRODUCT_LISTING_DEFAULT_SORT_ORDER') != '') {
+                $this->searchOptions->sort = zen_get_config_value('PRODUCT_LISTING_DEFAULT_SORT_ORDER');
             }
             if (empty($this->searchOptions->sort) ||
                 !preg_match('/[1-8][ad]/', $this->searchOptions->sort) ||
@@ -442,7 +442,7 @@ class Search extends \base
                     }
                 }
                 // if set to nothing use products_sort_order and PRODUCTS_LIST_NAME is off
-                if (PRODUCT_LISTING_DEFAULT_SORT_ORDER == '') {
+                if (zen_get_config_value('PRODUCT_LISTING_DEFAULT_SORT_ORDER') == '') {
                     $this->searchOptions->sort = '20a';
                 }
             } else {

--- a/includes/classes/class.search.php
+++ b/includes/classes/class.search.php
@@ -169,13 +169,13 @@ class Search extends \base
         }
 
         $define_list = [
-            'PRODUCT_LIST_MODEL' => zen_get_config_value('PRODUCT_LIST_MODEL'),
-            'PRODUCT_LIST_NAME' => zen_get_config_value('PRODUCT_LIST_NAME'),
-            'PRODUCT_LIST_MANUFACTURER' => zen_get_config_value('PRODUCT_LIST_MANUFACTURER'),
-            'PRODUCT_LIST_PRICE' => zen_get_config_value('PRODUCT_LIST_PRICE'),
-            'PRODUCT_LIST_QUANTITY' => zen_get_config_value('PRODUCT_LIST_QUANTITY'),
-            'PRODUCT_LIST_WEIGHT' => zen_get_config_value('PRODUCT_LIST_WEIGHT'),
-            'PRODUCT_LIST_IMAGE' => zen_get_config_value('PRODUCT_LIST_IMAGE')
+            'PRODUCT_LIST_MODEL' => zen_config('PRODUCT_LIST_MODEL'),
+            'PRODUCT_LIST_NAME' => zen_config('PRODUCT_LIST_NAME'),
+            'PRODUCT_LIST_MANUFACTURER' => zen_config('PRODUCT_LIST_MANUFACTURER'),
+            'PRODUCT_LIST_PRICE' => zen_config('PRODUCT_LIST_PRICE'),
+            'PRODUCT_LIST_QUANTITY' => zen_config('PRODUCT_LIST_QUANTITY'),
+            'PRODUCT_LIST_WEIGHT' => zen_config('PRODUCT_LIST_WEIGHT'),
+            'PRODUCT_LIST_IMAGE' => zen_config('PRODUCT_LIST_IMAGE')
         ];
 
         asort($define_list);
@@ -224,7 +224,7 @@ class Search extends \base
         */
 
         // always add quantity regardless of whether or not it is in the listing for add to cart buttons
-        if (zen_get_config_value('PRODUCT_LIST_QUANTITY') < 1) {
+        if (zen_config('PRODUCT_LIST_QUANTITY') < 1) {
             if (empty($select_column_list)) {
                 $select_column_list .= ' p.products_quantity ';
             } else {
@@ -244,7 +244,7 @@ class Search extends \base
             p.products_price, p.products_tax_class_id, p.products_price_sorter,
             p.products_qty_box_status, p.master_categories_id, p.product_is_call ";
 
-        if (zen_get_config_value('DISPLAY_PRICE_WITH_TAX') === 'true' && (!empty($this->searchOptions->pfrom) || !empty($this->searchOptions->pto))) {
+        if (zen_config('DISPLAY_PRICE_WITH_TAX') === 'true' && (!empty($this->searchOptions->pfrom) || !empty($this->searchOptions->pto))) {
             $select_str .= ", SUM(tr.tax_rate) AS tax_rate ";
         }
 
@@ -255,14 +255,14 @@ class Search extends \base
                     LEFT JOIN " . TABLE_MANUFACTURERS . " m
                     USING(manufacturers_id), " . TABLE_PRODUCTS_DESCRIPTION . " pd, " . TABLE_CATEGORIES . " c, " . TABLE_PRODUCTS_TO_CATEGORIES . " p2c )";
 
-        if (zen_get_config_value('ADVANCED_SEARCH_INCLUDE_METATAGS') === 'true') {
+        if (zen_config('ADVANCED_SEARCH_INCLUDE_METATAGS') === 'true') {
             $from_str .=
                 " LEFT JOIN " . TABLE_META_TAGS_PRODUCTS_DESCRIPTION . " mtpd
                     ON (mtpd.products_id= p2c.products_id AND mtpd.language_id = :languagesID)";
             $from_str = $db->bindVars($from_str, ':languagesID', $_SESSION['languages_id'], 'integer');
         }
 
-        if (zen_get_config_value('DISPLAY_PRICE_WITH_TAX') === 'true' && (!empty($this->searchOptions->pfrom) || !empty($this->searchOptions->pto))) {
+        if (zen_config('DISPLAY_PRICE_WITH_TAX') === 'true' && (!empty($this->searchOptions->pfrom) || !empty($this->searchOptions->pto))) {
             if (empty($_SESSION['customer_country_id'])) {
                 $_SESSION['customer_country_id'] = STORE_COUNTRY;
                 $_SESSION['customer_zone_id'] = STORE_ZONE;
@@ -336,7 +336,7 @@ class Search extends \base
                 'm.manufacturers_name',
             ];
 
-            if (zen_get_config_value('ADVANCED_SEARCH_INCLUDE_METATAGS') === 'true') {
+            if (zen_config('ADVANCED_SEARCH_INCLUDE_METATAGS') === 'true') {
                 $keyword_search_fields[] = 'mtpd.metatags_keywords';
                 $keyword_search_fields[] = 'mtpd.metatags_description';
             }
@@ -379,7 +379,7 @@ class Search extends \base
             }
         }
 
-        if (zen_get_config_value('DISPLAY_PRICE_WITH_TAX') === 'true') {
+        if (zen_config('DISPLAY_PRICE_WITH_TAX') === 'true') {
             if (!empty($this->searchOptions->pfrom)) {
                 $where_str .= " AND (p.products_price_sorter * IF(gz.geo_zone_id IS NULL, 1, 1 + (tr.tax_rate / 100)) >= :price)";
                 $where_str = $db->bindVars($where_str, ':price', $this->searchOptions->pfrom, 'float');
@@ -405,7 +405,7 @@ class Search extends \base
         $this->notify('NOTIFY_SEARCH_WHERE_STRING', $this->searchOptions->keywords, $where_str, $keyword_search_fields);
 
 
-        if (zen_get_config_value('DISPLAY_PRICE_WITH_TAX') === 'true' && (!empty($this->searchOptions->pfrom) || !empty($this->searchOptions->pto))) {
+        if (zen_config('DISPLAY_PRICE_WITH_TAX') === 'true' && (!empty($this->searchOptions->pfrom) || !empty($this->searchOptions->pto))) {
             $where_str .= " GROUP BY p.products_id, tr.tax_priority";
         }
 
@@ -422,8 +422,8 @@ class Search extends \base
         //
         } else {
             // set the default sort order setting from the Admin when not defined by customer
-            if (empty($this->searchOptions->sort) && zen_get_config_value('PRODUCT_LISTING_DEFAULT_SORT_ORDER') != '') {
-                $this->searchOptions->sort = zen_get_config_value('PRODUCT_LISTING_DEFAULT_SORT_ORDER');
+            if (empty($this->searchOptions->sort) && zen_config('PRODUCT_LISTING_DEFAULT_SORT_ORDER') != '') {
+                $this->searchOptions->sort = zen_config('PRODUCT_LISTING_DEFAULT_SORT_ORDER');
             }
             if (empty($this->searchOptions->sort) ||
                 !preg_match('/[1-8][ad]/', $this->searchOptions->sort) ||
@@ -442,7 +442,7 @@ class Search extends \base
                     }
                 }
                 // if set to nothing use products_sort_order and PRODUCTS_LIST_NAME is off
-                if (zen_get_config_value('PRODUCT_LISTING_DEFAULT_SORT_ORDER') == '') {
+                if (zen_config('PRODUCT_LISTING_DEFAULT_SORT_ORDER') == '') {
                     $this->searchOptions->sort = '20a';
                 }
             } else {

--- a/includes/classes/currencies.php
+++ b/includes/classes/currencies.php
@@ -60,7 +60,7 @@ class currencies extends base
      */
     public function format(mixed $number, bool $calculate_using_exchange_rate = true, string $currency_code = '', mixed $currency_value = ''): string
     {
-        if (IS_ADMIN_FLAG === false && zen_get_config_value('DOWN_FOR_MAINTENANCE') === 'true' && zen_get_config_value('DOWN_FOR_MAINTENANCE_PRICES_OFF') === 'true' && !zen_is_whitelisted_admin_ip()) {
+        if (IS_ADMIN_FLAG === false && zen_config('DOWN_FOR_MAINTENANCE') === 'true' && zen_config('DOWN_FOR_MAINTENANCE_PRICES_OFF') === 'true' && !zen_is_whitelisted_admin_ip()) {
             return '';
         }
 
@@ -81,7 +81,7 @@ class currencies extends base
         if ($calculate_using_exchange_rate === true) {
             // Special Case: if the selected currency is in the european euro-conversion and the default currency is euro,
             // then the currency will displayed in both the national currency and euro currency
-            if (zen_get_config_value('DEFAULT_CURRENCY') === 'EUR' && in_array($currency_code, ['DEM', 'BEF', 'LUF', 'ESP', 'FRF', 'IEP', 'ITL', 'NLG', 'ATS', 'PTE', 'FIM', 'GRD'])) {
+            if (zen_config('DEFAULT_CURRENCY') === 'EUR' && in_array($currency_code, ['DEM', 'BEF', 'LUF', 'ESP', 'FRF', 'IEP', 'ITL', 'NLG', 'ATS', 'PTE', 'FIM', 'GRD'])) {
                 $formatted_string .= ' <small>[' . $this->format($number, true, 'EUR') . ']</small>';
             }
         }
@@ -215,7 +215,7 @@ class currencies extends base
         // default otherwise.
         //
         if (empty($currency_code)) {
-            $currency_code = $_SESSION['currency'] ?? zen_get_config_value('DEFAULT_CURRENCY');
+            $currency_code = $_SESSION['currency'] ?? zen_config('DEFAULT_CURRENCY');
         }
 
         // -----
@@ -229,11 +229,11 @@ class currencies extends base
         // An amount for this case would be formatted similar to 'EUR 20.00'.
         //
         if (empty($this->currencies[$currency_code])) {
-            $this->currencies[$currency_code] = $this->currencies[zen_get_config_value('DEFAULT_CURRENCY')];
+            $this->currencies[$currency_code] = $this->currencies[zen_config('DEFAULT_CURRENCY')];
             $this->currencies[$currency_code]['symbol_left'] = $currency_code . ' ';
             $this->currencies[$currency_code]['symbol_right'] = '';
             if ($this->debug === true) {
-                trigger_error("Creating currency settings for $currency_code, based on " . zen_get_config_value('DEFAULT_CURRENCY') . " settings.", E_USER_NOTICE);
+                trigger_error("Creating currency settings for $currency_code, based on " . zen_config('DEFAULT_CURRENCY') . " settings.", E_USER_NOTICE);
             }
         }
 

--- a/includes/classes/currencies.php
+++ b/includes/classes/currencies.php
@@ -60,7 +60,7 @@ class currencies extends base
      */
     public function format(mixed $number, bool $calculate_using_exchange_rate = true, string $currency_code = '', mixed $currency_value = ''): string
     {
-        if (IS_ADMIN_FLAG === false && DOWN_FOR_MAINTENANCE === 'true' && DOWN_FOR_MAINTENANCE_PRICES_OFF === 'true' && !zen_is_whitelisted_admin_ip()) {
+        if (IS_ADMIN_FLAG === false && zen_get_config_value('DOWN_FOR_MAINTENANCE') === 'true' && zen_get_config_value('DOWN_FOR_MAINTENANCE_PRICES_OFF') === 'true' && !zen_is_whitelisted_admin_ip()) {
             return '';
         }
 
@@ -81,7 +81,7 @@ class currencies extends base
         if ($calculate_using_exchange_rate === true) {
             // Special Case: if the selected currency is in the european euro-conversion and the default currency is euro,
             // then the currency will displayed in both the national currency and euro currency
-            if (DEFAULT_CURRENCY === 'EUR' && in_array($currency_code, ['DEM', 'BEF', 'LUF', 'ESP', 'FRF', 'IEP', 'ITL', 'NLG', 'ATS', 'PTE', 'FIM', 'GRD'])) {
+            if (zen_get_config_value('DEFAULT_CURRENCY') === 'EUR' && in_array($currency_code, ['DEM', 'BEF', 'LUF', 'ESP', 'FRF', 'IEP', 'ITL', 'NLG', 'ATS', 'PTE', 'FIM', 'GRD'])) {
                 $formatted_string .= ' <small>[' . $this->format($number, true, 'EUR') . ']</small>';
             }
         }
@@ -215,7 +215,7 @@ class currencies extends base
         // default otherwise.
         //
         if (empty($currency_code)) {
-            $currency_code = $_SESSION['currency'] ?? DEFAULT_CURRENCY;
+            $currency_code = $_SESSION['currency'] ?? zen_get_config_value('DEFAULT_CURRENCY');
         }
 
         // -----
@@ -229,11 +229,11 @@ class currencies extends base
         // An amount for this case would be formatted similar to 'EUR 20.00'.
         //
         if (empty($this->currencies[$currency_code])) {
-            $this->currencies[$currency_code] = $this->currencies[DEFAULT_CURRENCY];
+            $this->currencies[$currency_code] = $this->currencies[zen_get_config_value('DEFAULT_CURRENCY')];
             $this->currencies[$currency_code]['symbol_left'] = $currency_code . ' ';
             $this->currencies[$currency_code]['symbol_right'] = '';
             if ($this->debug === true) {
-                trigger_error("Creating currency settings for $currency_code, based on " . DEFAULT_CURRENCY . " settings.", E_USER_NOTICE);
+                trigger_error("Creating currency settings for $currency_code, based on " . zen_get_config_value('DEFAULT_CURRENCY') . " settings.", E_USER_NOTICE);
             }
         }
 

--- a/includes/functions/functions_general_shared.php
+++ b/includes/functions/functions_general_shared.php
@@ -402,12 +402,12 @@ function zen_get_shipping_enabled(string $shipping_module): bool
     $check_cart_weight = $_SESSION['cart']->show_weight();
 
     // Free Shipping when 0 weight - enable freeshipper - ORDER_WEIGHT_ZERO_STATUS must be on
-    if (zen_get_config_value('ORDER_WEIGHT_ZERO_STATUS') == '1' && $check_cart_weight == 0 && $shipping_module === 'freeshipper') {
+    if (zen_config('ORDER_WEIGHT_ZERO_STATUS') == '1' && $check_cart_weight == 0 && $shipping_module === 'freeshipper') {
         return true;
     }
 
     // Free Shipping when 0 weight - disable everyone - ORDER_WEIGHT_ZERO_STATUS must be on
-    if (zen_get_config_value('ORDER_WEIGHT_ZERO_STATUS') == '1' && $check_cart_weight == 0 && $shipping_module !== 'freeshipper') {
+    if (zen_config('ORDER_WEIGHT_ZERO_STATUS') == '1' && $check_cart_weight == 0 && $shipping_module !== 'freeshipper') {
         return false;
     }
 
@@ -724,7 +724,7 @@ function zen_add_filemtime(string $relative_path, ?string $absolute_path = null)
  *
  * @since ZC 3.0.0
  */
-function zen_get_config_value(string $key): mixed
+function zen_config(string $key): mixed
 {
     global $configurationRepository;
 

--- a/includes/functions/functions_general_shared.php
+++ b/includes/functions/functions_general_shared.php
@@ -402,35 +402,35 @@ function zen_get_shipping_enabled(string $shipping_module): bool
     $check_cart_weight = $_SESSION['cart']->show_weight();
 
     // Free Shipping when 0 weight - enable freeshipper - ORDER_WEIGHT_ZERO_STATUS must be on
-    if (ORDER_WEIGHT_ZERO_STATUS == '1' && ($check_cart_weight == 0 && $shipping_module == 'freeshipper')) {
+    if (zen_get_config_value('ORDER_WEIGHT_ZERO_STATUS') == '1' && $check_cart_weight == 0 && $shipping_module === 'freeshipper') {
         return true;
     }
 
     // Free Shipping when 0 weight - disable everyone - ORDER_WEIGHT_ZERO_STATUS must be on
-    if (ORDER_WEIGHT_ZERO_STATUS == '1' && ($check_cart_weight == 0 && $shipping_module != 'freeshipper')) {
+    if (zen_get_config_value('ORDER_WEIGHT_ZERO_STATUS') == '1' && $check_cart_weight == 0 && $shipping_module !== 'freeshipper') {
         return false;
     }
 
-    if ($_SESSION['cart']->free_shipping_items() == $check_cart_cnt && $shipping_module == 'freeshipper') {
+    if ($_SESSION['cart']->free_shipping_items() == $check_cart_cnt && $shipping_module === 'freeshipper') {
         return true;
     }
 
-    if ($_SESSION['cart']->free_shipping_items() == $check_cart_cnt && $shipping_module != 'freeshipper') {
+    if ($_SESSION['cart']->free_shipping_items() == $check_cart_cnt && $shipping_module !== 'freeshipper') {
         return false;
     }
 
     // Always free shipping only true - enable freeshipper
-    if ($check_cart_free == $check_cart_cnt && $shipping_module == 'freeshipper') {
+    if ($check_cart_free == $check_cart_cnt && $shipping_module === 'freeshipper') {
         return true;
     }
 
     // Always free shipping only true - disable everyone
-    if ($check_cart_free == $check_cart_cnt && $shipping_module != 'freeshipper') {
+    if ($check_cart_free == $check_cart_cnt && $shipping_module !== 'freeshipper') {
         return false;
     }
 
     // Always free shipping only is false - disable freeshipper
-    if ($check_cart_free != $check_cart_cnt && $shipping_module == 'freeshipper') {
+    if ($check_cart_free != $check_cart_cnt && $shipping_module === 'freeshipper') {
         return false;
     }
     return true;
@@ -561,7 +561,7 @@ function zen_get_admin_name($id = null)
     $sql = "SELECT admin_name FROM " . TABLE_ADMIN . " WHERE admin_id = :adminid: LIMIT 1";
     $sql = $db->bindVars($sql, ':adminid:', $id, 'integer');
     $result = $db->Execute($sql);
-    return $result->RecordCount() ? $result->fields['admin_name'] : null;
+    return !$result->EOF ? $result->fields['admin_name'] : null;
 }
 
 /**
@@ -716,4 +716,17 @@ function zen_add_filemtime(string $relative_path, ?string $absolute_path = null)
         return $relative_path;
     }
     return $relative_path . '?' . $mtime;
+}
+
+/**
+ * A helper function to retrieve a specific database constant (either in
+ * the configuration or product_type_layout tables).
+ *
+ * @since ZC 3.0.0
+ */
+function zen_get_config_value(string $key): mixed
+{
+    global $configurationRepository;
+
+    return $configurationRepository->get($key);
 }


### PR DESCRIPTION
In a future release of Zen Cart, we will do away with the 'conversion' of configuration settings to PHP `define` values and, instead, use a class-based method to access these values.  The helper function `zen_get_config_value` provides an easy way to perform this 'conversion'.

This is a preliminary step to support template-specific settings.  I've made the required modifications to a couple of the `/includes/classes` files, but wanted to get this change "out there" for both review and to gather help in doing the conversion on the rest of the files!

We'll need to come up with a way to indicate that you're working on a file (or collection of files) so that effort isn't duplicated in this time-consuming process.