### PR TITLE
Pin safe Composer versions in CI

### DIFF
--- a/.github/workflows/zc_feature_test_admin_suite.yml
+++ b/.github/workflows/zc_feature_test_admin_suite.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           ini-values: log_errors=On
-          tools: composer, phpunit
+          tools: composer:v2.9.8, phpunit
 
       - name: Install Apache2
         run: sudo apt-get update && sudo apt-get install apache2 -y

--- a/.github/workflows/zc_feature_test_store_suite.yml
+++ b/.github/workflows/zc_feature_test_store_suite.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           ini-values: log_errors=On
-          tools: composer, phpunit
+          tools: composer:v2.9.8, phpunit
 
       - name: Install Apache2
         run: sudo apt-get update && sudo apt-get install apache2 -y

--- a/.github/workflows/zc_unit_test_suite.yml
+++ b/.github/workflows/zc_unit_test_suite.yml
@@ -22,7 +22,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          tools: composer, phpunit
+          tools: composer:v2.9.8, phpunit
 
       - name: Install Composer dependencies
         run: composer install --no-progress --no-interaction --ignore-platform-reqs --prefer-dist --optimize-autoloader --no-ansi --no-scripts

--- a/not_for_release/testFramework/docker/test-runner/Dockerfile
+++ b/not_for_release/testFramework/docker/test-runner/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.9.8 /usr/bin/composer /usr/bin/composer
 
 RUN { \
         echo "memory_limit=512M"; \

--- a/not_for_release/testFramework/test-runner-container-ghcr.md
+++ b/not_for_release/testFramework/test-runner-container-ghcr.md
@@ -83,7 +83,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.9.8 /usr/bin/composer /usr/bin/composer
 
 RUN { \
         echo "memory_limit=512M"; \


### PR DESCRIPTION
https://github.com/shivammathur/setup-php/releases/tag/2.37.1

we may not be affected but until I can audit, this is the safest route.