### PR TITLE
`configuration.php`, focus on selected item

### DIFF
--- a/admin/configuration.php
+++ b/admin/configuration.php
@@ -220,6 +220,9 @@ echo zen_draw_form('configuration', FILENAME_CONFIGURATION, 'gID=' . $_GET['gID'
 <?php
 foreach ($configuration as $item) {
     $fieldName = 'cfg_' . $item['configuration_id'];
+    if (isset($_GET['cID']) && $_GET['cID'] === $item['configuration_id']) {
+        $focusField = $fieldName;
+    }
     $cfgValue = htmlspecialchars($item['configuration_value'], ENT_COMPAT, CHARSET, true);
 
     if (defined('CFGTITLE_' . $item['configuration_key'])) {
@@ -274,7 +277,17 @@ foreach ($configuration as $item) {
     </div>
     <?= '</form>' ?>
 </div>
-
+<?php
+if (isset($focusField)) {
+?>
+<script id="config-focus">
+$(window).on('load', function() {
+    $('input[name="<?= $focusField ?>"], input[name="configuration[<?= $focusField ?>]"]:checked, select[name="configuration[<?= $focusField ?>]"]').focus();
+});
+</script>
+<?php
+}
+?>
 <!-- body_eof //-->
 
 <!-- footer //-->


### PR DESCRIPTION
When you search for a configuration setting via the "Developers' Tool Kit" and a match is found, you can click a link that takes you to the page of configuration settings for that setting's group.

This PR adds a `focus` on the specified field, which was kind of lost when the full-group edit feature was added.