### PR TITLE
Shipping modules: Using `zen_config` and ...

### DIFF
--- a/includes/modules/shipping/flat.php
+++ b/includes/modules/shipping/flat.php
@@ -16,18 +16,19 @@ class flat extends ZenShipping
         $this->code = 'flat';
         $this->title = MODULE_SHIPPING_FLAT_TEXT_TITLE;
         $this->description = MODULE_SHIPPING_FLAT_TEXT_DESCRIPTION;
-        $this->sort_order = defined('MODULE_SHIPPING_FLAT_SORT_ORDER') ? MODULE_SHIPPING_FLAT_SORT_ORDER : null;
+        $this->sort_order = zen_config('MODULE_SHIPPING_FLAT_SORT_ORDER');
         if (null === $this->sort_order) {
-            return false;
+            return;
         }
 
+        $this->sort_order = (int)$this->sort_order;
         $this->icon = '';
-        $this->tax_class = MODULE_SHIPPING_FLAT_TAX_CLASS;
-        $this->tax_basis = MODULE_SHIPPING_FLAT_TAX_BASIS;
+        $this->tax_class = zen_config('MODULE_SHIPPING_FLAT_TAX_CLASS');
+        $this->tax_basis = zen_config('MODULE_SHIPPING_FLAT_TAX_BASIS');
 
         // disable only when entire cart is free shipping
         if (zen_get_shipping_enabled($this->code)) {
-            $this->enabled = (MODULE_SHIPPING_FLAT_STATUS == 'True');
+            $this->enabled = zen_config('MODULE_SHIPPING_FLAT_STATUS') === 'True';
         } else {
             $this->enabled = false;
         }
@@ -45,7 +46,7 @@ class flat extends ZenShipping
             return;
         }
 
-        $this->checkEnabledForZone(MODULE_SHIPPING_FLAT_ZONE);
+        $this->checkEnabledForZone(zen_config('MODULE_SHIPPING_FLAT_ZONE'));
 
         if ($this->enabled) {
             // -----
@@ -69,7 +70,7 @@ class flat extends ZenShipping
                 [
                     'id' => $this->code,
                     'title' => MODULE_SHIPPING_FLAT_TEXT_WAY,
-                    'cost' => MODULE_SHIPPING_FLAT_COST,
+                    'cost' => zen_config('MODULE_SHIPPING_FLAT_COST'),
                 ],
             ],
         ];
@@ -89,10 +90,8 @@ class flat extends ZenShipping
      */
     function check()
     {
-        global $db;
-        if (!isset($this->_check)) {
-            $check_query = $db->Execute("select configuration_value from " . TABLE_CONFIGURATION . " where configuration_key = 'MODULE_SHIPPING_FLAT_STATUS'");
-            $this->_check = $check_query->RecordCount();
+        if (!isset($this->_check)) { 
+            $this->_check = (int)(zen_config('MODULE_SHIPPING_FLAT_STATUS') !== null);
         }
         return $this->_check;
     }

--- a/includes/modules/shipping/freeoptions.php
+++ b/includes/modules/shipping/freeoptions.php
@@ -14,18 +14,19 @@ class freeoptions extends ZenShipping
         $this->code = 'freeoptions';
         $this->title = MODULE_SHIPPING_FREEOPTIONS_TEXT_TITLE;
         $this->description = MODULE_SHIPPING_FREEOPTIONS_TEXT_DESCRIPTION;
-        $this->sort_order = defined('MODULE_SHIPPING_FREEOPTIONS_SORT_ORDER') ? MODULE_SHIPPING_FREEOPTIONS_SORT_ORDER : null;
+        $this->sort_order = zen_config('MODULE_SHIPPING_FREEOPTIONS_SORT_ORDER');
         if (null === $this->sort_order) {
-            return false;
+            return;
         }
 
+        $this->sort_order = (int)$this->sort_order;
         $this->icon = '';
-        $this->tax_class = MODULE_SHIPPING_FREEOPTIONS_TAX_CLASS;
-        $this->tax_basis = MODULE_SHIPPING_FREEOPTIONS_TAX_BASIS;
+        $this->tax_class = zen_config('MODULE_SHIPPING_FREEOPTIONS_TAX_CLASS');
+        $this->tax_basis = zen_config('MODULE_SHIPPING_FREEOPTIONS_TAX_BASIS');
 
         // disable only when entire cart is free shipping
         if (zen_get_shipping_enabled($this->code)) {
-            $this->enabled = ((MODULE_SHIPPING_FREEOPTIONS_STATUS == 'True') ? true : false);
+            $this->enabled = (zen_config('MODULE_SHIPPING_FREEOPTIONS_STATUS') === 'True');
         } else {
             $this->enabled = false;
         }
@@ -43,7 +44,7 @@ class freeoptions extends ZenShipping
             return;
         }
 
-        $this->checkEnabledForZone(MODULE_SHIPPING_FREEOPTIONS_ZONE);
+        $this->checkEnabledForZone(zen_config('MODULE_SHIPPING_FREEOPTIONS_ZONE'));
 
         // -----
         // If still enabled, check to see if any "Free Options" should be presented to the customer.
@@ -67,12 +68,12 @@ class freeoptions extends ZenShipping
         // -----
         // Convert each of the min/max configured values into their floating-point equivalent.
         //
-        $total_min = (float)MODULE_SHIPPING_FREEOPTIONS_TOTAL_MIN;
-        $total_max = (float)MODULE_SHIPPING_FREEOPTIONS_TOTAL_MAX;
-        $weight_min = (float)MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MIN;
-        $weight_max = (float)MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MAX;
-        $items_min = (float)MODULE_SHIPPING_FREEOPTIONS_ITEMS_MIN;
-        $items_max = (float)MODULE_SHIPPING_FREEOPTIONS_ITEMS_MAX;
+        $total_min = (float)zen_config('MODULE_SHIPPING_FREEOPTIONS_TOTAL_MIN');
+        $total_max = (float)zen_config('MODULE_SHIPPING_FREEOPTIONS_TOTAL_MAX');
+        $weight_min = (float)zen_config('MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MIN');
+        $weight_max = (float)zen_config('MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MAX');
+        $items_min = (float)zen_config('MODULE_SHIPPING_FREEOPTIONS_ITEMS_MIN');
+        $items_max = (float)zen_config('MODULE_SHIPPING_FREEOPTIONS_ITEMS_MAX');
 
         // -----
         // First, see if any of the 3 options for free shipping are configured.  If none are configured, there's no quote
@@ -100,7 +101,7 @@ class freeoptions extends ZenShipping
             } else {
                 $freeoptions_total = ($cart_total <= $total_max);
             }
-            $this->debug[] = ['total', $cart_total, $freeoptions_total, MODULE_SHIPPING_FREEOPTIONS_TOTAL_MIN, MODULE_SHIPPING_FREEOPTIONS_TOTAL_MAX];
+            $this->debug[] = ['total', $cart_total, $freeoptions_total, zen_config('MODULE_SHIPPING_FREEOPTIONS_TOTAL_MIN'), zen_config('MODULE_SHIPPING_FREEOPTIONS_TOTAL_MAX')];
         }
 
         // -----
@@ -115,7 +116,7 @@ class freeoptions extends ZenShipping
             } else {
                 $freeoptions_weight = ($order_weight <= $weight_max);
             }
-            $this->debug[] = ['weight', $order_weight, $freeoptions_weight, MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MIN, MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MAX];
+            $this->debug[] = ['weight', $order_weight, $freeoptions_weight, zen_config('MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MIN'), zen_config('MODULE_SHIPPING_FREEOPTIONS_WEIGHT_MAX')];
         }
 
         // -----
@@ -130,7 +131,7 @@ class freeoptions extends ZenShipping
             } else {
                 $freeoptions_items = ($num_items <= $items_max);
             }
-            $this->debug[] = ['items', $num_items, $freeoptions_items, MODULE_SHIPPING_FREEOPTIONS_ITEMS_MIN, MODULE_SHIPPING_FREEOPTIONS_ITEMS_MAX];
+            $this->debug[] = ['items', $num_items, $freeoptions_items, zen_config('MODULE_SHIPPING_FREEOPTIONS_ITEMS_MIN'), zen_config('MODULE_SHIPPING_FREEOPTIONS_ITEMS_MAX')];
         }
 
         // -----
@@ -168,7 +169,7 @@ class freeoptions extends ZenShipping
                 [
                     'id' => $this->code,
                     'title' => MODULE_SHIPPING_FREEOPTIONS_TEXT_WAY,
-                    'cost' => (float)MODULE_SHIPPING_FREEOPTIONS_COST + (float)MODULE_SHIPPING_FREEOPTIONS_HANDLING,
+                    'cost' => (float)zen_config('MODULE_SHIPPING_FREEOPTIONS_COST') + (float)zen_config('MODULE_SHIPPING_FREEOPTIONS_HANDLING'),
                 ],
             ],
         ];
@@ -189,10 +190,8 @@ class freeoptions extends ZenShipping
      */
     public function check()
     {
-        global $db;
         if (!isset($this->_check)) {
-            $check_query = $db->Execute("SELECT configuration_value FROM " . TABLE_CONFIGURATION . " WHERE configuration_key = 'MODULE_SHIPPING_FREEOPTIONS_STATUS'");
-            $this->_check = $check_query->RecordCount();
+            $this->_check = (int)(zen_config('MODULE_SHIPPING_FREEOPTIONS_STATUS') !== null);
         }
         return $this->_check;
     }

--- a/includes/modules/shipping/freeshipper.php
+++ b/includes/modules/shipping/freeshipper.php
@@ -15,17 +15,18 @@ class freeshipper extends ZenShipping
         $this->code = 'freeshipper';
         $this->title = MODULE_SHIPPING_FREESHIPPER_TEXT_TITLE;
         $this->description = MODULE_SHIPPING_FREESHIPPER_TEXT_DESCRIPTION;
-        $this->sort_order = defined('MODULE_SHIPPING_FREESHIPPER_SORT_ORDER') ? (int)MODULE_SHIPPING_FREESHIPPER_SORT_ORDER : null;
+        $this->sort_order = zen_config('MODULE_SHIPPING_FREESHIPPER_SORT_ORDER');
         if (null === $this->sort_order) {
-            return false;
+            return;
         }
 
+        $this->sort_order = (int)$this->sort_order;
         $this->icon = '';
-        $this->tax_class = MODULE_SHIPPING_FREESHIPPER_TAX_CLASS;
+        $this->tax_class = zen_config('MODULE_SHIPPING_FREESHIPPER_TAX_CLASS');
 
         // enable only when entire cart is free shipping
         if (zen_get_shipping_enabled($this->code)) {
-            $this->enabled = (MODULE_SHIPPING_FREESHIPPER_STATUS === 'True');
+            $this->enabled = (zen_config('MODULE_SHIPPING_FREESHIPPER_STATUS') === 'True');
         } else {
             $this->enabled = false;
         }
@@ -43,7 +44,7 @@ class freeshipper extends ZenShipping
             return;
         }
 
-        $this->checkEnabledForZone(MODULE_SHIPPING_FREESHIPPER_ZONE);
+        $this->checkEnabledForZone(zen_config('MODULE_SHIPPING_FREESHIPPER_ZONE'));
 
         if ($this->enabled) {
             // -----
@@ -67,7 +68,7 @@ class freeshipper extends ZenShipping
                 [
                     'id' => $this->code,
                     'title' => MODULE_SHIPPING_FREESHIPPER_TEXT_WAY,
-                    'cost' => MODULE_SHIPPING_FREESHIPPER_COST + MODULE_SHIPPING_FREESHIPPER_HANDLING,
+                    'cost' => zen_config('MODULE_SHIPPING_FREESHIPPER_COST') + zen_config('MODULE_SHIPPING_FREESHIPPER_HANDLING'),
                 ],
             ],
         ];
@@ -88,10 +89,8 @@ class freeshipper extends ZenShipping
      */
     function check()
     {
-        global $db;
         if (!isset($this->_check)) {
-            $check_query = $db->Execute("select configuration_value from " . TABLE_CONFIGURATION . " where configuration_key = 'MODULE_SHIPPING_FREESHIPPER_STATUS'");
-            $this->_check = $check_query->RecordCount();
+            $this->_check = (int)(zen_config('MODULE_SHIPPING_FREESHIPPER_STATUS') !== null);
         }
         return $this->_check;
     }

--- a/includes/modules/shipping/item.php
+++ b/includes/modules/shipping/item.php
@@ -16,18 +16,19 @@ class item extends ZenShipping
         $this->code = 'item';
         $this->title = MODULE_SHIPPING_ITEM_TEXT_TITLE;
         $this->description = MODULE_SHIPPING_ITEM_TEXT_DESCRIPTION;
-        $this->sort_order = defined('MODULE_SHIPPING_ITEM_SORT_ORDER') ? MODULE_SHIPPING_ITEM_SORT_ORDER : null;
+        $this->sort_order = zen_config('MODULE_SHIPPING_ITEM_SORT_ORDER');
         if (null === $this->sort_order) {
-            return false;
+            return;
         }
 
+        $this->sort_order = (int)$this->sort_order;
         $this->icon = '';
-        $this->tax_class = MODULE_SHIPPING_ITEM_TAX_CLASS;
-        $this->tax_basis = MODULE_SHIPPING_ITEM_TAX_BASIS;
+        $this->tax_class = zen_config('MODULE_SHIPPING_ITEM_TAX_CLASS');
+        $this->tax_basis = zen_config('MODULE_SHIPPING_ITEM_TAX_BASIS');
 
         // disable only when entire cart is free shipping
         if (zen_get_shipping_enabled($this->code)) {
-            $this->enabled = (MODULE_SHIPPING_ITEM_STATUS === 'True');
+            $this->enabled = (zen_config('MODULE_SHIPPING_ITEM_STATUS') === 'True');
         } else {
             $this->enabled = false;
         }
@@ -45,7 +46,7 @@ class item extends ZenShipping
             return;
         }
 
-        $this->checkEnabledForZone(MODULE_SHIPPING_ITEM_ZONE);
+        $this->checkEnabledForZone(zen_config('MODULE_SHIPPING_ITEM_ZONE'));
 
         if ($this->enabled) {
             // -----
@@ -71,7 +72,7 @@ class item extends ZenShipping
                 [
                     'id' => $this->code,
                     'title' => MODULE_SHIPPING_ITEM_TEXT_WAY,
-                    'cost' => (MODULE_SHIPPING_ITEM_COST * $item_total_count) + MODULE_SHIPPING_ITEM_HANDLING,
+                    'cost' => (zen_config('MODULE_SHIPPING_ITEM_COST') * $item_total_count) + zen_config('MODULE_SHIPPING_ITEM_HANDLING'),
                 ],
             ],
         ];
@@ -92,10 +93,8 @@ class item extends ZenShipping
      */
     function check()
     {
-        global $db;
-        if (!isset($this->_check)) {
-            $check_query = $db->Execute("select configuration_value from " . TABLE_CONFIGURATION . " where configuration_key = 'MODULE_SHIPPING_ITEM_STATUS'");
-            $this->_check = $check_query->RecordCount();
+         if (!isset($this->_check)) {
+            $this->_check = (int)(zen_config('MODULE_SHIPPING_ITEM_STATUS') !== null);
         }
         return $this->_check;
     }

--- a/includes/modules/shipping/perweightunit.php
+++ b/includes/modules/shipping/perweightunit.php
@@ -25,26 +25,26 @@ class perweightunit extends ZenShipping
         $this->code = 'perweightunit';
         $this->title = MODULE_SHIPPING_PERWEIGHTUNIT_TEXT_TITLE;
         $this->description = MODULE_SHIPPING_PERWEIGHTUNIT_TEXT_DESCRIPTION;
-        $this->sort_order = defined('MODULE_SHIPPING_PERWEIGHTUNIT_SORT_ORDER') ? MODULE_SHIPPING_PERWEIGHTUNIT_SORT_ORDER : null;
+        $this->sort_order = zen_config('MODULE_SHIPPING_PERWEIGHTUNIT_SORT_ORDER');
         if (null === $this->sort_order) {
-            return false;
+            return;
         }
 
+        $this->sort_order = (int)$this->sort_order;
         $this->icon = '';
-        $this->tax_class = MODULE_SHIPPING_PERWEIGHTUNIT_TAX_CLASS;
-        $this->tax_basis = MODULE_SHIPPING_PERWEIGHTUNIT_TAX_BASIS;
+        $this->tax_class = zen_config('MODULE_SHIPPING_PERWEIGHTUNIT_TAX_CLASS');
+        $this->tax_basis = zen_config('MODULE_SHIPPING_PERWEIGHTUNIT_TAX_BASIS');
 
         // disable only when entire cart is free shipping
         if (zen_get_shipping_enabled($this->code)) {
-            $this->enabled = (MODULE_SHIPPING_PERWEIGHTUNIT_STATUS === 'True');
+            $this->enabled = (zen_config('MODULE_SHIPPING_PERWEIGHTUNIT_STATUS') === 'True');
         } else {
             $this->enabled = false;
         }
 
         if ($this->enabled) {
             // check MODULE_SHIPPING_PERWEIGHTUNIT_HANDLING_METHOD is in
-            $check_query = $db->Execute("select configuration_value from " . TABLE_CONFIGURATION . " where configuration_key = 'MODULE_SHIPPING_PERWEIGHTUNIT_HANDLING_METHOD'");
-            if ($check_query->EOF) {
+            if (zen_config('MODULE_SHIPPING_PERWEIGHTUNIT_HANDLING_METHOD') === null) {
                 $db->Execute("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Handling Per Order or Per Box', 'MODULE_SHIPPING_PERWEIGHTUNIT_HANDLING_METHOD', 'Order', 'Do you want to charge Handling Fee Per Order or Per Box?', '6', '0', 'zen_cfg_select_option(array(\'Order\', \'Box\'), ', now())");
             }
         }
@@ -62,7 +62,7 @@ class perweightunit extends ZenShipping
             return;
         }
 
-        $this->checkEnabledForZone(MODULE_SHIPPING_PERWEIGHTUNIT_ZONE);
+        $this->checkEnabledForZone(zen_config('MODULE_SHIPPING_PERWEIGHTUNIT_ZONE'));
 
         if ($this->enabled) {
             // -----
@@ -91,8 +91,11 @@ class perweightunit extends ZenShipping
                 [
                     'id' => $this->code,
                     'title' => MODULE_SHIPPING_PERWEIGHTUNIT_TEXT_WAY,
-                    'cost' => (float)MODULE_SHIPPING_PERWEIGHTUNIT_COST * ($total_weight_units * $shipping_num_boxes) +
-                        (MODULE_SHIPPING_PERWEIGHTUNIT_HANDLING_METHOD == 'Box' ? (float)MODULE_SHIPPING_PERWEIGHTUNIT_HANDLING * $shipping_num_boxes : (float)MODULE_SHIPPING_PERWEIGHTUNIT_HANDLING),
+                    'cost' => (float)zen_config('MODULE_SHIPPING_PERWEIGHTUNIT_COST') * ($total_weight_units * $shipping_num_boxes) +
+                        (zen_config('MODULE_SHIPPING_PERWEIGHTUNIT_HANDLING_METHOD') === 'Box'
+                            ? (float)zen_config('MODULE_SHIPPING_PERWEIGHTUNIT_HANDLING') * $shipping_num_boxes
+                            : (float)zen_config('MODULE_SHIPPING_PERWEIGHTUNIT_HANDLING')
+                        ),
                 ],
             ],
         ];
@@ -117,10 +120,8 @@ class perweightunit extends ZenShipping
      */
     function check()
     {
-        global $db;
         if (!isset($this->_check)) {
-            $check_query = $db->Execute("select configuration_value from " . TABLE_CONFIGURATION . " where configuration_key = 'MODULE_SHIPPING_PERWEIGHTUNIT_STATUS'");
-            $this->_check = $check_query->RecordCount();
+            $this->_check = (int)(zen_config('MODULE_SHIPPING_PERWEIGHTUNIT_STATUS') !== null);
         }
         return $this->_check;
     }

--- a/includes/modules/shipping/storepickup.php
+++ b/includes/modules/shipping/storepickup.php
@@ -34,15 +34,16 @@ class storepickup extends ZenShipping
         $this->code = 'storepickup';
         $this->title = MODULE_SHIPPING_STOREPICKUP_TEXT_TITLE;
         $this->description = MODULE_SHIPPING_STOREPICKUP_TEXT_DESCRIPTION;
-        $this->sort_order = defined('MODULE_SHIPPING_STOREPICKUP_SORT_ORDER') ? MODULE_SHIPPING_STOREPICKUP_SORT_ORDER : null;
+        $this->sort_order = zen_config('MODULE_SHIPPING_STOREPICKUP_SORT_ORDER');
         if (null === $this->sort_order) {
-            return false;
+            return;
         }
 
+        $this->sort_order = (int)$this->sort_order;
         $this->icon = ''; // add image filename here; must be uploaded to the /images/ subdirectory
-        $this->tax_class = MODULE_SHIPPING_STOREPICKUP_TAX_CLASS;
-        $this->tax_basis = MODULE_SHIPPING_STOREPICKUP_TAX_BASIS;
-        $this->enabled = (MODULE_SHIPPING_STOREPICKUP_STATUS === 'True');
+        $this->tax_class = zen_config('MODULE_SHIPPING_STOREPICKUP_TAX_CLASS');
+        $this->tax_basis = zen_config('MODULE_SHIPPING_STOREPICKUP_TAX_BASIS');
+        $this->enabled = (zen_config('MODULE_SHIPPING_STOREPICKUP_STATUS') === 'True');
         $this->update_status();
     }
 
@@ -56,7 +57,7 @@ class storepickup extends ZenShipping
             return;
         }
 
-        $this->checkEnabledForZone(MODULE_SHIPPING_STOREPICKUP_ZONE);
+        $this->checkEnabledForZone(zen_config('MODULE_SHIPPING_STOREPICKUP_ZONE'));
 
         // other status checks?
         if ($this->enabled) {
@@ -82,14 +83,14 @@ class storepickup extends ZenShipping
 
         // this code looks to see if there's a language-specific translation for the available shipping locations/methods, to override what is entered in the Admin (since the admin setting is in the default language)
         $ways_translated = (defined('MODULE_SHIPPING_STOREPICKUP_MULTIPLE_WAYS')) ? trim(MODULE_SHIPPING_STOREPICKUP_MULTIPLE_WAYS) : '';
-        $ways_default = trim(MODULE_SHIPPING_STOREPICKUP_LOCATIONS_LIST);
+        $ways_default = trim(zen_config('MODULE_SHIPPING_STOREPICKUP_LOCATIONS_LIST'));
         $methodsToParse = ($ways_translated == '') ? $ways_default : $ways_translated;
 
         if ($methodsToParse == '') {
             $this->methodsList[] = [
                 'id' => $this->code,
                 'title' => trim((string)MODULE_SHIPPING_STOREPICKUP_TEXT_WAY),
-                'cost' => MODULE_SHIPPING_STOREPICKUP_COST,
+                'cost' => zen_config('MODULE_SHIPPING_STOREPICKUP_COST'),
             ];
         } else {
             $this->locations = explode(';', (string)$methodsToParse);
@@ -98,7 +99,7 @@ class storepickup extends ZenShipping
                 if ($method != '' && $method != $this->code . (string)$key) {
                     continue;
                 }
-                $cost = MODULE_SHIPPING_STOREPICKUP_COST;
+                $cost = zen_config('MODULE_SHIPPING_STOREPICKUP_COST');
                 $title = $val;
                 if (strstr($val, ',')) {
                     [$title, $cost] = explode(',', $val);
@@ -138,10 +139,9 @@ class storepickup extends ZenShipping
     {
         global $db;
         if (!isset($this->_check)) {
-            $check_query = $db->Execute("select configuration_value from " . TABLE_CONFIGURATION . " where configuration_key = 'MODULE_SHIPPING_STOREPICKUP_STATUS'");
-            $this->_check = $check_query->RecordCount();
+            $this->_check = (int)(zen_config('MODULE_SHIPPING_STOREPICKUP_STATUS') !== null);
         }
-        if ($this->_check > 0 && !defined('MODULE_SHIPPING_STOREPICKUP_LOCATIONS_LIST')) {
+        if ($this->_check > 0 && zen_config('MODULE_SHIPPING_STOREPICKUP_LOCATIONS_LIST') === null) {
             $db->Execute("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Pickup Locations', 'MODULE_SHIPPING_STOREPICKUP_LOCATIONS_LIST', 'Walk In', 'Enter a list of locations, separated by semicolons (;).<br>Optionally you may specify a fee/surcharge for each location by adding a comma and an amount. If no amount is specified, then the generic Shipping Cost amount from the next setting will be applied.<br><br>Examples:<br>121 Main Street;20 Church Street<br>Sunnyside,4.00;Lee Park,5.00;High Street,0.00<br>Dallas;Tulsa,5.00;Phoenix,0.00<br>For multilanguage use, see the define-statement in the language file for this module.', '6', '0', now())");
         }
         return $this->_check;

--- a/includes/modules/shipping/table.php
+++ b/includes/modules/shipping/table.php
@@ -25,25 +25,25 @@ class table extends ZenShipping
         $this->code = 'table';
         $this->title = MODULE_SHIPPING_TABLE_TEXT_TITLE;
         $this->description = MODULE_SHIPPING_TABLE_TEXT_DESCRIPTION;
-        $this->sort_order = defined('MODULE_SHIPPING_TABLE_SORT_ORDER') ? MODULE_SHIPPING_TABLE_SORT_ORDER : null;
+        $this->sort_order = zen_config('MODULE_SHIPPING_TABLE_SORT_ORDER');
         if (null === $this->sort_order) {
-            return false;
+            return;
         }
 
+        $this->sort_order = (int)$this->sort_order;
         $this->icon = '';
-        $this->tax_class = MODULE_SHIPPING_TABLE_TAX_CLASS;
-        $this->tax_basis = MODULE_SHIPPING_TABLE_TAX_BASIS;
+        $this->tax_class = zen_config('MODULE_SHIPPING_TABLE_TAX_CLASS');
+        $this->tax_basis = zen_config('MODULE_SHIPPING_TABLE_TAX_BASIS');
         // disable only when entire cart is free shipping
         if (zen_get_shipping_enabled($this->code)) {
-            $this->enabled = (MODULE_SHIPPING_TABLE_STATUS === 'True');
+            $this->enabled = (zen_config('MODULE_SHIPPING_TABLE_STATUS') === 'True');
         } else {
             $this->enabled = false;
         }
 
         if ($this->enabled) {
             // check MODULE_SHIPPING_TABLE_HANDLING_METHOD is in
-            $check_query = $db->Execute("select configuration_value from " . TABLE_CONFIGURATION . " where configuration_key = 'MODULE_SHIPPING_TABLE_HANDLING_METHOD'");
-            if ($check_query->EOF) {
+            if (zen_config('MODULE_SHIPPING_TABLE_HANDLING_METHOD') === null) {
                 $db->Execute("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Handling Per Order or Per Box', 'MODULE_SHIPPING_TABLE_HANDLING_METHOD', 'Order', 'Do you want to charge Handling Fee Per Order or Per Box?', '6', '0', 'zen_cfg_select_option(array(\'Order\', \'Box\'), ', now())");
             }
         }
@@ -61,7 +61,7 @@ class table extends ZenShipping
             return;
         }
 
-        $this->checkEnabledForZone(MODULE_SHIPPING_TABLE_ZONE);
+        $this->checkEnabledForZone(zen_config('MODULE_SHIPPING_TABLE_ZONE'));
 
         if ($this->enabled) {
             // -----
@@ -83,7 +83,7 @@ class table extends ZenShipping
         global $order, $shipping_weight, $shipping_num_boxes, $total_count;
 
         // shipping adjustment
-        switch (MODULE_SHIPPING_TABLE_MODE) {
+        switch (zen_config('MODULE_SHIPPING_TABLE_MODE')) {
             case 'price':
                 $order_total = $_SESSION['cart']->show_total() - $_SESSION['cart']->free_shipping_prices();
                 break;
@@ -97,7 +97,7 @@ class table extends ZenShipping
 
         $order_total_amount = $_SESSION['cart']->show_total() - $_SESSION['cart']->free_shipping_prices();
 
-        $table_cost = preg_split("/[:,]/", MODULE_SHIPPING_TABLE_COST);
+        $table_cost = preg_split("/[:,]/", zen_config('MODULE_SHIPPING_TABLE_COST'));
         $size = count($table_cost);
         $shipping = 0;
         for ($i = 0, $n = $size; $i < $n; $i += 2) {
@@ -138,7 +138,11 @@ class table extends ZenShipping
                 [
                     'id' => $this->code,
                     'title' => MODULE_SHIPPING_TABLE_TEXT_WAY,
-                    'cost' => $shipping + (MODULE_SHIPPING_TABLE_HANDLING_METHOD === 'Box' ? MODULE_SHIPPING_TABLE_HANDLING * $shipping_num_boxes : MODULE_SHIPPING_TABLE_HANDLING),
+                    'cost' => $shipping +
+                        (zen_config('MODULE_SHIPPING_TABLE_HANDLING_METHOD') === 'Box'
+                            ? zen_config('MODULE_SHIPPING_TABLE_HANDLING') * $shipping_num_boxes
+                            : zen_config('MODULE_SHIPPING_TABLE_HANDLING')
+                        ),
                 ],
             ],
         ];
@@ -162,10 +166,8 @@ class table extends ZenShipping
      */
     function check()
     {
-        global $db;
         if (!isset($this->_check)) {
-            $check_query = $db->Execute("select configuration_value from " . TABLE_CONFIGURATION . " where configuration_key = 'MODULE_SHIPPING_TABLE_STATUS'");
-            $this->_check = $check_query->RecordCount();
+            $this->_check = (int)(zen_config('MODULE_SHIPPING_TABLE_STATUS') !== null);
         }
         return $this->_check;
     }

--- a/includes/modules/shipping/zones.php
+++ b/includes/modules/shipping/zones.php
@@ -108,18 +108,19 @@ class zones extends ZenShipping
         $this->code = 'zones';
         $this->title = MODULE_SHIPPING_ZONES_TEXT_TITLE;
         $this->description = MODULE_SHIPPING_ZONES_TEXT_DESCRIPTION;
-        $this->sort_order = defined('MODULE_SHIPPING_ZONES_SORT_ORDER') ? MODULE_SHIPPING_ZONES_SORT_ORDER : null;
+        $this->sort_order = zen_config('MODULE_SHIPPING_ZONES_SORT_ORDER');
         if (null === $this->sort_order) {
-            return false;
+            return;
         }
 
+        $this->sort_order = (int)$this->sort_order;
         $this->icon = '';
-        $this->tax_class = MODULE_SHIPPING_ZONES_TAX_CLASS;
-        $this->tax_basis = MODULE_SHIPPING_ZONES_TAX_BASIS;
+        $this->tax_class = zen_config('MODULE_SHIPPING_ZONES_TAX_CLASS');
+        $this->tax_basis = zen_config('MODULE_SHIPPING_ZONES_TAX_BASIS');
 
         // disable only when entire cart is free shipping
         if (zen_get_shipping_enabled($this->code)) {
-            $this->enabled = ((MODULE_SHIPPING_ZONES_STATUS == 'True') ? true : false);
+            $this->enabled = (zen_config('MODULE_SHIPPING_ZONES_STATUS') === 'True');
         } else {
             $this->enabled = false;
         }
@@ -127,18 +128,19 @@ class zones extends ZenShipping
         // CUSTOMIZE THIS SETTING FOR THE NUMBER OF ZONES NEEDED
         $this->num_zones = 3;
 
-        if (IS_ADMIN_FLAG === true) {
+        if (IS_ADMIN_FLAG === true && $this->enabled) {
             // build in admin only additional zones if missing in the configuration table due to customization of default $this->num_zones = 3
             global $db;
             for ($i = 1; $i <= $this->num_zones; $i++) {
-                $check = $db->Execute("select * from " . TABLE_CONFIGURATION . " where configuration_key = 'MODULE_SHIPPING_ZONES_COUNTRIES_" . $i . "'");
-                if ($this->enabled && $check->EOF) {
-                    $default_countries = '';
-                    $db->Execute("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Zone " . $i . " Countries', 'MODULE_SHIPPING_ZONES_COUNTRIES_" . $i . "', '" . $default_countries . "', 'Comma separated list of two character ISO country codes that are part of Zone " . $i . ".<br>Set as 00 to indicate all two character ISO country codes that are not specifically defined.', '6', '0', 'zen_cfg_textarea(', now())");
-                    $db->Execute("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Zone " . $i . " Shipping Table', 'MODULE_SHIPPING_ZONES_COST_" . $i . "', '3:8.50,7:10.50,99:20.00', 'Shipping rates to Zone " . $i . " destinations based on a group of maximum order weights/prices. Example: 3:8.50,7:10.50,... Weight/Price less than or equal to 3 would cost 8.50 for Zone " . $i . " destinations.<br>You can end the last amount as 10000:7% to charge 7% of the Order Total', '6', '0', 'zen_cfg_textarea(', now())");
-                    $db->Execute("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Zone " . $i . " Handling Fee', 'MODULE_SHIPPING_ZONES_HANDLING_" . $i . "', '0', 'Handling Fee for this shipping zone', '6', '0', now())");
-                    $db->Execute("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Handling Per Order or Per Box Zone " . $i . "  (when by weight)' , 'MODULE_SHIPPING_ZONES_HANDLING_METHOD_" . $i . "', 'Order', 'Do you want to charge Handling Fee Per Order or Per Box?', '6', '0', 'zen_cfg_select_option(array(\'Order\', \'Box\'), ', now())");
+                if (zen_config("MODULE_SHIPPING_ZONES_COUNTRIES_$i") !== null) {
+                    continue;
                 }
+
+                $default_countries = '';
+                $db->Execute("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Zone " . $i . " Countries', 'MODULE_SHIPPING_ZONES_COUNTRIES_" . $i . "', '" . $default_countries . "', 'Comma separated list of two character ISO country codes that are part of Zone " . $i . ".<br>Set as 00 to indicate all two character ISO country codes that are not specifically defined.', '6', '0', 'zen_cfg_textarea(', now())");
+                $db->Execute("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Zone " . $i . " Shipping Table', 'MODULE_SHIPPING_ZONES_COST_" . $i . "', '3:8.50,7:10.50,99:20.00', 'Shipping rates to Zone " . $i . " destinations based on a group of maximum order weights/prices. Example: 3:8.50,7:10.50,... Weight/Price less than or equal to 3 would cost 8.50 for Zone " . $i . " destinations.<br>You can end the last amount as 10000:7% to charge 7% of the Order Total', '6', '0', 'zen_cfg_textarea(', now())");
+                $db->Execute("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Zone " . $i . " Handling Fee', 'MODULE_SHIPPING_ZONES_HANDLING_" . $i . "', '0', 'Handling Fee for this shipping zone', '6', '0', now())");
+                $db->Execute("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Handling Per Order or Per Box Zone " . $i . "  (when by weight)' , 'MODULE_SHIPPING_ZONES_HANDLING_METHOD_" . $i . "', 'Order', 'Do you want to charge Handling Fee Per Order or Per Box?', '6', '0', 'zen_cfg_select_option(array(\'Order\', \'Box\'), ', now())");
             }
         } // build in admin only
 
@@ -146,10 +148,11 @@ class zones extends ZenShipping
             global $db;
             for ($i = 1; $i <= $this->num_zones; $i++) {
                 // check MODULE_SHIPPING_TABLE_HANDLING_METHOD is in
-                $check_query = $db->Execute("select configuration_value from " . TABLE_CONFIGURATION . " where configuration_key = 'MODULE_SHIPPING_ZONES_HANDLING_METHOD_" . $i . "'");
-                if ($check_query->EOF) {
-                    $db->Execute("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Handling Per Order or Per Box Zone " . $i . "  (when by weight)' , 'MODULE_SHIPPING_ZONES_HANDLING_METHOD_" . $i . "', 'Order', 'Do you want to charge Handling Fee Per Order or Per Box?', '6', '0', 'zen_cfg_select_option(array(\'Order\', \'Box\'), ', now())");
+                if (zen_config("MODULE_SHIPPING_ZONES_HANDLING_METHOD_$i") !== null) {
+                    continue;
                 }
+
+                $db->Execute("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Handling Per Order or Per Box Zone " . $i . "  (when by weight)' , 'MODULE_SHIPPING_ZONES_HANDLING_METHOD_" . $i . "', 'Order', 'Do you want to charge Handling Fee Per Order or Per Box?', '6', '0', 'zen_cfg_select_option(array(\'Order\', \'Box\'), ', now())");
             }
         }
         $this->update_status();
@@ -188,7 +191,7 @@ class zones extends ZenShipping
         $order_total_amount = $_SESSION['cart']->show_total() - $_SESSION['cart']->free_shipping_prices();
 
         for ($i = 1; $i <= $this->num_zones; $i++) {
-            $countries_table = constant('MODULE_SHIPPING_ZONES_COUNTRIES_' . $i);
+            $countries_table = zen_config('MODULE_SHIPPING_ZONES_COUNTRIES_' . $i);
             $countries_table = strtoupper(str_replace(' ', '', $countries_table));
             $country_zones = preg_split("/[,]/", $countries_table);
             if (in_array($dest_country, $country_zones)) {
@@ -205,16 +208,16 @@ class zones extends ZenShipping
             $error = true;
         } else {
             $shipping = -1;
-            $zones_cost = constant('MODULE_SHIPPING_ZONES_COST_' . $dest_zone);
+            $zones_cost = zen_config('MODULE_SHIPPING_ZONES_COST_' . $dest_zone);
 
             $zones_table = preg_split("/[:,]/", $zones_cost);
             $size = sizeof($zones_table);
             $done = false;
             for ($i = 0; $i < $size; $i += 2) {
-                switch (MODULE_SHIPPING_ZONES_METHOD) {
-                    case (MODULE_SHIPPING_ZONES_METHOD == 'Weight'):
+                switch (zen_config('MODULE_SHIPPING_ZONES_METHOD')) {
+                    case 'Weight':
                         if (round($shipping_weight, 9) <= $zones_table[$i]) {
-                            switch (SHIPPING_BOX_WEIGHT_DISPLAY) {
+                            switch (zen_config('SHIPPING_BOX_WEIGHT_DISPLAY')) {
                                 case (0):
                                     $show_box_weight = '';
                                     break;
@@ -239,7 +242,7 @@ class zones extends ZenShipping
                             break;
                         }
                         break;
-                    case (MODULE_SHIPPING_ZONES_METHOD == 'Price'):
+                    case 'Price':
                         // shipping adjustment
                         if (($_SESSION['cart']->show_total() - $_SESSION['cart']->free_shipping_prices()) <= $zones_table[$i]) {
                             $shipping_method = MODULE_SHIPPING_ZONES_TEXT_WAY . ' ' . $dest_country;
@@ -252,7 +255,7 @@ class zones extends ZenShipping
                             break;
                         }
                         break;
-                    case (MODULE_SHIPPING_ZONES_METHOD == 'Item'):
+                    case 'Item':
                         // shipping adjustment
                         if (($total_count - $_SESSION['cart']->free_shipping_items()) <= $zones_table[$i]) {
                             $shipping_method = MODULE_SHIPPING_ZONES_TEXT_WAY . ' ' . $dest_country;
@@ -275,23 +278,23 @@ class zones extends ZenShipping
                 $shipping_cost = 0;
                 $shipping_method = MODULE_SHIPPING_ZONES_UNDEFINED_RATE;
             } else {
-                switch (MODULE_SHIPPING_ZONES_METHOD) {
-                    case (MODULE_SHIPPING_ZONES_METHOD == 'Weight'):
+                switch (zen_config('MODULE_SHIPPING_ZONES_METHOD')) {
+                    case 'Weight':
                         // charge per box when done by Weight
                         // Handling fee per box or order
-                        if (constant('MODULE_SHIPPING_ZONES_HANDLING_METHOD_' . $dest_zone) == 'Box') {
-                            $shipping_cost = ($shipping * $shipping_num_boxes) + (float)constant('MODULE_SHIPPING_ZONES_HANDLING_' . $dest_zone) * $shipping_num_boxes;
+                        if (zen_config('MODULE_SHIPPING_ZONES_HANDLING_METHOD_' . $dest_zone) == 'Box') {
+                            $shipping_cost = ($shipping * $shipping_num_boxes) + (float)zen_config('MODULE_SHIPPING_ZONES_HANDLING_' . $dest_zone) * $shipping_num_boxes;
                         } else {
-                            $shipping_cost = ($shipping * $shipping_num_boxes) + (float)constant('MODULE_SHIPPING_ZONES_HANDLING_' . $dest_zone);
+                            $shipping_cost = ($shipping * $shipping_num_boxes) + (float)zen_config('MODULE_SHIPPING_ZONES_HANDLING_' . $dest_zone);
                         }
                         break;
-                    case (MODULE_SHIPPING_ZONES_METHOD == 'Price'):
+                    case 'Price':
                         // don't charge per box when done by Price
-                        $shipping_cost = ($shipping) + (float)constant('MODULE_SHIPPING_ZONES_HANDLING_' . $dest_zone);
+                        $shipping_cost = ($shipping) + (float)zen_config('MODULE_SHIPPING_ZONES_HANDLING_' . $dest_zone);
                         break;
-                    case (MODULE_SHIPPING_ZONES_METHOD == 'Item'):
+                    case 'Item':
                         // don't charge per box when done by Item
-                        $shipping_cost = ($shipping) + (float)constant('MODULE_SHIPPING_ZONES_HANDLING_' . $dest_zone);
+                        $shipping_cost = ($shipping) + (float)zen_config('MODULE_SHIPPING_ZONES_HANDLING_' . $dest_zone);
                         break;
                 }
             }
@@ -316,7 +319,7 @@ class zones extends ZenShipping
             $this->quotes['icon'] = zen_image($this->icon, $this->title);
         }
 
-        if (strpos(MODULE_SHIPPING_ZONES_SKIPPED, $dest_country) !== false) {
+        if (strpos(zen_config('MODULE_SHIPPING_ZONES_SKIPPED'), $dest_country) !== false) {
             // don't show anything for this country
             $this->quotes = [];
         } else {
@@ -333,10 +336,8 @@ class zones extends ZenShipping
      */
     function check()
     {
-        global $db;
         if (!isset($this->_check)) {
-            $check_query = $db->Execute("select configuration_value from " . TABLE_CONFIGURATION . " where configuration_key = 'MODULE_SHIPPING_ZONES_STATUS'");
-            $this->_check = $check_query->RecordCount();
+            $this->_check = (int)(zen_config('MODULE_SHIPPING_ZONES_STATUS') !== null);
         }
         return $this->_check;
     }


### PR DESCRIPTION
- removing `false` return from constructor; constructor's shouldn't be returning values.
- Ensure that an enabled module's sort-order is cast to an int.
- Simplifies `check` methods, noting that users of this method only care about 0 and non-0.
- Simplification to `zones` switches.