### PR TITLE
ConfigurationRepository->getByKey, correct output hint

### DIFF
--- a/includes/classes/DbRepositories/ConfigurationRepository.php
+++ b/includes/classes/DbRepositories/ConfigurationRepository.php
@@ -56,7 +56,7 @@ class ConfigurationRepository
     /**
      * @since ZC v2.2.0
      */
-    public function getByKey(string $configurationKey, bool $valueOnly = false): ?array
+    public function getByKey(string $configurationKey, bool $valueOnly = false): array|string|null
     {
         $configurationKey = $this->db->prepare_input($configurationKey);
         $result = $this->db->Execute(


### PR DESCRIPTION
... since the output can also be a string.