### PR TITLE
`zen_config`: Adding product_type_layout settings

### DIFF
--- a/includes/classes/DbRepositories/ProductTypeLayoutRepository.php
+++ b/includes/classes/DbRepositories/ProductTypeLayoutRepository.php
@@ -35,4 +35,50 @@ class ProductTypeLayoutRepository
             }
         }
     }
+
+    /**
+     * @since ZC v3.0.0
+     */
+    public function getByKey(string $configurationKey): ?string
+    {
+        $configurationKey = $this->db->prepare_input($configurationKey);
+        $result = $this->db->Execute(
+            "SELECT configuration_value FROM " . TABLE_PRODUCT_TYPE_LAYOUT .
+            " WHERE configuration_key = '" . $configurationKey . "' LIMIT 1"
+        );
+
+        if ($result->EOF) {
+            return null;
+        }
+        return $result->fields['configuration_value'];
+    }
+
+    /**
+     * @since ZC v3.0.0
+     */
+    public function updateValueByKey(string $configurationKey, string $configurationValue): int
+    {
+        $configurationKey = $this->db->prepare_input($configurationKey);
+        $configurationValue = $this->db->prepare_input($configurationValue);
+
+        $this->db->Execute(
+            "UPDATE " . TABLE_PRODUCT_TYPE_LAYOUT .
+            " SET configuration_value = '" . $configurationValue . "'" .
+            " WHERE configuration_key = '" . $configurationKey . "' LIMIT 1"
+        );
+
+        return $this->db->affectedRows();
+    }
+
+    /**
+     * @since ZC v3.0.0
+     */
+    public function get(string $configurationKey): mixed
+    {
+        if (defined($configurationKey)) {
+            return constant($configurationKey);
+        }
+
+        return $this->getByKey($configurationKey);
+    }
 }

--- a/includes/functions/functions_general_shared.php
+++ b/includes/functions/functions_general_shared.php
@@ -726,7 +726,7 @@ function zen_add_filemtime(string $relative_path, ?string $absolute_path = null)
  */
 function zen_config(string $key): mixed
 {
-    global $configurationRepository;
+    global $configurationRepository, $productTypeLayoutRepository;
 
-    return $configurationRepository->get($key);
+    return $configurationRepository->get($key) ?? $productTypeLayoutRepository->get($key) ?? null;
 }

--- a/includes/functions/functions_general_shared.php
+++ b/includes/functions/functions_general_shared.php
@@ -728,5 +728,5 @@ function zen_config(string $key): mixed
 {
     global $configurationRepository, $productTypeLayoutRepository;
 
-    return $configurationRepository->get($key) ?? $productTypeLayoutRepository->get($key) ?? null;
+    return $configurationRepository->get($key) ?? $productTypeLayoutRepository->get($key);
 }


### PR DESCRIPTION
Noting that the `getByKey` method is on-purpose different from that present in the `ConfigurationRepository` class, as there's no need for anything but the 'configuration_value'.