### PR TITLE
Load psr4Autoload.php if present in zc_plugins dirs

### DIFF
--- a/admin/includes/application_bootstrap.php
+++ b/admin/includes/application_bootstrap.php
@@ -191,6 +191,10 @@ foreach ($installedPlugins as $plugin) {
     $filePathCatalog = $filePath . 'catalog/includes/classes/';
     $psr4Autoloader->addPrefix($namespaceAdmin, $filePathAdmin);
     $psr4Autoloader->addPrefix($namespaceCatalog, $filePathCatalog);
+    // Load registered psr4Autoload in the plugin's root directory
+    if (file_exists($filePath . 'psr4Autoload.php')) {
+        require $filePath . 'psr4Autoload.php';
+    }
 }
 
 /**

--- a/includes/application_top.php
+++ b/includes/application_top.php
@@ -398,6 +398,10 @@ foreach ($installedPlugins as $plugin) {
     $filePathCatalog = $filePath . 'catalog/includes/classes/';
     $psr4Autoloader->addPrefix($namespaceAdmin, $filePathAdmin);
     $psr4Autoloader->addPrefix($namespaceCatalog, $filePathCatalog);
+    // Load registered psr4Autoload in the plugin's root directory
+    if (file_exists($filePath . 'psr4Autoload.php')) {
+        require $filePath . 'psr4Autoload.php';
+    }
 }
 
 if (isset($loaderPrefix)) {


### PR DESCRIPTION
Loading an encap plugin's `/psr4Autoload.php` (if present) will allow registering autoloaders in either of the following ways:

```php
<?php
/** @var \Aura\Autoload\Loader $psr4Autoloader */
$psr4Autoloader->addPrefix('Foo', __DIR__ . '/vendor/foo/foo-php/src');
```
or
```php
<?php
// Load composer vendor/autoload.php
require __DIR__ . '/vendor/autoload.php';
```