### PR TITLE
Moneyorder_hard_coded_message

### DIFF
--- a/includes/languages/english/modules/payment/lang.moneyorder.php
+++ b/includes/languages/english/modules/payment/lang.moneyorder.php
@@ -3,6 +3,7 @@ $define = [
     'MODULE_PAYMENT_MONEYORDER_TEXT_TITLE' => 'Check/Money Order',
     'MODULE_PAYMENT_MONEYORDER_TEXT_DESCRIPTION' => 'Customers can mail in their payment. Their order confirmation email will ask them to: <br><br>Please make your check or money order payable to:<br>' . (defined('MODULE_PAYMENT_MONEYORDER_PAYTO') ? zen_config('MODULE_PAYMENT_MONEYORDER_PAYTO') : '<br>(your store name)') . '<br><br>Mail your payment to:<br>' . nl2br(zen_config('STORE_NAME_ADDRESS'), false) . '<br><br>' . 'Your order will not ship until we receive payment.',
     'MODULE_PAYMENT_MONEYORDER_REMINDER' => 'Please be sure to write your order number on the front of your check or money order.',
+    'MODULE_PAYMENT_MONEYORDER_TEXT_MISSING_INFO' => '(not configured - needs pay-to)',
 ];
 if (defined('MODULE_PAYMENT_MONEYORDER_STATUS')) {
     $define['MODULE_PAYMENT_MONEYORDER_TEXT_EMAIL_FOOTER'] = 'Please make your check or money order payable to:' . "\n\n" . zen_config('MODULE_PAYMENT_MONEYORDER_PAYTO') . "\n\n" . 'Mail your payment to:' . "\n" . zen_config('STORE_NAME_ADDRESS') . "\n\n" . 'Your order will not ship until we receive payment.';

--- a/includes/modules/payment/moneyorder.php
+++ b/includes/modules/payment/moneyorder.php
@@ -77,7 +77,7 @@ class moneyorder extends base
             }
 
             if (IS_ADMIN_FLAG === true && (MODULE_PAYMENT_MONEYORDER_PAYTO == 'the Store Owner/Website Name' || MODULE_PAYMENT_MONEYORDER_PAYTO == '')) {
-                $this->title .= '<span class="alert"> (not configured - needs pay-to)</span>';
+                $this->title .= '<span class="alert">' . MODULE_PAYMENT_MONEYORDER_TEXT_MISSING_INFO . '</span>';
             }
 
             if ((int)MODULE_PAYMENT_MONEYORDER_ORDER_STATUS_ID > 0) {


### PR DESCRIPTION
When Money Order module is installed but account information are not set, an alert message is displayed next to the title. This message was hard coded in module file.
This PR adds a constant in language file for this message.