### PR TITLE
moneyorder: Simplify use of zen_config ...

### DIFF
--- a/includes/languages/english/modules/payment/lang.moneyorder.php
+++ b/includes/languages/english/modules/payment/lang.moneyorder.php
@@ -1,12 +1,9 @@
 <?php
 $define = [
     'MODULE_PAYMENT_MONEYORDER_TEXT_TITLE' => 'Check/Money Order',
-    'MODULE_PAYMENT_MONEYORDER_TEXT_DESCRIPTION' => 'Customers can mail in their payment. Their order confirmation email will ask them to: <br><br>Please make your check or money order payable to:<br>' . (defined('MODULE_PAYMENT_MONEYORDER_PAYTO') ? zen_config('MODULE_PAYMENT_MONEYORDER_PAYTO') : '<br>(your store name)') . '<br><br>Mail your payment to:<br>' . nl2br(zen_config('STORE_NAME_ADDRESS'), false) . '<br><br>' . 'Your order will not ship until we receive payment.',
+    'MODULE_PAYMENT_MONEYORDER_TEXT_DESCRIPTION' => 'Customers can mail in their payment. Their order confirmation email will ask them to:<br><br>Please make your check or money order payable to:<br><br>' . zen_config('MODULE_PAYMENT_MONEYORDER_PAYTO', '(your store name)') . '<br><br>Mail your payment to:<br>' . nl2br(zen_config('STORE_NAME_ADDRESS'), false) . '<br><br>' . 'Your order will not ship until we receive payment.',
     'MODULE_PAYMENT_MONEYORDER_REMINDER' => 'Please be sure to write your order number on the front of your check or money order.',
     'MODULE_PAYMENT_MONEYORDER_TEXT_MISSING_INFO' => '(not configured - needs pay-to)',
+    'MODULE_PAYMENT_MONEYORDER_TEXT_EMAIL_FOOTER' => 'Please make your check or money order payable to:' . "\n\n" . zen_config('MODULE_PAYMENT_MONEYORDER_PAYTO', '') . "\n\n" . 'Mail your payment to:' . "\n" . zen_config('STORE_NAME_ADDRESS') . "\n\n" . 'Your order will not ship until we receive payment.',
 ];
-if (defined('MODULE_PAYMENT_MONEYORDER_STATUS')) {
-    $define['MODULE_PAYMENT_MONEYORDER_TEXT_EMAIL_FOOTER'] = 'Please make your check or money order payable to:' . "\n\n" . zen_config('MODULE_PAYMENT_MONEYORDER_PAYTO') . "\n\n" . 'Mail your payment to:' . "\n" . zen_config('STORE_NAME_ADDRESS') . "\n\n" . 'Your order will not ship until we receive payment.';
-}
-
 return $define;


### PR DESCRIPTION
.., and remove unwanted use of `defined`. Previously updated via PR #7740