### PR TITLE
Allow debug level overrides in configure.php

### DIFF
--- a/admin/includes/application_bootstrap.php
+++ b/admin/includes/application_bootstrap.php
@@ -12,10 +12,6 @@ use Zencart\FileSystem\FileSystem;
 use Zencart\PluginManager\PluginManager;
 use Zencart\PageLoader\PageLoader;
 /**
- * boolean if true the autoloader scripts will be parsed and their output shown. For debugging purposes only.
- */
-if (!defined('DEBUG_AUTOLOAD')) define('DEBUG_AUTOLOAD', false);
-/**
  * boolean used to see if we are in the admin script, obviously set to false here.
  * DO NOT REMOVE THE define BELOW. WILL BREAK ADMIN
  */
@@ -49,22 +45,6 @@ if ($detected_locale === false || $detected_locale === 'C') {
 }
 
 if (!defined('DIR_FS_ADMIN')) define('DIR_FS_ADMIN', preg_replace('#/includes/$#', '/', realpath(__DIR__ . '/../') . '/'));
-
-/**
- * set the level of error reporting
- *
- * Note STRICT_ERROR_REPORTING should never be set to true on a production site.
- * It is mainly there to show php warnings during testing/bug fixing phases.
- * note for strict error reporting we also turn on show_errors as this may be disabled
- * in php.ini. Otherwise we respect the php.ini setting
- *
- */
-if ((defined('DEBUG_AUTOLOAD') && DEBUG_AUTOLOAD === true) || (defined('STRICT_ERROR_REPORTING') && STRICT_ERROR_REPORTING === true)) {
-    @ini_set('display_errors', TRUE);
-    error_reporting(defined('STRICT_ERROR_REPORTING_LEVEL') ? STRICT_ERROR_REPORTING_LEVEL : E_ALL);
-} else {
-    error_reporting(0);
-}
 
 /**
  * Ensure minimum PHP version.
@@ -106,6 +86,28 @@ if (!defined('DIR_FS_CATALOG') || !is_dir(DIR_FS_CATALOG.'/includes/classes') ||
         die('ERROR: includes/configure.php file not found. Suggest running zc_install/index.php?');
     }
 }
+
+/**
+ * boolean if true the autoloader scripts will be parsed and their output shown. For debugging purposes only.
+ */
+if (!defined('DEBUG_AUTOLOAD')) define('DEBUG_AUTOLOAD', false);
+
+/**
+ * set the level of error reporting
+ *
+ * Note STRICT_ERROR_REPORTING should never be set to true on a production site.
+ * It is mainly there to show php warnings during testing/bug fixing phases.
+ * note for strict error reporting we also turn on show_errors as this may be disabled
+ * in php.ini. Otherwise we respect the php.ini setting
+ *
+ */
+if ((defined('DEBUG_AUTOLOAD') && DEBUG_AUTOLOAD === true) || (defined('STRICT_ERROR_REPORTING') && STRICT_ERROR_REPORTING === true)) {
+    @ini_set('display_errors', TRUE);
+    error_reporting(defined('STRICT_ERROR_REPORTING_LEVEL') ? STRICT_ERROR_REPORTING_LEVEL : E_ALL);
+} else {
+    error_reporting(0);
+}
+
 /**
  * check for and load system defined path constants
  */

--- a/includes/application_top.php
+++ b/includes/application_top.php
@@ -250,24 +250,6 @@ if (PHP_VERSION_ID < 80300) {
     exit(0);
 }
 
-/**
- * boolean if true the autoloader scripts will be parsed and their output shown. For debugging purposes only.
- */
-define('DEBUG_AUTOLOAD', false);
-
-/**
- * set the level of error reporting
- *
- * Note STRICT_ERROR_REPORTING should never be set to true on a production site.
- * It is mainly there to show php warnings during testing/bug fixing phases.
- */
-if (DEBUG_AUTOLOAD || (defined('STRICT_ERROR_REPORTING') && STRICT_ERROR_REPORTING == true)) {
-    @ini_set('display_errors', true);
-    error_reporting(defined('STRICT_ERROR_REPORTING_LEVEL') ? STRICT_ERROR_REPORTING_LEVEL : E_ALL);
-} else {
-    error_reporting(0);
-}
-
 date_default_timezone_set(date_default_timezone_get());
 
 /*
@@ -314,6 +296,24 @@ if (!defined('DIR_FS_CATALOG') || !is_dir(DIR_FS_CATALOG.'/includes/classes')) {
     $problemString = 'includes/configure.php file contents invalid.  ie: DIR_FS_CATALOG not valid or not set';
     require 'includes/templates/template_default/templates/tpl_zc_install_suggested_default.php';
     exit;
+}
+
+/**
+ * boolean if true the autoloader scripts will be parsed and their output shown. For debugging purposes only.
+ */
+define('DEBUG_AUTOLOAD', false);
+
+/**
+ * set the level of error reporting
+ *
+ * Note STRICT_ERROR_REPORTING should never be set to true on a production site.
+ * It is mainly there to show php warnings during testing/bug fixing phases.
+ */
+if (DEBUG_AUTOLOAD || (defined('STRICT_ERROR_REPORTING') && STRICT_ERROR_REPORTING == true)) {
+    @ini_set('display_errors', true);
+    error_reporting(defined('STRICT_ERROR_REPORTING_LEVEL') ? STRICT_ERROR_REPORTING_LEVEL : E_ALL);
+} else {
+    error_reporting(0);
 }
 
 /**

--- a/includes/application_top.php
+++ b/includes/application_top.php
@@ -301,7 +301,7 @@ if (!defined('DIR_FS_CATALOG') || !is_dir(DIR_FS_CATALOG.'/includes/classes')) {
 /**
  * boolean if true the autoloader scripts will be parsed and their output shown. For debugging purposes only.
  */
-define('DEBUG_AUTOLOAD', false);
+if (!defined('DEBUG_AUTOLOAD')) define('DEBUG_AUTOLOAD', false);
 
 /**
  * set the level of error reporting


### PR DESCRIPTION
Updates #7773 

Rearranging this logic allows `/includes/configure.php` or `/includes/local/configure.php` to have debug constants defined which can control debug flow.

