### PR TITLE
`zc_cli` can read the `set_time_zone.php`

### DIFF
--- a/includes/application_cli_bootstrap.php
+++ b/includes/application_cli_bootstrap.php
@@ -55,6 +55,10 @@ if (!defined('DIR_WS_ADMIN')) {
 require_once DIR_FS_INCLUDES . 'defined_paths.php';
 require_once DIR_FS_INCLUDES . 'functions/php_polyfills.php';
 require_once DIR_FS_INCLUDES . 'functions/zen_define_default.php';
+
+require_once DIR_FS_INCLUDES . 'functions/functions_error_handling.php';
+require_once DIR_FS_INCLUDES . 'extra_configures/set_time_zone.php';
+
 require_once DIR_FS_INCLUDES . 'classes/vendors/AuraAutoload/src/Loader.php';
 
 $psr4Autoloader = new \Aura\Autoload\Loader();

--- a/not_for_release/testFramework/Unit/testsSundry/TestFrameworkRunnersTest.php
+++ b/not_for_release/testFramework/Unit/testsSundry/TestFrameworkRunnersTest.php
@@ -1318,6 +1318,8 @@ PHP
         copy($this->rootPath . '/includes/database_tables.php', $root . '/includes/database_tables.php');
         copy($this->rootPath . '/includes/functions/php_polyfills.php', $root . '/includes/functions/php_polyfills.php');
         copy($this->rootPath . '/includes/functions/zen_define_default.php', $root . '/includes/functions/zen_define_default.php');
+        copy($this->rootPath . '/includes/functions/functions_error_handling.php', $root . '/includes/functions/functions_error_handling.php');
+        copy($this->rootPath . '/includes/extra_configures/set_time_zone.php', $root . '/includes/extra_configures/set_time_zone.php');
         copy($this->rootPath . '/includes/classes/class.base.php', $root . '/includes/classes/class.base.php');
         copy($this->rootPath . '/includes/classes/EventDto.php', $root . '/includes/classes/EventDto.php');
         copy($this->rootPath . '/includes/classes/traits/Singleton.php', $root . '/includes/classes/traits/Singleton.php');

--- a/not_for_release/testFramework/Unit/testsSundry/TestFrameworkRunnersTest.php
+++ b/not_for_release/testFramework/Unit/testsSundry/TestFrameworkRunnersTest.php
@@ -1304,6 +1304,7 @@ PHP
         mkdir($root, 0777, true);
         mkdir($root . '/bin', 0777, true);
         mkdir($root . '/includes/functions', 0777, true);
+        mkdir($root . '/includes/extra_configures', 0777, true);
         mkdir($root . '/includes/classes/traits', 0777, true);
         mkdir($root . '/includes/classes/vendors/AuraAutoload/src', 0777, true);
         mkdir($root . '/includes/classes/vendors/polyfill-mbstring/Resources/unidata', 0777, true);


### PR DESCRIPTION
CLI tool can read the configured timezone file and apply the setting.

This also enables the error-handler.