### PR TITLE
[codex] Add code review guidance for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,45 @@ Key developer workflows (commands & examples)
   - Copy `includes/dist-configure.php` and `admin/includes/dist-configure.php` to `configure.php` (in those same folders) and make the files writable. Fill DB constants (see `includes/configure.php` example in repo).
   - Make `cache/` and `logs/` writable.
 
+Code review guidance
+--------------------
+When asked to review a pull request or patch, review it as a Zen Cart maintainer, not as a general PHP style checker. Lead with material findings: bugs, security regressions, backwards-compatibility breaks, deployment risks, and missing tests for changed behavior.
+
+Use `CONVENTIONS.md` as the review baseline:
+- Favor stability over purity. Do not ask for broad rewrites, unrelated refactors, or legacy cleanup unless the change introduces a real defect.
+- Apply PSR-12, naming, `declare(strict_types=1)`, and no-colon-syntax rules to new code and files already being modified, while respecting documented legacy exceptions.
+- Flag direct edits to bootstrap/path files that are listed as "should never be directly edited"; prefer `extra_configures`, `init_includes`, plugin hooks, or other established extension points.
+
+Review security-sensitive changes closely:
+- Preserve the early request-sanitizing behavior in `includes/application_top.php`.
+- Ensure user-supplied output is protected with `zen_output_string_protected()`.
+- Avoid spreading direct `$_GET`, `$_POST`, or `$_REQUEST` access where sanitized helpers are available.
+- For admin fields, require the documented admin sanitization whitelist approach before relaxing sanitization.
+- Check file/path handling, upload/download behavior, redirects, webhook/payment listeners, and plugin autoload paths for traversal or trust-boundary mistakes.
+
+Review data and compatibility carefully:
+- SQL should use table-name constants such as `TABLE_ORDERS`, not raw or prefixed table names.
+- Check query construction for unsafe interpolation, missing casting, and changed assumptions about Zen Cart's database layer.
+- Keep compatibility with the supported runtime documented for this branch: PHP 8.3-8.5 and the supported MySQL/MariaDB versions.
+- Do not introduce production dependencies on Composer autoloading; Composer is used for the test suite, while runtime code uses Zen Cart's own autoloading and plugin loading.
+
+For plugin-related changes:
+- Verify the `zc_plugins/<unique_key>/<version>/catalog|admin/...` layout, plugin `manifest.php`, `filenames.php`, `database_tables.php`, PSR-4 mappings, and installer patterns match this file.
+- Installer scripts should be idempotent and should use Plugin Manager conventions. Direct `plugin_control` database inserts are acceptable only in tests/CI setup, not application code.
+- If a new plugin is added, ensure `zc_plugins/.gitignore` allowlists it.
+
+Review testing expectations by changed area:
+- Unit-level logic should have focused PHPUnit coverage where practical.
+- Storefront/admin behavior changes should use the relevant feature test suite.
+- Plugin filesystem/bootstrap changes should exercise plugin enablement/loading paths.
+- Prefer the composer scripts defined in `composer.json` and referenced in this file; mention when a useful test was not run or cannot be run.
+
+Review output should be concise and actionable:
+- Put findings first, ordered by severity, with file/line references where possible.
+- Flag only material issues. Do not nitpick spelling, formatting, or style unless it causes a defect or violates a project rule being applied to new/touched code.
+- Prefer minimal, deterministic fixes that fit the existing procedural, bootstrap, template, and plugin patterns.
+- If no issues are found, say so clearly and note any remaining test gaps or assumptions.
+
 Project-specific conventions and patterns
 ---------------------------------------
 - Entrypoints are procedural files that require `application_top.php` and later `application_bottom.php` (see `index.php` flow comments).


### PR DESCRIPTION
## Summary

Adds a `Code review guidance` section to `AGENTS.md` so automated agents know how to respond when asked to review pull requests or patches.

The guidance incorporates the existing repo documentation by pointing reviews at `CONVENTIONS.md`, emphasizing stability over broad rewrites, and calling out Zen Cart-specific areas such as bootstrap/path files, request sanitization, output escaping, table-name constants, plugin structure, Composer/runtime boundaries, and relevant test expectations.

## Validation

- Confirmed the branch is one commit ahead of `master`.
- Confirmed the only changed file is `AGENTS.md` with 39 inserted lines.
- Did not run the PHP test suite because this is documentation-only.