### PR TITLE
Add php-cs-fixer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,7 @@
 *not_for_release* export-ignore
 /phpunit.xml      export-ignore
 /phpunit.xml.dist export-ignore
+.php*.php         export-ignore
 /crowdin.yml      export-ignore
 /.aiignore        export-ignore
 /AGENTS.md        export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -246,10 +246,11 @@ zc_plugins/zenTestPlugin
 ppr_listener.php
 ppr_webhook.php
 
-# ignore phpunit cache file
+# Tests, Linting and Analysis
 .phpunit.cache/
 .phpunit.result.cache
-
+.php-cs-fixer.php
+.php-cs-fixer.cache
 
 # local per-dev control
 CLAUDE.local.md

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpCsFixer\Config;
+use PhpCsFixer\Finder;
+
+return (new Config())
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@auto' => true,
+        //'@auto:risky' => true,
+        '@PER-CS' => true, // PER includes PSR-12
+        '@PHP8x5Migration' => true, // includes requirements for prior PHP versions
+        'concat_space' => ['spacing' => 'one'],
+        'cast_spaces' => ['space' => 'none'],
+        'no_alternative_syntax' => true, // avoid using endif style
+        'operator_linebreak' => [
+            'only_booleans' => true,
+        ],
+        'blank_line_after_opening_tag' => false,
+
+        //'blank_line_after_opening_tag' => true,
+        //'declare_strict_types' => [
+        //    'strategy' => 'add_when_missing',
+        //],
+
+        'include' => true,
+        'echo_tag_syntax' => [
+            'format' => 'short',
+            'shorten_simple_statements_only' => true,
+        ],
+
+        'single_line_comment_spacing' => false,
+        'single_line_comment_style' => false,
+
+        'statement_indentation' => true,
+        //'statement_indentation' => [
+        //    'stick_comment_to_next_continuous_control_statement' => false,
+        //],
+
+    ])
+    ->setFinder(
+        (new Finder())
+            ->in(['includes', 'admin', 'zc_install', 'zc_plugins', 'not_for_release'])
+            ->exclude([
+                'classes/vendors',
+            ])
+            ->notName([
+                'configure.php',
+
+                // Legacy files to ignore
+                'paypalwpp.php',
+                'paypaldp.php',
+                'paypal.php',
+                'lang.paypalwpp.php',
+                'lang.paypaldp.php',
+                'lang.paypal.php',
+                'compoundtaxes.php', // legacy test file artifact retained for reference
+
+                'PayPalShippingCarriers.php', // NOWDOC shouldn't be reformatted.
+
+                // dev/distro files to ignore
+                'dist-*.php',
+                'dev-*.php',
+
+                'class.sfYaml*.php',
+            ])
+            ->notPath([
+                'includes/classes/products.php',
+
+
+                // PHP-CS-Fixer 3.95.x crashes (TypeError in StatementIndentationFixer)
+                // on these switch/HTML-mixed templates. Exclude until fixed upstream.
+                'templates/responsive_classic/templates/tpl_index_categories.php',
+                'templates/responsive_classic/templates/tpl_shopping_cart_default.php',
+                'templates/template_default/templates/tpl_shopping_cart_default.php',
+                'templates/template_default/templates/tpl_address_book_process_default.php',
+                'templates/template_default/templates/tpl_index_categories.php',
+                'templates/template_default/templates/tpl_index_default.php',
+                'ResponsiveClassicPlugin/v1.0.0/catalog/includes/templates/responsive_classic_plugin/templates/tpl_index_categories.php',
+                'ResponsiveClassicPlugin/v1.0.0/catalog/includes/templates/responsive_classic_plugin/templates/tpl_shopping_cart_default.php',
+            ])
+            ->ignoreDotFiles(true)
+    );

--- a/admin/gv_sent.php
+++ b/admin/gv_sent.php
@@ -9,7 +9,7 @@ require 'includes/application_top.php';
 $currencies = new currencies();
 ?>
 <!doctype html>
-<html <?php echo HTML_PARAMS; ?>>
+<html <?= HTML_PARAMS; ?>>
   <head>
     <?php require DIR_WS_INCLUDES . 'admin_html_head.php'; ?>
   </head>
@@ -20,18 +20,18 @@ $currencies = new currencies();
     <!-- body //-->
     <div class="container-fluid">
       <!-- body_text //-->
-      <h1 class="pageHeading"><?php echo HEADING_TITLE; ?></h1>
+      <h1 class="pageHeading"><?= HEADING_TITLE; ?></h1>
         <div class="row">
           <div class="col-xs-12 col-sm-12 col-md-9 col-lg-9 configurationColumnLeft">
             <table class="table table-hover table-striped">
               <thead>
                 <tr>
-                  <th class="dataTableHeadingContent"><?php echo TABLE_HEADING_SENDERS_NAME; ?></th>
-                  <th class="dataTableHeadingContent text-center"><?php echo TABLE_HEADING_VOUCHER_VALUE; ?></th>
-                  <th class="dataTableHeadingContent text-center"><?php echo TABLE_HEADING_VOUCHER_CODE; ?></th>
-                  <th class="dataTableHeadingContent text-right"><?php echo TABLE_HEADING_DATE_SENT; ?></th>
-                  <th class="dataTableHeadingContent text-right"><?php echo TEXT_HEADING_DATE_REDEEMED; ?></th>
-                  <th class="dataTableHeadingContent text-right"><?php echo TABLE_HEADING_ACTION; ?></th>
+                  <th class="dataTableHeadingContent"><?= TABLE_HEADING_SENDERS_NAME; ?></th>
+                  <th class="dataTableHeadingContent text-center"><?= TABLE_HEADING_VOUCHER_VALUE; ?></th>
+                  <th class="dataTableHeadingContent text-center"><?= TABLE_HEADING_VOUCHER_CODE; ?></th>
+                  <th class="dataTableHeadingContent text-right"><?= TABLE_HEADING_DATE_SENT; ?></th>
+                  <th class="dataTableHeadingContent text-right"><?= TEXT_HEADING_DATE_REDEEMED; ?></th>
+                  <th class="dataTableHeadingContent text-right"><?= TABLE_HEADING_ACTION; ?></th>
                 </tr>
               </thead>
               <tbody>
@@ -43,31 +43,31 @@ $currencies = new currencies();
                                  WHERE c.coupon_id = et.coupon_id
                                  AND c.coupon_type = 'G'
                                  ORDER BY date_sent desc";
-                $gv_split = new splitPageResults($_GET['page'], zen_config('MAX_DISPLAY_SEARCH_RESULTS'), $gv_query_raw, $gv_query_numrows);
-                $gv_lists = $db->Execute($gv_query_raw);
-                foreach ($gv_lists as $gv_list) {
-                  if ((empty($_GET['gid']) || (@$_GET['gid'] == $gv_list['coupon_id'])) && !isset($gInfo)) {
-                    $gInfo = new objectInfo($gv_list);
-                  }
-                  if (isset($gInfo) && is_object($gInfo) && $gv_list['coupon_id'] == $gInfo->coupon_id) {
-                    ?>
-                    <tr class="dataTableRowSelected" onclick="document.location.href = '<?php echo zen_href_link('gv_sent.php', zen_get_all_get_params(array('gid', 'action')) . 'gid=' . $gInfo->coupon_id . '&action=edit'); ?>'">
+$gv_split = new splitPageResults($_GET['page'], zen_config('MAX_DISPLAY_SEARCH_RESULTS'), $gv_query_raw, $gv_query_numrows);
+$gv_lists = $db->Execute($gv_query_raw);
+foreach ($gv_lists as $gv_list) {
+    if ((empty($_GET['gid']) || (@$_GET['gid'] == $gv_list['coupon_id'])) && !isset($gInfo)) {
+        $gInfo = new objectInfo($gv_list);
+    }
+    if (isset($gInfo) && is_object($gInfo) && $gv_list['coupon_id'] == $gInfo->coupon_id) {
+        ?>
+                    <tr class="dataTableRowSelected" onclick="document.location.href = '<?= zen_href_link('gv_sent.php', zen_get_all_get_params(['gid', 'action']) . 'gid=' . $gInfo->coupon_id . '&action=edit'); ?>'">
                     <?php } else { ?>
-                    <tr class="dataTableRow" onclick="document.location.href = '<?php echo zen_href_link('gv_sent.php', zen_get_all_get_params(array('gid', 'action')) . 'gid=' . $gv_list['coupon_id']); ?>'">
+                    <tr class="dataTableRow" onclick="document.location.href = '<?= zen_href_link('gv_sent.php', zen_get_all_get_params(['gid', 'action']) . 'gid=' . $gv_list['coupon_id']); ?>'">
                     <?php } ?>
-                    <td class="dataTableContent"><?php echo $gv_list['sent_firstname'] . ' ' . $gv_list['sent_lastname']; ?></td>
-                    <td class="dataTableContent text-center"><?php echo $currencies->format($gv_list['coupon_amount']); ?></td>
-                    <td class="dataTableContent text-center"><?php echo $gv_list['coupon_code']; ?></td>
-                    <td class="dataTableContent text-right"><?php echo zen_date_short($gv_list['date_sent']); ?></td>
-                    <td class="dataTableContent text-right"><?php echo (empty($gv_list['redeem_date']) ? TEXT_INFO_NOT_REDEEMED : zen_date_short($gv_list['redeem_date'])); ?></td>
+                    <td class="dataTableContent"><?= $gv_list['sent_firstname'] . ' ' . $gv_list['sent_lastname']; ?></td>
+                    <td class="dataTableContent text-center"><?= $currencies->format($gv_list['coupon_amount']); ?></td>
+                    <td class="dataTableContent text-center"><?= $gv_list['coupon_code']; ?></td>
+                    <td class="dataTableContent text-right"><?= zen_date_short($gv_list['date_sent']); ?></td>
+                    <td class="dataTableContent text-right"><?=(empty($gv_list['redeem_date']) ? TEXT_INFO_NOT_REDEEMED : zen_date_short($gv_list['redeem_date'])); ?></td>
                     <td class="dataTableContent text-right">
                       <?php
-                      if (isset($gInfo) && (is_object($gInfo)) && ($gv_list['coupon_id'] == $gInfo->coupon_id)) {
-                        echo zen_icon('caret-right', '', '2x', true);
-                      } else {
-                        echo '<a href="' . zen_href_link(FILENAME_GV_SENT, 'page=' . $_GET['page'] . '&gid=' . $gv_list['coupon_id']) . '">' . zen_icon('circle-info', IMAGE_ICON_INFO, '2x', true, false) . '</a>';
-                      }
-                      ?>
+          if (isset($gInfo) && (is_object($gInfo)) && ($gv_list['coupon_id'] == $gInfo->coupon_id)) {
+              echo zen_icon('caret-right', '', '2x', true);
+          } else {
+              echo '<a href="' . zen_href_link(FILENAME_GV_SENT, 'page=' . $_GET['page'] . '&gid=' . $gv_list['coupon_id']) . '">' . zen_icon('circle-info', IMAGE_ICON_INFO, '2x', true, false) . '</a>';
+          }
+    ?>
                     </td>
                   </tr>
                 <?php } ?>
@@ -75,43 +75,44 @@ $currencies = new currencies();
             </table>
             <table class="table">
               <tr>
-                <td><?php echo $gv_split->display_count($gv_query_numrows, zen_config('MAX_DISPLAY_SEARCH_RESULTS'), $_GET['page'], TEXT_DISPLAY_NUMBER_OF_GIFT_VOUCHERS); ?></td>
-                <td class="text-right"><?php echo $gv_split->display_links($gv_query_numrows, zen_config('MAX_DISPLAY_SEARCH_RESULTS'), zen_config('MAX_DISPLAY_PAGE_LINKS'), $_GET['page']); ?></td>
+                <td><?= $gv_split->display_count($gv_query_numrows, zen_config('MAX_DISPLAY_SEARCH_RESULTS'), $_GET['page'], TEXT_DISPLAY_NUMBER_OF_GIFT_VOUCHERS); ?></td>
+                <td class="text-right"><?= $gv_split->display_links($gv_query_numrows, zen_config('MAX_DISPLAY_SEARCH_RESULTS'), zen_config('MAX_DISPLAY_PAGE_LINKS'), $_GET['page']); ?></td>
               </tr>
             </table>
           </div>
           <div class="col-xs-12 col-sm-12 col-md-3 col-lg-3 configurationColumnRight">
             <?php
             $heading = [];
-            $contents = [];
+$contents = [];
 
-            if (isset($gInfo)) {
-              $heading[] = array('text' => '[' . $gInfo->coupon_id . '] ' . ' ' . $currencies->format($gInfo->coupon_amount));
-              $redeem = $db->Execute("SELECT *
+if (isset($gInfo)) {
+    $heading[] = ['text' => '[' . $gInfo->coupon_id . '] ' . ' ' . $currencies->format($gInfo->coupon_amount)];
+    $redeem = $db->Execute("SELECT *
                                       FROM " . TABLE_COUPON_REDEEM_TRACK . "
                                       WHERE coupon_id = " . (int)$gInfo->coupon_id);
-              $redeemed = 'No';
-              if ($redeem->RecordCount() > 0)
-                $redeemed = 'Yes';
-              $contents[] = array('text' => TEXT_INFO_SENDERS_ID . ' ' . $gInfo->customer_id_sent . ' ' . ($gInfo->customer_id_sent != 0 ? zen_get_customer_email_from_id($gInfo->customer_id_sent) : ''));
-              $contents[] = array('text' => TEXT_INFO_AMOUNT_SENT . ' ' . $currencies->format($gInfo->coupon_amount));
-              $contents[] = array('text' => TEXT_INFO_DATE_SENT . ' ' . zen_date_short($gInfo->date_sent));
-              $contents[] = array('text' => TEXT_INFO_VOUCHER_CODE . ' ' . $gInfo->coupon_code);
-              $contents[] = array('text' => TEXT_INFO_EMAIL_ADDRESS . ' ' . $gInfo->emailed_to);
-              if ($redeemed == 'Yes') {
-                $contents[] = array('text' => '<br>' . TEXT_INFO_DATE_REDEEMED . ' ' . zen_date_short($redeem->fields['redeem_date']));
-                $contents[] = array('text' => TEXT_INFO_IP_ADDRESS . ' ' . $redeem->fields['redeem_ip']);
-                $contents[] = array('text' => TEXT_INFO_CUSTOMERS_ID . ' ' . $redeem->fields['customer_id'] . ' ' . ($redeem->fields['customer_id'] != 0 ? zen_get_customer_email_from_id($redeem->fields['customer_id']) : ''));
-              } else {
-                $contents[] = array('text' => '<br>' . TEXT_INFO_NOT_REDEEMED);
-              }
+    $redeemed = 'No';
+    if ($redeem->RecordCount() > 0) {
+        $redeemed = 'Yes';
+    }
+    $contents[] = ['text' => TEXT_INFO_SENDERS_ID . ' ' . $gInfo->customer_id_sent . ' ' . ($gInfo->customer_id_sent != 0 ? zen_get_customer_email_from_id($gInfo->customer_id_sent) : '')];
+    $contents[] = ['text' => TEXT_INFO_AMOUNT_SENT . ' ' . $currencies->format($gInfo->coupon_amount)];
+    $contents[] = ['text' => TEXT_INFO_DATE_SENT . ' ' . zen_date_short($gInfo->date_sent)];
+    $contents[] = ['text' => TEXT_INFO_VOUCHER_CODE . ' ' . $gInfo->coupon_code];
+    $contents[] = ['text' => TEXT_INFO_EMAIL_ADDRESS . ' ' . $gInfo->emailed_to];
+    if ($redeemed == 'Yes') {
+        $contents[] = ['text' => '<br>' . TEXT_INFO_DATE_REDEEMED . ' ' . zen_date_short($redeem->fields['redeem_date'])];
+        $contents[] = ['text' => TEXT_INFO_IP_ADDRESS . ' ' . $redeem->fields['redeem_ip']];
+        $contents[] = ['text' => TEXT_INFO_CUSTOMERS_ID . ' ' . $redeem->fields['customer_id'] . ' ' . ($redeem->fields['customer_id'] != 0 ? zen_get_customer_email_from_id($redeem->fields['customer_id']) : '')];
+    } else {
+        $contents[] = ['text' => '<br>' . TEXT_INFO_NOT_REDEEMED];
+    }
 
-              if (!empty($heading) && !empty($contents)) {
-                $box = new box();
-                echo $box->infoBox($heading, $contents);
-              }
-            }
-            ?>
+    if (!empty($heading) && !empty($contents)) {
+        $box = new box();
+        echo $box->infoBox($heading, $contents);
+    }
+}
+?>
           </div>
         </div>
         <!-- body_text_eof //-->

--- a/admin/includes/admin_html_head.php
+++ b/admin/includes/admin_html_head.php
@@ -30,8 +30,8 @@ $zen_admin_html_head_loaded = true;
     <link rel="stylesheet" href="<?= zen_add_filemtime($value) ?>">
     <link rel="stylesheet" href="<?= zen_add_filemtime(DIR_WS_INCLUDES . 'fontawesome/css/solid.min.css') ?>">
     <link rel="stylesheet" href="<?= zen_add_filemtime(DIR_WS_INCLUDES . 'fontawesome/css/regular.min.css') ?>">
-    <?php if (empty($disableFontAwesomeV4Compatibility) &&
-        file_exists($value = DIR_WS_INCLUDES . 'fontawesome/css/v4-shims.min.css')) { ?>
+    <?php if (empty($disableFontAwesomeV4Compatibility)
+        && file_exists($value = DIR_WS_INCLUDES . 'fontawesome/css/v4-shims.min.css')) { ?>
         <link rel="stylesheet" href="<?= zen_add_filemtime($value) ?>">
     <?php } ?>
 <?php } else { ?>
@@ -67,20 +67,20 @@ foreach ($installedPlugins as $plugin) {
     }
     $directory_array = $template->get_template_part($absoluteDir . 'admin/includes/css/', '/^global_stylesheet/', '.css');
     foreach ($directory_array as $key => $value) {
-?>
+        ?>
         <link rel="stylesheet" href="<?= zen_add_filemtime($relativeDir . 'admin/includes/css/' . $value, $absoluteDir . 'admin/includes/css/' . $value) ?>">
 <?php
     }
 
-    if (file_exists($absoluteDir  . 'admin/includes/css/' . $page_base_name . '.css')) {
-?>
+    if (file_exists($absoluteDir . 'admin/includes/css/' . $page_base_name . '.css')) {
+        ?>
         <link rel="stylesheet" href="<?= zen_add_filemtime($relativeDir . 'admin/includes/css/' . $page_base_name . '.css', $absoluteDir . 'admin/includes/css/' . $page_base_name . '.css') ?>">
 <?php
     }
 
     $directory_array = $template->get_template_part($absoluteDir . 'admin/includes/css/', '/^' . $page_base_name . '_/', '.css');
     foreach ($directory_array as $key => $value) {
-?>
+        ?>
         <link rel="stylesheet" href="<?= zen_add_filemtime($relativeDir . 'admin/includes/css/' . $value, $absoluteDir . 'admin/includes/css/' . $value) ?>">
 <?php
     }
@@ -94,7 +94,7 @@ foreach ($installedPlugins as $plugin) {
 
 $directory_array = $template->get_template_part(DIR_WS_INCLUDES . 'css/', '/^' . $page_base_name . '_/', '.css');
 foreach ($directory_array as $key => $value) {
-?>
+    ?>
     <link rel="stylesheet" href="<?= DIR_WS_INCLUDES ?>css/<?= $value ?>">
 <?php
 }

--- a/admin/includes/application_bootstrap.php
+++ b/admin/includes/application_bootstrap.php
@@ -11,6 +11,7 @@ use Zencart\DbRepositories\PluginControlVersionRepository;
 use Zencart\FileSystem\FileSystem;
 use Zencart\PluginManager\PluginManager;
 use Zencart\PageLoader\PageLoader;
+
 /**
  * boolean used to see if we are in the admin script, obviously set to false here.
  * DO NOT REMOVE THE define BELOW. WILL BREAK ADMIN
@@ -29,7 +30,7 @@ if (basename($PHP_SELF, '.php') === 'index') {
 $PHP_SELF = htmlspecialchars($PHP_SELF, ENT_COMPAT);
 $_SERVER['SCRIPT_NAME'] = str_replace($serverScript, '', $_SERVER['SCRIPT_NAME']) . $PHP_SELF;
 // Suppress html from error messages
-@ini_set("html_errors","0");
+@ini_set("html_errors", "0");
 /*
  * Get time zone info from PHP config
 */
@@ -44,7 +45,9 @@ if ($detected_locale === false || $detected_locale === 'C') {
     setlocale(LC_TIME, ['en_US', 'en_US.UTF-8', 'en-US', 'en']);
 }
 
-if (!defined('DIR_FS_ADMIN')) define('DIR_FS_ADMIN', preg_replace('#/includes/$#', '/', realpath(__DIR__ . '/../') . '/'));
+if (!defined('DIR_FS_ADMIN')) {
+    define('DIR_FS_ADMIN', preg_replace('#/includes/$#', '/', realpath(__DIR__ . '/../') . '/'));
+}
 
 /**
  * Ensure minimum PHP version.
@@ -59,26 +62,26 @@ if (PHP_VERSION_ID < 80300) {
 }
 
 if (file_exists('../not_for_release/testFramework/Support/application_testing.php')) {
-    require('../not_for_release/testFramework/Support/application_testing.php');
+    require '../not_for_release/testFramework/Support/application_testing.php';
 }
 /**
  * check for and load application configuration parameters
  */
 if (!defined('ZENCART_TESTFRAMEWORK_RUNNING')) {
     if (file_exists('includes/local/configure.php')) {
-        include('includes/local/configure.php');
+        include 'includes/local/configure.php';
     } elseif (file_exists('../includes/local/configure.php')) {
-        include('../includes/local/configure.php');
+        include '../includes/local/configure.php';
     } elseif (file_exists('includes/configure.php')) {
-        include('includes/configure.php');
+        include 'includes/configure.php';
     } elseif (file_exists('../includes/configure.php')) {
-        include('../includes/configure.php');
+        include '../includes/configure.php';
     }
 }
 
-if (!defined('DIR_FS_CATALOG') || !is_dir(DIR_FS_CATALOG.'/includes/classes') || !defined('DB_TYPE') || DB_TYPE === '') {
+if (!defined('DIR_FS_CATALOG') || !is_dir(DIR_FS_CATALOG . '/includes/classes') || !defined('DB_TYPE') || DB_TYPE === '') {
     if (file_exists('../includes/templates/template_default/templates/tpl_zc_install_suggested_default.php')) {
-        require('../includes/templates/template_default/templates/tpl_zc_install_suggested_default.php');
+        require '../includes/templates/template_default/templates/tpl_zc_install_suggested_default.php';
         exit;
     } elseif (file_exists('../zc_install/index.php')) {
         echo 'ERROR: configure.php not found. Suggest running install? <a href="../zc_install/index.php">Click here for installation</a>';
@@ -104,7 +107,7 @@ if (!defined('DEBUG_AUTOLOAD')) {
  *
  */
 if ((defined('DEBUG_AUTOLOAD') && DEBUG_AUTOLOAD === true) || (defined('STRICT_ERROR_REPORTING') && STRICT_ERROR_REPORTING === true)) {
-    @ini_set('display_errors', TRUE);
+    @ini_set('display_errors', true);
     error_reporting(defined('STRICT_ERROR_REPORTING_LEVEL') ? STRICT_ERROR_REPORTING_LEVEL : E_ALL);
 } else {
     error_reporting(0);
@@ -117,7 +120,7 @@ if (file_exists('includes/defined_paths.php')) {
     /**
      * load the system-defined path constants
      */
-    require('includes/defined_paths.php');
+    require 'includes/defined_paths.php';
 } else {
     die('ERROR: /includes/defined_paths.php file not found. Cannot continue.');
     exit;
@@ -136,7 +139,7 @@ zen_enable_error_logging();
  * include the extra_configures files
  */
 foreach (glob(DIR_WS_INCLUDES . 'extra_configures/*.php') ?? [] as $file) {
-    include($file);
+    include $file;
 }
 /**
  * init some vars
@@ -147,7 +150,7 @@ zen_define_default('DIR_WS_TEMPLATES', DIR_WS_INCLUDES . 'templates/');
  * psr-4 autoloading
  */
 require DIR_FS_CATALOG . DIR_WS_CLASSES . 'vendors/AuraAutoload/src/Loader.php';
-$psr4Autoloader = new \Aura\Autoload\Loader;
+$psr4Autoloader = new \Aura\Autoload\Loader();
 $psr4Autoloader->register();
 require DIR_FS_CATALOG . 'includes/psr4Autoload.php';
 require DIR_FS_CATALOG . DIR_WS_CLASSES . 'class.base.php';
@@ -160,9 +163,9 @@ $pluginManager = new PluginManager(new PluginControlRepository($db), new PluginC
 $installedPlugins = $pluginManager->getInstalledPlugins();
 
 $pageLoader = PageLoader::getInstance();
-$pageLoader->init($installedPlugins, $PHP_SELF, new FileSystem);
+$pageLoader->init($installedPlugins, $PHP_SELF, new FileSystem());
 
-$fs = new FileSystem;
+$fs = new FileSystem();
 $fs->loadFilesFromPluginsDirectory($installedPlugins, 'admin/includes/extra_configures', '~^[^\._].*\.php$~i');
 $fs->loadFilesFromPluginsDirectory($installedPlugins, 'admin/includes/extra_datafiles', '~^[^\._].*\.php$~i');
 $fs->loadFilesFromPluginsDirectory($installedPlugins, '', '~^database_tables\.php$~i');

--- a/admin/includes/classes/object_info.php
+++ b/admin/includes/classes/object_info.php
@@ -28,7 +28,9 @@ class objectInfo
      */
     public function objectInfo($object_array)
     {
-        if (!is_array($object_array)) return;
+        if (!is_array($object_array)) {
+            return;
+        }
 
         foreach ($object_array as $key => $value) {
             $this->$key = zen_db_prepare_input($value);
@@ -42,7 +44,9 @@ class objectInfo
      */
     public function updateObjectInfo($object_array)
     {
-        if (!is_array($object_array)) return;
+        if (!is_array($object_array)) {
+            return;
+        }
 
         foreach ($object_array as $key => $value) {
             $this->$key = zen_db_prepare_input($value);
@@ -72,9 +76,13 @@ class objectInfo
      */
     public function __get($field)
     {
-        if (isset($this->$field)) return $this->$field;
+        if (isset($this->$field)) {
+            return $this->$field;
+        }
 
-        if ($field == 'keys') return array();
+        if ($field == 'keys') {
+            return [];
+        }
 
         return null;
     }

--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -126,13 +126,13 @@ function zen_cfg_select_coupon_id(string $coupon_id, string $key = ''): string
     $coupons = Coupon::getAllCouponsByName();
     $coupon_array[] = [
         'id' => '0',
-        'text' => TEXT_NONE
+        'text' => TEXT_NONE,
     ];
 
     foreach ($coupons as $coupon) {
         $coupon_array[] = [
             'id' => $coupon['coupon_id'],
-            'text' => $coupon['coupon_name']
+            'text' => $coupon['coupon_name'],
         ];
     }
 
@@ -361,10 +361,10 @@ function zen_get_system_information(bool $privacy = false): array
     $mysql_slow_query_log_status = '';
     $result = $db->Execute("SHOW VARIABLES LIKE 'slow\_query\_log'");
     if (!$result->EOF) {
-       $mysql_slow_query_log_status = '0';
-       if (in_array($result->fields['Value'] ?? '', ['On', 'ON', '1',], false)) {
-         $mysql_slow_query_log_status = '1';
-       }
+        $mysql_slow_query_log_status = '0';
+        if (in_array($result->fields['Value'] ?? '', ['On', 'ON', '1',], false)) {
+            $mysql_slow_query_log_status = '1';
+        }
     }
     $result = $db->Execute("SHOW VARIABLES LIKE 'slow\_query\_log\_file'");
     $mysql_slow_query_log_file = $result->fields['Value'] ?? '';
@@ -429,7 +429,7 @@ function zen_get_system_information(bool $privacy = false): array
     ];
 
     if ($privacy) {
-        unset ($systemInfo['mysql_slow_query_log_file']);
+        unset($systemInfo['mysql_slow_query_log_file']);
     }
 
     return $systemInfo;
@@ -535,7 +535,7 @@ function zen_draw_order_status_dropdown(string $field_name, $default_value, stri
     foreach ($statuses as $status) {
         $statuses_array[] = [
             'id' => $status['id'],
-            'text' => "{$status['text']} [{$status['id']}]"
+            'text' => "{$status['text']} [{$status['id']}]",
         ];
     }
     return zen_draw_pull_down_menu($field_name, $statuses_array, $default_value, $parms);
@@ -552,7 +552,8 @@ function zen_draw_order_status_dropdown(string $field_name, $default_value, stri
 function zen_get_language_icon(string|int $lookup): string
 {
     global $db;
-    $languages_icon = $db->Execute("
+    $languages_icon = $db->Execute(
+        "
         SELECT directory, image FROM " . TABLE_LANGUAGES . "
          WHERE languages_id = " . (int)$lookup . "
             OR code = '" . zen_db_input((string)$lookup) . "'
@@ -734,7 +735,8 @@ function zen_geo_zones_pull_down_coupon(string $parameters, $selected = ''): str
     $zones = $db->Execute(
         "SELECT geo_zone_id, geo_zone_name
            FROM " . TABLE_GEO_ZONES . "
-          ORDER BY geo_zone_name");
+          ORDER BY geo_zone_name"
+    );
 
     if ($selected == 0) {
         $select_string .= '<option value="0" SELECTED>' . TEXT_NONE . '</option>';
@@ -783,7 +785,7 @@ function zen_get_orders_comments(int|string $orders_id): string
 function zen_set_ezpage_status(int $pages_id, int $status, string $status_field): void
 {
     global $db, $sniffer;
-    
+
     // Use the $sniffer class to check if the field exists in the table
     if (!$sniffer->field_exists(TABLE_EZPAGES, $status_field)) {
         return; // invalid field, do not proceed
@@ -847,7 +849,7 @@ function zen_getOrdersStatuses(bool $keyed = false): array
  */
 function zen_get_customer_email_from_id(int|string $cid): string
 {
-   global $db;
-   $query = $db->Execute("SELECT customers_email_address FROM " . TABLE_CUSTOMERS . " WHERE customers_id = " . (int)$cid);
-   return ($query->EOF) ? '' : $query->fields['customers_email_address'];
+    global $db;
+    $query = $db->Execute("SELECT customers_email_address FROM " . TABLE_CUSTOMERS . " WHERE customers_id = " . (int)$cid);
+    return ($query->EOF) ? '' : $query->fields['customers_email_address'];
 }

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
     },
     "require-dev": {
         "ext-pdo": "*",
+        "friendsofphp/php-cs-fixer": "^3.95",
         "guzzlehttp/guzzle": "^7.7",
         "mikey179/vfsstream": "^1.6",
         "phpstan/phpstan": "^2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,11 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-<<<<<<< HEAD
-    "content-hash": "35377ff79cc523cb8692d4732e41947d",
-=======
-    "content-hash": "f91348b58da853c2b76232777a1ab575",
->>>>>>> 8bbb1f3a2 (Add php-cs-fixer)
+    "content-hash": "961539c325c64b9b070647dfc7ef176a",
     "packages": [],
     "packages-dev": [
         {
@@ -77,28 +73,29 @@
         },
         {
             "name": "composer/pcre",
-            "version": "3.3.2",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/d5a341b3fb61f3001970940afb1d332968a183ed",
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0"
             },
             "conflict": {
-                "phpstan/phpstan": "<1.11.10"
+                "phpstan/phpstan": "<2.2.2"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.12 || ^2",
-                "phpstan/phpstan-strict-rules": "^1 || ^2",
-                "phpunit/phpunit": "^8 || ^9"
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^9"
             },
             "type": "library",
             "extra": {
@@ -136,7 +133,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.3.2"
+                "source": "https://github.com/composer/pcre/tree/3.4.0"
             },
             "funding": [
                 {
@@ -146,13 +143,9 @@
                 {
                     "url": "https://github.com/composer",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2024-11-12T16:29:46+00:00"
+            "time": "2026-06-07T11:47:49+00:00"
         },
         {
             "name": "composer/semver",
@@ -388,17 +381,6 @@
             "time": "2025-08-10T19:31:58+00:00"
         },
         {
-<<<<<<< HEAD
-            "name": "guzzlehttp/guzzle",
-            "version": "7.11.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "5af96f374e0ab4ebd747b8310888c99d3adb0a8c"
-            },
-            "dist": {
-                "type": "zip",
-=======
             "name": "ergebnis/agent-detector",
             "version": "1.2.0",
             "source": {
@@ -690,7 +672,6 @@
             },
             "dist": {
                 "type": "zip",
->>>>>>> 8bbb1f3a2 (Add php-cs-fixer)
                 "url": "https://api.github.com/repos/guzzle/guzzle/zipball/5af96f374e0ab4ebd747b8310888c99d3adb0a8c",
                 "reference": "5af96f374e0ab4ebd747b8310888c99d3adb0a8c",
                 "shasum": ""
@@ -2857,77 +2838,15 @@
                     "type": "liberapay"
                 },
                 {
-<<<<<<< HEAD
                     "url": "https://thanks.dev/u/gh/sebastianbergmann",
                     "type": "thanks_dev"
                 },
-=======
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-03-19T07:56:08+00:00"
-        },
-        {
-            "name": "sebastian/code-unit-reverse-lookup",
-            "version": "4.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "183a9b2632194febd219bb9246eee421dad8d45e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/183a9b2632194febd219bb9246eee421dad8d45e",
-                "reference": "183a9b2632194febd219bb9246eee421dad8d45e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^11.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
->>>>>>> 8bbb1f3a2 (Add php-cs-fixer)
                 {
                     "url": "https://tidelift.com/funding/github/packagist/sebastian/cli-parser",
                     "type": "tidelift"
                 }
             ],
-<<<<<<< HEAD
             "time": "2026-05-17T05:29:34+00:00"
-=======
-            "description": "Looks up which function or method a line of code belongs to",
-            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "security": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/security/policy",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/4.0.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-07-03T04:45:54+00:00"
->>>>>>> 8bbb1f3a2 (Add php-cs-fixer)
         },
         {
             "name": "sebastian/comparator",
@@ -5967,8 +5886,6 @@
             ],
             "support": {
                 "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
-<<<<<<< HEAD
-=======
             },
             "funding": [
                 {
@@ -6213,7 +6130,6 @@
             ],
             "support": {
                 "source": "https://github.com/symfony/polyfill-php84/tree/v1.38.1"
->>>>>>> 8bbb1f3a2 (Add php-cs-fixer)
             },
             "funding": [
                 {
@@ -6233,91 +6149,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-27T06:59:30+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php80",
-            "version": "v1.37.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
-                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ion Bazan",
-                    "email": "ion.bazan@gmail.com"
-                },
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-04-10T16:19:22+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
             "name": "symfony/polyfill-php85",

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,299 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
+<<<<<<< HEAD
     "content-hash": "35377ff79cc523cb8692d4732e41947d",
+=======
+    "content-hash": "f91348b58da853c2b76232777a1ab575",
+>>>>>>> 8bbb1f3a2 (Add php-cs-fixer)
     "packages": [],
     "packages-dev": [
+        {
+            "name": "clue/ndjson-react",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/clue/reactphp-ndjson.git",
+                "reference": "392dc165fce93b5bb5c637b67e59619223c931b0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/clue/reactphp-ndjson/zipball/392dc165fce93b5bb5c637b67e59619223c931b0",
+                "reference": "392dc165fce93b5bb5c637b67e59619223c931b0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "react/stream": "^1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35",
+                "react/event-loop": "^1.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Clue\\React\\NDJson\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering"
+                }
+            ],
+            "description": "Streaming newline-delimited JSON (NDJSON) parser and encoder for ReactPHP.",
+            "homepage": "https://github.com/clue/reactphp-ndjson",
+            "keywords": [
+                "NDJSON",
+                "json",
+                "jsonlines",
+                "newline",
+                "reactphp",
+                "streaming"
+            ],
+            "support": {
+                "issues": "https://github.com/clue/reactphp-ndjson/issues",
+                "source": "https://github.com/clue/reactphp-ndjson/tree/v1.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://clue.engineering/support",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/clue",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-12-23T10:58:28+00:00"
+        },
+        {
+            "name": "composer/pcre",
+            "version": "3.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/pcre.git",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<1.11.10"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.12 || ^2",
+                "phpstan/phpstan-strict-rules": "^1 || ^2",
+                "phpunit/phpunit": "^8 || ^9"
+            },
+            "type": "library",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Pcre\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "keywords": [
+                "PCRE",
+                "preg",
+                "regex",
+                "regular expression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/pcre/issues",
+                "source": "https://github.com/composer/pcre/tree/3.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-12T16:29:46+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.11",
+                "symfony/phpunit-bridge": "^3 || ^7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.4.4"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-20T19:15:30+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "3.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/6c1925561632e83d60a44492e0b344cf48ab85ef",
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef",
+                "shasum": ""
+            },
+            "require": {
+                "composer/pcre": "^1 || ^2 || ^3",
+                "php": "^7.2.5 || ^8.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "phpunit/phpunit": "^8.5 || ^9.6 || ^10.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/xdebug-handler/issues",
+                "source": "https://github.com/composer/xdebug-handler/tree/3.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-05-06T16:37:16+00:00"
+        },
         {
             "name": "doctrine/inflector",
             "version": "2.1.0",
@@ -98,6 +388,7 @@
             "time": "2025-08-10T19:31:58+00:00"
         },
         {
+<<<<<<< HEAD
             "name": "guzzlehttp/guzzle",
             "version": "7.11.1",
             "source": {
@@ -107,6 +398,299 @@
             },
             "dist": {
                 "type": "zip",
+=======
+            "name": "ergebnis/agent-detector",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ergebnis/agent-detector.git",
+                "reference": "e211f17928c8b95a51e06040792d57f5462fb271"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ergebnis/agent-detector/zipball/e211f17928c8b95a51e06040792d57f5462fb271",
+                "reference": "e211f17928c8b95a51e06040792d57f5462fb271",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0 || ~8.6.0"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.51.0",
+                "ergebnis/license": "^2.7.0",
+                "ergebnis/php-cs-fixer-config": "^6.60.2",
+                "ergebnis/phpstan-rules": "^2.13.1",
+                "ergebnis/phpunit-slow-test-detector": "^2.24.0",
+                "ergebnis/rector-rules": "^1.18.1",
+                "fakerphp/faker": "^1.24.1",
+                "infection/infection": "^0.26.6",
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^2.1.54",
+                "phpstan/phpstan-deprecation-rules": "^2.0.4",
+                "phpstan/phpstan-phpunit": "^2.0.16",
+                "phpstan/phpstan-strict-rules": "^2.0.10",
+                "phpunit/phpunit": "^9.6.34",
+                "rector/rector": "^2.4.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.2-dev"
+                },
+                "composer-normalize": {
+                    "indent-size": 2,
+                    "indent-style": "space"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ergebnis\\AgentDetector\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com",
+                    "homepage": "https://localheinz.com"
+                }
+            ],
+            "description": "Provides a detector for detecting the presence of an agent.",
+            "homepage": "https://github.com/ergebnis/agent-detector",
+            "support": {
+                "issues": "https://github.com/ergebnis/agent-detector/issues",
+                "security": "https://github.com/ergebnis/agent-detector/blob/main/.github/SECURITY.md",
+                "source": "https://github.com/ergebnis/agent-detector"
+            },
+            "time": "2026-05-07T08:19:07+00:00"
+        },
+        {
+            "name": "evenement/evenement",
+            "version": "v3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/igorw/evenement.git",
+                "reference": "0a16b0d71ab13284339abb99d9d2bd813640efbc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/igorw/evenement/zipball/0a16b0d71ab13284339abb99d9d2bd813640efbc",
+                "reference": "0a16b0d71ab13284339abb99d9d2bd813640efbc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9 || ^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Evenement\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                }
+            ],
+            "description": "Événement is a very simple event dispatching library for PHP",
+            "keywords": [
+                "event-dispatcher",
+                "event-emitter"
+            ],
+            "support": {
+                "issues": "https://github.com/igorw/evenement/issues",
+                "source": "https://github.com/igorw/evenement/tree/v3.0.2"
+            },
+            "time": "2023-08-08T05:53:35+00:00"
+        },
+        {
+            "name": "fidry/cpu-core-counter",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theofidry/cpu-core-counter.git",
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/db9508f7b1474469d9d3c53b86f817e344732678",
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "fidry/makefile": "^0.2.0",
+                "fidry/php-cs-fixer-config": "^1.1.2",
+                "phpstan/extension-installer": "^1.2.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-deprecation-rules": "^2.0.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^8.5.31 || ^9.5.26",
+                "webmozarts/strict-phpunit": "^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Fidry\\CpuCoreCounter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Théo FIDRY",
+                    "email": "theo.fidry@gmail.com"
+                }
+            ],
+            "description": "Tiny utility to get the number of CPU cores.",
+            "keywords": [
+                "CPU",
+                "core"
+            ],
+            "support": {
+                "issues": "https://github.com/theofidry/cpu-core-counter/issues",
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/1.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theofidry",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-14T07:29:31+00:00"
+        },
+        {
+            "name": "friendsofphp/php-cs-fixer",
+            "version": "v3.95.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
+                "reference": "7f86d8763063f5d2e2e2d0e1e45bb2f15895361d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/7f86d8763063f5d2e2e2d0e1e45bb2f15895361d",
+                "reference": "7f86d8763063f5d2e2e2d0e1e45bb2f15895361d",
+                "shasum": ""
+            },
+            "require": {
+                "clue/ndjson-react": "^1.3",
+                "composer/semver": "^3.4",
+                "composer/xdebug-handler": "^3.0.5",
+                "ergebnis/agent-detector": "^1.2",
+                "ext-filter": "*",
+                "ext-hash": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "fidry/cpu-core-counter": "^1.3",
+                "php": "^7.4 || ^8.0",
+                "react/child-process": "^0.6.6",
+                "react/event-loop": "^1.5",
+                "react/socket": "^1.16",
+                "react/stream": "^1.4",
+                "sebastian/diff": "^4.0.6 || ^5.1.1 || ^6.0.2 || ^7.0 || ^8.0 || ^9.0",
+                "symfony/console": "^5.4.47 || ^6.4.24 || ^7.0 || ^8.0",
+                "symfony/event-dispatcher": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
+                "symfony/filesystem": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
+                "symfony/finder": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
+                "symfony/options-resolver": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.37",
+                "symfony/polyfill-php80": "^1.37",
+                "symfony/polyfill-php81": "^1.37",
+                "symfony/polyfill-php84": "^1.37",
+                "symfony/process": "^5.4.47 || ^6.4.24 || ^7.2 || ^8.0",
+                "symfony/stopwatch": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "facile-it/paraunit": "^1.3.1 || ^2.11.0",
+                "infection/infection": "^0.32.7",
+                "justinrainbow/json-schema": "^6.8.0",
+                "keradus/cli-executor": "^2.3",
+                "mikey179/vfsstream": "^1.6.12",
+                "php-coveralls/php-coveralls": "^2.9.1",
+                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.8",
+                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.8",
+                "phpunit/phpunit": "^9.6.34 || ^10.5.63 || ^11.5.55",
+                "symfony/polyfill-php85": "^1.37",
+                "symfony/var-dumper": "^5.4.48 || ^6.4.32 || ^7.4.4 || ^8.0.8",
+                "symfony/yaml": "^5.4.45 || ^6.4.30 || ^7.4.1 || ^8.0.11"
+            },
+            "suggest": {
+                "ext-dom": "For handling output formats in XML",
+                "ext-mbstring": "For handling non-UTF8 characters."
+            },
+            "bin": [
+                "php-cs-fixer"
+            ],
+            "type": "application",
+            "autoload": {
+                "psr-4": {
+                    "PhpCsFixer\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/**/Internal/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Dariusz Rumiński",
+                    "email": "dariusz.ruminski@gmail.com"
+                }
+            ],
+            "description": "A tool to automatically fix PHP code style",
+            "keywords": [
+                "Static code analysis",
+                "fixer",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/keradus",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-09T14:55:16+00:00"
+        },
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "7.11.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "5af96f374e0ab4ebd747b8310888c99d3adb0a8c"
+            },
+            "dist": {
+                "type": "zip",
+>>>>>>> 8bbb1f3a2 (Add php-cs-fixer)
                 "url": "https://api.github.com/repos/guzzle/guzzle/zipball/5af96f374e0ab4ebd747b8310888c99d3adb0a8c",
                 "reference": "5af96f374e0ab4ebd747b8310888c99d3adb0a8c",
                 "shasum": ""
@@ -1689,6 +2273,532 @@
             "time": "2019-03-08T08:55:37+00:00"
         },
         {
+            "name": "react/cache",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/cache.git",
+                "reference": "d47c472b64aa5608225f47965a484b75c7817d5b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/cache/zipball/d47c472b64aa5608225f47965a484b75c7817d5b",
+                "reference": "d47c472b64aa5608225f47965a484b75c7817d5b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "react/promise": "^3.0 || ^2.0 || ^1.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async, Promise-based cache interface for ReactPHP",
+            "keywords": [
+                "cache",
+                "caching",
+                "promise",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/cache/issues",
+                "source": "https://github.com/reactphp/cache/tree/v1.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2022-11-30T15:59:55+00:00"
+        },
+        {
+            "name": "react/child-process",
+            "version": "v0.6.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/child-process.git",
+                "reference": "970f0e71945556422ee4570ccbabaedc3cf04ad3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/child-process/zipball/970f0e71945556422ee4570ccbabaedc3cf04ad3",
+                "reference": "970f0e71945556422ee4570ccbabaedc3cf04ad3",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.0",
+                "react/event-loop": "^1.2",
+                "react/stream": "^1.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/socket": "^1.16",
+                "sebastian/environment": "^5.0 || ^3.0 || ^2.0 || ^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\ChildProcess\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Event-driven library for executing child processes with ReactPHP.",
+            "keywords": [
+                "event-driven",
+                "process",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/child-process/issues",
+                "source": "https://github.com/reactphp/child-process/tree/v0.6.7"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-12-23T15:25:20+00:00"
+        },
+        {
+            "name": "react/dns",
+            "version": "v1.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/dns.git",
+                "reference": "7562c05391f42701c1fccf189c8225fece1cd7c3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/dns/zipball/7562c05391f42701c1fccf189c8225fece1cd7c3",
+                "reference": "7562c05391f42701c1fccf189c8225fece1cd7c3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "react/cache": "^1.0 || ^0.6 || ^0.5",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.7 || ^1.2.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/async": "^4.3 || ^3 || ^2",
+                "react/promise-timer": "^1.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Dns\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async DNS resolver for ReactPHP",
+            "keywords": [
+                "async",
+                "dns",
+                "dns-resolver",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/dns/issues",
+                "source": "https://github.com/reactphp/dns/tree/v1.14.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-11-18T19:34:28+00:00"
+        },
+        {
+            "name": "react/event-loop",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/event-loop.git",
+                "reference": "ba276bda6083df7e0050fd9b33f66ad7a4ac747a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/ba276bda6083df7e0050fd9b33f66ad7a4ac747a",
+                "reference": "ba276bda6083df7e0050fd9b33f66ad7a4ac747a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "suggest": {
+                "ext-pcntl": "For signal handling support when using the StreamSelectLoop"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\EventLoop\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "ReactPHP's core reactor event loop that libraries can use for evented I/O.",
+            "keywords": [
+                "asynchronous",
+                "event-loop"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/event-loop/issues",
+                "source": "https://github.com/reactphp/event-loop/tree/v1.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-11-17T20:46:25+00:00"
+        },
+        {
+            "name": "react/promise",
+            "version": "v3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise.git",
+                "reference": "23444f53a813a3296c1368bb104793ce8d88f04a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/23444f53a813a3296c1368bb104793ce8d88f04a",
+                "reference": "23444f53a813a3296c1368bb104793ce8d88f04a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "1.12.28 || 1.4.10",
+                "phpunit/phpunit": "^9.6 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "keywords": [
+                "promise",
+                "promises"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/promise/issues",
+                "source": "https://github.com/reactphp/promise/tree/v3.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-08-19T18:57:03+00:00"
+        },
+        {
+            "name": "react/socket",
+            "version": "v1.17.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/socket.git",
+                "reference": "ef5b17b81f6f60504c539313f94f2d826c5faa08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/socket/zipball/ef5b17b81f6f60504c539313f94f2d826c5faa08",
+                "reference": "ef5b17b81f6f60504c539313f94f2d826c5faa08",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.0",
+                "react/dns": "^1.13",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.6 || ^1.2.1",
+                "react/stream": "^1.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/async": "^4.3 || ^3.3 || ^2",
+                "react/promise-stream": "^1.4",
+                "react/promise-timer": "^1.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Socket\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async, streaming plaintext TCP/IP and secure TLS socket server and client connections for ReactPHP",
+            "keywords": [
+                "Connection",
+                "Socket",
+                "async",
+                "reactphp",
+                "stream"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/socket/issues",
+                "source": "https://github.com/reactphp/socket/tree/v1.17.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-11-19T20:47:34+00:00"
+        },
+        {
+            "name": "react/stream",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/stream.git",
+                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/stream/zipball/1e5b0acb8fe55143b5b426817155190eb6f5b18d",
+                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.8",
+                "react/event-loop": "^1.2"
+            },
+            "require-dev": {
+                "clue/stream-filter": "~1.2",
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Stream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Event-driven readable and writable streams for non-blocking I/O in ReactPHP",
+            "keywords": [
+                "event-driven",
+                "io",
+                "non-blocking",
+                "pipe",
+                "reactphp",
+                "readable",
+                "stream",
+                "writable"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/stream/issues",
+                "source": "https://github.com/reactphp/stream/tree/v1.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-06-11T12:45:25+00:00"
+        },
+        {
             "name": "sebastian/cli-parser",
             "version": "4.2.1",
             "source": {
@@ -1747,15 +2857,77 @@
                     "type": "liberapay"
                 },
                 {
+<<<<<<< HEAD
                     "url": "https://thanks.dev/u/gh/sebastianbergmann",
                     "type": "thanks_dev"
                 },
+=======
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-19T07:56:08+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/183a9b2632194febd219bb9246eee421dad8d45e",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+>>>>>>> 8bbb1f3a2 (Add php-cs-fixer)
                 {
                     "url": "https://tidelift.com/funding/github/packagist/sebastian/cli-parser",
                     "type": "tidelift"
                 }
             ],
+<<<<<<< HEAD
             "time": "2026-05-17T05:29:34+00:00"
+=======
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "security": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:45:54+00:00"
+>>>>>>> 8bbb1f3a2 (Add php-cs-fixer)
         },
         {
             "name": "sebastian/comparator",
@@ -4239,6 +5411,77 @@
             "time": "2026-05-23T14:40:34+00:00"
         },
         {
+            "name": "symfony/options-resolver",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "2888fcdc4dc2fd5f7c7397be78631e8af12e02b4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/2888fcdc4dc2fd5f7c7397be78631e8af12e02b4",
+                "reference": "2888fcdc4dc2fd5f7c7397be78631e8af12e02b4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an improved replacement for the array_replace PHP function",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/options-resolver/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
+        },
+        {
             "name": "symfony/phpunit-bridge",
             "version": "v7.4.8",
             "source": {
@@ -4724,6 +5967,253 @@
             ],
             "support": {
                 "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
+<<<<<<< HEAD
+=======
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-27T06:59:30+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php81",
+            "version": "v1.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php81.git",
+                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
+                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php81\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.1+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.38.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-26T12:45:58+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php84",
+            "version": "v1.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php84.git",
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php84\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.4+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.38.1"
+>>>>>>> 8bbb1f3a2 (Add php-cs-fixer)
             },
             "funding": [
                 {
@@ -5145,6 +6635,72 @@
                 }
             ],
             "time": "2026-03-28T09:44:51+00:00"
+        },
+        {
+            "name": "symfony/stopwatch",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/stopwatch.git",
+                "reference": "70a852d72fec4d51efb1f48dcd968efcaf5ccb89"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/70a852d72fec4d51efb1f48dcd968efcaf5ccb89",
+                "reference": "70a852d72fec4d51efb1f48dcd968efcaf5ccb89",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Stopwatch\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a way to profile code",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/stopwatch/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/string",

--- a/includes/classes/InitSystem.php
+++ b/includes/classes/InitSystem.php
@@ -112,7 +112,7 @@ class InitSystem
         if ($entry['loaderType'] === 'plugin') {
             $filePath = $this->findPluginDirectory($entry['classPath'] ?? DIR_WS_CLASSES, $entry['pluginInfo']['unique_key']);
         }
-        $this->debugList[] = 'processing class - ' . $filePath  . $entry['loadFile'];
+        $this->debugList[] = 'processing class - ' . $filePath . $entry['loadFile'];
         $result = 'FAILED';
         if (file_exists($filePath . $entry['loadFile'])) {
             $result = 'SUCCESS';

--- a/includes/classes/breadcrumb.php
+++ b/includes/classes/breadcrumb.php
@@ -16,7 +16,9 @@ if (!defined('IS_ADMIN_FLAG')) {
  * If you desire to have the older behaviour of having all product and category items in the breadcrumb be shown as links
  * then you should add a define() for this item in the extra_datafiles folder and set it to 'false' instead of 'true':
  */
-if (!defined('DISABLE_BREADCRUMB_LINKS_ON_LAST_ITEM')) define('DISABLE_BREADCRUMB_LINKS_ON_LAST_ITEM', 'true');
+if (!defined('DISABLE_BREADCRUMB_LINKS_ON_LAST_ITEM')) {
+    define('DISABLE_BREADCRUMB_LINKS_ON_LAST_ITEM', 'true');
+}
 
 /**
  * Handle page breadcrumbs
@@ -26,7 +28,7 @@ class breadcrumb extends base
 {
     protected $_trail = [];
 
-    function __construct()
+    public function __construct()
     {
         $this->reset();
     }
@@ -34,7 +36,7 @@ class breadcrumb extends base
     /**
      * @since ZC v1.0.3
      */
-    function reset()
+    public function reset()
     {
         $this->_trail = [];
     }
@@ -42,7 +44,7 @@ class breadcrumb extends base
     /**
      * @since ZC v1.0.3
      */
-    function add($title, $link = '')
+    public function add($title, $link = '')
     {
         $this->_trail[] = ['title' => $title, 'link' => $link];
     }
@@ -50,12 +52,12 @@ class breadcrumb extends base
     /**
      * @since ZC v1.0.3
      */
-    function trail($separator = '&nbsp;&nbsp;', $prefix = '', $suffix = '')
+    public function trail($separator = '&nbsp;&nbsp;', $prefix = '', $suffix = '')
     {
         $trail_string = '';
 
         for ($i = 0, $n = count($this->_trail); $i < $n; $i++) {
-        // echo 'breadcrumb ' . $i . ' of ' . $n . ': ' . $this->_trail[$i]['title'] . '<br>';
+            // echo 'breadcrumb ' . $i . ' of ' . $n . ': ' . $this->_trail[$i]['title'] . '<br>';
             $skip_link = false;
             if ($i == ($n - 1) && DISABLE_BREADCRUMB_LINKS_ON_LAST_ITEM == 'true') {
                 $skip_link = true;
@@ -73,7 +75,9 @@ class breadcrumb extends base
                 }
             }
 
-            if (($i + 1) < $n) $trail_string .= $separator;
+            if (($i + 1) < $n) {
+                $trail_string .= $separator;
+            }
             $trail_string .= "\n";
         }
 
@@ -83,7 +87,7 @@ class breadcrumb extends base
     /**
      * @since ZC v1.0.3
      */
-    function last()
+    public function last()
     {
         $trail_size = count($this->_trail);
         return $this->_trail[$trail_size - 1]['title'];
@@ -92,7 +96,7 @@ class breadcrumb extends base
     /**
      * @since ZC v1.5.7c
      */
-    function removeLast()
+    public function removeLast()
     {
         $trail_size = count($this->_trail);
         unset($this->_trail[$trail_size - 1]);
@@ -101,9 +105,11 @@ class breadcrumb extends base
     /**
      * @since ZC v1.5.7c
      */
-    function replaceLast($title = null, $link = null)
+    public function replaceLast($title = null, $link = null)
     {
-        if ($title === null && $link === null) return $this->removeLast();
+        if ($title === null && $link === null) {
+            return $this->removeLast();
+        }
 
         $trail_size = count($this->_trail);
         if ($title !== null) {
@@ -117,7 +123,7 @@ class breadcrumb extends base
     /**
      * @since ZC v1.5.7
      */
-    function isEmpty()
+    public function isEmpty()
     {
         return empty($this->_trail);
     }
@@ -125,15 +131,15 @@ class breadcrumb extends base
     /**
      * @since ZC v1.5.7
      */
-    function count()
+    public function count()
     {
         return count($this->_trail);
     }
     /**
      * @since ZC v1.5.8a
      */
-    function getTrail()
+    public function getTrail()
     {
-       return $this->_trail;
+        return $this->_trail;
     }
 }

--- a/includes/classes/payment.php
+++ b/includes/classes/payment.php
@@ -85,7 +85,7 @@ class payment
             $freecharger_enabled = (zen_config('MODULE_PAYMENT_FREECHARGER_STATUS') === 'True' && isset($modules_found['freecharger.php']));
             if ($freecharger_enabled && $_SESSION['cart']->show_total() == 0 && (!isset($_SESSION['shipping']['cost']) || $_SESSION['shipping']['cost'] == 0)) {
                 $this->selected_module = $module;
-                $include_modules[] = ['class'=> 'freecharger', 'file' => 'freecharger.php'];
+                $include_modules[] = ['class' => 'freecharger', 'file' => 'freecharger.php'];
             } else {
                 // All Other Payment Modules show
                 foreach ($this->modules as $value) {
@@ -249,7 +249,7 @@ class payment
         $js .=  '    alert(error_message);' . "\n";
         $js .=  '    return false;' . "\n";
         $js .=  '  } else {' . "\n";
-        $js .=  ' var result = true; '  . "\n";
+        $js .=  ' var result = true; ' . "\n";
         if ($this->doesCollectsCardDataOnsite === true && zen_config('PADSS_AJAX_CHECKOUT') === '1') {
             $js .= '      result = !(doesCollectsCardDataOnsite(payment_value));' . "\n";
         }
@@ -282,7 +282,7 @@ class payment
                 $selection['fields'][] = [
                     'title' => '',
                     'field' => zen_draw_hidden_field($class . '_collects_onsite', 'true', 'id="' . $class . '_collects_onsite"'),
-                    'tag' => ''
+                    'tag' => '',
                 ];
             }
             if (is_array($selection)) {
@@ -362,7 +362,7 @@ class payment
      */
     public function process_button_ajax()
     {
-         if ($this->isPaymentModuleMethodPresent('process_button_ajax') === false) {
+        if ($this->isPaymentModuleMethodPresent('process_button_ajax') === false) {
             return;
         }
         return $GLOBALS[$this->selected_module]->process_button_ajax();
@@ -417,7 +417,7 @@ class payment
      */
     public function admin_notification($zf_order_id)
     {
-         if ($this->isPaymentModuleMethodPresent('admin_notification') === false) {
+        if ($this->isPaymentModuleMethodPresent('admin_notification') === false) {
             return;
         }
         return $GLOBALS[$this->selected_module]->admin_notification($zf_order_id);

--- a/includes/classes/traits/Singleton.php
+++ b/includes/classes/traits/Singleton.php
@@ -15,12 +15,12 @@ trait Singleton
 {
     private static array $instances = [];
 
-    final protected function __construct() { }
+    final protected function __construct() {}
 
     /**
      * @since ZC v1.5.7
      */
-    final protected function __clone() { }
+    final protected function __clone() {}
 
     /**
      * @since ZC v2.2.0
@@ -45,7 +45,7 @@ trait Singleton
     {
         $cls = get_called_class(); // late-static-bound class name
         if (!isset(self::$instances[$cls])) {
-            self::$instances[$cls] = new static;
+            self::$instances[$cls] = new static();
         }
         return self::$instances[$cls];
     }

--- a/includes/classes/zcDate.php
+++ b/includes/classes/zcDate.php
@@ -7,14 +7,16 @@
  */
 class zcDate extends base
 {
-    protected
-        $useIntlDate = false,
-        $useStrftime = false,
-        $locale,                //- Only used when $this->useIntlDate is true
-        $strftime2date,         //- Only used when $this->useStrftime is false
-        $strftime2intl,         //- Only used when $this->useStrftime is false
-        $debug = false,
-        $dateObject;
+    protected $useIntlDate = false;
+    protected $useStrftime = false;
+    protected $locale;
+    //- Only used when $this->useIntlDate is true
+    protected $strftime2date;
+    //- Only used when $this->useStrftime is false
+    protected $strftime2intl;
+    //- Only used when $this->useStrftime is false
+    protected $debug = false;
+    protected $dateObject;
 
     // -----
     // Initial construction; initializes the conversion arrays and determines which PHP
@@ -81,7 +83,7 @@ class zcDate extends base
         ];
         $this->strftime2date = [
             'from' => array_keys($strftime2date),
-            'to' => array_values($strftime2date)
+            'to' => array_values($strftime2date),
         ];
 
         if ($this->useIntlDate === true) {
@@ -130,7 +132,7 @@ class zcDate extends base
             ];
             $this->strftime2intl = [
                 'from' => array_keys($strftime2intl),
-                'to' => array_values($strftime2intl)
+                'to' => array_values($strftime2intl),
             ];
         }
     }
@@ -175,15 +177,15 @@ class zcDate extends base
         if ($this->useStrftime === true) {
             $converted_format = $format;
             $output = strftime($format, $timestamp);
-        // -----
-        // Otherwise, if there's no international date support, format the requested string using date.
-        //
+            // -----
+            // Otherwise, if there's no international date support, format the requested string using date.
+            //
         } elseif ($this->useIntlDate === false) {
             $converted_format = $this->convertFormat($format, $this->strftime2date);
             $output = date($converted_format, $timestamp);
-        // -----
-        // Otherwise, the string is to be formatted using the IntlDateFormatter ...
-        //
+            // -----
+            // Otherwise, the string is to be formatted using the IntlDateFormatter ...
+            //
         } else {
             // -----
             // If the locale has changes (as it might between the class construction and

--- a/includes/functions/functions_lookups.php
+++ b/includes/functions/functions_lookups.php
@@ -59,7 +59,9 @@ function zen_get_buyable_product_type_handlers(): array
 function zen_get_manufacturers($manufacturers_array = [], $only_those_with_products = false)
 {
     global $db;
-    if (!is_array($manufacturers_array)) $manufacturers_array = [];
+    if (!is_array($manufacturers_array)) {
+        $manufacturers_array = [];
+    }
 
     if (!empty($only_those_with_products)) {
         $manufacturers_query = "SELECT DISTINCT m.manufacturers_id, m.manufacturers_name
@@ -77,10 +79,10 @@ function zen_get_manufacturers($manufacturers_array = [], $only_those_with_produ
     $manufacturers = $db->Execute($manufacturers_query);
 
     foreach ($manufacturers as $manufacturer) {
-        $manufacturers_array[] = array(
+        $manufacturers_array[] = [
             'id' => $manufacturer['manufacturers_id'],
-            'text' => $manufacturer['manufacturers_name']
-        );
+            'text' => $manufacturer['manufacturers_name'],
+        ];
     }
 
     return $manufacturers_array;
@@ -99,7 +101,9 @@ function zen_get_manufacturer_url($manufacturer_id, $language_id)
                                   FROM " . TABLE_MANUFACTURERS_INFO . "
                                   WHERE manufacturers_id = " . (int)$manufacturer_id . "
                                   AND languages_id = " . (int)$language_id);
-    if ($manufacturer->EOF) return '';
+    if ($manufacturer->EOF) {
+        return '';
+    }
     return $manufacturer->fields['manufacturers_url'];
 }
 
@@ -308,7 +312,9 @@ function zen_get_orders_status_id_from_name(string $status_name): int|false
 function zen_get_orders_status_name(int|string $order_status_id, int $language_id = 0): string
 {
     global $db;
-    if (empty($language_id)) $language_id = $_SESSION['languages_id'];
+    if (empty($language_id)) {
+        $language_id = $_SESSION['languages_id'];
+    }
 
     $sql = "SELECT orders_status_name
             FROM " . TABLE_ORDERS_STATUS . "
@@ -316,7 +322,9 @@ function zen_get_orders_status_name(int|string $order_status_id, int $language_i
             AND language_id = " . (int)$language_id;
     $result = $db->Execute($sql);
 
-    if ($result->EOF) return '';
+    if ($result->EOF) {
+        return '';
+    }
     return $result->fields['orders_status_name'];
 }
 
@@ -332,16 +340,22 @@ function zen_get_order_status_name(int|string $order_status_id, int $language_id
 {
     global $db;
 
-    if ($order_status_id < 1) return TEXT_DEFAULT;
+    if ($order_status_id < 1) {
+        return TEXT_DEFAULT;
+    }
 
-    if (empty($language_id)) $language_id = $_SESSION['languages_id'];
+    if (empty($language_id)) {
+        $language_id = $_SESSION['languages_id'];
+    }
 
     $sql = "SELECT orders_status_name
             FROM " . TABLE_ORDERS_STATUS . "
             WHERE orders_status_id = " . (int)$order_status_id . "
             AND language_id = " . (int)$language_id;
     $result = $db->Execute($sql);
-    if ($result->EOF) return 'ERROR: INVALID STATUS ID: ' . (int)$order_status_id;
+    if ($result->EOF) {
+        return 'ERROR: INVALID STATUS ID: ' . (int)$order_status_id;
+    }
     return $result->fields['orders_status_name'] . ' [' . (int)$order_status_id . ']';
 }
 

--- a/includes/index_filters/default_filter.php
+++ b/includes/index_filters/default_filter.php
@@ -34,8 +34,8 @@ if (!isset($do_filter_list)) {
     $do_filter_list = false;
 }
 
-$and = $and ?? '';
-$sql_joins = $sql_joins ?? '';
+$and ??= '';
+$sql_joins ??= '';
 
 // show the products of a specified manufacturer
 if (isset($_GET['manufacturers_id']) && $_GET['manufacturers_id'] > 0) {
@@ -84,7 +84,7 @@ $order_by = $default_sort_order ?? '';
 if (empty($order_by) || !empty($_GET['disp_order'])) {
     // Build ORDER BY sort chosen from dropdown, or apply defaults
     $order_by_backup = $order_by;
-    require(DIR_WS_MODULES . zen_get_module_directory(FILENAME_LISTING_DISPLAY_ORDER));
+    require DIR_WS_MODULES . zen_get_module_directory(FILENAME_LISTING_DISPLAY_ORDER);
     if (empty($order_by)) {
         $order_by = $order_by_backup;
     }

--- a/includes/index_filters/music_genre_filter.php
+++ b/includes/index_filters/music_genre_filter.php
@@ -34,8 +34,8 @@ if (!isset($do_filter_list)) {
     $do_filter_list = false;
 }
 
-$and = $and ?? '';
-$sql_joins = $sql_joins ?? '';
+$and ??= '';
+$sql_joins ??= '';
 
 // show the products of a specified music_genre
 if (!empty($_GET['music_genre_id'])) {
@@ -86,7 +86,7 @@ $order_by = $default_sort_order ?? '';
 if (empty($order_by) || !empty($_GET['disp_order'])) {
     // Build ORDER BY sort chosen from dropdown, or apply defaults
     $order_by_backup = $order_by;
-    require(DIR_WS_MODULES . zen_get_module_directory(FILENAME_LISTING_DISPLAY_ORDER));
+    require DIR_WS_MODULES . zen_get_module_directory(FILENAME_LISTING_DISPLAY_ORDER);
     if (empty($order_by)) {
         $order_by = $order_by_backup;
     }

--- a/includes/index_filters/record_company_filter.php
+++ b/includes/index_filters/record_company_filter.php
@@ -34,8 +34,8 @@ if (!isset($do_filter_list)) {
     $do_filter_list = false;
 }
 
-$and = $and ?? '';
-$sql_joins = $sql_joins ?? '';
+$and ??= '';
+$sql_joins ??= '';
 
 // show the products of a specified record-company
 if (!empty($_GET['record_company_id'])) {
@@ -87,7 +87,7 @@ $order_by = $default_sort_order ?? '';
 if (empty($order_by) || !empty($_GET['disp_order'])) {
     // Build ORDER BY sort chosen from dropdown, or apply defaults
     $order_by_backup = $order_by;
-    require(DIR_WS_MODULES . zen_get_module_directory(FILENAME_LISTING_DISPLAY_ORDER));
+    require DIR_WS_MODULES . zen_get_module_directory(FILENAME_LISTING_DISPLAY_ORDER);
     if (empty($order_by)) {
         $order_by = $order_by_backup;
     }

--- a/includes/init_includes/init_file_db_names.php
+++ b/includes/init_includes/init_file_db_names.php
@@ -11,7 +11,7 @@
 use Zencart\Request\Request;
 
 if (!defined('IS_ADMIN_FLAG')) {
-  die('Illegal Access');
+    die('Illegal Access');
 }
 
 /**
@@ -24,7 +24,9 @@ $request_type = Request::isSecure() ? 'SSL' : 'NONSSL';
 /**
  * set php_self in the local scope
  */
-if (!isset($PHP_SELF)) $PHP_SELF = $_SERVER['SCRIPT_NAME'];
+if (!isset($PHP_SELF)) {
+    $PHP_SELF = $_SERVER['SCRIPT_NAME'];
+}
 /**
  * require global definitons for Filenames
  */
@@ -46,5 +48,5 @@ $ws_extra_datafiles_directory = DIR_WS_INCLUDES . 'extra_datafiles/';
 
 // Check for new database tables and filenames etc in extra_datafiles directory, usually for plugins
 foreach (glob($extra_datafiles_directory . '*.php') ?? [] as $file) {
-    include($ws_extra_datafiles_directory . basename($file));
+    include $ws_extra_datafiles_directory . basename($file);
 }

--- a/includes/modules/category_row.php
+++ b/includes/modules/category_row.php
@@ -83,8 +83,8 @@ foreach ($categories as $next_category) {
     if ($category_row_layout_style === 'columns') {
         $style = ' style="width:' . $col_width . '%;"';
     }
-    $grid_category_card_params = $grid_category_card_params ?? 'categoryListBoxContents centeredContent back gridlayout';
-    $grid_category_wrap_classes = $grid_category_wrap_classes ?? '';
+    $grid_category_card_params ??= 'categoryListBoxContents centeredContent back gridlayout';
+    $grid_category_wrap_classes ??= '';
     $list_box_contents[$rows][] = [
         'params' => 'class="' . $grid_category_card_params . '"' . $style,
         'text' =>

--- a/includes/modules/pages/checkout_payment_address/header_php.php
+++ b/includes/modules/pages/checkout_payment_address/header_php.php
@@ -13,7 +13,7 @@ $zco_notifier->notify('NOTIFY_HEADER_START_CHECKOUT_PAYMENT_ADDRESS');
 
 // if there is nothing in the customers cart, redirect them to the shopping cart page
 if ($_SESSION['cart']->count_contents() <= 0) {
-  zen_redirect(zen_href_link(FILENAME_SHOPPING_CART));
+    zen_redirect(zen_href_link(FILENAME_SHOPPING_CART));
 }
 
 // if the customer is not logged on, redirect them to the login page
@@ -25,16 +25,16 @@ if (!zen_is_logged_in()) {
 $customer = new Customer($_SESSION['customer_id']);
 // validate customer
 if (zen_get_customer_validate_session($_SESSION['customer_id']) === false) {
-    $_SESSION['navigation']->set_snapshot(array('mode' => 'SSL', 'page' => FILENAME_CHECKOUT_SHIPPING));
+    $_SESSION['navigation']->set_snapshot(['mode' => 'SSL', 'page' => FILENAME_CHECKOUT_SHIPPING]);
     zen_redirect(zen_href_link(FILENAME_LOGIN, '', 'SSL'));
 }
 
-require(DIR_WS_MODULES . zen_get_module_directory('require_languages.php'));
+require DIR_WS_MODULES . zen_get_module_directory('require_languages.php');
 $addressType = "billto";
-require(DIR_WS_MODULES . zen_get_module_directory('checkout_new_address'));
+require DIR_WS_MODULES . zen_get_module_directory('checkout_new_address');
 // if no billing destination address was selected, use their own address as default
 if (empty($_SESSION['billto'])) {
-  $_SESSION['billto'] = $_SESSION['customer_default_address_id'];
+    $_SESSION['billto'] = $_SESSION['customer_default_address_id'];
 }
 
 $breadcrumb->add(NAVBAR_TITLE_1, zen_href_link(FILENAME_CHECKOUT_PAYMENT, '', 'SSL'));

--- a/includes/modules/pages/shippinginfo/header_php.php
+++ b/includes/modules/pages/shippinginfo/header_php.php
@@ -8,8 +8,7 @@
  * @version $Id: DrByte 2020 Jul 10 Modified in v1.5.8-alpha $
  */
 
-require(DIR_WS_MODULES . zen_get_module_directory('require_languages.php'));
+require DIR_WS_MODULES . zen_get_module_directory('require_languages.php');
 // include template specific file name defines
 $define_page = zen_get_file_directory(DIR_WS_LANGUAGES . $_SESSION['language'] . '/html_includes/', FILENAME_DEFINE_SHIPPINGINFO, 'false');
 $breadcrumb->add(NAVBAR_TITLE);
-?>

--- a/includes/modules/pages/site_map/header_php.php
+++ b/includes/modules/pages/site_map/header_php.php
@@ -13,7 +13,7 @@ $zco_notifier->notify('NOTIFY_HEADER_START_SITE_MAP');
 /**
  * load language files
  */
-require(DIR_WS_MODULES . zen_get_module_directory('require_languages.php'));
+require DIR_WS_MODULES . zen_get_module_directory('require_languages.php');
 $breadcrumb->add(NAVBAR_TITLE);
 // include template specific file name defines
 $define_page = zen_get_file_directory(DIR_WS_LANGUAGES . $_SESSION['language'] . '/html_includes/', FILENAME_DEFINE_SITE_MAP, 'false');
@@ -21,7 +21,6 @@ $define_page = zen_get_file_directory(DIR_WS_LANGUAGES . $_SESSION['language'] .
  * load the site map class
  */
 require DIR_WS_CLASSES . 'site_map.php';
-$zen_SiteMapTree = new zen_SiteMapTree;
+$zen_SiteMapTree = new zen_SiteMapTree();
 // This should be last line of the script:
 $zco_notifier->notify('NOTIFY_HEADER_END_SITE_MAP');
-?>

--- a/includes/templates/template_default/templates/tpl_privacy_default.php
+++ b/includes/templates/template_default/templates/tpl_privacy_default.php
@@ -9,7 +9,7 @@
  */
 ?>
 <div class="centerColumn" id="privacy">
-<h1 id="privacyDefaultHeading"><?php echo HEADING_TITLE; ?></h1>
+<h1 id="privacyDefaultHeading"><?= HEADING_TITLE; ?></h1>
 
 <?php if (DEFINE_PRIVACY_STATUS >= 1 and DEFINE_PRIVACY_STATUS <= 2) { ?>
 <div id="privacyDefaultMainContent" class="content">
@@ -17,10 +17,10 @@
 /**
  * require the html_define for the privacy page
  */
-  require($define_page);
-?>
+  require $define_page;
+    ?>
 </div>
 <?php } ?>
 
-<div class="buttonRow back"><?php echo zen_back_link() . zen_image_button(BUTTON_IMAGE_BACK, BUTTON_BACK_ALT) . '</a>'; ?></div>
+<div class="buttonRow back"><?= zen_back_link() . zen_image_button(BUTTON_IMAGE_BACK, BUTTON_BACK_ALT) . '</a>'; ?></div>
 </div>

--- a/not_for_release/testFramework/FeatureStore/StoreEndpoints/PasswordResetInProcessTest.php
+++ b/not_for_release/testFramework/FeatureStore/StoreEndpoints/PasswordResetInProcessTest.php
@@ -40,11 +40,11 @@ class PasswordResetInProcessTest extends zcInProcessFeatureTestCaseStore
             ->assertOk()
             ->assertSee('Your password has been successfully updated. Please login using your email address and the password you have just created.');
 
-        $newHash = (string) TestDb::selectValue(
+        $newHash = (string)TestDb::selectValue(
             'SELECT customers_password FROM customers WHERE customers_id = :customer_id LIMIT 1',
             [':customer_id' => $reset['customer_id']]
         );
-        $tokenCount = (int) TestDb::selectValue(
+        $tokenCount = (int)TestDb::selectValue(
             'SELECT COUNT(*) FROM customer_password_reset_tokens WHERE customer_id = :customer_id',
             [':customer_id' => $reset['customer_id']]
         );
@@ -95,7 +95,7 @@ class PasswordResetInProcessTest extends zcInProcessFeatureTestCaseStore
             ->assertOk()
             ->assertSee('Thank you. If that email address is in our system, we will send password recovery instructions');
 
-        $token = (string) TestDb::selectValue(
+        $token = (string)TestDb::selectValue(
             'SELECT token
                FROM customer_password_reset_tokens
               WHERE customer_id = :customer_id
@@ -107,9 +107,9 @@ class PasswordResetInProcessTest extends zcInProcessFeatureTestCaseStore
         $this->assertNotSame('', $token);
 
         return [
-            'customer_id' => (int) $customer['customers_id'],
+            'customer_id' => (int)$customer['customers_id'],
             'email_address' => $profile['email_address'],
-            'old_hash' => (string) $customer['customers_password'],
+            'old_hash' => (string)$customer['customers_password'],
             'token' => $token,
         ];
     }

--- a/not_for_release/testFramework/FeatureStore/StoreEndpoints/ProductReviewsWriteInProcessTest.php
+++ b/not_for_release/testFramework/FeatureStore/StoreEndpoints/ProductReviewsWriteInProcessTest.php
@@ -63,7 +63,7 @@ class ProductReviewsWriteInProcessTest extends zcInProcessFeatureTestCaseStore
         );
 
         $this->assertNotNull($review);
-        $this->assertSame('5', (string) $review['reviews_rating']);
+        $this->assertSame('5', (string)$review['reviews_rating']);
         $this->assertSame('Test Review', $review['reviews_title']);
         $this->assertSame('In-process review text for coverage that is long enough to pass validation.', $review['reviews_text']);
     }

--- a/not_for_release/testFramework/Support/zcDiscountCouponTest.php
+++ b/not_for_release/testFramework/Support/zcDiscountCouponTest.php
@@ -13,7 +13,6 @@ use Tests\Support\zcUnitTestCase;
  */
 abstract class zcDiscountCouponTest extends zcUnitTestCase
 {
-
     /**
      * @param $qfrResult
      */

--- a/not_for_release/testFramework/Support/zcFeatureTestCase.php
+++ b/not_for_release/testFramework/Support/zcFeatureTestCase.php
@@ -21,7 +21,13 @@ require_once __DIR__ . '/configs/runtime_config.php';
  */
 abstract class zcFeatureTestCase extends zcInProcessFeatureTestCase
 {
-    use DatabaseConcerns, GeneralConcerns, CustomerAccountConcerns, ConfigurationSettingsConcerns, LogFileConcerns, LowOrderFeeConcerns, DiscountCouponConcerns;
+    use DatabaseConcerns;
+    use GeneralConcerns;
+    use CustomerAccountConcerns;
+    use ConfigurationSettingsConcerns;
+    use LogFileConcerns;
+    use LowOrderFeeConcerns;
+    use DiscountCouponConcerns;
 
     /**
      * @return void
@@ -77,7 +83,7 @@ abstract class zcFeatureTestCase extends zcInProcessFeatureTestCase
 
         $artifactDirectory = zc_test_config_artifact_directory(ROOTCWD, $context);
         if (!is_dir($artifactDirectory)) {
-            mkdir($artifactDirectory, 0777, true);
+            mkdir($artifactDirectory, 0o777, true);
         }
 
         copy($file, $artifactDirectory . basename($file));

--- a/zc_install/includes/modules/pages/database/header_php.php
+++ b/zc_install/includes/modules/pages/database/header_php.php
@@ -29,22 +29,22 @@ if (defined('DEVELOPER_MODE') && DEVELOPER_MODE === true) {
     if (empty($db_user_fallback)) {
         $db_user_fallback = (defined('DEVELOPER_DBUSER_DEFAULT') ? DEVELOPER_DBUSER_DEFAULT : 'zencart');
     }
-    $db_user = $db_user ?? $db_user_fallback;
+    $db_user ??= $db_user_fallback;
 
     if (empty($db_password_fallback)) {
         $db_password_fallback = (defined('DEVELOPER_DBPASSWORD_DEFAULT') ? DEVELOPER_DBPASSWORD_DEFAULT : 'zencart');
     }
-    $db_password = $db_password ?? $db_password_fallback;
+    $db_password ??= $db_password_fallback;
 
     if (empty($db_name_fallback)) {
         $db_name_fallback = (defined('DEVELOPER_DBNAME_DEFAULT') ? DEVELOPER_DBNAME_DEFAULT : 'zencart');
     }
-    $db_name = $db_name ?? $db_name_fallback;
+    $db_name ??= $db_name_fallback;
 
     if (empty($db_host_fallback)) {
         $db_host_fallback = (defined('DEVELOPER_DBHOST_DEFAULT') ? DEVELOPER_DBHOST_DEFAULT : 'localhost');
     }
-    $db_host = $db_host ?? $db_host_fallback;
+    $db_host ??= $db_host_fallback;
 
     if (defined('DEVELOPER_INSTALL_DEMO_DATA')) {
         $install_demo_data = !empty(DEVELOPER_INSTALL_DEMO_DATA);
@@ -61,13 +61,13 @@ if (defined('DEVELOPER_MODE') && DEVELOPER_MODE === true) {
     }
     $db_user = $db_user_fallback;
     $db_password = $db_password_fallback;
-    $db_name = $db_name ?? $db_name_fallback;
+    $db_name ??= $db_name_fallback;
 }
 
-$db_user = $db_user ?? '';
-$db_password = $db_password ?? '';
-$db_host = $db_host ?? 'localhost';
-$db_prefix = $db_prefix ?? '';
+$db_user ??= '';
+$db_password ??= '';
+$db_host ??= 'localhost';
+$db_prefix ??= '';
 
 
 // attempt to intelligently manage user-adjusted subdirectory values if they are different from detected defaults

--- a/zc_install/includes/template/common/tpl_main_page.php
+++ b/zc_install/includes/template/common/tpl_main_page.php
@@ -48,7 +48,7 @@ if (empty($hasFatalErrors) && empty($hasWarnErrors) && (!empty($hasUpdatedConfig
                     </form>
                 <?php
                 }
-                ?>
+?>
 
                 <h1><?= constant('TEXT_PAGE_HEADING_' . strtoupper($_GET['main_page'])) ?></h1>
 
@@ -59,7 +59,7 @@ if (empty($hasFatalErrors) && empty($hasWarnErrors) && (!empty($hasUpdatedConfig
                 $header_text = constant('TEXT_HEADER_MAIN');
             }
 
-            if (!empty($header_text && empty($skip_header))) { ?>
+if (!empty($header_text && empty($skip_header))) { ?>
                 <div class="alert alert-primary"><?= $header_text ?></div>
             <?php } ?>
 

--- a/zc_plugins/DisplayLogs/v3.0.3/admin/includes/init_includes/init_display_logs.php
+++ b/zc_plugins/DisplayLogs/v3.0.3/admin/includes/init_includes/init_display_logs.php
@@ -15,7 +15,7 @@ if ($current_page !== FILENAME_DISPLAY_LOGS . '.php' && (zen_is_superuser() || c
     $path = (defined('DIR_FS_LOGS')) ? DIR_FS_LOGS : DIR_FS_SQL_CACHE;
     $log_files = glob($path . '/myDEBUG-*.log');
     $num_log_files = ($log_files === false) ? 0 : count($log_files);
-    unset ($log_files);
+    unset($log_files);
     if ($num_log_files > 0) {
         $messageStack->add(sprintf(DISPLAY_LOGS_MESSAGE_LOGS_PRESENT, $num_log_files, zen_href_link(FILENAME_DISPLAY_LOGS)), 'caution');
     }

--- a/zc_plugins/POSM/v6.1.2/admin/includes/init_includes/init_posm_admin.php
+++ b/zc_plugins/POSM/v6.1.2/admin/includes/init_includes/init_posm_admin.php
@@ -33,7 +33,7 @@ if (defined('EO_VERSION') && version_compare(EO_VERSION, '4.2.0', '<')) {
 // Starting with v2.3.0 of POSM, check (if enabled) to see if any back-in-stock dates are within the expiration period.
 //
 if (((int)POSM_BIS_DATE_REMINDER) !== 0) {
-    $posm_check = $db->Execute (
+    $posm_check = $db->Execute(
         "SELECT pos.pos_id
            FROM " . TABLE_PRODUCTS_OPTIONS_STOCK . " pos
              LEFT JOIN " . TABLE_PRODUCTS_OPTIONS_STOCK_NAMES . " posn
@@ -53,7 +53,7 @@ if (((int)POSM_BIS_DATE_REMINDER) !== 0) {
 // - Subtract stock ............................... true
 //
 $configuration_array = [
-    'STOCK_LIMITED' => 'true'
+    'STOCK_LIMITED' => 'true',
 ];
 foreach ($configuration_array as $key => $value) {
     if (constant($key) !== $value) {

--- a/zc_plugins/PayPalRestful/v2.0.0/catalog/includes/modules/payment/paypal/PayPalRestful/Admin/GetPayPalOrderTransactions.php
+++ b/zc_plugins/PayPalRestful/v2.0.0/catalog/includes/modules/payment/paypal/PayPalRestful/Admin/GetPayPalOrderTransactions.php
@@ -8,6 +8,7 @@
  *
  * Last updated: v1.3.0
  */
+
 namespace PayPalRestful\Admin;
 
 use PayPalRestful\Admin\Formatters\Messages;
@@ -136,7 +137,7 @@ class GetPayPalOrderTransactions
         $db_txns = [];
         foreach ($txns as $txn) {
             // -----
-            // 
+            //
             //
             if ($txn['txn_type'] === 'CREATE') {
                 $db_txns[] = $txn;
@@ -227,7 +228,7 @@ class GetPayPalOrderTransactions
     {
         foreach ($authorizations as $next_authorization) {
             $authorization_txn_id = $next_authorization['id'];
-            $first_auth_txn_id = $first_auth_txn_id ?? $authorization_txn_id;
+            $first_auth_txn_id ??= $authorization_txn_id;
             if ($this->transactionExists($authorization_txn_id) === true) {
                 continue;
             }


### PR DESCRIPTION
## Using
(Must run `composer install` or `composer update` to pull it in.)

`php-cs-fixer check` will report which files could be reformatted by running `fix`. 
`php-cs-fixer fix {dir/filename}` will reformat the specified file(s) according to Zen Cart code conventions.

(Those conventions are largely outlined in `/docs/CONVENTIONS.md`, but are basically PSR-12 with a few adjustments to whitespace.)

**But ALWAYS manually review whatever changes it proposes before committing.**

---
## CAVEATS:

One downside to php-cs-fixer is that it doesn't handle mixed PHP/HTML files well, and thus it may strangely indent/outdent sections of code, or rearrange comments, in strange ways. Some rules have been tweaked to try to minimize the pain of that.

Conversion to short-echo syntax works well, except php-cs-fixer won't remove the trailing `;` because it's syntactically valid and php-cs-fixer operates on php tokens not regular-expressions.

This is a starting point. We'll tweak/refine it as we go.

---
## ADVANCED:

If you want to force the inclusion of rewrites to function-aliases, insertion of declare-strict-types, and adding return types, you can create your own local `.php-cs-fixer.php` file by copying the `dist` version and enabling `@auto:risky` and uncommenting the declare-strict-types section (and set the blank-line-after-open-tag to true).

I've left these disabled for core at this point, in favor of manual implementation of such where code can be fully reviewed for compatibility with those changes.

---

I've included a few reformatted files in this PR as examples of what the current rules "do".