### PR TITLE
Ensure `zc_plugins` extra functions are loaded

### DIFF
--- a/admin/includes/init_includes/init_general_funcs.php
+++ b/admin/includes/init_includes/init_general_funcs.php
@@ -52,48 +52,48 @@ require DIR_FS_CATALOG . DIR_WS_FUNCTIONS . 'password_funcs.php';
 require DIR_WS_FUNCTIONS . 'functions_metatags.php';
 
 
-// include the list of extra functions
-foreach (zen_get_files_in_directory(DIR_WS_FUNCTIONS . 'extra_functions') as $file) {
-    require $file;
-}
+// include the list of extra functions, using the common catalog module
+require DIR_FS_CATALOG . DIR_WS_MODULES . 'extra_functions.php';
 
 // brief pre-sanitize
-if (isset($_GET) & sizeof($_GET) > 0 ) {
-  foreach ($_GET as $key=>$value) {
-    $_GET[$key] = strip_tags($value);
-  }
+if (count($_GET) > 0 ) {
+    foreach ($_GET as $key => $value) {
+        $_GET[$key] = strip_tags($value);
+    }
 }
 
 // check for SSL configuration changes:
-if (!defined('SSLPWSTATUSCHECK')) die('database upgrade required. please run the 1.3.9-to-1.5.0 upgrade via zc_install');
+if (!defined('SSLPWSTATUSCHECK')) {
+    die('database upgrade required. please run the 1.3.9-to-1.5.0 upgrade via zc_install');
+}
 $e = (str_starts_with(HTTP_SERVER, 'https')) ? '1' : '0';
 if (zen_config('SSLPWSTATUSCHECK') === '') {
-  $sql = "UPDATE " . TABLE_CONFIGURATION . " set configuration_value = '".$e.':'.$e."', last_modified = now() where configuration_key = 'SSLPWSTATUSCHECK'";
-  $db->Execute($sql);
-  header('Location: ' . $_SERVER['REQUEST_URI']);
-  die('<meta http-equiv="refresh" content="0; url=' . $_SERVER['REQUEST_URI'] . '">One-time auto-configuration completed. Please refresh the page.');
+    $sql = "UPDATE " . TABLE_CONFIGURATION . " SET configuration_value = '".$e.':'.$e."', last_modified = now() WHERE configuration_key = 'SSLPWSTATUSCHECK'";
+    $db->Execute($sql);
+    header('Location: ' . $_SERVER['REQUEST_URI']);
+    die('<meta http-equiv="refresh" content="0; url=' . $_SERVER['REQUEST_URI'] . '">One-time auto-configuration completed. Please refresh the page.');
 }
 [$a, $c] = explode(':', zen_config('SSLPWSTATUSCHECK')); $a = (int)$a; $c = (int)$c;
 if ($a === 0) {
-  if ($c === 0 && (int)$e === 1) { // was nonSSL but now is SSL, so need to exp pwds
-    $sql = "UPDATE " . TABLE_CONFIGURATION . " set configuration_value = '1:" . $e . "', last_modified = now() where configuration_key = 'SSLPWSTATUSCHECK'";
-    $db->Execute($sql);
-    $sql = "UPDATE " . TABLE_ADMIN . " set pwd_last_change_date = '1990-01-01 14:02:22'";
-    $db->Execute($sql);
-  }
-  if ($c === 1 && (int)$e === 0) { // was nonSSL then SSL and now nonSSL again, so recording that we're now nonSSL
-    $sql = "UPDATE " . TABLE_CONFIGURATION . " set configuration_value = '0:". $e . "', last_modified = now() where configuration_key = 'SSLPWSTATUSCHECK'";
-    $db->Execute($sql);
-  }
-} else if ($a === 1) {  // == 1
-  if ($c === 1 && (int)$e === 0) {  // was SSL, but is now nonSSL, so recording the change
-    $sql = "UPDATE " . TABLE_CONFIGURATION . " set configuration_value = '0:". $e . "', last_modified = now() where configuration_key = 'SSLPWSTATUSCHECK'";
-    $db->Execute($sql);
-  }
-  if ($c === 0 && (int)$e === 1) {  // was changed to SSL last time checked, so recording that is all SSL now
-    $sql = "UPDATE " . TABLE_CONFIGURATION . " set configuration_value = '1:" . $e . "', last_modified = now() where configuration_key = 'SSLPWSTATUSCHECK'";
-    $db->Execute($sql);
-  }
+    if ($c === 0 && (int)$e === 1) { // was nonSSL but now is SSL, so need to exp pwds
+        $sql = "UPDATE " . TABLE_CONFIGURATION . " SET configuration_value = '1:" . $e . "', last_modified = now() WHERE configuration_key = 'SSLPWSTATUSCHECK'";
+        $db->Execute($sql);
+        $sql = "UPDATE " . TABLE_ADMIN . " SET pwd_last_change_date = '1990-01-01 14:02:22'";
+        $db->Execute($sql);
+    }
+    if ($c === 1 && (int)$e === 0) { // was nonSSL then SSL and now nonSSL again, so recording that we're now nonSSL
+        $sql = "UPDATE " . TABLE_CONFIGURATION . " SET configuration_value = '0:". $e . "', last_modified = now() WHERE configuration_key = 'SSLPWSTATUSCHECK'";
+        $db->Execute($sql);
+    }
+} elseif ($a === 1) {  // == 1
+    if ($c === 1 && (int)$e === 0) {  // was SSL, but is now nonSSL, so recording the change
+        $sql = "UPDATE " . TABLE_CONFIGURATION . " SET configuration_value = '0:". $e . "', last_modified = now() WHERE configuration_key = 'SSLPWSTATUSCHECK'";
+        $db->Execute($sql);
+    }
+    if ($c === 0 && (int)$e === 1) {  // was changed to SSL last time checked, so recording that is all SSL now
+        $sql = "UPDATE " . TABLE_CONFIGURATION . " SET configuration_value = '1:" . $e . "', last_modified = now() WHERE configuration_key = 'SSLPWSTATUSCHECK'";
+        $db->Execute($sql);
+    }
 }
 unset($a,$c,$e);
 // end ssl config change detection


### PR DESCRIPTION
Fixes #7797

Uses the storefront (no template override) module to load both the 'base' extra functions and those present in `zc_plugins` directories.

Also includes some slight refactor/reformat of the pre-santize and SSL configuration changes sections.