### PR TITLE
Reformatting

### DIFF
--- a/admin/includes/classes/AdminNotifications.php
+++ b/admin/includes/classes/AdminNotifications.php
@@ -59,7 +59,7 @@ class AdminNotifications
     /**
      * @since ZC v1.5.6
      */
-    protected function getNotificationInfo(): array|false
+    protected function getNotificationInfo()
     {
         if (empty($this->projectNotificationServer)) {
             return [];

--- a/admin/includes/classes/AdminNotifications.php
+++ b/admin/includes/classes/AdminNotifications.php
@@ -1,16 +1,18 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
- * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @license https://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: DrByte 2025 Sep 18 Modified in v2.2.0 $
  * @since ZC v1.5.6
  */
 
 class AdminNotifications
 {
-    protected $enabled = true;
-    private $projectNotificationServer;
+    protected bool $enabled = true;
+    private string $projectNotificationServer = 'https://ping.zen-cart.com/api/notifications';
 
     public function __construct()
     {
@@ -31,7 +33,7 @@ class AdminNotifications
     /**
      * @since ZC v1.5.6
      */
-    public function getNotifications($target, $adminId)
+    public function getNotifications(string $target, int $adminId): array
     {
         if ($this->enabled === false) {
             return [];
@@ -45,6 +47,7 @@ class AdminNotifications
         $this->pruneSavedState($notificationList);
         $savedState = $this->getSavedState($adminId);
         $result = [];
+
         foreach ($notificationList as $name => $notification) {
             if ($this->isNotificationAvailable($name, $target, $notification, $savedState)) {
                 $result[$name] = $notification;
@@ -56,19 +59,19 @@ class AdminNotifications
     /**
      * @since ZC v1.5.6
      */
-    protected function getNotificationInfo()
+    protected function getNotificationInfo(): array|false
     {
-        if (empty($this->projectNotificationServer)){
+        if (empty($this->projectNotificationServer)) {
             return [];
         }
         $ch = curl_init();
-        curl_setopt($ch, CURLOPT_URL, $this->projectNotificationServer);
-        curl_setopt($ch, CURLOPT_VERBOSE, 0);
-        curl_setopt($ch, CURLOPT_HEADER, false);
-        curl_setopt($ch, CURLOPT_TIMEOUT, 9);
-        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 9);
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_USERAGENT, 'Notification Messages Check');
+        curl_setopt($ch, \CURLOPT_URL, $this->projectNotificationServer);
+        curl_setopt($ch, \CURLOPT_VERBOSE, 0);
+        curl_setopt($ch, \CURLOPT_HEADER, false);
+        curl_setopt($ch, \CURLOPT_TIMEOUT, 9);
+        curl_setopt($ch, \CURLOPT_CONNECTTIMEOUT, 9);
+        curl_setopt($ch, \CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, \CURLOPT_USERAGENT, 'Notification Messages Check');
         $response = curl_exec($ch);
         $error = curl_error($ch);
         $errno = curl_errno($ch);
@@ -82,7 +85,7 @@ class AdminNotifications
     /**
      * @since ZC v1.5.6
      */
-    protected function isNotificationAvailable($name, $target, $notification, $savedState)
+    protected function isNotificationAvailable(string $name, string $target, array $notification, array $savedState): bool
     {
         if ($notification['target'] !== $target) {
             return false;
@@ -90,10 +93,10 @@ class AdminNotifications
         if ($this->isNotificationDismissed($name, $savedState)) {
             return false;
         }
-        if (!$this->isNotificationInDate($notification, $this->getCurrentDate())) {
+        if (!$this->isNotificationInCountry($notification)) {
             return false;
         }
-        if (!$this->isNotificationInCountry($notification)) {
+        if (!$this->isNotificationInDate($notification, $this->getCurrentDate())) {
             return false;
         }
         return true;
@@ -102,7 +105,7 @@ class AdminNotifications
     /**
      * @since ZC v1.5.6
      */
-    protected function isNotificationDismissed($name, $savedState)
+    protected function isNotificationDismissed(string $name, array $savedState): bool
     {
         if (!isset($savedState[$name])) {
             return false;
@@ -113,7 +116,7 @@ class AdminNotifications
     /**
      * @since ZC v1.5.6
      */
-    protected function isNotificationInDate($notification, $currentDatetime)
+    protected function isNotificationInDate(array $notification, DateTimeInterface $currentDatetime): bool
     {
         if (!isset($notification['start-date']) && !isset($notification['end-date'])) {
             return true;
@@ -130,13 +133,13 @@ class AdminNotifications
     /**
      * @since ZC v1.5.6
      */
-    protected function isNotificationInCountry($notification)
+    protected function isNotificationInCountry(array $notification): bool
     {
         if (!isset($notification['countries'])) {
             return true;
         }
         $iso3 = $this->getStoreCountryIso3();
-        if (!in_array($iso3, $notification['countries'])) {
+        if (!in_array($iso3, $notification['countries'], true)) {
             return false;
         }
         return true;
@@ -145,20 +148,19 @@ class AdminNotifications
     /**
      * @since ZC v1.5.6
      */
-    protected  function getStoreCountryIso3()
+    protected function getStoreCountryIso3(): string
     {
         global $db;
 
-        $sql = "SELECT countries_iso_code_3 from " . TABLE_COUNTRIES . " WHERE countries_id = " . zen_config('STORE_COUNTRY');
-        $r = $db->Execute($sql);
-        $iso3 = $r->fields['countries_iso_code_3'];
-        return $iso3;
+        $sql = "SELECT countries_iso_code_3 from " . TABLE_COUNTRIES . " WHERE countries_id = " . (int)zen_config('STORE_COUNTRY');
+        $result = $db->Execute($sql);
+        return $result->fields['countries_iso_code_3'] ?? '';
     }
 
     /**
      * @since ZC v1.5.6
      */
-    protected function getSavedState($adminId)
+    protected function getSavedState(int $adminId): array
     {
         global $db;
 
@@ -175,15 +177,15 @@ class AdminNotifications
     /**
      * @since ZC v1.5.6
      */
-    protected function getCurrentDate()
+    protected function getCurrentDate(): DateTime
     {
-        return new DateTime("now");
+        return new DateTime('now');
     }
 
     /**
      * @since ZC v1.5.6
      */
-    protected function pruneSavedState($notificationList)
+    protected function pruneSavedState($notificationList): void
     {
         global $db;
 

--- a/admin/includes/classes/AdminRequestSanitizer.php
+++ b/admin/includes/classes/AdminRequestSanitizer.php
@@ -147,7 +147,7 @@ class AdminRequestSanitizer extends base
         foreach ($this->requestParameterList as $parameterName => $parameterDefinitions) {
             $result = $this->findSanitizerFromContext($parameterDefinitions);
             if (!$result) {
-                $result = $this->findSanitizerFromRequestMethod($parameterName, $parameterDefinitions);
+                $result = self::findSanitizerFromRequestMethod($parameterName, $parameterDefinitions);
             }
             if ($result) {
                 $this->arrayName = '';
@@ -156,13 +156,13 @@ class AdminRequestSanitizer extends base
         }
         if ($this->doStrictSanitization) {
             $this->arrayName = '';
-            $this->filterStrictSanitizeKeys();
+            self::filterStrictSanitizeKeys();
             $this->filterStrictSanitizeValues();
         }
         $this->debugMessages[] = 'Outgoing GET Request ' . print_r($_GET, true);
         $this->debugMessages[] = 'Outgoing POST Request ' . print_r($_POST, true);
         if ($this->debug) {
-            $this->errorLog($this->debugMessages);
+            self::errorLog($this->debugMessages);
         }
     }
 
@@ -201,14 +201,14 @@ class AdminRequestSanitizer extends base
     /**
      * @since ZC v1.5.5a
      */
-    private function findSanitizerFromRequestMethod($parameterName, $parameterDefinitions): array|false
+    private static function findSanitizerFromRequestMethod($parameterName, $parameterDefinitions): array|false
     {
         $result = false;
         foreach ($parameterDefinitions as $parameterDefinition) {
             if (!empty($parameterDefinition['pages'])) {
                 continue;
             }
-            if ($this->parameterExistsForMethod($parameterName, $parameterDefinition)) {
+            if (self::parameterExistsForMethod($parameterName, $parameterDefinition)) {
                 $result = $parameterDefinition;
                 break;
             }
@@ -219,7 +219,7 @@ class AdminRequestSanitizer extends base
     /**
      * @since ZC v1.5.5a
      */
-    private function parameterExistsForMethod($parameterName, $parameterDefinition): bool
+    private static function parameterExistsForMethod($parameterName, $parameterDefinition): bool
     {
         $hasGet = isset($_GET[$parameterName]);
         $hasPost = isset($_POST[$parameterName]);
@@ -424,12 +424,12 @@ class AdminRequestSanitizer extends base
         if (is_array($_POST[$parameterName])) {
             foreach ($_POST[$parameterName] as $pKey => $pValue) {
                 $currentArrayName = $this->setCurrentArrayName($pKey);
-                $_POST[$parameterName][$pKey] = htmlspecialchars($_POST[$parameterName][$pKey], ENT_COMPAT, $this->charset, false);
+                $_POST[$parameterName][$pKey] = htmlspecialchars($_POST[$parameterName][$pKey], \ENT_COMPAT, $this->charset, false);
                 $this->postKeysAlreadySanitized[] = $currentArrayName;
             }
             return;
         }
-        $_POST[$parameterName] = htmlspecialchars($_POST[$parameterName], ENT_COMPAT, $this->charset, false);
+        $_POST[$parameterName] = htmlspecialchars($_POST[$parameterName], \ENT_COMPAT, $this->charset, false);
         $this->postKeysAlreadySanitized[] = $this->arrayName;
     }
 
@@ -442,12 +442,12 @@ class AdminRequestSanitizer extends base
             // Add the parameterName to the base arrayname.
             $this->arrayName = $this->setCurrentArrayName($parameterName);
             $this->debugMessages[] = 'PROCESSING SANITIZE_EMAIL (POST) == ' . $this->arrayName;
-            $_POST[$parameterName] = filter_var($_POST[$parameterName], FILTER_SANITIZE_EMAIL);
+            $_POST[$parameterName] = filter_var($_POST[$parameterName], \FILTER_SANITIZE_EMAIL);
             $this->postKeysAlreadySanitized[] = $this->arrayName;
         }
         if (isset($_GET[$parameterName])) {
             $this->debugMessages[] = 'PROCESSING SANITIZE_EMAIL (GET) == ' . $parameterName;
-            $result = filter_var($_GET[$parameterName], FILTER_SANITIZE_EMAIL);
+            $result = filter_var($_GET[$parameterName], \FILTER_SANITIZE_EMAIL);
             $_GET[$parameterName] = $result;
             $this->getKeysAlreadySanitized[] = $parameterName;
         }
@@ -464,7 +464,7 @@ class AdminRequestSanitizer extends base
         // Add the parameterName to the base arrayname.
         $this->arrayName = $this->setCurrentArrayName($parameterName);
         $this->debugMessages[] = 'PROCESSING SANITIZE_EMAIL_AUDIENCE (POST) == ' . $this->arrayName;
-        $_POST[$parameterName] = htmlspecialchars($_POST[$parameterName], ENT_COMPAT, $this->charset, true);
+        $_POST[$parameterName] = htmlspecialchars($_POST[$parameterName], \ENT_COMPAT, $this->charset, true);
         $this->postKeysAlreadySanitized[] = $this->arrayName;
     }
 
@@ -483,7 +483,7 @@ class AdminRequestSanitizer extends base
         if (is_array($_POST[$parameterName])) {
             foreach ($_POST[$parameterName] as $pKey => $pValue) {
                 $currentArrayName = $this->setCurrentArrayName($pKey);
-                $newValue = filter_var($_POST[$parameterName][$pKey], FILTER_SANITIZE_URL);
+                $newValue = filter_var($_POST[$parameterName][$pKey], \FILTER_SANITIZE_URL);
                 if ($newValue === false) {
                     $newValue = preg_replace($urlRegex, '', $_POST[$parameterName][$pKey]);
                 }
@@ -493,7 +493,7 @@ class AdminRequestSanitizer extends base
             return;
         }
         // Perform similar sanitization for $_POST of non-array value.
-        $newValue = filter_var($_POST[$parameterName], FILTER_SANITIZE_URL);
+        $newValue = filter_var($_POST[$parameterName], \FILTER_SANITIZE_URL);
         if ($newValue === false) {
             $newValue = preg_replace($urlRegex, '', $_POST[$parameterName]);
         }
@@ -515,7 +515,7 @@ class AdminRequestSanitizer extends base
         $this->debugMessages[] = 'PROCESSING FILE_PATH_OR_URL_REGEX == ' . $this->arrayName;
         if (is_array($_POST[$parameterName])) {
             foreach ($_POST[$parameterName] as $pKey => $pValue) {
-                $newValue = filter_var($_POST[$parameterName][$pKey], FILTER_SANITIZE_URL);
+                $newValue = filter_var($_POST[$parameterName][$pKey], \FILTER_SANITIZE_URL);
                 if ($newValue === false) {
                     $newValue = preg_replace($regex, '', $_POST[$parameterName][$pKey]);
                 }
@@ -524,7 +524,7 @@ class AdminRequestSanitizer extends base
             }
             return;
         }
-        $newValue = filter_var($_POST[$parameterName], FILTER_SANITIZE_URL);
+        $newValue = filter_var($_POST[$parameterName], \FILTER_SANITIZE_URL);
         if ($newValue === false) {
             $newValue = preg_replace($regex, '', $_POST[$parameterName]);
         }
@@ -593,14 +593,14 @@ class AdminRequestSanitizer extends base
                 unset($_POST);
                 $_POST[$key] = $key;
                 // $this->arrayName = $currentArrayName; // Unnecessary as already set above.
-                $this->filterStrictSanitizeKeys();
+                self::filterStrictSanitizeKeys();
                 if (!array_key_exists($key, $_POST)) {
                     continue; // Key is "unclean" and therefore should use the next key.
                 }
                 $this->arrayName = $currentArrayName;
                 $currentPostKeysAlreadySanitized = $this->postKeysAlreadySanitized;
                 $this->filterStrictSanitizeValues();
-                unset($this->postKeysAlreadySanitized);
+                $this->postKeysAlreadySanitized = null;
                 $this->postKeysAlreadySanitized = $currentPostKeysAlreadySanitized;
                 unset($currentPostKeysAlreadySanitized);
                 $this->postKeysAlreadySanitized[] = $this->setCurrentArrayName($key);
@@ -636,7 +636,7 @@ class AdminRequestSanitizer extends base
                     unset($_POST);
                     $_POST[$pkey] = $pvalue;
                     // $this->arrayName = $newCurrentArrayName; // Unnecessary as set above
-                    $this->filterStrictSanitizeKeys();
+                    self::filterStrictSanitizeKeys();
                     if (array_key_exists($pkey, $_POST)) {
                         $this->filterStrictSanitizeValues();
                         // $this->arrayName = $newCurrentArrayName; // Unnecessary as set below or in next loop
@@ -682,12 +682,12 @@ class AdminRequestSanitizer extends base
                 unset($requestPost[$parameterName][$pkey]);
                 unset($_POST);
                 $_POST[$pkey] = $pkey;
-                $this->filterStrictSanitizeKeys();
+                self::filterStrictSanitizeKeys();
                 if (array_key_exists(/*$parameterName*/ $pkey, $_POST)) {
                     $this->arrayName = $currentArrayName;
                     $currentPostKeysAlreadySanitized = $this->postKeysAlreadySanitized;
                     $this->filterStrictSanitizeValues();
-                    unset($this->postKeysAlreadySanitized);
+                    $this->postKeysAlreadySanitized = null;
                     $this->postKeysAlreadySanitized = $currentPostKeysAlreadySanitized;
                     unset($currentPostKeysAlreadySanitized);
                     $this->postKeysAlreadySanitized[] = $this->setCurrentArrayName($pkey);
@@ -702,13 +702,13 @@ class AdminRequestSanitizer extends base
                 unset($_POST);
                 $_POST[$pkey] = $requestPost[$parameterName][$pkey];
                 unset($requestPost[$parameterName][$pkey]);
-                $this->filterStrictSanitizeKeys();
+                self::filterStrictSanitizeKeys();
                 if (array_key_exists($pkey, $_POST)) {
                     $this->arrayName = $currentArrayName;
                     $currentPostKeysAlreadySanitized = $this->postKeysAlreadySanitized;
                     $this->filterStrictSanitizeValues();
                     // $this->arrayName = $currentArrayName; // Unnecessary as set below or in next loop.
-                    unset($this->postKeysAlreadySanitized);
+                    $this->postKeysAlreadySanitized = null;
                     $this->postKeysAlreadySanitized = $currentPostKeysAlreadySanitized;
                     unset($currentPostKeysAlreadySanitized);
                     $this->postKeysAlreadySanitized[] = $this->setCurrentArrayName($pkey);
@@ -779,7 +779,7 @@ class AdminRequestSanitizer extends base
                     if (!in_array($this->arrayName, $ignore, false)) {
                         $this->debugMessages[] = 'PROCESSING STRICT_SANITIZE_VALUES == ' . $this->arrayName;
                         if (!is_int($item[$k])) {
-                            $item[$k] = htmlspecialchars($item[$k], ENT_COMPAT, $this->charset, true);
+                            $item[$k] = htmlspecialchars($item[$k], \ENT_COMPAT, $this->charset, true);
                         }
                         if ($inner) {
                             if ($type === 'post') {
@@ -836,7 +836,7 @@ class AdminRequestSanitizer extends base
      *
      * @since ZC v1.5.5
      */
-    private function filterStrictSanitizeKeys(): void
+    private static function filterStrictSanitizeKeys(): void
     {
         if (isset($_POST)) {
             foreach ($_POST as $key => $value) {
@@ -870,7 +870,7 @@ class AdminRequestSanitizer extends base
     /**
      * @since ZC v1.5.5
      */
-    private function errorLog(array $errorMessages = []): void
+    private static function errorLog(array $errorMessages = []): void
     {
         $logDir = defined('DIR_FS_LOGS') ? DIR_FS_LOGS : DIR_FS_SQL_CACHE;
         $message = date('M-d-Y h:i:s')

--- a/admin/includes/classes/MultiFactorAuth.php
+++ b/admin/includes/classes/MultiFactorAuth.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Handle Multi-Factor authentication via TOTP
  * Compatible with most Authenticator apps and in-browser support.
@@ -16,8 +18,8 @@
 foreach ([
     DIR_FS_CATALOG . DIR_WS_CLASSES . 'vendors/DaspridEnum/autoload.php', // required by BaconQrCode
     DIR_FS_CATALOG . DIR_WS_CLASSES . 'vendors/BaconQrCode/autoload.php', // required by BaconQrCode
-//    DIR_FS_CATALOG . DIR_WS_CLASSES . 'vendors/tc-lib-color/autoload.php', // required by TCBarcode
-//    DIR_FS_CATALOG . DIR_WS_CLASSES . 'vendors/tc-lib-barcode/autoload.php', // required by TCBarcode
+    //DIR_FS_CATALOG . DIR_WS_CLASSES . 'vendors/tc-lib-color/autoload.php', // required by TCBarcode
+    //DIR_FS_CATALOG . DIR_WS_CLASSES . 'vendors/tc-lib-barcode/autoload.php', // required by TCBarcode
 ] as $file) {
     if (file_exists($file)) {
         include $file;
@@ -81,7 +83,7 @@ class MultiFactorAuth
      */
     public function getCode(string $secret, ?int $time = null): string
     {
-        $secretkey = $this->base32Decode($secret);
+        $secretkey = self::base32Decode($secret);
 
         $timestamp = "\0\0\0\0" . pack('N*', $this->getTimeSlice($time ?? time()));      // Pack time into binary string
         $hashhmac = hash_hmac($this->algorithm, $timestamp, $secretkey, true); // Hash it with users secret key
@@ -89,7 +91,7 @@ class MultiFactorAuth
         $value = unpack('N', $hashpart);                                       // Unpack binary value
         $value = $value[1] & 0x7FFFFFFF;                                              // Drop MSB, keep only 31 bits
 
-        return str_pad((string)($value % 10 ** $this->codeLength), $this->codeLength, '0', STR_PAD_LEFT);
+        return str_pad((string)($value % 10 ** $this->codeLength), $this->codeLength, '0', \STR_PAD_LEFT);
     }
 
     /**
@@ -138,14 +140,14 @@ class MultiFactorAuth
      */
     private function getTimeSlice(?int $time = null, int $offset = 0): int
     {
-        $time = $time ?? time();
+        $time ??= time();
         return (int)floor($time / $this->period) + ($offset * $this->period);
     }
 
     /**
      * @since ZC v2.1.0
      */
-    private function base32Decode(string $value): string
+    private static function base32Decode(string $value): string
     {
         if ($value === '') {
             return '';
@@ -158,7 +160,7 @@ class MultiFactorAuth
         $buffer = '';
         foreach (str_split($value) as $char) {
             if ($char !== '=') {
-                $buffer .= str_pad(decbin(self::$_base32lookup[$char]), 5, '0', STR_PAD_LEFT);
+                $buffer .= str_pad(decbin(self::$_base32lookup[$char]), 5, '0', \STR_PAD_LEFT);
             }
         }
         $length = strlen($buffer);
@@ -166,7 +168,7 @@ class MultiFactorAuth
 
         $output = '';
         foreach (explode(' ', $blocks) as $block) {
-            $output .= chr(bindec(str_pad($block, 8, '0', STR_PAD_RIGHT)));
+            $output .= chr(bindec(str_pad($block, 8, '0', \STR_PAD_RIGHT)));
         }
         return $output;
     }

--- a/admin/includes/classes/Paginator.php
+++ b/admin/includes/classes/Paginator.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * split_page_results Class.
  *
@@ -11,7 +13,7 @@
 namespace Zencart\Paginator;
 
 if (!defined('IS_ADMIN_FLAG')) {
-  die('Illegal Access');
+    die('Illegal Access');
 }
 /**
  * Split Page Result Class
@@ -21,212 +23,242 @@ if (!defined('IS_ADMIN_FLAG')) {
  *
  * @since ZC v1.5.7
  */
-class Paginator extends \base {
-    protected $cmd;
-    protected $countQuery;
-    protected $current_page_number;
-    protected $number_of_pages;
-    protected $number_of_rows_per_page;
-    protected $number_of_rows;
-    protected $page_name;
-    protected $sql_query;
+class Paginator extends \base
+{
+    protected string $cmd;
+    protected string $countQuery;
+    protected int $current_page_number;
+    protected int $number_of_pages;
+    protected int $number_of_rows_per_page;
+    protected int $number_of_rows;
+    protected string $page_name;
+    protected string $sql_query;
 
-  /* class constructor */
-  function __construct($query, $max_rows, $count_key = '*', $page_holder = 'page', $debug = false, $countQuery = "") {
-    global $db;
-    $this->cmd = isset($_GET['cmd']) ? $_GET['cmd'] : 'home';
-    $max_rows = ($max_rows == '' || $max_rows == 0) ? 20 : $max_rows;
+    public function __construct(string $query, int|string $max_rows, string $count_key = '*', string $page_holder = 'page', bool $debug = false, string $countQuery = "")
+    {
+        global $db;
+        $this->cmd = $_GET['cmd'] ?? 'home';
+        $max_rows = ($max_rows === '' || $max_rows === 0) ? 20 : $max_rows;
 
-    $this->sql_query = preg_replace("/\n\r|\r\n|\n|\r/", " ", $query);
-    if ($countQuery != "") $countQuery = preg_replace("/\n\r|\r\n|\n|\r/", " ", $countQuery);
-    $this->countQuery = ($countQuery != "") ? $countQuery : $this->sql_query;
-    $this->page_name = $page_holder;
+        $this->sql_query = preg_replace("/\n\r|\r\n|\n|\r/", " ", $query);
+        if ($countQuery !== "") {
+            $countQuery = preg_replace("/\n\r|\r\n|\n|\r/", " ", $countQuery);
+        }
+        $this->countQuery = ($countQuery !== "") ? $countQuery : $this->sql_query;
+        $this->page_name = $page_holder;
 
-    if ($debug) {
-      echo '<br><br>';
-      echo 'original_query=' . $query . '<br><br>';
-      echo 'original_count_query=' . $countQuery . '<br><br>';
-      echo 'sql_query=' . $this->sql_query . '<br><br>';
-      echo 'count_query=' . $this->countQuery . '<br><br>';
-    }
-    if (isset($_GET[$page_holder])) {
-      $page = $_GET[$page_holder];
-    } elseif (isset($_POST[$page_holder])) {
-      $page = $_POST[$page_holder];
-    } else {
-      $page = '';
-    }
+        if ($debug) {
+            echo '<br><br>';
+            echo 'original_query=' . $query . '<br><br>';
+            echo 'original_count_query=' . $countQuery . '<br><br>';
+            echo 'sql_query=' . $this->sql_query . '<br><br>';
+            echo 'count_query=' . $this->countQuery . '<br><br>';
+        }
+        if (isset($_GET[$page_holder])) {
+            $page = $_GET[$page_holder];
+        } elseif (isset($_POST[$page_holder])) {
+            $page = $_POST[$page_holder];
+        } else {
+            $page = '';
+        }
 
-    if (empty($page) || !is_numeric($page)) $page = 1;
-    $this->current_page_number = $page;
+        if (empty($page) || !is_numeric($page)) {
+            $page = 1;
+        }
+        $this->current_page_number = $page;
 
-    $this->number_of_rows_per_page = $max_rows;
+        $this->number_of_rows_per_page = $max_rows;
 
-    $pos_to = strlen($this->countQuery);
+        $pos_to = strlen($this->countQuery);
 
-    $query_lower = strtolower($this->countQuery);
-    $pos_from = strpos($query_lower, ' from', 0);
+        $query_lower = strtolower($this->countQuery);
+        $pos_from = strpos($query_lower, ' from', 0);
 
-    $pos_group_by = strpos($query_lower, ' group by', $pos_from);
-    if (($pos_group_by < $pos_to) && ($pos_group_by != false)) $pos_to = $pos_group_by;
+        $pos_group_by = strpos($query_lower, ' group by', $pos_from);
+        if (($pos_group_by < $pos_to) && ($pos_group_by !== false)) {
+            $pos_to = $pos_group_by;
+        }
 
-    $pos_having = strpos($query_lower, ' having', $pos_from);
-    if (($pos_having < $pos_to) && ($pos_having != false)) $pos_to = $pos_having;
+        $pos_having = strpos($query_lower, ' having', $pos_from);
+        if (($pos_having < $pos_to) && ($pos_having !== false)) {
+            $pos_to = $pos_having;
+        }
 
-    $pos_order_by = strrpos($query_lower, ' order by', $pos_from);
-    if (($pos_order_by < $pos_to) && ($pos_order_by != false)) $pos_to = $pos_order_by;
+        $pos_order_by = strrpos($query_lower, ' order by', $pos_from);
+        if (($pos_order_by < $pos_to) && ($pos_order_by !== false)) {
+            $pos_to = $pos_order_by;
+        }
 
-    if (strpos($query_lower, 'distinct') || strpos($query_lower, 'group by')) {
-      $count_string = 'distinct ' . zen_db_input($count_key);
-    } else {
-      $count_string = zen_db_input($count_key);
-    }
-    $count_query = "select count(" . $count_string . ") as total " . substr($this->countQuery, $pos_from, ($pos_to - $pos_from));
-    if ($debug) {
-      echo 'count_query=' . $count_query . '<br><br>';
-    }
-    $count = $db->Execute($count_query);
+        if (strpos($query_lower, 'distinct') || strpos($query_lower, 'group by')) {
+            $count_string = 'distinct ' . zen_db_input($count_key);
+        } else {
+            $count_string = zen_db_input($count_key);
+        }
+        $count_query = "SELECT count(" . $count_string . ") AS total " . substr($this->countQuery, $pos_from, ($pos_to - $pos_from));
 
-    $this->number_of_rows = $count->fields['total'];
+        if ($debug) {
+            echo 'count_query=' . $count_query . '<br><br>';
+        }
 
-    $this->number_of_pages = ceil($this->number_of_rows / $this->number_of_rows_per_page);
+        $count = $db->Execute($count_query);
 
-    if ($this->current_page_number > $this->number_of_pages) {
-      $this->current_page_number = $this->number_of_pages;
-    }
+        $this->number_of_rows = (int)$count->fields['total'];
 
-    $offset = ($this->number_of_rows_per_page * ($this->current_page_number - 1));
+        $this->number_of_pages = (int)ceil($this->number_of_rows / $this->number_of_rows_per_page);
 
-    // fix offset error on some versions
-    if ($offset <= 0) { $offset = 0; }
+        if ($this->current_page_number > $this->number_of_pages) {
+            $this->current_page_number = $this->number_of_pages;
+        }
 
-    $this->sql_query .= " limit " . ($offset > 0 ? $offset . ", " : '') . $this->number_of_rows_per_page;
+        $offset = ($this->number_of_rows_per_page * ($this->current_page_number - 1));
 
-  }
+        // fix offset error on some versions
+        if ($offset <= 0) {
+            $offset = 0;
+        }
 
-  /**
-   * display split-page-number-links
-   *
-   * @since ZC v1.5.7
-   */
-  function display_links($max_page_links, $parameters = '', $outputAsUnorderedList = false, $navElementLabel = '') {
-    global $request_type;
-    if ($max_page_links == '') $max_page_links = 1;
-
-    if ($this->number_of_pages <= 1) return;
-
-    $display_links_string = $ul_elements = '';
-    $counter_actual_page_links = 0;
-
-    $class = '';
-
-    if (!empty($parameters) && (substr($parameters, -1) != '&')) $parameters .= '&';
-
-    // previous button - not displayed on first page
-    $link = '<a href="' . zen_href_link($this->cmd, $parameters . $this->page_name . '=' . ($this->current_page_number - 1), $request_type) . '" title="' . PREVNEXT_TITLE_PREVIOUS_PAGE . '">' . PREVNEXT_BUTTON_PREV . '</a>';
-    if ($this->current_page_number > 1) {
-      $display_links_string .= $link . '&nbsp;&nbsp;';
-      $ul_elements .= '  <li class="pagination-previous" aria-label="' . ARIA_PAGINATION_PREVIOUS_PAGE . '">' . $link . '</li>' . "\n";
-    } else {
-      // $ul_elements .= '  <li class="disabled pagination-previous">' . $link . '</li>' . "\n";
+        $this->sql_query .= " limit " . ($offset > 0 ? $offset . ", " : '') . $this->number_of_rows_per_page;
     }
 
+    /**
+     * display split-page-number-links
+     *
+     * @since ZC v1.5.7
+     */
+    public function display_links(int|string $max_page_links, string $parameters = '', bool $outputAsUnorderedList = false, string $navElementLabel = ''): ?string
+    {
+        global $request_type;
+        if (empty($max_page_links)) {
+            $max_page_links = 1;
+        }
 
-    // check if number_of_pages > $max_page_links
-    $cur_window_num = (int)$this->current_page_number / $max_page_links;
-    if ($this->current_page_number % $max_page_links) $cur_window_num++;
+        if ($this->number_of_pages <= 1) {
+            return '';
+        }
 
-    $max_window_num = (int)$this->number_of_pages / $max_page_links;
-    if ($this->number_of_pages % $max_page_links) $max_window_num++;
+        $display_links_string = $ul_elements = '';
+        $counter_actual_page_links = 0;
 
-    // previous group of pages
-    $link = '<a href="' . zen_href_link($this->cmd, $parameters . $this->page_name . '=' . (($cur_window_num - 1) * $max_page_links), $request_type) . '" title="' . sprintf(PREVNEXT_TITLE_PREV_SET_OF_NO_PAGE, $max_page_links) . '" aria-label="' . ARIA_PAGINATION_ELLIPSIS_PREVIOUS . '">...</a>';
-    if ($cur_window_num > 1) {
-      $display_links_string .= $link;
-      $ul_elements .= '  <li class="ellipsis">' . $link . '</li>' . "\n";
-    } else {
-      // $ul_elements .= '  <li class="ellipsis" aria-hidden="true">' . $link . '</li>' . "\n";
+        $class = '';
+
+        if (!empty($parameters) && (!str_ends_with($parameters, '&'))) {
+            $parameters .= '&';
+        }
+
+        // previous button - not displayed on first page
+        $link = '<a href="' . zen_href_link($this->cmd, $parameters . $this->page_name . '=' . ($this->current_page_number - 1), $request_type) . '" title="' . PREVNEXT_TITLE_PREVIOUS_PAGE . '">' . PREVNEXT_BUTTON_PREV . '</a>';
+        if ($this->current_page_number > 1) {
+            $display_links_string .= $link . '&nbsp;&nbsp;';
+            $ul_elements .= '  <li class="pagination-previous" aria-label="' . ARIA_PAGINATION_PREVIOUS_PAGE . '">' . $link . '</li>' . "\n";
+        } else {
+            // $ul_elements .= '  <li class="disabled pagination-previous">' . $link . '</li>' . "\n";
+        }
+
+
+        // check if number_of_pages > $max_page_links
+        $cur_window_num = (int)$this->current_page_number / $max_page_links;
+        if ($this->current_page_number % $max_page_links) {
+            $cur_window_num++;
+        }
+
+        $max_window_num = (int)$this->number_of_pages / $max_page_links;
+        if ($this->number_of_pages % $max_page_links) {
+            $max_window_num++;
+        }
+
+        // previous group of pages
+        $link = '<a href="' . zen_href_link($this->cmd, $parameters . $this->page_name . '=' . (($cur_window_num - 1) * $max_page_links), $request_type) . '" title="' . sprintf(PREVNEXT_TITLE_PREV_SET_OF_NO_PAGE, $max_page_links) . '" aria-label="' . ARIA_PAGINATION_ELLIPSIS_PREVIOUS . '">...</a>';
+        if ($cur_window_num > 1) {
+            $display_links_string .= $link;
+            $ul_elements .= '  <li class="ellipsis">' . $link . '</li>' . "\n";
+        } else {
+            // $ul_elements .= '  <li class="ellipsis" aria-hidden="true">' . $link . '</li>' . "\n";
+        }
+
+        // page nn button
+        for ($jump_to_page = 1 + (($cur_window_num - 1) * $max_page_links); ($jump_to_page <= ($cur_window_num * $max_page_links)) && ($jump_to_page <= $this->number_of_pages); $jump_to_page++) {
+            if ($jump_to_page == $this->current_page_number) {
+                $display_links_string .= '&nbsp;<strong class="current" aria-current="true" aria-label="' . ARIA_PAGINATION_CURRENT_PAGE . ', ' . sprintf(ARIA_PAGINATION_PAGE_NUM, $jump_to_page) . '">' . $jump_to_page . '</strong>&nbsp;';
+                $ul_elements .= '  <li class="current active">' . $jump_to_page . '</li>' . "\n";
+                $counter_actual_page_links++;
+            } else {
+                $link = '<a href="' . zen_href_link($this->cmd, $parameters . $this->page_name . '=' . $jump_to_page, $request_type) . '" title="' . sprintf(PREVNEXT_TITLE_PAGE_NO, $jump_to_page) . '" aria-label="' . ARIA_PAGINATION_GOTO . sprintf(ARIA_PAGINATION_PAGE_NUM, $jump_to_page) . '">' . $jump_to_page . '</a>';
+                $display_links_string .= '&nbsp;' . $link . '&nbsp;';
+                $ul_elements .= '  <li>' . $link . '</li>' . "\n";
+                $counter_actual_page_links++;
+            }
+        }
+
+        // next group of pages
+        if ($cur_window_num < $max_window_num) {
+            $link = '<a href="' . zen_href_link($this->cmd, $parameters . $this->page_name . '=' . (($cur_window_num) * $max_page_links + 1), $request_type) . '" title="' . sprintf(PREVNEXT_TITLE_NEXT_SET_OF_NO_PAGE, $max_page_links) . '" aria-label="' . ARIA_PAGINATION_ELLIPSIS_NEXT . '">...</a>';
+            $display_links_string .= $link . '&nbsp;';
+            $ul_elements .= '  <li class="ellipsis">' . $link . '</li>' . "\n";
+        } else {
+            // $ul_elements .= '  <li class="ellipsis" aria-hidden="true">' . $link . '</li>' . "\n";
+        }
+
+        // next button
+        if (($this->current_page_number < $this->number_of_pages) && ($this->number_of_pages != 1)) {
+            $link = '<a href="' . zen_href_link($this->cmd, $parameters . 'page=' . ($this->current_page_number + 1), $request_type) . '" title="' . PREVNEXT_TITLE_NEXT_PAGE . '" aria-label="' . ARIA_PAGINATION_NEXT_PAGE . '">' . PREVNEXT_BUTTON_NEXT . '</a>';
+            $display_links_string .= '&nbsp;' . $link . '&nbsp;';
+            $ul_elements .= '  <li class="pagination-next">' . $link . '</li>' . "\n";
+        } else {
+            // $ul_elements .= '  <li class="disabled pagination-next">' . $link . '</li>' . "\n";
+        }
+
+        // if no pagination needed, return blank
+        if ($counter_actual_page_links === 0) {
+            return '';
+        }
+
+        // return <nav><ul> format with a-hrefs wrapped in <li>
+        // not setting role="navigation" because we're using a <nav> element already.
+        if ($outputAsUnorderedList) {
+            $aria_label = empty($navElementLabel) ? ARIA_PAGINATION_ROLE_LABEL_GENERAL : sprintf(ARIA_PAGINATION_ROLE_LABEL_FOR, zen_output_string_protected($navElementLabel));
+            $aria_label .= sprintf(ARIA_PAGINATION_CURRENTLY_ON, $this->current_page_number);
+            return  '<nav class="pagination" aria-label="' . $aria_label . '">' . "\n" .
+                '<ul class="pagination">' . "\n" .
+                $ul_elements .
+                '</ul>' . "\n" .
+                '</nav>';
+        }
+        // return unformatted collection of a-hrefs
+        return $display_links_string;
     }
 
-    // page nn button
-    for ($jump_to_page = 1 + (($cur_window_num - 1) * $max_page_links); ($jump_to_page <= ($cur_window_num * $max_page_links)) && ($jump_to_page <= $this->number_of_pages); $jump_to_page++) {
-      if ($jump_to_page == $this->current_page_number) {
-        $display_links_string .= '&nbsp;<strong class="current" aria-current="true" aria-label="' . ARIA_PAGINATION_CURRENT_PAGE . ', ' . sprintf(ARIA_PAGINATION_PAGE_NUM, $jump_to_page) . '">' . $jump_to_page . '</strong>&nbsp;';
-        $ul_elements .= '  <li class="current active">' . $jump_to_page . '</li>' . "\n";
-        $counter_actual_page_links++;
-      } else {
-        $link = '<a href="' . zen_href_link($this->cmd, $parameters . $this->page_name . '=' . $jump_to_page, $request_type) . '" title="' . sprintf(PREVNEXT_TITLE_PAGE_NO, $jump_to_page) . '" aria-label="' . ARIA_PAGINATION_GOTO . sprintf(ARIA_PAGINATION_PAGE_NUM, $jump_to_page) . '">' . $jump_to_page . '</a>';
-        $display_links_string .= '&nbsp;' . $link . '&nbsp;';
-        $ul_elements .= '  <li>' . $link . '</li>' . "\n";
-        $counter_actual_page_links++;
-      }
+    /**
+     * display number of total products found
+     * @since ZC v1.5.7
+     */
+    public function display_count(string $text_output): string
+    {
+        $to_num = ($this->number_of_rows_per_page * $this->current_page_number);
+        if ($to_num > $this->number_of_rows) {
+            $to_num = $this->number_of_rows;
+        }
+
+        $from_num = ($this->number_of_rows_per_page * ($this->current_page_number - 1));
+
+        if ($to_num === 0) {
+            $from_num = 0;
+        } else {
+            $from_num++;
+        }
+
+        if ($to_num <= 1) {
+            // don't show count when 1
+            return '';
+        }
+
+        return sprintf($text_output, $from_num, $to_num, $this->number_of_rows);
     }
 
-    // next group of pages
-    if ($cur_window_num < $max_window_num) {
-      $link = '<a href="' . zen_href_link($this->cmd, $parameters . $this->page_name . '=' . (($cur_window_num) * $max_page_links + 1), $request_type) . '" title="' . sprintf(PREVNEXT_TITLE_NEXT_SET_OF_NO_PAGE, $max_page_links) . '" aria-label="' . ARIA_PAGINATION_ELLIPSIS_NEXT . '">...</a>';
-      $display_links_string .= $link . '&nbsp;';
-      $ul_elements .= '  <li class="ellipsis">' . $link . '</li>' . "\n";
-    } else {
-      // $ul_elements .= '  <li class="ellipsis" aria-hidden="true">' . $link . '</li>' . "\n";
+    /**
+     * @since ZC v1.5.7
+     */
+    public function getSqlQuery(): string
+    {
+        return $this->sql_query;
     }
-
-    // next button
-    if (($this->current_page_number < $this->number_of_pages) && ($this->number_of_pages != 1)) {
-      $link = '<a href="' . zen_href_link($this->cmd, $parameters . 'page=' . ($this->current_page_number + 1), $request_type) . '" title="' . PREVNEXT_TITLE_NEXT_PAGE . '" aria-label="' . ARIA_PAGINATION_NEXT_PAGE . '">' . PREVNEXT_BUTTON_NEXT . '</a>';
-      $display_links_string .= '&nbsp;' . $link . '&nbsp;';
-      $ul_elements .= '  <li class="pagination-next">' . $link . '</li>' . "\n";
-    } else {
-      // $ul_elements .= '  <li class="disabled pagination-next">' . $link . '</li>' . "\n";
-    }
-
-    // if no pagination needed, return blank
-    if ($counter_actual_page_links == 0) return;
-
-    // return <nav><ul> format with a-hrefs wrapped in <li>
-    // not setting role="navigation" because we're using a <nav> element already.
-    if ($outputAsUnorderedList) {
-        $aria_label = empty($navElementLabel) ? ARIA_PAGINATION_ROLE_LABEL_GENERAL : sprintf(ARIA_PAGINATION_ROLE_LABEL_FOR, zen_output_string_protected($navElementLabel));
-        $aria_label .= sprintf(ARIA_PAGINATION_CURRENTLY_ON, $this->current_page_number);
-        return  '<nav class="pagination" aria-label="' . $aria_label . '">' . "\n" .
-            '<ul class="pagination">' . "\n" .
-            $ul_elements .
-            '</ul>' . "\n" .
-            '</nav>';
-    }
-    // return unformatted collection of a-hrefs
-    return $display_links_string;
-  }
-
-  /**
-   * display number of total products found
-   * @since ZC v1.5.7
-   */
-  function display_count($text_output) {
-    $to_num = ($this->number_of_rows_per_page * $this->current_page_number);
-    if ($to_num > $this->number_of_rows) $to_num = $this->number_of_rows;
-
-    $from_num = ($this->number_of_rows_per_page * ($this->current_page_number - 1));
-
-    if ($to_num == 0) {
-      $from_num = 0;
-    } else {
-      $from_num++;
-    }
-
-    if ($to_num <= 1) {
-      // don't show count when 1
-      return '';
-    } else {
-      return sprintf($text_output, $from_num, $to_num, $this->number_of_rows);
-    }
-  }
-
-  /**
-   * @since ZC v1.5.7
-   */
-  public function getSqlQuery()
-  {
-      return $this->sql_query;
-  }
 }

--- a/admin/includes/classes/VersionServer.php
+++ b/admin/includes/classes/VersionServer.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -11,9 +13,9 @@ class VersionServer
     protected string $projectVersionServer = 'https://ping.zen-cart.com/zcversioncheck';
     protected string $pluginVersionServer = 'https://ping.zen-cart.com/plugincheck';
 
-    protected const TIMEOUT = 3;
+    protected const int TIMEOUT = 3;
 
-    protected const CONNECTTIMEOUT = 2;
+    protected const int CONNECTTIMEOUT = 2;
 
     public function __construct()
     {
@@ -40,22 +42,22 @@ class VersionServer
     {
         $currentInfo = $this->getZcVersioninfo();
         $ch = curl_init();
-        curl_setopt($ch, CURLOPT_URL, $this->projectVersionServer);
-        curl_setopt($ch, CURLOPT_POST, 1);
-        curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($currentInfo));
-        curl_setopt($ch, CURLOPT_VERBOSE, 0);
-        curl_setopt($ch, CURLOPT_HEADER, false);
-        curl_setopt($ch, CURLOPT_TIMEOUT, self::TIMEOUT);
-        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, self::CONNECTTIMEOUT);
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-        curl_setopt($ch, CURLOPT_MAXREDIRS, 2);
-        curl_setopt($ch, CURLOPT_USERAGENT, 'Core Version Check ' . HTTP_SERVER);
+        curl_setopt($ch, \CURLOPT_URL, $this->projectVersionServer);
+        curl_setopt($ch, \CURLOPT_POST, 1);
+        curl_setopt($ch, \CURLOPT_POSTFIELDS, http_build_query($currentInfo));
+        curl_setopt($ch, \CURLOPT_VERBOSE, 0);
+        curl_setopt($ch, \CURLOPT_HEADER, false);
+        curl_setopt($ch, \CURLOPT_TIMEOUT, self::TIMEOUT);
+        curl_setopt($ch, \CURLOPT_CONNECTTIMEOUT, self::CONNECTTIMEOUT);
+        curl_setopt($ch, \CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, \CURLOPT_FOLLOWLOCATION, true);
+        curl_setopt($ch, \CURLOPT_MAXREDIRS, 2);
+        curl_setopt($ch, \CURLOPT_USERAGENT, 'Core Version Check ' . HTTP_SERVER);
 
         $response = curl_exec($ch);
         $error = curl_error($ch);
         $errno = curl_errno($ch);
-        $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $http_code = curl_getinfo($ch, \CURLINFO_HTTP_CODE);
 
         if ($errno > 0 || $response === false || $http_code > 299) {
             return json_decode($this->formatCurlError($errno, $error), true);
@@ -85,21 +87,21 @@ class VersionServer
 
         $currentInfo = $this->getZcVersioninfo();
         $ch = curl_init();
-        curl_setopt($ch, CURLOPT_URL, $this->pluginVersionServer . '/' . $keylist);
-        curl_setopt($ch, CURLOPT_POST, 1);
-        curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($currentInfo));
-        curl_setopt($ch, CURLOPT_VERBOSE, 0);
-        curl_setopt($ch, CURLOPT_HEADER, false);
-        curl_setopt($ch, CURLOPT_TIMEOUT, self::TIMEOUT);
-        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, self::CONNECTTIMEOUT);
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-        curl_setopt($ch, CURLOPT_MAXREDIRS, 2);
-        curl_setopt($ch, CURLOPT_USERAGENT, 'Plugin Version Check ' . $type . ' ' . HTTP_SERVER);
+        curl_setopt($ch, \CURLOPT_URL, $this->pluginVersionServer . '/' . $keylist);
+        curl_setopt($ch, \CURLOPT_POST, 1);
+        curl_setopt($ch, \CURLOPT_POSTFIELDS, http_build_query($currentInfo));
+        curl_setopt($ch, \CURLOPT_VERBOSE, 0);
+        curl_setopt($ch, \CURLOPT_HEADER, false);
+        curl_setopt($ch, \CURLOPT_TIMEOUT, self::TIMEOUT);
+        curl_setopt($ch, \CURLOPT_CONNECTTIMEOUT, self::CONNECTTIMEOUT);
+        curl_setopt($ch, \CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, \CURLOPT_FOLLOWLOCATION, true);
+        curl_setopt($ch, \CURLOPT_MAXREDIRS, 2);
+        curl_setopt($ch, \CURLOPT_USERAGENT, 'Plugin Version Check ' . $type . ' ' . HTTP_SERVER);
         $response = curl_exec($ch);
         $error = curl_error($ch);
         $errno = curl_errno($ch);
-        $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $http_code = curl_getinfo($ch, \CURLINFO_HTTP_CODE);
 
         if ($errno > 0 || $response === false || $http_code > 299) {
             return $this->formatCurlError($errno, $error);
@@ -164,7 +166,7 @@ class VersionServer
 
         $country_iso = $this->getCountryIso();
 
-        $results = [
+        return [
             'currentVersionMajor' => PROJECT_VERSION_MAJOR,
             'currentVersionMinor' => PROJECT_VERSION_MINOR,
             'httpServer' => HTTP_SERVER,
@@ -172,7 +174,6 @@ class VersionServer
             'systemInfo' => $systemInfo,
             'moduleInfo' => $moduleInfo,
         ];
-        return $results;
     }
 
     /**
@@ -180,19 +181,17 @@ class VersionServer
      */
     protected function getModuleinfo(): array
     {
-        $modules = [
+        return [
             'MODULE_PAYMENT_INSTALLED' => zen_config('MODULE_PAYMENT_INSTALLED'),
             'MODULE_SHIPPING_INSTALLED' => zen_config('MODULE_SHIPPING_INSTALLED'),
             'MODULE_ORDER_TOTAL_INSTALLED' => zen_config('MODULE_ORDER_TOTAL_INSTALLED'),
         ];
-
-        return $modules;
     }
 
     /**
      * @since ZC v1.5.5f
      */
-    protected function getCountryIso()
+    protected function getCountryIso(): string
     {
         global $db;
         $result = $db->Execute('SELECT countries_iso_code_3 FROM ' . TABLE_COUNTRIES . ' WHERE countries_id = ' . (int)zen_config('STORE_COUNTRY'));

--- a/admin/includes/classes/WhosOnline.php
+++ b/admin/includes/classes/WhosOnline.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -9,24 +11,25 @@
 class WhosOnline extends base
 {
     /* @var int seconds when considered inactive - 180 default = 3 minutes */
-    protected $timer_inactive_threshold = 180;
+    protected int $timer_inactive_threshold = 180;
 
     /* @var int seconds til dead, ie: considered dead after this long since last click; default 540 seconds = 9 minutes */
-    protected $timer_dead_threshold = 540;
+    protected int $timer_dead_threshold = 540;
 
     /* @var int purge after how many seconds? default= 1200 = 20 minutes */
-    protected $timer_remove_threshold = 1200;
+    protected int $timer_remove_threshold = 1200;
 
-    protected $total_sessions = 0;
-    protected $duplicates = 0;
-    protected $unique_sessions = 0;
-    protected $whos_online = [];
+    protected int $total_sessions = 0;
+    protected int $duplicates = 0;
+    protected int $unique_sessions = 0;
+    protected array $whos_online = [];
 
-    protected $user_array = [0 => 0, 1 => 0, 2 => 0, 3 => 0];
-    protected $guest_array = [0 => 0, 1 => 0, 2 => 0, 3 => 0];
-    protected $spider_array = [0 => 0, 1 => 0, 2 => 0, 3 => 0];
+    protected array $user_array = [0 => 0, 1 => 0, 2 => 0, 3 => 0];
+    protected array $guest_array = [0 => 0, 1 => 0, 2 => 0, 3 => 0];
+    protected array $spider_array = [0 => 0, 1 => 0, 2 => 0, 3 => 0];
 
-    protected $statsCacheLastCalculatedAt = 0;
+    // @TODO - this cache calculation timestamp is never set, so isn't caching.
+    protected int $statsCacheLastCalculatedAt = 0;
 
 
     public function __construct($forceRebuild = false, $skip_gc = false)
@@ -55,7 +58,7 @@ class WhosOnline extends base
     /**
      * @since ZC v1.5.7
      */
-    public function getTimerInactive()
+    public function getTimerInactive(): int
     {
         return (int)$this->timer_inactive_threshold;
     }
@@ -63,7 +66,7 @@ class WhosOnline extends base
     /**
      * @since ZC v1.5.7
      */
-    public function getTimerDead()
+    public function getTimerDead(): int
     {
         return (int)$this->timer_dead_threshold;
     }
@@ -71,7 +74,7 @@ class WhosOnline extends base
     /**
      * @since ZC v1.5.7
      */
-    public function getUniques()
+    public function getUniques(): int
     {
         return (int)$this->unique_sessions;
     }
@@ -79,7 +82,7 @@ class WhosOnline extends base
     /**
      * @since ZC v1.5.7
      */
-    public function getDuplicates()
+    public function getDuplicates(): int
     {
         return (int)$this->duplicates;
     }
@@ -87,7 +90,7 @@ class WhosOnline extends base
     /**
      * @since ZC v1.5.7
      */
-    public function getTotalSessions()
+    public function getTotalSessions(): int
     {
         return (int)$this->total_sessions;
     }
@@ -95,54 +98,29 @@ class WhosOnline extends base
     /**
      * @since ZC v1.5.7
      */
-    public function retrieve($selectedView = '', $sessionToInspect = '', $exclude_spiders = false, $exclude_admins = true)
+    public function retrieve(string $selectedView = '', string $sessionToInspect = '', bool $exclude_spiders = false, bool $exclude_admins = true): array
     {
-        switch ($selectedView) {
-            case "full_name-desc":
-                $order = "full_name DESC, LPAD(ip_address,11,'0')";
-                break;
-            case "full_name":
-                $order = "full_name, LPAD(ip_address,11,'0')";
-                break;
-            case "ip_address":
-                $order = "ip_address, session_id";
-                break;
-            case "ip_address-desc":
-                $order = "ip_address DESC, session_id";
-                break;
-            case "time_last_click-desc":
-                $order = "time_last_click DESC, LPAD(ip_address,11,'0')";
-                break;
-            case "time_last_click":
-                $order = "time_last_click, LPAD(ip_address,11,'0')";
-                break;
-            case "time_entry-desc":
-                $order = "time_entry DESC, LPAD(ip_address,11,'0')";
-                break;
-            case "time_entry":
-                $order = "time_entry, LPAD(ip_address,11,'0')";
-                break;
-            case "last_page_url-desc":
-                $order = "last_page_url DESC, LPAD(ip_address,11,'0')";
-                break;
-            case "last_page_url":
-                $order = "last_page_url, LPAD(ip_address,11,'0')";
-                break;
-            case "session_id":
-                $order = "session_id, ip_address";
-                break;
-            case "session_id-desc":
-                $order = "session_id DESC, ip_address";
-                break;
-            default:
-                $order = "time_entry, LPAD(ip_address,11,'0')";
-        }
+        $order = match ($selectedView) {
+            "full_name-desc" => "full_name DESC, LPAD(ip_address,11,'0')",
+            "full_name" => "full_name, LPAD(ip_address,11,'0')",
+            "ip_address" => "ip_address, session_id",
+            "ip_address-desc" => "ip_address DESC, session_id",
+            "time_last_click-desc" => "time_last_click DESC, LPAD(ip_address,11,'0')",
+            "time_last_click" => "time_last_click, LPAD(ip_address,11,'0')",
+            "time_entry-desc" => "time_entry DESC, LPAD(ip_address,11,'0')",
+            "time_entry" => "time_entry, LPAD(ip_address,11,'0')",
+            "last_page_url-desc" => "last_page_url DESC, LPAD(ip_address,11,'0')",
+            "last_page_url" => "last_page_url, LPAD(ip_address,11,'0')",
+            "session_id" => "session_id, ip_address",
+            "session_id-desc" => "session_id DESC, ip_address",
+            default => "time_entry, LPAD(ip_address,11,'0')",
+        };
         $where = '';
         if ($exclude_spiders) {
             $where = "WHERE session_id != '' ";
         }
         if ($exclude_admins) {
-            $where .= ($where == '') ? " WHERE " : " AND ";
+            $where .= ($where === '') ? " WHERE " : " AND ";
             $where .= "ip_address != '' AND ip_address NOT IN ('" . implode("','", preg_split('/[\s,]/', zen_db_input(zen_config('EXCLUDE_ADMIN_IP_FOR_MAINTENANCE')) . ',' . zen_db_input($_SERVER['REMOTE_ADDR']))) . "') ";
         }
         $sql = "SELECT customer_id, full_name, ip_address, time_entry, time_last_click, last_page_url, session_id, host_address, user_agent, s.value as session_data
@@ -187,7 +165,7 @@ class WhosOnline extends base
             $this->whos_online[$result['session_id']] = $result;
 
             // track duplicate IPs
-            if (in_array($result['ip_address'], $ip_array)) {
+            if (in_array($result['ip_address'], $ip_array, true)) {
                 $this->duplicates++;
             } else {
                 $ip_array[] = $result['ip_address'];
@@ -209,44 +187,34 @@ class WhosOnline extends base
     /**
      * @since ZC v1.5.7
      */
-    public function getImageForStatus($status_code = 0)
+    public function getImageForStatus(int|string $status_code = 0): string
     {
-        switch ($status_code) {
-            case 3:
-                return zen_icon('status-red-light');
-            case 2:
-                return zen_icon('status-red');
-            case 1:
-                return zen_icon('status-yellow');
-            default:
-            case 0:
-                return zen_icon('status-green');
-        }
+        return match ((int)$status_code) {
+            3 => zen_icon('status-red-light'),
+            2 => zen_icon('status-red'),
+            1 => zen_icon('status-yellow'),
+            default => zen_icon('status-green'),
+        };
     }
 
     // future-use CSS classes for icons
     /**
      * @since ZC v1.5.7
      */
-    public function getIconClassForStatus($status_code = 0)
+    public function getIconClassForStatus(int|string $status_code = 0): string
     {
-        switch ($status_code) {
-            case 3:
-                return 'wo-inactive-empty';
-            case 2:
-                return 'wo-active-empty';
-            case 1:
-                return 'wo-inactive-not-empty';
-            default:
-            case 0:
-                return 'wo-active-not-empty';
-        }
+        return match ((int)$status_code) {
+            3 => 'wo-inactive-empty',
+            2 => 'wo-active-empty',
+            1 => 'wo-inactive-not-empty',
+            default => 'wo-active-not-empty',
+        };
     }
 
     /**
      * @since ZC v1.5.7
      */
-    public function getStats()
+    public function getStats(): array
     {
         if ($this->statsCacheLastCalculatedAt < (time() - 15)) {
             $this->retrieve();
@@ -258,7 +226,7 @@ class WhosOnline extends base
     /**
      * @since ZC v1.5.7
      */
-    protected function getHumanFriendlyTimeSince($timestamp_of_last_click)
+    protected function getHumanFriendlyTimeSince($timestamp_of_last_click): string
     {
         $diff_in_seconds = (time() - $timestamp_of_last_click);
         return gmdate('H:i:s', $diff_in_seconds);
@@ -267,7 +235,7 @@ class WhosOnline extends base
     /**
      * @since ZC v1.5.7
      */
-    protected function getStatusCode($data)
+    protected function getStatusCode($data): int
     {
         $xx_mins_ago_long = (time() - (int)$this->timer_inactive_threshold);
         $inactive = ($data['time_last_click'] ?? 0) < $xx_mins_ago_long;
@@ -302,7 +270,7 @@ class WhosOnline extends base
     /**
      * @since ZC v1.5.7
      */
-    protected function calculateStats()
+    protected function calculateStats(): void
     {
         foreach ($this->whos_online as $session) {
             if (empty($session['session_id'])) {
@@ -321,7 +289,7 @@ class WhosOnline extends base
      * Remove expired entries
      * @since ZC v1.5.7
      */
-    public function doGarbageCollection()
+    public function doGarbageCollection(): void
     {
         global $db;
         $xx_mins_ago_dead = (time() - (int)$this->timer_dead_threshold);
@@ -334,33 +302,32 @@ class WhosOnline extends base
 
     }
 
-
     /**
      * @param string $session_id
      * @param string $session_data
      * @return array|null
      * @since ZC v1.5.7
      */
-    protected function inspectSessionCart($session_id = '', $session_data = '')
+    protected function inspectSessionCart(string $session_id = '', string $session_data = ''): ?array
     {
         // we need at least one of these parameters
         if (empty($session_id) && empty($session_data)) {
-          return null;
+            return null;
         }
 
         // or we can pass in the already-queried session data
         if (empty($session_data)) {
             $result = $GLOBALS['db']->Execute("
-                SELECT value as session_data
+                SELECT value AS session_data
                 FROM " . TABLE_SESSIONS . "
                 WHERE sesskey = '" . zen_db_input($session_id) . "'");
             $session_data = $result->EOF === false ? trim($result->fields['session_data']) : '';
         }
 
-        if (strpos($session_data, 'cart|O') == 0) {
+        if (str_starts_with($session_data, 'cart|O')) {
             $session_data = base64_decode($session_data);
         }
-        if (strpos($session_data, 'cart|O') == 0) {
+        if (str_starts_with($session_data, 'cart|O')) {
             $session_data = '';
         }
 
@@ -404,7 +371,7 @@ class WhosOnline extends base
                 $extracted_data['cartID'] = $_SESSION['cartID'];
             }
 
-            foreach($fields_to_extract as $field => $as) {
+            foreach ($fields_to_extract as $field => $as) {
                 if (isset($_SESSION[$field])) {
                     $extracted_data[$as] = $_SESSION[$field];
                 }
@@ -413,7 +380,7 @@ class WhosOnline extends base
 
         // protect against tampering
         $_SESSION = $backupSessionArray;
-        foreach($_SESSION as $key => $value) {
+        foreach ($_SESSION as $key => $value) {
             if (!isset($backupSessionArray[$key])) {
                 unset($_SESSION[$key]);
             }

--- a/admin/includes/classes/WhosOnline.php
+++ b/admin/includes/classes/WhosOnline.php
@@ -158,7 +158,7 @@ class WhosOnline extends base
             // if a session_id has been passed, we inspect it now to save re-querying and re-processing
             $result['cart'] = null;
             if (!empty($sessionToInspect) && $sessionToInspect === $result['session_id']) {
-                $result['cart'] = $this->inspectSessionCart($result['session_id'], $result['session_data']);
+                $result['cart'] = $this->inspectSessionCart($result['session_id'], $result['session_data'] ?? '');
             }
             unset($result['session_data']);
 

--- a/admin/includes/classes/box.php
+++ b/admin/includes/classes/box.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
@@ -6,7 +8,7 @@
  * @version $Id: DrByte 2025 Sep 18 Modified in v2.2.0 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
-  die('Illegal Access');
+    die('Illegal Access');
 }
 /*
   Example usage:
@@ -23,31 +25,33 @@ if (!defined('IS_ADMIN_FLAG')) {
   echo $box->infoBox($heading, $contents);
 */
 
-    /**
-     * @since ZC v1.0.3
-     */
-class box extends boxTableBlock {
-      private
-          $heading,
-          $contents;
+/**
+ * @since ZC v1.0.3
+ */
+class box extends boxTableBlock
+{
+    private string $heading;
+    private string $contents;
 
-    function __construct() {
-      $this->heading = array();
-      $this->contents = array();
+    public function __construct()
+    {
+        $this->heading = '';
+        $this->contents = '';
     }
 
     /**
      * @since ZC v1.0.3
      */
-    function infoBox($heading, $contents) {
-      $this->table_row_parameters = 'infoBoxHeading';
-      $this->table_data_parameters = 'infoBoxHeading';
-      $this->heading = $this->tableBlock($heading);
+    public function infoBox(array $heading, array $contents): string
+    {
+        $this->table_row_parameters = 'infoBoxHeading';
+        $this->table_data_parameters = 'infoBoxHeading';
+        $this->heading = $this->tableBlock($heading);
 
-      $this->table_row_parameters = '';
-      $this->table_data_parameters = 'infoBoxContent';
-      $this->contents = $this->tableBlock($contents);
+        $this->table_row_parameters = '';
+        $this->table_data_parameters = 'infoBoxContent';
+        $this->contents = $this->tableBlock($contents);
 
-      return $this->heading . $this->contents;
+        return $this->heading . $this->contents;
     }
 }

--- a/admin/includes/classes/class.admin.zcObserverLogEventListener.php
+++ b/admin/includes/classes/class.admin.zcObserverLogEventListener.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -16,178 +18,180 @@
  * @since ZC v1.5.4
  */
 
-class zcObserverLogEventListener extends base {
-
-    private $notifier;
-
-  /**
-   * using integer values implemented by monolog API
-   */
-  const DEBUG = 100;
-  const INFO = 200; // user logs in, other basic logged activity
-  const NOTICE = 250; // uncommon
-  const WARNING = 300; //Exceptional occurrences that are not errors
-  const ERROR = 400; // Runtime errors
-  const CRITICAL = 500; // Application error
-  const ALERT = 550; // site down
-  const EMERGENCY = 600; // urgent
-  /**
-   * Logging levels from syslog protocol defined in RFC 5424
-   * @var array $levels Logging levels
-   */
-  protected static $levels = array(
-          100 => 'DEBUG',
-          200 => 'INFO',
-          250 => 'NOTICE',
-          300 => 'WARNING',
-          400 => 'ERROR',
-          500 => 'CRITICAL',
-          550 => 'ALERT',
-          600 => 'EMERGENCY',
-  );
-
-  public function __construct(?notifier $zco_notifier = null) {
-    if (!$zco_notifier) $zco_notifier = new notifier;
-    $this->notifier = $zco_notifier;
-    $this->notifier->attach($this, array('NOTIFY_ADMIN_ACTIVITY_LOG_EVENT', 'NOTIFY_ADMIN_ACTIVITY_LOG_RESET'));
-  }
-
-  /**
-   * @since ZC v1.5.4
-   */
-  public function updateNotifyAdminActivityLogEvent(&$class, $eventID, $message_to_log = '', $requested_severity = '')
-  {
-    $log_data = self::prepareLogdata($message_to_log, $requested_severity);
-    /**
-     * Now tell all log-writers to fire, using the curated data
-     */
-    $this->notifier->notify('NOTIFY_ADMIN_FIRE_LOG_WRITERS', $log_data);
-  }
-
-  /**
-   * @since ZC v1.5.4
-   */
-  static function prepareLogdata($message_to_log = '', $requested_severity = '')
-  {
-    global $PHP_SELF;
-    $flagged = 0;
-    $notes = $specific_message = $gzpostdata = $postdata = '';
-    $severity = self::INFO;
+class zcObserverLogEventListener extends base
+{
+    private notifier $notifier;
 
     /**
-     * Parse associated POST data
-     * This is to specifically avoid logging certain confidential details
-     * and also to draw attention to certain warnings which deserve highlighting for the benefit of storeowners, since they should be monitoring their logs
+     * using integer values implemented by monolog API
      */
-    $postdata = $_POST;
-    $postdata = self::filterArrayElements($postdata);
-    $notes = self::parseForMaliciousContent(print_r($postdata, true));
+    public const int DEBUG = 100;
+    public const int INFO = 200; // user logs in, other basic logged activity
+    public const int NOTICE = 250; // uncommon
+    public const int WARNING = 300; //Exceptional occurrences that are not errors
+    public const int ERROR = 400; // Runtime errors
+    public const int CRITICAL = 500; // Application error
+    public const int ALERT = 550; // site down
+    public const int EMERGENCY = 600; // urgent
     /**
-     * Since the POST data was an array, we json-encode the parsed POST data for storage in the logging system
+     * Logging levels from syslog protocol defined in RFC 5424
+     * @var array $levels Logging levels
      */
-    $postdata = json_encode($postdata);
+    protected static array $levels = [
+        100 => 'DEBUG',
+        200 => 'INFO',
+        250 => 'NOTICE',
+        300 => 'WARNING',
+        400 => 'ERROR',
+        500 => 'CRITICAL',
+        550 => 'ALERT',
+        600 => 'EMERGENCY',
+    ];
 
-    /**
-     * Handle specific message to be logged, if passed
-     */
-    if ($message_to_log != '' && $message_to_log != 'POST')
+    public function __construct(?notifier $zco_notifier = null)
     {
-      $data = $message_to_log;
-      if (is_array($message_to_log))
-      {
-        $data = self::filterArrayElements($data);
-        $data = print_r($data, true);
-      }
-      $specific_message = $data;
-      $notes2 = self::parseForMaliciousContent(print_r($data, true));
-      $notes = $notes . (strlen($notes) > 0 ? '; ' : '') . $notes2;
+        if (!$zco_notifier) {
+            $zco_notifier = new notifier();
+        }
+        $this->notifier = $zco_notifier;
+        $this->notifier->attach($this, ['NOTIFY_ADMIN_ACTIVITY_LOG_EVENT', 'NOTIFY_ADMIN_ACTIVITY_LOG_RESET']);
     }
-    if ($specific_message == '')
+
+    /**
+     * @since ZC v1.5.4
+     */
+    public function updateNotifyAdminActivityLogEvent(&$class, $eventID, $message_to_log = '', $requested_severity = '')
     {
-      $specific_message = "Accessed page [" . basename($PHP_SELF) . "]";
-      if (isset($_REQUEST['action'])) $specific_message .= ' with action=' . $_REQUEST['action'] . '. Review page_parameters and postdata for details.';
+        $log_data = self::prepareLogdata($message_to_log, $requested_severity);
+        /**
+         * Now tell all log-writers to fire, using the curated data
+         */
+        $this->notifier->notify('NOTIFY_ADMIN_FIRE_LOG_WRITERS', $log_data);
     }
 
     /**
-     * Set severity flags
-     * If $notes is not false, then that means the malicious-content detector found things which should be deemed remarkable, so we elevate the severity to 'notice'
+     * @since ZC v1.5.4
      */
-    if ($notes !== false && $notes != '')
+    public static function prepareLogdata(string|array $message_to_log = '', ?string $requested_severity = ''): array
     {
-      $severity = self::NOTICE;
-      $flagged = 1;
+        global $PHP_SELF;
+        $flagged = 0;
+        $notes = $specific_message = $gzpostdata = $postdata = '';
+        $severity = self::INFO;
+
+        /**
+         * Parse associated POST data
+         * This is to specifically avoid logging certain confidential details
+         * and also to draw attention to certain warnings which deserve highlighting for the benefit of storeowners, since they should be monitoring their logs
+         */
+        $postdata = $_POST;
+        $postdata = self::filterArrayElements($postdata);
+        $notes = self::parseForMaliciousContent(print_r($postdata, true));
+        /**
+         * Since the POST data was an array, we json-encode the parsed POST data for storage in the logging system
+         */
+        $postdata = json_encode($postdata);
+
+        /**
+         * Handle specific message to be logged, if passed
+         */
+        if ($message_to_log !== '' && $message_to_log !== 'POST') {
+            $data = $message_to_log;
+            if (is_array($message_to_log)) {
+                $data = self::filterArrayElements($data);
+                $data = print_r($data, true);
+            }
+            $specific_message = $data;
+            $notes2 = self::parseForMaliciousContent(print_r($data, true));
+            $notes .= ($notes !== '' ? '; ' : '') . $notes2;
+        }
+        if ($specific_message === '') {
+            $specific_message = "Accessed page [" . basename($PHP_SELF) . "]";
+            if (isset($_REQUEST['action'])) {
+                $specific_message .= ' with action=' . $_REQUEST['action'] . '. Review page_parameters and postdata for details.';
+            }
+        }
+
+        /**
+         * Set severity flags
+         * If $notes is not false, then that means the malicious-content detector found things which should be deemed remarkable, so we elevate the severity to 'notice'
+         */
+        if ($notes !== false && $notes !== '') {
+            $severity = self::NOTICE;
+            $flagged = 1;
+        }
+
+        /**
+         * escalate severity if requested level is higher than calculated level
+         */
+        $levels_lookup = array_flip(self::$levels);
+
+        $integer_requested_severity = 0;
+        if (is_string($requested_severity) && $requested_severity !== '') {
+            $integer_requested_severity = $levels_lookup[strtoupper($requested_severity)] ?? 0;
+        }
+        if ($integer_requested_severity > $severity) {
+            $severity = $integer_requested_severity;
+        }
+        if ($severity > self::INFO) {
+            $flagged = 1;
+        }
+
+
+        /**
+         * Prepare an array of data to be passed to all log-writers (which are observers listening for the Fire event, called below)
+         */
+        $log_data = [
+            'event_epoch_time' => time(),
+            'admin_id'        => (isset($_SESSION['admin_id'])) ? (int)$_SESSION['admin_id'] : 0,
+            'page_accessed'   => basename($PHP_SELF) . (!isset($_SESSION['admin_id']) || (int)$_SESSION['admin_id'] === 0 ? ' ' . ($_POST['admin_name'] ?? ($_POST['admin_email'] ?? '')) : ''),
+            'page_parameters' => preg_replace('/(&amp;|&)$/', '', zen_get_all_get_params()),
+            'specific_message' => $specific_message,
+            'ip_address'      => substr($_SERVER['REMOTE_ADDR'], 0, 45),
+            'postdata'        => $postdata,
+            'flagged'         => $flagged,
+            'attention'       => ($notes === false ? '' : $notes),
+            'severity'        => strtolower(self::$levels[$severity]),  // converts int to corresponding string
+        ];
+
+        return $log_data;
     }
 
     /**
-     * escalate severity if requested level is higher than calculated level
+     * Filter out things which ought not to be recorded in logs, such as actual pass words
+     * @since ZC v1.5.4
      */
-    $levels = self::$levels;
-    $levels_lookup = array_flip($levels);
-
-    $integer_requested_severity = $requested_severity;
-    if (is_string($requested_severity) && $requested_severity != '') {
-      if (isset($levels_lookup[strtoupper($requested_severity)])) {
-        $integer_requested_severity = $levels_lookup[strtoupper($requested_severity)];
-      }
+    public static function filterArrayElements(array $data): array
+    {
+        foreach ($data as $key => $nul) {
+            if (in_array($key, ['x','y','secur' . 'ityTo' . 'ken','admi' . 'n_p' . 'ass','pass' . 'word','confirm', 'newpwd-' . $_SESSION['securityToken'],'oldpwd-' . $_SESSION['securityToken'],'confpwd-' . $_SESSION['securityToken']], true)) {
+                unset($data[$key]);
+            }
+        }
+        return $data;
     }
-    if ($integer_requested_severity > $severity) {
-      $severity = $integer_requested_severity;
-    }
-    if ($severity > self::INFO) $flagged = 1;
-
 
     /**
-     * Prepare an array of data to be passed to all log-writers (which are observers listening for the Fire event, called below)
+     * Look for any risky kinds of incoming POST data which might be flagged under PCI safety rules
+     * @since ZC v1.5.4
      */
-    $log_data = array(
-        'event_epoch_time'=> time(),
-        'admin_id'        => (isset($_SESSION['admin_id'])) ? (int)$_SESSION['admin_id'] : 0,
-        'page_accessed'   => basename($PHP_SELF) . (!isset($_SESSION['admin_id']) || (int)$_SESSION['admin_id'] == 0 ? ' ' . (isset($_POST['admin_name']) ? $_POST['admin_name'] : (isset($_POST['admin_email']) ? $_POST['admin_email'] : '') ) : ''),
-        'page_parameters' => preg_replace('/(&amp;|&)$/', '', zen_get_all_get_params()),
-        'specific_message'=> $specific_message,
-        'ip_address'      => substr($_SERVER['REMOTE_ADDR'],0,45),
-        'postdata'        => $postdata,
-        'flagged'         => $flagged,
-        'attention'       => ($notes === false ? '' : $notes),
-        'severity'        => strtolower($levels[$severity]),  // converts int to corresponding string
-    );
+    public static function parseForMaliciousContent(string $string): false|string
+    {
+        $matches = '';
+        if (preg_match_all('~(file://|<iframe|<frame|<embed|<script|<meta)~i', $string, $matches)) {
+            return htmlspecialchars(WARNING_REVIEW_ROGUE_ACTIVITY . ' [' . implode(' and ', $matches[1]) . ']', \ENT_COMPAT, CHARSET, true);
+        }
 
-    return $log_data;
-  }
-
-  /**
-   * Filter out things which ought not to be recorded in logs, such as actual pass words
-   * @since ZC v1.5.4
-   */
-  static function filterArrayElements($data)
-  {
-    foreach ($data as $key=>$nul) {
-      if (in_array($key, array('x','y','secur'.'ityTo'.'ken','admi'.'n_p'.'ass','pass'.'word','confirm', 'newpwd-'.$_SESSION['securityToken'],'oldpwd-'.$_SESSION['securityToken'],'confpwd-'.$_SESSION['securityToken']))) unset($data[$key]);
+        return false;
     }
-    return $data;
-  }
 
-  /**
-   * Look for any risky kinds of incoming POST data which might be flagged under PCI safety rules
-   * @since ZC v1.5.4
-   */
-  static function parseForMaliciousContent($string)
-  {
-    $matches = '';
-    if (preg_match_all('~(file://|<iframe|<frame|<embed|<script|<meta)~i', $string, $matches)) {
-      return htmlspecialchars(WARNING_REVIEW_ROGUE_ACTIVITY . ' [' . implode(' and ', $matches[1]) . ']', ENT_COMPAT, CHARSET, true);
-    } else {
-      return false;
+    /**
+     * @since ZC v1.5.4
+     */
+    public function updateNotifyAdminActivityLogReset(): void
+    {
+        $this->notifier->notify('NOTIFY_ADMIN_FIRE_LOG_WRITER_RESET');
     }
-  }
-
-  /**
-   * @since ZC v1.5.4
-   */
-  public function updateNotifyAdminActivityLogReset()
-  {
-    $this->notifier->notify('NOTIFY_ADMIN_FIRE_LOG_WRITER_RESET');
-  }
 
 }
 
@@ -198,9 +202,9 @@ class zcObserverLogEventListener extends base {
  * @since ZC v1.5.4
  */
 if (!function_exists('zen_record_admin_activity')) {
-  function zen_record_admin_activity($message, $severity)
-  {
-    global $zco_notifier;
-    $zco_notifier->notify('NOTIFY_ADMIN_ACTIVITY_LOG_EVENT', $message, $severity);
-  }
+    function zen_record_admin_activity($message, $severity): void
+    {
+        global $zco_notifier;
+        $zco_notifier->notify('NOTIFY_ADMIN_ACTIVITY_LOG_EVENT', $message, $severity);
+    }
 }

--- a/admin/includes/classes/class.admin.zcObserverLogWriterDatabase.php
+++ b/admin/includes/classes/class.admin.zcObserverLogWriterDatabase.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -74,7 +76,7 @@ class zcObserverLogWriterDatabase
                 'admin_id' => (int)$admin_id,
                 'page_accessed' =>  'Log found to be empty. Logging started.',
                 'page_parameters' => '',
-                'ip_address' => $db->prepare_input(substr($_SERVER['REMOTE_ADDR'],0,45)),
+                'ip_address' => $db->prepare_input(substr($_SERVER['REMOTE_ADDR'], 0, 45)),
                 'gzpost' => '',
                 'flagged' => 0,
                 'attention' => '',

--- a/admin/includes/classes/class.admin.zcObserverLogWriterTextfile.php
+++ b/admin/includes/classes/class.admin.zcObserverLogWriterTextfile.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -9,109 +11,111 @@
  * @since ZC v1.5.4
  */
 
-class zcObserverLogWriterTextfile extends base {
+class zcObserverLogWriterTextfile extends base
+{
+    private string $destinationLogFilename = '';
+    private notifier $notifier;
 
-  private $destinationLogFilename = '';
-  private $notifier;
+    public function __construct(?notifier $zco_notifier = null)
+    {
+        if (!$zco_notifier) {
+            $zco_notifier = new notifier();
+        }
+        $this->notifier = $zco_notifier;
+        $this->notifier->attach($this, ['NOTIFY_ADMIN_FIRE_LOG_WRITERS', 'NOTIFY_ADMIN_FIRE_LOG_WRITER_RESET']);
+        $this->setLogFilename();
+    }
 
-  public function __construct(?notifier $zco_notifier = null) {
-    if (!$zco_notifier) $zco_notifier = new notifier;
-    $this->notifier = $zco_notifier;
-    $this->notifier->attach($this, array('NOTIFY_ADMIN_FIRE_LOG_WRITERS', 'NOTIFY_ADMIN_FIRE_LOG_WRITER_RESET'));
-    $this->setLogFilename();
-  }
-
-  /**
-   * Set the folderpath on the filesystem where the data will be logged
-   * @since ZC v1.5.4
-   */
-  public function setLogFilename($filepath = '')
-  {
-    if ($filepath == '') $filepath = DIR_FS_LOGS . '/admin_log.txt';
-
-    $this->destinationLogFilename = $filepath;
-  }
-
-  /**
-   * @since ZC v1.5.4
-   */
-  public function updateNotifyAdminFireLogWriters(&$class, $eventID, $log_data)
-  {
-    $this->initLogFile();
     /**
-     * The observer's $paramsArray contains the data passed to the notifier hook.
-     * That data is json-encoded here, and then stored to
-     * a custom specified text file on the filesystem using PHP error_log() function.
+     * Set the folderpath on the filesystem where the data will be logged
+     * @since ZC v1.5.4
      */
-    $data = json_encode($log_data);
-
-    error_log($log_data['severity'] . ' [' . date('M-d-Y H:i:s') . '] ' . $log_data['ip_address'] . ' ' . $data . "\n", 3, $this->destinationLogFilename);
-  }
-
-  /**
-   * PCI requires that if the log is blank, that the logs be initialized
-   * So this tests whether the logging file exists, creates it if necessary, and
-   * then if the file is empty initializes it
-   * @since ZC v1.5.4
-   */
-  public function initLogFile()
-  {
-    $init_required = false;
-    if (!file_exists($this->destinationLogFilename))
+    public function setLogFilename(string $filepath = ''): void
     {
-      touch($this->destinationLogFilename);
-      $init_required = true;
-    } else {
-      $val = file_get_contents($this->destinationLogFilename, false, null, 0, 100);
-      if ($val === false || strlen($val) < 20) {
-        $init_required = true;
-      }
-    }
-    if ($init_required)
-    {
-      /**
-       * builds a json-encoded array here, for consistency with normal logging
-       * @since ZC v1.5.4
-       */
-      $admin_id = (isset($_SESSION['admin_id'])) ? $_SESSION['admin_id'] : 0;
-      $data = array('access_date' => date('M-d-Y H:i:s'),
-              'admin_id' => (int)$admin_id,
-              'page_accessed' =>  'Log found to be empty. Logging started.',
-              'page_parameters' => '',
-              'ip_address' => substr($_SERVER['REMOTE_ADDR'],0,45),
-              'gzpost' => '',
-              'flagged' => 0,
-              'attention' => '',
-              'severity' => 'notice',
-      );
-      $data = json_encode($data);
+        if ($filepath === '') {
+            $filepath = DIR_FS_LOGS . '/admin_log.txt';
+        }
 
-      error_log('notice [' . date('M-d-Y H:i:s') . '] ' . substr($_SERVER['REMOTE_ADDR'],0,45) . ' ' . $data . "\n", 3, $this->destinationLogFilename);
-    }
-  }
-
-  public function updateNotifyAdminFireLogWriterReset()
-  {
-    if (file_exists($this->destinationLogFilename))
-    {
-      unlink($this->destinationLogFilename);
+        $this->destinationLogFilename = $filepath;
     }
 
-    $admname = '{' . preg_replace('/[^\w]/', '*', zen_get_admin_name() ?? '[Unknown/NotLoggedIn]') . '[' . (int)$_SESSION['admin_id'] . ']}';
-    $admin_id = (isset($_SESSION['admin_id'])) ? $_SESSION['admin_id'] : 0;
-    $data = array('access_date' => date('M-d-Y H:i:s'),
+    /**
+     * @since ZC v1.5.4
+     */
+    public function updateNotifyAdminFireLogWriters(&$class, $eventID, $log_data): void
+    {
+        $this->initLogFile();
+        /**
+         * The observer's $paramsArray contains the data passed to the notifier hook.
+         * That data is json-encoded here, and then stored to
+         * a custom specified text file on the filesystem using PHP error_log() function.
+         */
+        $data = json_encode($log_data);
+
+        error_log($log_data['severity'] . ' [' . date('M-d-Y H:i:s') . '] ' . $log_data['ip_address'] . ' ' . $data . "\n", 3, $this->destinationLogFilename);
+    }
+
+    /**
+     * PCI requires that if the log is blank, that the logs be initialized
+     * So this tests whether the logging file exists, creates it if necessary, and
+     * then if the file is empty initializes it
+     * @since ZC v1.5.4
+     */
+    public function initLogFile(): void
+    {
+        $init_required = false;
+        if (!file_exists($this->destinationLogFilename)) {
+            touch($this->destinationLogFilename);
+            $init_required = true;
+        } else {
+            $val = file_get_contents($this->destinationLogFilename, false, null, 0, 100);
+            if ($val === false || strlen($val) < 20) {
+                $init_required = true;
+            }
+        }
+        if ($init_required) {
+            /**
+             * builds a json-encoded array here, for consistency with normal logging
+             * @since ZC v1.5.4
+             */
+            $admin_id = $_SESSION['admin_id'] ?? 0;
+            $data = ['access_date' => date('M-d-Y H:i:s'),
+                'admin_id' => (int)$admin_id,
+                'page_accessed' =>  'Log found to be empty. Logging started.',
+                'page_parameters' => '',
+                'ip_address' => substr($_SERVER['REMOTE_ADDR'], 0, 45),
+                'gzpost' => '',
+                'flagged' => 0,
+                'attention' => '',
+                'severity' => 'notice',
+            ];
+            $data = json_encode($data);
+
+            error_log('notice [' . date('M-d-Y H:i:s') . '] ' . substr($_SERVER['REMOTE_ADDR'], 0, 45) . ' ' . $data . "\n", 3, $this->destinationLogFilename);
+        }
+    }
+
+    public function updateNotifyAdminFireLogWriterReset(): void
+    {
+        if (file_exists($this->destinationLogFilename)) {
+            unlink($this->destinationLogFilename);
+        }
+
+        $admname = '{' . preg_replace('/[^\w]/', '*', zen_get_admin_name() ?? '[Unknown/NotLoggedIn]') . '[' . (int)$_SESSION['admin_id'] . ']}';
+        $admin_id = $_SESSION['admin_id'] ?? 0;
+        $data = ['access_date' => date('M-d-Y H:i:s'),
             'admin_id' => (int)$admin_id,
             'page_accessed' =>  'Log reset by ' . $admname . '.',
             'page_parameters' => '',
-            'ip_address' => substr($_SERVER['REMOTE_ADDR'],0,45),
+            'ip_address' => substr($_SERVER['REMOTE_ADDR'], 0, 45),
             'gzpost' => '',
             'flagged' => 0,
             'attention' => '',
             'severity' => 'warning',
             'logmessage' =>  'Log reset by ' . $admname . '.',
-      );
-      $data = json_encode($data);
-      error_log('notice [' . date('M-d-Y H:i:s') . '] ' . substr($_SERVER['REMOTE_ADDR'],0,45) . ' ' . $data . "\n", 3, $this->destinationLogFilename);
-  }
+        ];
+        $data = json_encode($data);
+        error_log('notice [' . date('M-d-Y H:i:s') . '] ' . substr($_SERVER['REMOTE_ADDR'], 0, 45) . ' ' . $data . "\n", 3, $this->destinationLogFilename);
+    }
 
 }

--- a/admin/includes/classes/currencies.php
+++ b/admin/includes/classes/currencies.php
@@ -4,4 +4,4 @@
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  */
 
-include DIR_FS_CATALOG . DIR_WS_CLASSES . 'currencies.php'; 
+include DIR_FS_CATALOG . DIR_WS_CLASSES . 'currencies.php';

--- a/admin/includes/classes/language.php
+++ b/admin/includes/classes/language.php
@@ -6,7 +6,7 @@
  * @version $Id: DrByte 2020 Jul 10 Modified in v1.5.8-alpha $
  */
 if (!defined('IS_ADMIN_FLAG')) {
-  die('Illegal Access');
+    die('Illegal Access');
 }
 /////// NOTE: THIS FILE NO LONGER RELEVANT in v1.5.7 and higher.  PLEASE DELETE FROM YOUR SERVER.
 

--- a/admin/includes/classes/message_stack.php
+++ b/admin/includes/classes/message_stack.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
@@ -85,7 +87,7 @@ class messageStack extends boxTableBlock
     /**
      * @since ZC v1.0.3
      */
-    public function output(string $class='')
+    public function output(string $class = '')
     {
         $this->table_data_parameters = 'class="messageBox"';
         return $this->tableBlock($this->errors);

--- a/admin/includes/classes/object_info.php
+++ b/admin/includes/classes/object_info.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
@@ -14,19 +16,18 @@
 #[AllowDynamicProperties]
 class objectInfo
 {
-    /**
-     * @param $object_array
-     */
+    private array $object_array;
+
     public function __construct($object_array)
     {
         $this->updateObjectInfo($object_array);
     }
 
     /**
-     * @param $object_array array
+     * @param array $object_array
      * @since ZC v1.0.3
      */
-    public function objectInfo($object_array)
+    public function objectInfo($object_array): void
     {
         if (!is_array($object_array)) {
             return;
@@ -39,10 +40,10 @@ class objectInfo
     }
 
     /**
-     * @param $object_array array
+     * @param array $object_array
      * @since ZC v1.5.5
      */
-    public function updateObjectInfo($object_array)
+    public function updateObjectInfo($object_array): void
     {
         if (!is_array($object_array)) {
             return;
@@ -56,7 +57,7 @@ class objectInfo
     /**
      * @since ZC v1.5.6
      */
-    public function __isset($field)
+    public function __isset(string $field)
     {
         return isset($this->$field);
     }
@@ -64,23 +65,22 @@ class objectInfo
     /**
      * @since ZC v1.5.6
      */
-    public function __set($field, $value)
+    public function __set(string $field, mixed $value)
     {
         $this->$field = $value;
     }
 
     /**
-     * @param $field
-     * @return array|string
+     * @return array|string|null
      * @since ZC v1.5.6
      */
-    public function __get($field)
+    public function __get(string $field): mixed
     {
         if (isset($this->$field)) {
             return $this->$field;
         }
 
-        if ($field == 'keys') {
+        if ($field === 'keys') {
             return [];
         }
 

--- a/admin/includes/classes/observers/auto.search_box.php
+++ b/admin/includes/classes/observers/auto.search_box.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -10,18 +12,15 @@ class zcObserverSearchBox extends base
 {
     public function __construct()
     {
-        $this->attach(
-            $this,
-            [
-                'NOTIFY_BUILD_KEYWORD_SEARCH',
-            ]
-        );
+        $this->attach($this, [
+            'NOTIFY_BUILD_KEYWORD_SEARCH',
+            ]);
     }
 
     /**
      * @since ZC v1.5.8a
      */
-    public function update(&$class, $eventID, &$p1, &$p2, &$p3, &$p4)
+    public function update(&$class, $eventID, &$p1, &$p2, &$p3, &$p4): void
     {
         switch ($eventID) {
             case 'NOTIFY_BUILD_KEYWORD_SEARCH':

--- a/admin/includes/classes/split_page_results.php
+++ b/admin/includes/classes/split_page_results.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
@@ -11,95 +13,57 @@
  */
 class splitPageResults
 {
-    /**
-     * @var int
-     */
-    protected $num_pages;
-    /**
-     * @var string
-     */
-    protected $page_sql = '';
-    /**
-     * @var array
-     */
-    protected $pages_array = [];
-    /**
-     * @var int
-     */
-    protected $nextPage;
-    /**
-     * @var int
-     */
-    protected $previousPage;
-    /**
-     * @var string
-     */
-    protected $sql_after = '';
-    /**
-     * @var string
-     */
-    protected $sql_before = '';
-    /**
-     * @var string
-     */
-    protected $raw_sql_query = '';
+    protected int|float $num_pages;
+    protected string $page_sql = '';
+    protected array $pages_array = [];
+    protected mixed $nextPage;
+    protected mixed $previousPage;
+    protected string $sql_after = '';
+    protected string|array|null $sql_before = '';
+    protected string|array|null $raw_sql_query = '';
     /**
      * Paginate-by-letter mode
      * Enabled by setting $letterGroupColumn, and optionally $letterGrouplength
-     *
-     * @var bool
      */
-    protected $paginateByLetter = false;
+    protected bool $paginateByLetter = false;
     /**
      * If a field name is passed here, then pages will not be numbered, but rather grouped by results starting with same the first letter.
      * (Set $letterGroupLength to > 1 to group on more than 1 character)
-     *
-     * @var string
      */
-    protected $letterGroupColumn = '';
+    protected string $letterGroupColumn = '';
     /**
      * Specifies the number of characters to group pages by if $letterGroupColumn is specified.
      * Default is -1 for no grouping. Or 1 if $letterGroupColumn is set but no length specified.
-     * @var int
      */
-    protected $letterGroupLength = 1;
-
-    /**
-     * @var int
-     */
-    protected $totalByLetter = 0;
+    protected int $letterGroupLength = 1;
+    protected int $totalByLetter = 0;
     /**
      * The current page number
-     * @var int
      */
-    protected $current_page_number;
-   /**
-     * The total number of rows
-     * @var int
-     */
-    protected $number_of_rows;
+    protected int $current_page_number;
+    /**
+      * The total number of rows
+      */
+    protected int $number_of_rows;
     /**
      * The maximum number of rows to display on a page
-     * @var int
      */
-    protected $number_of_rows_per_page;
+    protected int $number_of_rows_per_page;
 
     /**
-     * @param int $current_page_number
-     * @param int $max_rows_per_page
-     * @param string $sql_query
-     * @param int $query_num_rows
      * @param string $letterGroupColumn column name to build letter-nav from (optional)
      * @param int $letterGroupLength number of characters to sort/filter on for letterGroupColumn
      */
-    public function __construct(&$current_page_number, $max_rows_per_page, &$sql_query, &$query_num_rows, $letterGroupColumn = '', $letterGroupLength = 0)
+    public function __construct(int|string &$current_page_number, int $max_rows_per_page, string &$sql_query, int &$query_num_rows, string $letterGroupColumn = '', int $letterGroupLength = 0)
     {
         global $db;
 
         $this->letterGroupColumn = zen_db_input($letterGroupColumn);
         if (!empty($letterGroupColumn)) {
             $this->paginateByLetter = true;
-            if (empty($letterGroupLength)) $letterGroupLength = 1;
+            if (empty($letterGroupLength)) {
+                $letterGroupLength = 1;
+            }
         }
         $this->letterGroupLength = (int)$letterGroupLength;
 
@@ -123,25 +87,37 @@ class splitPageResults
 
         // find end of where clause
         $pos_group_by = strpos($query_upper, ' GROUP BY', $pos_search);
-        if (($pos_group_by < $pos_to) && ($pos_group_by != false)) $pos_to = $pos_group_by;
+        if (($pos_group_by < $pos_to) && ($pos_group_by !== false)) {
+            $pos_to = $pos_group_by;
+        }
 
         $pos_having = strpos($query_upper, ' HAVING', $pos_search);
-        if (($pos_having < $pos_to) && ($pos_having != false)) $pos_to = $pos_having;
+        if (($pos_having < $pos_to) && ($pos_having !== false)) {
+            $pos_to = $pos_having;
+        }
 
         $pos_order_by = strpos($query_upper, ' ORDER BY', $pos_search);
-        if (($pos_order_by < $pos_to) && ($pos_order_by != false)) $pos_to = $pos_order_by;
+        if (($pos_order_by < $pos_to) && ($pos_order_by !== false)) {
+            $pos_to = $pos_order_by;
+        }
 
-        $query_num_rows = $this->numberRows($sql_query);
+        $query_num_rows = self::numberRows($sql_query);
 
         // Default behaviour
         if ($this->paginateByLetter === false) {
-            if (empty($max_rows_per_page)) $max_rows_per_page = $query_num_rows;
-            if ($query_num_rows == 0) $max_rows_per_page = 1;
+            if (empty($max_rows_per_page)) {
+                $max_rows_per_page = $query_num_rows;
+            }
+            if ($query_num_rows === 0) {
+                $max_rows_per_page = 1;
+            }
 
-            if (empty($current_page_number)) $current_page_number = 1;
+            if (empty($current_page_number)) {
+                $current_page_number = 1;
+            }
             $current_page_number = (int)$current_page_number;
 
-            $num_pages = ceil($query_num_rows / $max_rows_per_page);
+            $num_pages = (int)ceil($query_num_rows / $max_rows_per_page);
             if ($current_page_number > $num_pages) {
                 $current_page_number = $num_pages;
             }
@@ -163,8 +139,12 @@ class splitPageResults
 
             $this->num_pages = $num_pages;
 
-            if ($current_page_number > 1) $this->previousPage = $current_page_number - 1;
-            if ($current_page_number < $num_pages) $this->nextPage = $current_page_number + 1;
+            if ($current_page_number > 1) {
+                $this->previousPage = $current_page_number - 1;
+            }
+            if ($current_page_number < $num_pages) {
+                $this->nextPage = $current_page_number + 1;
+            }
 
         } else {
             // first store the total results number for display later.
@@ -180,7 +160,9 @@ class splitPageResults
 
             $this->num_pages = $num_pages = $pages_by_letter->RecordCount();
 
-            if (empty($current_page_number) && $current_page_number !== '0') $current_page_number = $pages_by_letter->fields['letter'];
+            if (empty($current_page_number) && $current_page_number !== 0) {
+                $current_page_number = $pages_by_letter->fields['letter'];
+            }
 
             foreach ($pages_by_letter as $page) {
                 if ($page['letter'] < $current_page_number) {
@@ -203,22 +185,21 @@ class splitPageResults
             $sql .= $this->sql_after;
 
             $sql_query = $sql;
-            $query_num_rows = $this->numberRows($sql_query);
+            $query_num_rows = self::numberRows($sql_query);
         }
     }
     /**
-     * NOTE:  Takes a query and counts the number of rows in that query.
+     * Takes a query and counts the number of rows in that query.
      *
-     * @param string $sql
-     * @return int
      * @since ZC v1.5.8
      */
 
-    private function numberRows(string $sql) {
+    private static function numberRows(string $sql): int
+    {
         global $db;
         // the following line makes use of a CTE which is only available with mysql 8 or mariadb-10.x
-//        $countSQL = 'WITH countresults AS (' . $sql . ') SELECT count(*) as total FROM countresults';
-        $countSQL = 'SELECT count(*) as total FROM (' . $sql . ') countresults';
+        //        $countSQL = 'WITH countresults AS (' . $sql . ') SELECT count(*) as total FROM countresults';
+        $countSQL = 'SELECT count(*) AS total FROM (' . $sql . ') countresults';
 
         try {
             $count_result = $db->Execute($countSQL);
@@ -228,20 +209,15 @@ class splitPageResults
         if ((is_object($count_result) && $count_result->EOF) || !empty($e)) {
             return 0;
         }
-        return (int) $count_result->fields['total'];
+        return (int)$count_result->fields['total'];
     }
 
     /**
      * NOTE: This causes the queries to be run multiple times on the same page. Could be slow with very complex joins or large numbers of records in results.
      *
-     * @param int $current_page_number
-     * @param int $max_rows_per_page
-     * @param string $sql_query
-     * @param string $criteria_field
-     * @param string $criteria_value
      * @since ZC v1.5.8
      */
-    public function findPage(&$current_page_number, $max_rows_per_page, &$sql_query, $criteria_field, $criteria_value)
+    public function findPage(int &$current_page_number, int $max_rows_per_page, string &$sql_query, string $criteria_field, string $criteria_value)
     {
         global $db;
         if ($this->paginateByLetter === true) {
@@ -249,7 +225,7 @@ class splitPageResults
             $sql = $this->page_sql . ' ' . zen_db_input($criteria_field) . "='" . zen_db_input($criteria_value) . "'";
             $check_page = $db->Execute($sql);
             $letter = $check_page->fields['letter'];
-            $sql_query = $this->sql_before;
+            $sql_query = (string)$this->sql_before;
             if (!empty($letter)) {
                 $sql_query .= "SUBSTRING(" . $this->letterGroupColumn . ", 1, " . $this->letterGroupLength . ") = '" . $letter . "' ";
             } else {
@@ -271,7 +247,9 @@ class splitPageResults
                 $cfield = substr($cfield, 1);
             }
 
-            if (empty($max_rows_per_page)) $max_rows_per_page = 2;
+            if (empty($max_rows_per_page)) {
+                $max_rows_per_page = 2;
+            }
 
             if ($check_page->RecordCount() > $max_rows_per_page) {
                 foreach ($check_page as $page) {
@@ -281,8 +259,8 @@ class splitPageResults
                     $check_count++;
                 }
             }
-            $sql_query = $this->sql_before;
-            $current_page_number = ceil($check_count / $max_rows_per_page) + 1;
+            $sql_query = (string)$this->sql_before;
+            $current_page_number = (int)ceil($check_count / $max_rows_per_page) + 1;
             $offset = ($max_rows_per_page * ($current_page_number - 1));
             $sql_query .= " LIMIT " . $offset . ", " . $max_rows_per_page;
         }
@@ -290,26 +268,25 @@ class splitPageResults
 
 
     /**
-     * @param int $query_numrows
-     * @param int $max_rows_per_page
-     * @param int $max_page_links
-     * @param int $current_page_number
      * @param string $parameters form URI parameters
      * @param string $page_name $_GET param for page number
-     * @return string
      * @since ZC v1.0.3
      */
-    public function display_links($query_numrows, $max_rows_per_page, $max_page_links, $current_page_number, $parameters = '', $page_name = 'page')
+    public function display_links(int $query_numrows, int $max_rows_per_page, int $max_page_links, int|string $current_page_number, string $parameters = '', string $page_name = 'page'): string
     {
         global $PHP_SELF;
 
         $displayAsDropdown = (!$this->paginateByLetter || $this->letterGroupLength !== 1);
 
-        if (!empty($parameters) && substr($parameters, -1) != '&') $parameters .= '&';
+        if (!empty($parameters) && !str_ends_with($parameters, '&')) {
+            $parameters .= '&';
+        }
 
         if ($this->num_pages > 1) {
             $display_links = '';
-            if ($displayAsDropdown) $display_links .= zen_draw_form('pages', basename($PHP_SELF, '.php'), '', 'get');
+            if ($displayAsDropdown) {
+                $display_links .= zen_draw_form('pages', basename($PHP_SELF, '.php'), '', 'get');
+            }
 
             if (!empty($this->previousPage)) {
                 $display_links .= '<a href="' . zen_href_link(basename($PHP_SELF), $parameters . $page_name . '=' . $this->previousPage) . '" class="splitPageLink">' . PREVNEXT_BUTTON_PREV . '</a>&nbsp;&nbsp;';
@@ -320,7 +297,7 @@ class splitPageResults
             if ($displayAsDropdown) {
                 $dropdown = zen_draw_pull_down_menu($page_name, $this->pages_array, $current_page_number, 'onChange="this.form.submit();"');
                 $display_links .= $dropdown;
-//                $display_links .= sprintf(TEXT_RESULT_PAGE, $dropdown, $this->num_pages);
+                // $display_links .= sprintf(TEXT_RESULT_PAGE, $dropdown, $this->num_pages);
             } else {
                 foreach ($this->pages_array as $page_id) {
                     $display_links .= '<a href="' . zen_href_link(basename($PHP_SELF), $parameters . $page_name . '=' . $page_id['id']) . '" class="splitPageLink' . ($page_id['id'] === $current_page_number ? ' splitPageLinkCurrent' : '') . '">' . $page_id['id'] . '</a>&nbsp;&nbsp;';
@@ -330,7 +307,7 @@ class splitPageResults
             if (!empty($this->nextPage)) {
                 $display_links .= '&nbsp;&nbsp;<a href="' . zen_href_link(basename($PHP_SELF), $parameters . $page_name . '=' . $this->nextPage) . '" class="splitPageLink">' . PREVNEXT_BUTTON_NEXT . '</a>';
             } else {
-                $display_links .='<span style="visibility:hidden;">' .  '&nbsp;&nbsp;' . PREVNEXT_BUTTON_NEXT . '</span>';
+                $display_links .= '<span style="visibility:hidden;">' . '&nbsp;&nbsp;' . PREVNEXT_BUTTON_NEXT . '</span>';
             }
             if ($displayAsDropdown) {
                 if (!empty($parameters)) {
@@ -342,7 +319,7 @@ class splitPageResults
                     }
                 }
 
-                if (PHP_VERSION_ID < 80401 && defined('SID') && !empty(constant('SID'))) {
+                if (\PHP_VERSION_ID < 80401 && defined('SID') && !empty(constant('SID'))) {
                     $display_links .= zen_draw_hidden_field(zen_session_name(), zen_session_id());
                 }
 
@@ -356,23 +333,22 @@ class splitPageResults
     }
 
     /**
-     * @param int $query_numrows
-     * @param int $max_rows_per_page
-     * @param int $current_page_number
-     * @param string $text_output
-     * @return string
      * @since ZC v1.0.3
      */
-    public function display_count($query_numrows, $max_rows_per_page, $current_page_number, $text_output)
+    public function display_count(int $query_numrows, int $max_rows_per_page, int|string $current_page_number, string $text_output): string
     {
         if ($this->paginateByLetter) {
             return sprintf($text_output, $query_numrows, $this->totalByLetter);
         }
 
         $current_page_number = (int)$current_page_number;
-        if ($max_rows_per_page == 0) $max_rows_per_page = 20;
+        if ($max_rows_per_page === 0) {
+            $max_rows_per_page = 20;
+        }
         $to_num = ($max_rows_per_page * $current_page_number);
-        if ($to_num > $query_numrows) $to_num = $query_numrows;
+        if ($to_num > $query_numrows) {
+            $to_num = $query_numrows;
+        }
         $from_num = ($max_rows_per_page * ($current_page_number - 1));
         if ($to_num === 0) {
             $from_num = 0;

--- a/admin/includes/classes/stats_sales_report_graph.php
+++ b/admin/includes/classes/stats_sales_report_graph.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -11,15 +12,15 @@ declare(strict_types=1);
 
 class statsSalesReportGraph
 {
-    const HOURLY_VIEW = 1;
-    const DAILY_VIEW = 2;
-    const WEEKLY_VIEW = 3;
-    const MONTHLY_VIEW = 4;
-    const QUARTERLY_VIEW = 6;
-    const YEARLY_VIEW = 5;
+    public const int HOURLY_VIEW = 1;
+    public const int DAILY_VIEW = 2;
+    public const int WEEKLY_VIEW = 3;
+    public const int MONTHLY_VIEW = 4;
+    public const int QUARTERLY_VIEW = 6;
+    public const int YEARLY_VIEW = 5;
 
     /** @var int Number of years to look backward in yearly mode */
-    const LOOKBACK_YEARS = 10;
+    public const int LOOKBACK_YEARS = 10;
 
     protected int $mode = self::MONTHLY_VIEW;
     protected int|false $globalStartDate;
@@ -36,7 +37,7 @@ class statsSalesReportGraph
     public string $filter_sql = '';
     public array $status_available = [];
     public int $status_available_size = 0;
-    public $size = 0;
+    public int $size = 0;
 
     /**
      * statsSalesReportGraph constructor.
@@ -83,10 +84,10 @@ class statsSalesReportGraph
             $startDate = (int)$startDate;
             $endDate = (int)$endDate;
             if ($endDate > $this->mktime(0, 0, 0, date('m'), date('d'), date('Y'))) {
-                $this->endDate = $this->mktime(0, 0, 0, date('m'), date('d') + 1, date('Y'));
+                $this->endDate = $this->mktime(0, 0, 0, date('m'), (int)date('d') + 1, date('Y'));
             } else {
                 // set endDate to the given Date with "round" on days
-                $this->endDate = $this->mktime(0, 0, 0, date('m', $endDate), date('d', $endDate) + 1, date('Y', $endDate));
+                $this->endDate = $this->mktime(0, 0, 0, date('m', $endDate), (int)date('d', $endDate) + 1, date('Y', $endDate));
             }
         }
         switch ($this->mode) {
@@ -94,7 +95,7 @@ class statsSalesReportGraph
                 if ($dateGiven === true) {
                     // "round" to midnight
                     $this->startDate = $this->mktime(0, 0, 0, date('m', $startDate), date('d', $startDate), date('Y', $startDate));
-                    $this->endDate = $this->mktime(0, 0, 0, date('m', $startDate), date('d', $startDate) + 1, date('Y', $startDate));
+                    $this->endDate = $this->mktime(0, 0, 0, date('m', $startDate), (int)date('d', $startDate) + 1, date('Y', $startDate));
                     // size to number of hours
                     $this->size = 24;
                 } else {
@@ -102,7 +103,7 @@ class statsSalesReportGraph
                     $this->startDate = $this->mktime(0, 0, 0, date('m'), date('d'), date('Y'));
                     $this->endDate = $this->mktime((int)date('G') + 1, 0, 0, date('m'), date('d'), date('Y'));
                     // size to number of hours
-                    $this->size = date('G') + 1;
+                    $this->size = (int)date('G') + 1;
                     if ($this->startDate < $this->globalStartDate) {
                         $this->startDate = $this->globalStartDate;
                     }
@@ -122,16 +123,16 @@ class statsSalesReportGraph
                 } else {
                     // startDate to start of this week
                     $this->startDate = $this->mktime(0, 0, 0, date('m'), date('d') - date('w'), date('Y'));
-                    $this->endDate = $this->mktime(0, 0, 0, date('m'), date('d') + 1, date('Y'));
+                    $this->endDate = $this->mktime(0, 0, 0, date('m'), (int)date('d') + 1, date('Y'));
                     // size to number of days
-                    $this->size = date('w') + 1;
+                    $this->size = (int)date('w') + 1;
                     if ($this->startDate < $this->globalStartDate) {
                         $this->startDate = $this->globalStartDate;
                     }
                 }
                 for ($i = 0; $i < $this->size; $i++) {
-                    $this->startDates[$i] = $this->mktime(0, 0, 0, date('m', $this->startDate), date('d', $this->startDate) + $i, date('Y', $this->startDate));
-                    $this->endDates[$i] = $this->mktime(0, 0, 0, date('m', $this->startDate), date('d', $this->startDate) + $i + 1, date('Y', $this->startDate));
+                    $this->startDates[$i] = $this->mktime(0, 0, 0, date('m', $this->startDate), (int)date('d', $this->startDate) + $i, date('Y', $this->startDate));
+                    $this->endDates[$i] = $this->mktime(0, 0, 0, date('m', $this->startDate), (int)date('d', $this->startDate) + $i + 1, date('Y', $this->startDate));
                 }
                 break;
 
@@ -147,10 +148,10 @@ class statsSalesReportGraph
                     $this->startDate = $this->globalStartDate;
                 }
                 // size to the number of weeks in this month till endDate
-                $this->size = ceil((($this->endDate - $this->startDate + 1) / (60 * 60 * 24)) / 7);
+                $this->size = (int)ceil((($this->endDate - $this->startDate + 1) / (60 * 60 * 24)) / 7);
                 for ($i = 0; $i < $this->size; $i++) {
-                    $this->startDates[$i] = $this->mktime(0, 0, 0, date('m', $this->startDate), date('d', $this->startDate) +  $i * 7, date('Y', $this->startDate));
-                    $this->endDates[$i] = $this->mktime(0, 0, 0, date('m', $this->startDate), date('d', $this->startDate) + ($i + 1) * 7, date('Y', $this->startDate));
+                    $this->startDates[$i] = $this->mktime(0, 0, 0, date('m', $this->startDate), (int)date('d', $this->startDate) +  $i * 7, date('Y', $this->startDate));
+                    $this->endDates[$i] = $this->mktime(0, 0, 0, date('m', $this->startDate), (int)date('d', $this->startDate) + ($i + 1) * 7, date('Y', $this->startDate));
                 }
                 break;
 
@@ -166,9 +167,9 @@ class statsSalesReportGraph
                 if ($this->startDate < $this->globalStartDate) {
                     $this->startDate = $this->mktime(0, 0, 0, date('m', $this->globalStartDate), 1, date('Y', $this->globalStartDate));
                 }
-                $this->size = (date('Y', $this->endDate) - date('Y', $this->startDate)) * 12 + (date('m', $this->endDate) - date('m', $this->startDate)) + 1;
-                $tmpMonth = date('m', $this->startDate);
-                $tmpYear = date('Y', $this->startDate);
+                $this->size = ((int)date('Y', $this->endDate) - (int)date('Y', $this->startDate)) * 12 + ((int)date('m', $this->endDate) - (int)date('m', $this->startDate)) + 1;
+                $tmpMonth = (int)date('m', $this->startDate);
+                $tmpYear = (int)date('Y', $this->startDate);
                 for ($i = 0; $i < $this->size; $i++) {
                     // the first of the $tmpMonth + $i
                     $this->startDates[$i] = $this->mktime(0, 0, 0, $tmpMonth + $i, 1, $tmpYear);
@@ -179,19 +180,19 @@ class statsSalesReportGraph
 
             case self::YEARLY_VIEW:
                 if ($dateGiven === true) {
-                    $this->startDate = $this->mktime(0, 0, 0, 1, 1, date('Y', $startDate));
-                    $this->endDate = $this->mktime(0, 0, 0, 1, 1, date('Y', $endDate) + 1);
+                    $this->startDate = $this->mktime(0, 0, 0, 1, 1, (int)date('Y', $startDate));
+                    $this->endDate = $this->mktime(0, 0, 0, 1, 1, (int)date('Y', $endDate) + 1);
                 } else {
                     // startDate to first of current year minus self::LOOKBACK_YEARS
-                    $this->startDate = $this->mktime(0, 0, 0, 1, 1, date('Y') - self::LOOKBACK_YEARS);
+                    $this->startDate = $this->mktime(0, 0, 0, 1, 1, (int)date('Y') - self::LOOKBACK_YEARS);
                     // endDate to today
                     $this->endDate = $this->mktime(0, 0, 0, date('m'), date('d'), date('Y'));
                 }
                 if ($this->startDate < $this->globalStartDate) {
                     $this->startDate = $this->globalStartDate;
                 }
-                $this->size = date('Y', $this->endDate) - date('Y', $this->startDate) + 1;
-                $tmpYear = date('Y', $this->startDate);
+                $this->size = (int)date('Y', $this->endDate) - (int)date('Y', $this->startDate) + 1;
+                $tmpYear = (int)date('Y', $this->startDate);
                 for ($i = 0; $i < $this->size; $i++) {
                     $this->startDates[$i] = $this->mktime(0, 0, 0, 1, 1, $tmpYear + $i);
                     $this->endDates[$i] = $this->mktime(0, 0, 0, 1, 1, $tmpYear + $i + 1);
@@ -202,12 +203,13 @@ class statsSalesReportGraph
         if (in_array($this->mode, [self::HOURLY_VIEW, self::DAILY_VIEW, self::WEEKLY_VIEW], true)) {
             // set previous to start - diff
             $tmpDiff = $this->endDate - $this->startDate;
-            if ($this->size == 0) {
+            if ($this->size === 0) {
                 $tmpUnit = 0;
             } else {
                 $tmpUnit = $tmpDiff / $this->size;
             }
 
+            $tmp1 = 30 * 24 * 60 * 60;
             switch ($this->mode) {
                 case self::HOURLY_VIEW:
                     $tmp1 =  24 * 60 * 60;
@@ -247,15 +249,15 @@ class statsSalesReportGraph
             $tmpStart = $this->mktime(0, 0, 0, 1, 1, $year);
             $tmpEnd = $this->mktime(0, 0, 0, 12, 1, $year);
             if (date('Y', $tmpStart) >= date('Y', $this->globalStartDate)) {
-               $this->previous = "report=" . $this->mode . "&startDate=" . $tmpStart . "&endDate=" . $tmpEnd;
+                $this->previous = "report=" . $this->mode . "&startDate=" . $tmpStart . "&endDate=" . $tmpEnd;
             }
 
             // compute next link if data is there
-            $year = date('Y', $this->startDate) + 1;
+            $year = (int)date('Y', $this->startDate) + 1;
             $tmpStart = $this->mktime(0, 0, 0, 1, 1, $year);
             $tmpEnd = $this->mktime(0, 0, 0, 12, 1, $year);
             if (date('Y', $tmpEnd) <= date('Y')) {
-               $this->next= "report=" . $this->mode . "&startDate=" . $tmpStart . "&endDate=" . $tmpEnd;
+                $this->next = "report=" . $this->mode . "&startDate=" . $tmpStart . "&endDate=" . $tmpEnd;
             }
         }
 
@@ -264,11 +266,11 @@ class statsSalesReportGraph
         // 01001 means use filter for status 2 and 5 set.
         $tmp = '';
         $tmp1 = '';
-        if (is_string($filter) && strlen($filter) > 0) {
+        if (is_string($filter) && $filter !== '') {
             for ($i = 0; $i < $this->status_available_size; $i++) {
                 if (substr($filter, $i, 1) === '1') {
                     $tmp1 .= '1';
-                    if (strlen($tmp) === 0) {
+                    if ($tmp === '') {
                         $tmp = "o.orders_status <> " . $this->status_available[$i]['id'];
                     } else {
                         $tmp .= " and o.orders_status <> " . $this->status_available[$i]['id'];
@@ -314,7 +316,7 @@ class statsSalesReportGraph
                FROM " . TABLE_ORDERS_TOTAL . " ot, " . TABLE_ORDERS . " o
               WHERE ot.orders_id = o.orders_id
                 AND ot.class = 'ot_subtotal'";
-        if (strlen($this->filter_sql) > 0) {
+        if ($this->filter_sql !== '') {
             $tmp_query .= " AND (" . $this->filter_sql . ")";
         }
         for ($i = 0; $i < $this->size; $i++) {

--- a/admin/includes/classes/table_block.php
+++ b/admin/includes/classes/table_block.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
@@ -15,7 +17,7 @@ class boxTableBlock
     /**
      * @since ZC v1.5.5
      */
-    public function tableBlock($contents): string
+    public function tableBlock(array $contents): string
     {
         $tableBox_string = '';
 
@@ -45,9 +47,9 @@ class boxTableBlock
                         $tableBox_string .= '"';
                         $tableBox_string .= '>';
                         if (isset($content['form']) && zen_not_null($content['form'])) {
-                            $tableBox_string .= $contents[$rowKey][$cell]['form'];
+                            $tableBox_string .= $content['form'];
                         }
-                        $tableBox_string .= $contents[$rowKey][$cell]['text'];
+                        $tableBox_string .= $content['text'];
                         if (isset($content['form']) && zen_not_null($content['form'])) {
                             $tableBox_string .= '</form>';
                         }

--- a/admin/modules.php
+++ b/admin/modules.php
@@ -53,7 +53,7 @@ $modules_found = $moduleFinder->findFromFilesystem($installedPlugins);
 
 $notificationType = $module_type . (($_GET['module']) ? '-' . $_GET['module'] : '') ;
 $notifications = new AdminNotifications();
-$availableNotifications = $notifications->getNotifications($notificationType, $_SESSION['admin_id']);
+$availableNotifications = $notifications->getNotifications($notificationType, (int)$_SESSION['admin_id']);
 
 $action = $_GET['action'] ?? '';
 if (!empty($action)) {

--- a/ajax.php
+++ b/ajax.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * ajax front controller
  *
@@ -63,7 +65,7 @@ if (isset($spider_flag) && $spider_flag === true) {
 }
 
 // --- begin support functions ------------------
-function ajaxAbort($status = 400, $msg = null)
+function ajaxAbort($status = 400, $msg = null): void
 {
     global $zc_ajax_base_dir;
     http_response_code($status); // 400 = "Bad Request"

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
         "ext-gd": "*",
         "ext-hash": "*",
         "ext-iconv": "*",
-        "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",

--- a/composer.json
+++ b/composer.json
@@ -30,11 +30,13 @@
         "ext-gd": "*",
         "ext-hash": "*",
         "ext-iconv": "*",
+        "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "ext-pcre": "*",
-        "ext-mysqli": "*"
+        "ext-mysqli": "*",
+        "ext-zlib": "*"
     },
     "require-dev": {
         "ext-pdo": "*",

--- a/includes/classes/Category.php
+++ b/includes/classes/Category.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**

--- a/includes/classes/Category.php
+++ b/includes/classes/Category.php
@@ -197,4 +197,3 @@ class Category
         $this->languages = $lng->get_language_list();  // [1 => 'en', 2 => 'fr']
     }
 }
-

--- a/includes/classes/Console/CommandRegistry.php
+++ b/includes/classes/Console/CommandRegistry.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0

--- a/includes/classes/Console/CommandResolver.php
+++ b/includes/classes/Console/CommandResolver.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -11,9 +13,7 @@ class CommandResolver
     /**
      * @since ZC v3.0.0
      */
-    public function __construct(private CommandRegistry $registry)
-    {
-    }
+    public function __construct(private CommandRegistry $registry) {}
 
     /**
      * @since ZC v3.0.0

--- a/includes/classes/Console/Commands/ConfigGetCommand.php
+++ b/includes/classes/Console/Commands/ConfigGetCommand.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -17,9 +19,7 @@ class ConfigGetCommand extends ConsoleCommand
      *
      * @param null|callable(string): ?array<string, mixed> $configurationProvider
      */
-    public function __construct(private $configurationProvider = null)
-    {
-    }
+    public function __construct(private $configurationProvider = null) {}
 
     /**
      * @since ZC v3.0.0

--- a/includes/classes/Console/Commands/HelpCommand.php
+++ b/includes/classes/Console/Commands/HelpCommand.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -16,9 +18,7 @@ class HelpCommand extends ConsoleCommand
     /**
      * @since ZC v3.0.0
      */
-    public function __construct(private CommandRegistry $registry)
-    {
-    }
+    public function __construct(private CommandRegistry $registry) {}
 
     /**
      * @since ZC v3.0.0

--- a/includes/classes/Console/Commands/ListCommand.php
+++ b/includes/classes/Console/Commands/ListCommand.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -16,9 +18,7 @@ class ListCommand extends ConsoleCommand
     /**
      * @since ZC v3.0.0
      */
-    public function __construct(private CommandRegistry $registry)
-    {
-    }
+    public function __construct(private CommandRegistry $registry) {}
 
     /**
      * @since ZC v3.0.0

--- a/includes/classes/Console/Commands/PluginListCommand.php
+++ b/includes/classes/Console/Commands/PluginListCommand.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -18,9 +20,7 @@ class PluginListCommand extends ConsoleCommand
      *
      * @param null|callable(): ?array<int|string, array<string, mixed>> $pluginProvider
      */
-    public function __construct(private $pluginProvider = null)
-    {
-    }
+    public function __construct(private $pluginProvider = null) {}
 
     /**
      * @since ZC v3.0.0
@@ -78,7 +78,7 @@ class PluginListCommand extends ConsoleCommand
         foreach ($plugins as $plugin) {
             $output->writeln(sprintf(
                 '  %-12s %-24s %-12s %s',
-                $this->formatStatus((int)($plugin['status'] ?? PluginStatus::NOT_INSTALLED)),
+                self::formatStatus((int)($plugin['status'] ?? PluginStatus::NOT_INSTALLED)),
                 (string)($plugin['unique_key'] ?? ''),
                 (string)($plugin['version'] ?? ''),
                 (string)($plugin['name'] ?? $plugin['unique_key'] ?? '')
@@ -91,7 +91,7 @@ class PluginListCommand extends ConsoleCommand
     /**
      * @since ZC v3.0.0
      */
-    private function formatStatus(int $status): string
+    private static function formatStatus(int $status): string
     {
         return match ($status) {
             PluginStatus::ENABLED => 'enabled',

--- a/includes/classes/Console/Commands/VersionShowCommand.php
+++ b/includes/classes/Console/Commands/VersionShowCommand.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -17,9 +19,7 @@ class VersionShowCommand extends ConsoleCommand
      *
      * @param null|callable(): array<string, ?array<string, mixed>> $versionProvider
      */
-    public function __construct(private $versionProvider = null)
-    {
-    }
+    public function __construct(private $versionProvider = null) {}
 
     /**
      * @since ZC v3.0.0
@@ -59,8 +59,8 @@ class VersionShowCommand extends ConsoleCommand
         $main = $rows['Zen-Cart Main'] ?? null;
         $database = $rows['Zen-Cart Database'] ?? null;
 
-        $output->writeln(sprintf('  %-12s %s', 'application', $this->formatVersion($main)));
-        $output->writeln(sprintf('  %-12s %s', 'database', $this->formatVersion($database)));
+        $output->writeln(sprintf('  %-12s %s', 'application', self::formatVersion($main)));
+        $output->writeln(sprintf('  %-12s %s', 'database', self::formatVersion($database)));
 
         return 0;
     }
@@ -68,7 +68,7 @@ class VersionShowCommand extends ConsoleCommand
     /**
      * @since ZC v3.0.0
      */
-    private function formatVersion(?array $version): string
+    private static function formatVersion(?array $version): string
     {
         if ($version === null) {
             return 'unavailable';

--- a/includes/classes/Console/ConsoleCommand.php
+++ b/includes/classes/Console/ConsoleCommand.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0

--- a/includes/classes/Console/ConsoleInput.php
+++ b/includes/classes/Console/ConsoleInput.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -132,7 +134,7 @@ class ConsoleInput
             return;
         }
 
-        if ($this->looksLikeOption($tokens[0])) {
+        if (self::looksLikeOption($tokens[0])) {
             $this->parseTokens($tokens);
             return;
         }
@@ -197,7 +199,7 @@ class ConsoleInput
         }
 
         $nextToken = $tokens[$index + 1] ?? null;
-        if ($nextToken !== null && !$this->looksLikeOption($nextToken)) {
+        if ($nextToken !== null && !self::looksLikeOption($nextToken)) {
             $this->options[$nameValue] = $nextToken;
             $index++;
             return;
@@ -226,7 +228,7 @@ class ConsoleInput
         }
 
         $nextToken = $tokens[$index + 1] ?? null;
-        if ($nextToken !== null && !$this->looksLikeOption($nextToken)) {
+        if ($nextToken !== null && !self::looksLikeOption($nextToken)) {
             $this->options[$flags] = $nextToken;
             $index++;
             return;
@@ -238,7 +240,7 @@ class ConsoleInput
     /**
      * @since ZC v3.0.0
      */
-    private function looksLikeOption(string $token): bool
+    private static function looksLikeOption(string $token): bool
     {
         return $token !== '-' && str_starts_with($token, '-');
     }

--- a/includes/classes/Console/ConsoleKernel.php
+++ b/includes/classes/Console/ConsoleKernel.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -76,16 +78,16 @@ class ConsoleKernel
         }
 
         if ($input->getCommandName() === null && $input->isHelpRequested()) {
-            return $this->executeCommand($command, $input, $output);
+            return self::executeCommand($command, $input, $output);
         }
 
         if ($input->isHelpRequested() && $command->getName() !== 'help') {
             $helpInput = new ConsoleInput([$input->getScriptName(), 'help', $command->getName()]);
             $helpCommand = $this->registry->find('help');
-            return $helpCommand === null ? 1 : $this->executeCommand($helpCommand, $helpInput, $output);
+            return $helpCommand === null ? 1 : self::executeCommand($helpCommand, $helpInput, $output);
         }
 
-        return $this->executeCommand($command, $input, $output);
+        return self::executeCommand($command, $input, $output);
     }
 
     /**
@@ -134,7 +136,7 @@ class ConsoleKernel
     /**
      * @since ZC v3.0.0
      */
-    private function executeCommand(ConsoleCommand $command, ConsoleInput $input, ConsoleOutput $output): int
+    private static function executeCommand(ConsoleCommand $command, ConsoleInput $input, ConsoleOutput $output): int
     {
         try {
             return $command->handle($input, $output);

--- a/includes/classes/Console/ConsoleOutput.php
+++ b/includes/classes/Console/ConsoleOutput.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -18,8 +20,8 @@ class ConsoleOutput
         private $stdout = null,
         private $stderr = null
     ) {
-        $this->stdout = $stdout ?? STDOUT;
-        $this->stderr = $stderr ?? STDERR;
+        $this->stdout = $stdout ?? \STDOUT;
+        $this->stderr = $stderr ?? \STDERR;
     }
 
     /**
@@ -35,7 +37,7 @@ class ConsoleOutput
      */
     public function writeln(string $message = ''): void
     {
-        $this->write($message . PHP_EOL);
+        $this->write($message . \PHP_EOL);
     }
 
     /**
@@ -51,6 +53,6 @@ class ConsoleOutput
      */
     public function errorln(string $message): void
     {
-        $this->error($message . PHP_EOL);
+        $this->error($message . \PHP_EOL);
     }
 }

--- a/includes/classes/Console/PluginCommandDiscovery.php
+++ b/includes/classes/Console/PluginCommandDiscovery.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -23,8 +25,7 @@ class PluginCommandDiscovery
         private string $pluginRootPath,
         private ?\Aura\Autoload\Loader $autoloader = null,
         private ?array $allowedPluginVersions = null
-    ) {
-    }
+    ) {}
 
     /**
      * @since ZC v3.0.0
@@ -111,7 +112,7 @@ class PluginCommandDiscovery
             return;
         }
 
-        $namespace = 'Zencart\\Plugins\\Console\\' . $this->normalizePluginNamespace($pluginKey);
+        $namespace = 'Zencart\\Plugins\\Console\\' . self::normalizePluginNamespace($pluginKey);
         $this->autoloader->addPrefix($namespace, $consolePath);
     }
 
@@ -126,7 +127,7 @@ class PluginCommandDiscovery
         }
 
         try {
-            $this->includePhpFile($autoloadFile, ['psr4Autoloader' => $this->autoloader]);
+            self::includePhpFile($autoloadFile, ['psr4Autoloader' => $this->autoloader]);
         } catch (Throwable $exception) {
             $pluginReference = $pluginKey . '/' . $pluginVersion;
             $this->errors[] = sprintf(
@@ -150,8 +151,7 @@ class PluginCommandDiscovery
         string $pluginVersion,
         string $versionPath,
         ?string $commandFile = null
-    ): array
-    {
+    ): array {
         $commandFile ??= $versionPath . '/Console/commands.php';
         if (!file_exists($commandFile)) {
             return [];
@@ -160,7 +160,7 @@ class PluginCommandDiscovery
         $definitionReference = $pluginKey . '/' . $pluginVersion . '/Console/commands.php';
 
         try {
-            $definitions = $this->includePhpFile($commandFile);
+            $definitions = self::includePhpFile($commandFile);
         } catch (Throwable $exception) {
             $this->errors[] = sprintf(
                 'Failed loading plugin commands from %s: %s',
@@ -178,7 +178,7 @@ class PluginCommandDiscovery
         $commands = [];
         foreach ($definitions as $definition) {
             try {
-                $commands[] = $this->resolveCommandDefinition($definition);
+                $commands[] = self::resolveCommandDefinition($definition);
             } catch (Throwable $exception) {
                 $this->errors[] = sprintf(
                     'Invalid plugin command definition in %s: %s',
@@ -206,9 +206,9 @@ class PluginCommandDiscovery
     /**
      * @since ZC v3.0.0
      */
-    private function includePhpFile(string $file, array $scopeVariables = []): mixed
+    private static function includePhpFile(string $file, array $scopeVariables = []): mixed
     {
-        extract($scopeVariables, EXTR_SKIP);
+        extract($scopeVariables, \EXTR_SKIP);
 
         if (!is_file($file) || !is_readable($file)) {
             throw new \RuntimeException('PHP file is not readable: ' . $file);
@@ -232,12 +232,12 @@ class PluginCommandDiscovery
         $absolutePathPattern = implode(
             '[\\\\/]',
             array_map(
-                static fn (string $segment): string => preg_quote($segment, '~'),
+                static fn(string $segment): string => preg_quote($segment, '~'),
                 explode('/', $normalizedAbsolutePath)
             )
         );
 
-        return (string) preg_replace_callback(
+        return (string)preg_replace_callback(
             '~' . $absolutePathPattern . '(?:[\\\\/][^\s\'":]+)*~',
             static function (array $matches) use ($normalizedAbsolutePath, $normalizedRelativePath): string {
                 $path = str_replace('\\', '/', $matches[0]);
@@ -250,7 +250,7 @@ class PluginCommandDiscovery
     /**
      * @since ZC v3.0.0
      */
-    private function resolveCommandDefinition(mixed $definition): ConsoleCommand
+    private static function resolveCommandDefinition(mixed $definition): ConsoleCommand
     {
         if ($definition instanceof ConsoleCommand) {
             return $definition;
@@ -266,15 +266,15 @@ class PluginCommandDiscovery
     /**
      * @since ZC v3.0.0
      */
-    private function normalizePluginNamespace(string $pluginKey): string
+    private static function normalizePluginNamespace(string $pluginKey): string
     {
         $segments = preg_split('/[^a-zA-Z0-9]+/', $pluginKey) ?: [];
-        $segments = array_filter($segments, static fn ($segment) => $segment !== '');
+        $segments = array_filter($segments, static fn($segment) => $segment !== '');
 
         if ($segments === []) {
             return 'Plugin';
         }
 
-        return implode('', array_map(static fn ($segment) => ucfirst((string) $segment), $segments));
+        return implode('', array_map(static fn($segment) => ucfirst((string)$segment), $segments));
     }
 }

--- a/includes/classes/Console/TrustedPluginVersionResolver.php
+++ b/includes/classes/Console/TrustedPluginVersionResolver.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -14,9 +16,7 @@ class TrustedPluginVersionResolver
     /**
      * @since ZC v3.0.0
      */
-    public function __construct(private PluginControlRepository $repository)
-    {
-    }
+    public function __construct(private PluginControlRepository $repository) {}
 
     /**
      * @since ZC v3.0.0

--- a/includes/classes/Coupon.php
+++ b/includes/classes/Coupon.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team

--- a/includes/classes/CouponValidation.php
+++ b/includes/classes/CouponValidation.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -46,19 +48,19 @@ class CouponValidation
         }
         if ($coupons->RecordCount() === 1) {
             // If product is restricted(deny) and is same as tested product deny
-            if ($coupons->fields['product_id'] > 0 && $coupons->fields['product_id'] == $product_id && $coupons->fields['coupon_restrict'] === 'Y') {
+            if ($coupons->fields['product_id'] > 0 && (int)$coupons->fields['product_id'] === $product_id && $coupons->fields['coupon_restrict'] === 'Y') {
                 return false;
             }
             // If product is not restricted(allow) and is not same as tested product deny
-            if ($coupons->fields['product_id'] > 0 && $coupons->fields['product_id'] != $product_id && $coupons->fields['coupon_restrict'] === 'N') {
+            if ($coupons->fields['product_id'] > 0 && (int)$coupons->fields['product_id'] !== $product_id && $coupons->fields['coupon_restrict'] === 'N') {
                 return false;
             }
             // if category is restricted(deny) and product in category deny
-            if ($coupons->fields['category_id'] > 0 && zen_product_in_category($product_id, $coupons->fields['category_id']) && $coupons->fields['coupon_restrict'] === 'Y') {
+            if ($coupons->fields['category_id'] > 0 && zen_product_in_category($product_id, (int)$coupons->fields['category_id']) && $coupons->fields['coupon_restrict'] === 'Y') {
                 return false;
             }
             // if category is not restricted(allow) and product not in category deny
-            if ($coupons->fields['category_id'] > 0 && !zen_product_in_category($product_id, $coupons->fields['category_id']) && $coupons->fields['coupon_restrict'] === 'N') {
+            if ($coupons->fields['category_id'] > 0 && !zen_product_in_category($product_id, (int)$coupons->fields['category_id']) && $coupons->fields['coupon_restrict'] === 'N') {
                 return false;
             }
             return true;
@@ -141,7 +143,7 @@ class CouponValidation
     }
 
     /**
-     * is coupon valid for specials and sales
+     * is coupon valid for specials and sales?
      * @since ZC v2.0.0
      */
     public static function is_coupon_valid_for_sales(int $product_id, int $coupon_id): bool
@@ -203,7 +205,7 @@ class CouponValidation
      * e.g. referrer 'abc.com' may only be assigned to one coupon, not two or more.
      *
      * @param string $referrer The domain to check e.g. 'abc.com'
-     * @param int $exclude_coupon_id Optional coupon_id to exclude/ignore (ie: "self" record)
+     * @param int|null $exclude_coupon_id Optional coupon_id to exclude/ignore (ie: "self" record)
      * @return ?array
      * @since ZC v2.0.0
      */

--- a/includes/classes/CouponValidation.php
+++ b/includes/classes/CouponValidation.php
@@ -8,7 +8,6 @@
 
 class CouponValidation
 {
-
     /**
      * Check whether the product is valid for the specified coupon, according to model/category/product restrictions assigned to the coupon
      * @since ZC v2.0.0
@@ -67,8 +66,8 @@ class CouponValidation
 
         $allow_for_category = self::validate_for_category($product_id, $coupon_id);
         $allow_for_product = self::validate_for_product($product_id, $coupon_id);
-//    echo '#'.$product_id . '#' . $allow_for_category;
-//    echo '#'.$product_id . '#' . $allow_for_product;
+        //    echo '#'.$product_id . '#' . $allow_for_category;
+        //    echo '#'.$product_id . '#' . $allow_for_product;
         if ($allow_for_category === 'none') {
             if ($allow_for_product === 'none') {
                 return true;

--- a/includes/classes/Customer.php
+++ b/includes/classes/Customer.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -9,11 +11,11 @@
 class Customer extends base
 {
     //- customers::customers_authorization values
-    public const AUTH_OK = 0;           //- customer is authorized
-    public const AUTH_NO_BROWSE = 1;    //- customer must be authorized to browse
-    public const AUTH_NO_PRICES = 2;    //- customer can browse, but no prices until authorized
-    public const AUTH_NO_PURCHASE = 3;  //- customer can browse with prices, but no cart/checkout until authorized
-    public const AUTH_BANNED = 4;       //- customer is banned
+    public const int AUTH_OK = 0;           //- customer is authorized
+    public const int AUTH_NO_BROWSE = 1;    //- customer must be authorized to browse
+    public const int AUTH_NO_PRICES = 2;    //- customer can browse, but no prices until authorized
+    public const int AUTH_NO_PURCHASE = 3;  //- customer can browse with prices, but no cart/checkout until authorized
+    public const int AUTH_BANNED = 4;       //- customer is banned
 
     protected ?int $customer_id = null;
     protected bool $is_logged_in = false;
@@ -30,7 +32,7 @@ class Customer extends base
         }
 
         if (!empty($customer_id) && empty($this->customer_id)) {
-            $this->customer_id = $customer_id;
+            $this->customer_id = (int)$customer_id;
         }
 
         if (!empty($this->customer_id)) {
@@ -82,7 +84,7 @@ class Customer extends base
      */
     public static function isWholesaleCustomer(): bool
     {
-        $wholesale_info = Customer::getCustomerWholesaleInfo();
+        $wholesale_info = self::getCustomerWholesaleInfo();
         return $wholesale_info['is_wholesale'];
     }
 
@@ -91,7 +93,7 @@ class Customer extends base
      */
     public static function isTaxExempt(): bool
     {
-        $wholesale_info = Customer::getCustomerWholesaleInfo();
+        $wholesale_info = self::getCustomerWholesaleInfo();
         $is_tax_exempt = $wholesale_info['is_tax_exempt'];
 
         global $zco_notifier;
@@ -105,7 +107,7 @@ class Customer extends base
      */
     public static function getCustomerWholesaleTier(): int
     {
-        $wholesale_info = Customer::getCustomerWholesaleInfo();
+        $wholesale_info = self::getCustomerWholesaleInfo();
         return $wholesale_info['wholesale_tier'];
     }
 
@@ -128,7 +130,7 @@ class Customer extends base
             return false;
         }
 
-        $length = defined('PASSWORD_RESET_TOKEN_LENGTH') ? constant('PASSWORD_RESET_TOKEN_LENGTH') : 24;
+        $length = defined('PASSWORD_RESET_TOKEN_LENGTH') ? (int)constant('PASSWORD_RESET_TOKEN_LENGTH') : 24;
         if ($length < 12 || $length > 100) { // under 12 is impractical; over 100 is too large for db field
             $length = 24;
         }
@@ -307,7 +309,7 @@ class Customer extends base
         }
 
         // fire notifier to check whether login should be allowed?
-//@TODO        $this->notify('NOTIFY_?LOGIN_ATTEMPT', null, $is_logged_in);
+        //@TODO        $this->notify('NOTIFY_?LOGIN_ATTEMPT', null, $is_logged_in);
 
         // -----
         // Load the customer's information from the database and set the appropriate
@@ -1105,7 +1107,7 @@ class Customer extends base
 
         $result = $db->Execute($sql);
 
-        return $result->fields['total'];
+        return (int)$result->fields['total'];
     }
 
     /**

--- a/includes/classes/DbRepositories/ConfigurationRepository.php
+++ b/includes/classes/DbRepositories/ConfigurationRepository.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license https://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -18,9 +20,7 @@ class ConfigurationRepository
     protected array $configAsIntArray = ['SECURITY_CODE_LENGTH'];
     protected array $keepAsStringArray = ['PRODUCTS_MANUFACTURERS_STATUS'];
 
-    public function __construct(private queryFactory $db)
-    {
-    }
+    public function __construct(private queryFactory $db) {}
 
     /**
      * @since ZC v2.2.0

--- a/includes/classes/DbRepositories/LayoutBoxRepository.php
+++ b/includes/classes/DbRepositories/LayoutBoxRepository.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license https://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -13,9 +15,7 @@ use queryFactory;
  */
 class LayoutBoxRepository
 {
-    public function __construct(private queryFactory $db)
-    {
-    }
+    public function __construct(private queryFactory $db) {}
 
     /**
      * @since ZC v2.2.0

--- a/includes/classes/DbRepositories/PluginControl.php
+++ b/includes/classes/DbRepositories/PluginControl.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * Back-compat shim: App\Models\PluginControl is an alias of
  * Zencart\DbRepositories\PluginControlRepository.

--- a/includes/classes/DbRepositories/PluginControlRepository.php
+++ b/includes/classes/DbRepositories/PluginControlRepository.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license https://www.zen-cart.com/license/2_0.txt GNU Public License V2.0

--- a/includes/classes/DbRepositories/PluginControlVersion.php
+++ b/includes/classes/DbRepositories/PluginControlVersion.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * Back-compat shim: App\Models\PluginControlVersion is an alias of
  * Zencart\DbRepositories\PluginControlVersionRepository.

--- a/includes/classes/DbRepositories/PluginControlVersionRepository.php
+++ b/includes/classes/DbRepositories/PluginControlVersionRepository.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license https://www.zen-cart.com/license/2_0.txt GNU Public License V2.0

--- a/includes/classes/DbRepositories/ProductTypeLayoutRepository.php
+++ b/includes/classes/DbRepositories/ProductTypeLayoutRepository.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license https://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -15,9 +17,7 @@ use queryFactory;
  */
 class ProductTypeLayoutRepository
 {
-    public function __construct(private queryFactory $db)
-    {
-    }
+    public function __construct(private queryFactory $db) {}
 
     /**
      * @since ZC v2.2.0

--- a/includes/classes/DbRepositories/ProjectVersionRepository.php
+++ b/includes/classes/DbRepositories/ProjectVersionRepository.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license https://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -15,9 +17,7 @@ use queryFactory;
  */
 class ProjectVersionRepository
 {
-    public function __construct(private queryFactory $db)
-    {
-    }
+    public function __construct(private queryFactory $db) {}
 
     /**
      * @since ZC v2.2.0

--- a/includes/classes/EventDto.php
+++ b/includes/classes/EventDto.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0

--- a/includes/classes/FileSystem.php
+++ b/includes/classes/FileSystem.php
@@ -5,6 +5,7 @@
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: DrByte 2026 Feb 26 Modified in v2.2.1 $
  */
+
 namespace Zencart\FileSystem;
 
 /**
@@ -25,7 +26,7 @@ class FileSystem
         }
         while ($file = $dir->read()) {
             if (preg_match($fileRegx, $file) > 0) {
-                require_once($rootDir . '/' . $file);
+                require_once $rootDir . '/' . $file;
             }
         }
         $dir->close();
@@ -160,7 +161,7 @@ class FileSystem
         foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($path)) as $file) {
             $bytes += $file->getSize();
         }
-        $size = array('B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB');
+        $size = ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
         $factor = floor((strlen($bytes) - 1) / 3);
         $suffix = 'bloody huge!';
         if (isset($size[$factor])) {

--- a/includes/classes/FileSystem.php
+++ b/includes/classes/FileSystem.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  *
  * @copyright Copyright 2003-2026 Zen Cart Development Team
@@ -113,10 +115,8 @@ class FileSystem
             return false;
         }
         $test = str_replace(DIR_FS_ADMIN, '', $filePath);
-        if ($test != $filePath) {
-            return false;
-        }
-        return true;
+
+        return $test === $filePath;
     }
 
     /**
@@ -162,7 +162,7 @@ class FileSystem
             $bytes += $file->getSize();
         }
         $size = ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
-        $factor = floor((strlen($bytes) - 1) / 3);
+        $factor = floor((strlen((string)$bytes) - 1) / 3);
         $suffix = 'bloody huge!';
         if (isset($size[$factor])) {
             $suffix = $size[$factor];
@@ -233,7 +233,7 @@ class FileSystem
      */
     protected function realpath(string $path): string
     {
-        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+        if (strtoupper(substr(\PHP_OS, 0, 3)) === 'WIN') {
             return str_replace('\\', '/', realpath($path));
         }
         return realpath($path);
@@ -258,7 +258,7 @@ class FileSystem
                 continue;
             }
 
-            $path = $directory . DIRECTORY_SEPARATOR . $item;
+            $path = $directory . \DIRECTORY_SEPARATOR . $item;
             if (is_dir($path)) {
                 $this->deleteDirectory($path);
                 continue;

--- a/includes/classes/Filters/FilterFactory.php
+++ b/includes/classes/Filters/FilterFactory.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -15,11 +17,11 @@ class FilterFactory
     /**
      * @since ZC v1.5.8
      */
-    public function make(array $filterDefinition) : RequestFilter
+    public function make(array $filterDefinition): RequestFilter
     {
         $filterName = ucfirst($filterDefinition['type']) . 'Filter';
-        $className = __NAMESPACE__ . '\\'.  $filterName;
-        $filter = new $className;
+        $className = __NAMESPACE__ . '\\' . $filterName;
+        $filter = new $className();
         return $filter;
     }
 }

--- a/includes/classes/Filters/FilterManager.php
+++ b/includes/classes/Filters/FilterManager.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -14,21 +16,14 @@ use Zencart\Request\Request;
  */
 class FilterManager
 {
+    protected array $filters = [];
 
-    protected $filterDefinitions = [];
-    protected $filterFactory;
-    protected $filters = [];
-
-    public function __construct(array $filterDefinitions, FilterFactory $filterFactory)
-    {
-        $this->filterDefinitions = $filterDefinitions;
-        $this->filterFactory = $filterFactory;
-    }
+    public function __construct(protected array $filterDefinitions, protected FilterFactory $filterFactory) {}
 
     /**
      * @since ZC v1.5.8
      */
-    public function build() : void
+    public function build(): void
     {
         $this->filters = [];
         if (!$this->hasFilters()) {
@@ -58,7 +53,7 @@ class FilterManager
     /**
      * @since ZC v1.5.8
      */
-    public function hasFilters() : bool
+    public function hasFilters(): bool
     {
         if (!count($this->filterDefinitions)) {
             return false;
@@ -69,7 +64,7 @@ class FilterManager
     /**
      * @since ZC v1.5.8
      */
-    public function getFilters() : array
+    public function getFilters(): array
     {
         return $this->filters;
     }

--- a/includes/classes/Filters/RequestFilter.php
+++ b/includes/classes/Filters/RequestFilter.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -17,7 +19,7 @@ interface RequestFilter
     /**
      * @since ZC v1.5.8
      */
-    public function make(array $filterDefinition) : void;
+    public function make(array $filterDefinition): void;
     /**
      * @since ZC v1.5.8
      */
@@ -25,5 +27,5 @@ interface RequestFilter
     /**
      * @since ZC v1.5.8
      */
-    public function output() : string;
+    public function output(): string;
 }

--- a/includes/classes/Filters/SelectWhereFilter.php
+++ b/includes/classes/Filters/SelectWhereFilter.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -14,38 +16,37 @@ use Zencart\Request\Request;
  */
 class SelectWhereFilter extends baseFilter implements RequestFilter
 {
-    private $default;
-    protected $filterDefinition = [];
-    protected $options = [];
-    protected $parameters =[];
+    private string $default;
+    protected array $filterDefinition = [];
+    protected array $options = [];
+    protected array $parameters = [];
 
     /**
      * @since ZC v1.5.8
      */
-    public function make(array $filterDefinition) : void
+    public function make(array $filterDefinition): void
     {
         $this->filterDefinition = $filterDefinition;
         $this->default = $filterDefinition['default'] ?? '';
-        $this->options = $this->getOptionsForSelect($filterDefinition);
-        $this->parameters = $this->setParameters($filterDefinition);
+        $this->options = self::getOptionsForSelect($filterDefinition);
+        $this->parameters = self::setParameters($filterDefinition);
     }
 
     /**
      * @since ZC v1.5.8
      */
-    public function output() : string
+    public function output(): string
     {
-        $select = $this->makeSelect($this->options, $this->default, $this->parameters);
-        return $select;
+        return $this->makeSelect($this->options, $this->default, $this->parameters);
     }
 
     /**
      * @since ZC v1.5.8
      */
-    public function processRequest(Request $request, $query)
+    public function processRequest(Request $request, $query): mixed
     {
         $this->default = $request->input($this->filterDefinition['selectName'], '*');
-        if ((string)$this->default == '*') {
+        if ((string)$this->default === '*') {
             return $query;
         }
 
@@ -66,7 +67,7 @@ class SelectWhereFilter extends baseFilter implements RequestFilter
     /**
      * @since ZC v1.5.8
      */
-    private function getOptionsForSelect(array $filterDefinition) : array
+    private static function getOptionsForSelect(array $filterDefinition): array
     {
         return $filterDefinition['options'];
     }
@@ -74,7 +75,7 @@ class SelectWhereFilter extends baseFilter implements RequestFilter
     /**
      * @since ZC v1.5.8
      */
-    private function setParameters($filterDefinition) : array
+    private static function setParameters(array $filterDefinition): array
     {
         $parameters['label'] = $filterDefinition['label'];
         $parameters['name'] = $filterDefinition['selectName'];

--- a/includes/classes/Filters/baseFilter.php
+++ b/includes/classes/Filters/baseFilter.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -15,15 +17,15 @@ class baseFilter
     /**
      * @since ZC v1.5.8
      */
-    protected function makeSelect(array $options, string $default, array $parameters) : string
+    protected function makeSelect(array $options, string $default, array $parameters): string
     {
         $parameters['autoJs'] = ($parameters['auto']) ? 'onChange="this.form.submit();"' : '';
         $parameters['options'] = $options;
         $parameters['default'] = $default;
         $class = isset($parameters['class']) ? ' class="' . $parameters['class'] . '"' : '';
         $parameters['class'] = $class;
-//        $view = view('filters.searchWhere', ['tpl' => $parameters]);
-//        return $view->render();
+        //        $view = view('filters.searchWhere', ['tpl' => $parameters]);
+        //        return $view->render();
         return '';
     }
 }

--- a/includes/classes/InitSystem.php
+++ b/includes/classes/InitSystem.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  *
  * @copyright Copyright 2003-2025 Zen Cart Development Team
@@ -8,32 +10,19 @@
 
 namespace Zencart\InitSystem;
 
+use Zencart\FileSystem\FileSystem;
+use Zencart\PluginManager\PluginManager;
+
 /**
  * @since ZC v1.5.7
  */
 class InitSystem
 {
-    private $installedPlugins;
-    private bool $debug;
-    private array $debugList;
-    private array $actionList;
+    private bool $debug = false;
+    private array $debugList = [];
+    private array $actionList = [];
 
-    private string $context;
-    private string $loaderPrefix;
-    private $fileSystem;
-    private $pluginManager;
-
-    public function __construct(string $context, string $loaderPrefix, $fileSystem, $pluginManager, $installedPlugins)
-    {
-        $this->context = $context;
-        $this->loaderPrefix = $loaderPrefix;
-        $this->fileSystem = $fileSystem;
-        $this->pluginManager = $pluginManager;
-        $this->installedPlugins = $installedPlugins;
-        $this->debug = false;
-        $this->debugList = [];
-        $this->actionList = [];
-    }
+    public function __construct(private string $context, private string $loaderPrefix, private FileSystem $fileSystem, private PluginManager $pluginManager, private array $installedPlugins) {}
 
     /**
      * @since ZC v1.5.7
@@ -179,7 +168,7 @@ class InitSystem
     {
         $filePath = $entry['loadFile'];
         $this->debugList[] = 'processing include - ' . $entry['loadFile'];
-        if ($entry['loaderType'] == 'plugin') {
+        if ($entry['loaderType'] === 'plugin') {
 
         }
         $result = 'FAILED';
@@ -196,11 +185,11 @@ class InitSystem
     protected function processAutoTypeInit_script(array $entry): void
     {
         $actualDir = DIR_WS_INCLUDES . 'init_includes/';
-        if ($entry['loaderType'] == 'plugin') {
+        if ($entry['loaderType'] === 'plugin') {
             $actualDir = $this->findPluginDirectory($actualDir, $entry['pluginInfo']['unique_key']);
         }
         if (file_exists($actualDir . 'overrides/' . $entry['loadFile'])) {
-            $actualDir = $actualDir . 'overrides/';
+            $actualDir .= 'overrides/';
         }
         $this->actionList[] = ['type' => 'require', 'filePath' => $actualDir . $entry['loadFile'], 'forceLoad' => $entry['forceLoad']];
         $this->debugList[] = 'loading init_script - ' . $actualDir . $entry['loadFile'];
@@ -215,8 +204,7 @@ class InitSystem
         $fileList = $this->fileSystem->listFilesFromDirectoryAlphaSorted($rootDir);
         $fileList = $this->processForOverrides($loaderType, $fileList, $rootDir);
         $loaderList = $this->getLoadersFromFileList($fileList);
-        $loaderList = $this->processLoaderListForType($loaderType, $loaderList, $plugin);
-        return $loaderList;
+        return $this->processLoaderListForType($loaderType, $loaderList, $plugin);
     }
 
     /**
@@ -270,10 +258,7 @@ class InitSystem
     protected function fileMatchesLoaderPrefix(string $file): bool
     {
         $fileParts = explode('.', $file);
-        if (($fileParts[0] ?? '') !== $this->loaderPrefix) {
-            return false;
-        }
-        return true;
+        return ($fileParts[0] ?? '') === $this->loaderPrefix;
     }
 
     /**

--- a/includes/classes/MeasurementUnits.php
+++ b/includes/classes/MeasurementUnits.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0

--- a/includes/classes/PluginManager.php
+++ b/includes/classes/PluginManager.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  *
  * @copyright Copyright 2003-2026 Zen Cart Development Team

--- a/includes/classes/PluginManager.php
+++ b/includes/classes/PluginManager.php
@@ -20,9 +20,7 @@ class PluginManager
     public function __construct(
         private PluginControlRepository $pluginControl,
         private PluginControlVersionRepository $pluginControlVersion
-    )
-    {
-    }
+    ) {}
 
     /**
      * @since ZC v1.5.7

--- a/includes/classes/PluginSupport/BasePluginInstaller.php
+++ b/includes/classes/PluginSupport/BasePluginInstaller.php
@@ -21,9 +21,7 @@ class BasePluginInstaller
      */
     protected string $pluginDir;
 
-    public function __construct(protected queryFactory $dbConn, protected Installer $pluginInstaller, protected PluginErrorContainer $errorContainer)
-    {
-    }
+    public function __construct(protected queryFactory $dbConn, protected Installer $pluginInstaller, protected PluginErrorContainer $errorContainer) {}
 
     /**
      * @since ZC v1.5.7

--- a/includes/classes/PluginSupport/BasePluginInstaller.php
+++ b/includes/classes/PluginSupport/BasePluginInstaller.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0

--- a/includes/classes/PluginSupport/Installer.php
+++ b/includes/classes/PluginSupport/Installer.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0

--- a/includes/classes/PluginSupport/Installer.php
+++ b/includes/classes/PluginSupport/Installer.php
@@ -17,9 +17,7 @@ class Installer
     protected string $version;
     protected ?string $oldVersion;
 
-    public function __construct(protected SqlPatchInstaller $patchInstaller, protected ScriptedInstallerFactory $scriptedInstallerFactory, protected PluginErrorContainer $errorContainer)
-    {
-    }
+    public function __construct(protected SqlPatchInstaller $patchInstaller, protected ScriptedInstallerFactory $scriptedInstallerFactory, protected PluginErrorContainer $errorContainer) {}
 
     /**
      * @since ZC v2.1.0

--- a/includes/classes/PluginSupport/InstallerFactory.php
+++ b/includes/classes/PluginSupport/InstallerFactory.php
@@ -15,9 +15,7 @@ use Zencart\Exceptions\PluginInstallerException;
  */
 class InstallerFactory
 {
-    public function __construct(protected queryFactory $dbConn, protected Installer $pluginInstaller, protected PluginErrorContainer $errorContainer)
-    {
-    }
+    public function __construct(protected queryFactory $dbConn, protected Installer $pluginInstaller, protected PluginErrorContainer $errorContainer) {}
 
     /**
      * @since ZC v1.5.7

--- a/includes/classes/PluginSupport/InstallerFactory.php
+++ b/includes/classes/PluginSupport/InstallerFactory.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0

--- a/includes/classes/PluginSupport/PluginErrorContainer.php
+++ b/includes/classes/PluginSupport/PluginErrorContainer.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -36,23 +38,23 @@ class PluginErrorContainer
     /**
      * @since ZC v1.5.7
      */
-    public function hasLogErrors()
+    public function hasLogErrors(): bool
     {
-        return (count($this->logErrors));
+        return count($this->logErrors) > 0;
     }
 
     /**
      * @since ZC v1.5.7
      */
-    public function hasFriendlyErrors()
+    public function hasFriendlyErrors(): bool
     {
-        return (count($this->friendlyErrors));
+        return count($this->friendlyErrors) > 0;
     }
 
     /**
      * @since ZC v1.5.7
      */
-    public function addError($logSeverity, $logMessage, $useLogMessageForFriendly = false, $friendlyMessage = '')
+    public function addError($logSeverity, $logMessage, $useLogMessageForFriendly = false, $friendlyMessage = ''): void
     {
         if ($useLogMessageForFriendly) {
             $friendlyMessage = $logMessage;
@@ -71,15 +73,15 @@ class PluginErrorContainer
     /**
      * @since ZC v1.5.7
      */
-    public function hasErrors()
+    public function hasErrors(): bool
     {
-        return (count($this->logErrors + $this->friendlyErrors));
+        return count($this->logErrors + $this->friendlyErrors) > 0;
     }
 
     /**
      * @since ZC v1.5.7
      */
-    public function getFriendlyErrors()
+    public function getFriendlyErrors(): array
     {
         return $this->friendlyErrors;
     }
@@ -87,7 +89,7 @@ class PluginErrorContainer
     /**
      * @since ZC v1.5.7
      */
-    public function getLogErrors()
+    public function getLogErrors(): array
     {
         return $this->logErrors;
     }

--- a/includes/classes/PluginSupport/PluginErrorContainer.php
+++ b/includes/classes/PluginSupport/PluginErrorContainer.php
@@ -12,7 +12,6 @@ namespace Zencart\PluginSupport;
  */
 class PluginErrorContainer
 {
-
     /**
      * $logger "null" the logger to use.
      * @var object
@@ -59,7 +58,9 @@ class PluginErrorContainer
             $friendlyMessage = $logMessage;
         }
         $this->logErrors[] = $logMessage;
-        if ($friendlyMessage === '') return;
+        if ($friendlyMessage === '') {
+            return;
+        }
         $friendlyHash = hash('md5', $friendlyMessage);
         $this->friendlyErrors[$friendlyHash] = $friendlyMessage;
         if ($this->logger) {

--- a/includes/classes/PluginSupport/PluginStatus.php
+++ b/includes/classes/PluginSupport/PluginStatus.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -6,6 +8,7 @@
  *
  * @since ZC v2.2.0
  */
+
 namespace Zencart\PluginSupport;
 
 class PluginStatus

--- a/includes/classes/PluginSupport/ScriptedInstallHelpers.php
+++ b/includes/classes/PluginSupport/ScriptedInstallHelpers.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0

--- a/includes/classes/PluginSupport/ScriptedInstaller.php
+++ b/includes/classes/PluginSupport/ScriptedInstaller.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0

--- a/includes/classes/PluginSupport/ScriptedInstaller.php
+++ b/includes/classes/PluginSupport/ScriptedInstaller.php
@@ -22,9 +22,7 @@ class ScriptedInstaller
     protected string $version;
     protected ?string $oldVersion; // null if not in upgrade mode
 
-    public function __construct(protected queryFactory $dbConn, protected PluginErrorContainer $errorContainer)
-    {
-    }
+    public function __construct(protected queryFactory $dbConn, protected PluginErrorContainer $errorContainer) {}
 
     /***** START: METHODS FOR IMPLEMENTATION IN EXTENDED CLASSES *********/
     /***** There is no need to implement any other methods in extended classes ****/
@@ -192,7 +190,7 @@ class ScriptedInstaller
             return false;
         }
         return $this->executeInstall();
-     }
+    }
 
     /**
      * @since ZC v1.5.7

--- a/includes/classes/PluginSupport/ScriptedInstallerFactory.php
+++ b/includes/classes/PluginSupport/ScriptedInstallerFactory.php
@@ -14,9 +14,7 @@ use queryFactory;
  */
 class ScriptedInstallerFactory
 {
-    public function __construct(protected queryFactory $dbConn, protected PluginErrorContainer $errorContainer)
-    {
-    }
+    public function __construct(protected queryFactory $dbConn, protected PluginErrorContainer $errorContainer) {}
 
     /**
      * @since ZC v1.5.7

--- a/includes/classes/PluginSupport/ScriptedInstallerFactory.php
+++ b/includes/classes/PluginSupport/ScriptedInstallerFactory.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -22,7 +24,6 @@ class ScriptedInstallerFactory
     public function make($pluginDir): ScriptedInstaller
     {
         require_once $pluginDir . '/Installer/ScriptedInstaller.php';
-        $scriptedInstaller = new \ScriptedInstaller($this->dbConn, $this->errorContainer);
-        return $scriptedInstaller;
+        return new \ScriptedInstaller($this->dbConn, $this->errorContainer);
     }
 }

--- a/includes/classes/PluginSupport/SqlPatchInstaller.php
+++ b/includes/classes/PluginSupport/SqlPatchInstaller.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -23,10 +25,9 @@ class SqlPatchInstaller
      */
     protected $errorContainer;
     /**
-     * $sqlFunctionMap is a list of acceptable SQL
-     * @var array
+     * @var array $sqlFunctionMap is a list of acceptable SQL
      */
-    protected $sqlFunctionMap = [
+    protected array $sqlFunctionMap = [
         ['find' => 'DROP TABLE IF EXISTS ', 'length' => 21, 'method' => 'basic', 'tableParamsOffset' => 4],
         ['find' => 'DROP TABLE ', 'length' => 11, 'method' => 'basic', 'tableParamsOffset' => 2],
         ['find' => 'CREATE TABLE IF NOT EXISTS ', 'length' => 27, 'method' => 'basic', 'tableParamsOffset' => 5],
@@ -54,7 +55,7 @@ class SqlPatchInstaller
     /**
      * @since ZC v1.5.7
      */
-    public function parse($lines)
+    public function parse($lines): array
     {
         $builtLines = $this->getFullLines($lines);
         $paramLines = [];
@@ -67,7 +68,7 @@ class SqlPatchInstaller
     /**
      * @since ZC v1.5.7
      */
-    public function executePatchSql($paramLines)
+    public function executePatchSql($paramLines): void
     {
         $this->dbConn->dieOnErrors = false;
         foreach ($paramLines as $line) {
@@ -84,14 +85,14 @@ class SqlPatchInstaller
     /**
      * @since ZC v1.5.7
      */
-    protected function getFullLines($lines)
+    protected function getFullLines($lines): array
     {
         $fullLine = '';
         $builtLines = [];
         foreach ($lines as $line) {
             $line = str_replace('`', '', trim($line));
             $fullLine .= ' ' . $line;
-            if (substr($line, -1) == ';') {
+            if (str_ends_with($line, ';')) {
                 $builtLines[] = ltrim($fullLine);
                 $fullLine = '';
             }
@@ -102,7 +103,7 @@ class SqlPatchInstaller
     /**
      * @since ZC v1.5.7
      */
-    protected function processLine($line)
+    protected function processLine($line): array
     {
         $params = explode(" ", (substr($line, -1) == ';') ? substr($line, 0, strlen($line) - 1) : $line);
         $type = $this->findSqlLineType(strtoupper($line));
@@ -152,7 +153,7 @@ class SqlPatchInstaller
      */
     protected function processLineSelect($params, $typeEntry)
     {
-        $fromKey = array_search('FROM', $params);
+        $fromKey = array_search('FROM', $params, true);
         if ($fromKey === false) {
             return [];
         }
@@ -171,7 +172,7 @@ class SqlPatchInstaller
      */
     protected function processLineIndex($params, $typeEntry)
     {
-        $fromKey = array_search('ON', $params);
+        $fromKey = array_search('ON', $params, true);
         if ($fromKey === false) {
             return [];
         }

--- a/includes/classes/PluginSupport/SqlPatchInstaller.php
+++ b/includes/classes/PluginSupport/SqlPatchInstaller.php
@@ -12,7 +12,6 @@ namespace Zencart\PluginSupport;
  */
 class SqlPatchInstaller
 {
-
     /**
      * $dbConn is a database object
      * @var object
@@ -109,7 +108,7 @@ class SqlPatchInstaller
         $type = $this->findSqlLineType(strtoupper($line));
 
         if (count($type) === 0) {
-             $this->errorContainer->addError(0, ERROR_NOT_FOUND_IN_SQL_FUNCTIONS_MAP. $line, true);
+            $this->errorContainer->addError(0, ERROR_NOT_FOUND_IN_SQL_FUNCTIONS_MAP . $line, true);
             return [];
         }
         $method = 'processLine' . ucfirst($type['method']);
@@ -118,7 +117,7 @@ class SqlPatchInstaller
          * if empty the line could not be correctly parsed
          */
         if (empty($newParams)) {
-             $this->errorContainer->addError(0, ERROR_INVALID_SYNTAX . $line, true);
+            $this->errorContainer->addError(0, ERROR_INVALID_SYNTAX . $line, true);
         }
         return $newParams;
     }

--- a/includes/classes/Product.php
+++ b/includes/classes/Product.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**

--- a/includes/classes/ProductConfigurationSwitch.php
+++ b/includes/classes/ProductConfigurationSwitch.php
@@ -13,7 +13,10 @@ class ProductConfigurationSwitch extends base
 {
     protected $layout_data = [];
     protected $configuration_data = [];
-    protected $prefix, $suffix,  $field_prefix, $field_suffix;
+    protected $prefix;
+    protected $suffix;
+    protected $field_prefix;
+    protected $field_suffix;
     protected $type_handler;
     protected $products_type;
 
@@ -30,7 +33,7 @@ class ProductConfigurationSwitch extends base
         $type_lookup = $db->Execute($sql, 1);
 
         if ($type_lookup->RecordCount() == 0) {
-          return false;
+            return false;
         }
 
         $this->products_type = $type_lookup->fields['products_type'];
@@ -46,14 +49,14 @@ class ProductConfigurationSwitch extends base
         $zv_key_values = $db->Execute($sql);
 
         foreach ($zv_key_values as $entry) {
-          $this->layout_data[$entry['configuration_key']] = $entry['configuration_value'];
+            $this->layout_data[$entry['configuration_key']] = $entry['configuration_value'];
         }
 
         $sql = "SELECT configuration_key, configuration_value FROM " . TABLE_CONFIGURATION . " WHERE configuration_key LIKE '" . zen_db_input($zv_key) . "'";
         $zv_key_values = $db->Execute($sql);
 
         foreach ($zv_key_values as $entry) {
-          $this->configuration_data[$entry['configuration_key']] = $entry['configuration_value'];
+            $this->configuration_data[$entry['configuration_key']] = $entry['configuration_value'];
         }
     }
 
@@ -64,11 +67,11 @@ class ProductConfigurationSwitch extends base
     {
         $switch = strtoupper($this->prefix . $this->type_handler . $this->suffix . $this->field_prefix . $field . $this->field_suffix);
         if (isset($this->layout_data[$switch])) {
-           return $this->layout_data[$switch];
-        } else if (isset($this->configuration_data[$switch])) {
-           return $this->configuration_data[$switch];
+            return $this->layout_data[$switch];
+        } elseif (isset($this->configuration_data[$switch])) {
+            return $this->configuration_data[$switch];
         } else {
-           return false;
+            return false;
         }
     }
 
@@ -77,6 +80,6 @@ class ProductConfigurationSwitch extends base
      */
     public function getProductsType()
     {
-       return $this->products_type;
+        return $this->products_type;
     }
 }

--- a/includes/classes/ProductConfigurationSwitch.php
+++ b/includes/classes/ProductConfigurationSwitch.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * Class ProductConfigurationSwitch
  *
@@ -9,34 +11,25 @@
  * @since ZC v1.5.8
  */
 
-class ProductConfigurationSwitch extends base
+class ProductConfigurationSwitch
 {
-    protected $layout_data = [];
-    protected $configuration_data = [];
-    protected $prefix;
-    protected $suffix;
-    protected $field_prefix;
-    protected $field_suffix;
-    protected $type_handler;
-    protected $products_type;
+    protected array $layout_data = [];
+    protected array $configuration_data = [];
+    protected string $type_handler;
+    protected int $products_type;
 
-    public function __construct($lookup, $prefix = 'SHOW_', $suffix = '_INFO', $field_prefix = '_', $field_suffix = '')
+    public function __construct($lookup, protected string $prefix = 'SHOW_', protected string $suffix = '_INFO', protected string $field_prefix = '_', protected string $field_suffix = '')
     {
         global $db;
-
-        $this->prefix = $prefix;
-        $this->suffix = $suffix;
-        $this->field_prefix = $field_prefix;
-        $this->field_suffix = $field_suffix;
 
         $sql = "SELECT products_type FROM " . TABLE_PRODUCTS . " WHERE products_id=" . (int)$lookup;
         $type_lookup = $db->Execute($sql, 1);
 
-        if ($type_lookup->RecordCount() == 0) {
-            return false;
+        if ($type_lookup->RecordCount() === 0) {
+            return;
         }
 
-        $this->products_type = $type_lookup->fields['products_type'];
+        $this->products_type = (int)$type_lookup->fields['products_type'];
 
         $sql = "SELECT type_handler FROM " . TABLE_PRODUCT_TYPES . " WHERE type_id = " . (int)$type_lookup->fields['products_type'];
         $show_key = $db->Execute($sql, 1);
@@ -63,22 +56,16 @@ class ProductConfigurationSwitch extends base
     /**
      * @since ZC v1.5.8
      */
-    public function getSwitch($field)
+    public function getSwitch($field): string|false
     {
         $switch = strtoupper($this->prefix . $this->type_handler . $this->suffix . $this->field_prefix . $field . $this->field_suffix);
-        if (isset($this->layout_data[$switch])) {
-            return $this->layout_data[$switch];
-        } elseif (isset($this->configuration_data[$switch])) {
-            return $this->configuration_data[$switch];
-        } else {
-            return false;
-        }
+        return $this->layout_data[$switch] ?? $this->configuration_data[$switch] ?? false;
     }
 
     /**
      * @since ZC v1.5.8
      */
-    public function getProductsType()
+    public function getProductsType(): int
     {
         return $this->products_type;
     }

--- a/includes/classes/QueryBuilder.php
+++ b/includes/classes/QueryBuilder.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * Class QueryBuilder
  *
@@ -7,65 +9,48 @@
  * @version $Id: DrByte 2025 Sep 18 Modified in v2.2.0 $
  */
 
-/**
- * Class QueryBuilder
- */
-
 namespace Zencart\QueryBuilder;
 
+use queryFactory;
+
 /**
+ * Class QueryBuilder
+ *
  * @since ZC v1.5.7
  */
 class QueryBuilder extends \base
 {
-    /**
-     * @var
-     */
-    protected $dbConn;
-    /**
-     * query parts
-     *
-     * @var array
-     */
-    protected $parts;
-    /**
-     * query
-     *
-     * @var array
-     */
-    protected $query;
+    protected ?array $parts = null;
+    protected ?array $query = null;
 
-    /**
-     * @param array $listingQuery
-     */
-    public function __construct($dbConn, array $listingQuery = [])
+    public function __construct(protected queryFactory $dbConn, array $listingQuery = [])
     {
-        $this->dbConn = $dbConn;
         $this->parts = null;
         if (count($listingQuery) > 0) {
             $this->initParts($listingQuery);
         }
     }
+
     /**
      * @since ZC v1.5.7
      */
-    public function initParts(array $listingQuery)
+    public function initParts(array $listingQuery): void
     {
         $this->notify('NOTIFY_QUERYBUILDER_INIT_START');
-        $this->parts ['bindVars'] = issetorArray($listingQuery, 'bindVars', array());
-        $this->parts ['selectList'] = issetorArray($listingQuery, 'selectList', array());
-        $this->parts ['orderBys'] = issetorArray($listingQuery, 'orderBys', array());
-        $this->parts ['groupBys'] = issetorArray($listingQuery, 'groupBys', array());
-        $this->parts ['filters'] = issetorArray($listingQuery, 'filters', array());
-        $this->parts ['derivedItems'] = issetorArray($listingQuery, 'derivedItems', array());
-        $this->parts ['joinTables'] = issetorArray($listingQuery, 'joinTables', array());
-        $this->parts ['whereClauses'] = issetorArray($listingQuery, 'whereClauses', array());
-        $this->parts ['mainTableName'] = TABLE_PRODUCTS;
-        $this->parts ['countField'] = 'products_id';
+        $this->parts['bindVars'] = issetorArray($listingQuery, 'bindVars', []);
+        $this->parts['selectList'] = issetorArray($listingQuery, 'selectList', []);
+        $this->parts['orderBys'] = issetorArray($listingQuery, 'orderBys', []);
+        $this->parts['groupBys'] = issetorArray($listingQuery, 'groupBys', []);
+        $this->parts['filters'] = issetorArray($listingQuery, 'filters', []);
+        $this->parts['derivedItems'] = issetorArray($listingQuery, 'derivedItems', []);
+        $this->parts['joinTables'] = issetorArray($listingQuery, 'joinTables', []);
+        $this->parts['whereClauses'] = issetorArray($listingQuery, 'whereClauses', []);
+        $this->parts['mainTableName'] = TABLE_PRODUCTS;
+        $this->parts['countField'] = 'products_id';
         if (isset($listingQuery['mainTable'])) {
-            $this->parts ['mainTableName'] = $listingQuery['mainTable'] ['table'];
-            $this->parts ['countField'] =
-                $listingQuery['mainTable'] ['countField'];
+            $this->parts['mainTableName'] = $listingQuery['mainTable']['table'];
+            $this->parts['countField'] =
+                $listingQuery['mainTable']['countField'];
         }
         $this->notify('NOTIFY_QUERYBUILDER_INIT_END');
     }
@@ -75,20 +60,22 @@ class QueryBuilder extends \base
      *
      * @since ZC v1.5.7
      */
-    public function processQuery($listingQuery)
+    public function processQuery($listingQuery): void
     {
         if (!isset($this->parts)) {
             $this->initParts($listingQuery);
         }
         $this->notify('NOTIFY_QUERYBUILDER_PROCESSQUERY_START');
-        $this->query ['select'] = "SELECT " . (issetorArray($listingQuery, 'isDistinct', false) ? ' DISTINCT ' : '');
-        if (count($this->parts ['groupBys']) == 0) $this->query ['select'] .= $this->parts ['mainTableName'] . ".*";
+        $this->query['select'] = "SELECT " . (issetorArray($listingQuery, 'isDistinct', false) ? ' DISTINCT ' : '');
+        if (count($this->parts['groupBys']) === 0) {
+            $this->query['select'] .= $this->parts['mainTableName'] . ".*";
+        }
         $this->processSelectList();
         $this->preProcessJoins();
-        $this->query ['joins'] = '';
-        $this->query ['table'] = ' FROM ';
+        $this->query['joins'] = '';
+        $this->query['table'] = ' FROM ';
         $this->processJoins();
-        $this->query ['table'] .= $this->parts ['mainTableName'] . " AS " . $this->parts ['mainTableName'] . " ";
+        $this->query['table'] .= $this->parts['mainTableName'] . " AS " . $this->parts['mainTableName'] . " ";
         $this->processWhereClause();
         $this->processGroupBys();
         $this->processOrderBys();
@@ -100,30 +87,31 @@ class QueryBuilder extends \base
     /**
      * @since ZC v1.5.7
      */
-    protected function setFinalQuery($listingQuery)
+    protected function setFinalQuery($listingQuery): void
     {
         $this->notify('NOTIFY_QUERYBUILDER_SETFINALQUERY_START');
-        $this->query['mainSql'] = $this->query ['select'] . $this->query ['table'] .  $this->query ['joins'] .  $this->query ['where'] . $this->query ['groupBy'] . $this->query ['orderBy'];
+        $this->query['mainSql'] = $this->query['select'] . $this->query['table'] . $this->query['joins'] . $this->query['where'] . $this->query['groupBy'] . $this->query['orderBy'];
         if (!isset($this->query['countSql'])) {
             $this->query['countSql'] = "SELECT COUNT(" . (issetorArray($listingQuery, 'isDistinct', false) ? "DISTINCT " : '') .
-                $this->parts ['mainTableName'] . "." . $this->parts ['countField'] . ")
-                                 AS total " . $this->query ['table'] . $this->query ['joins'] .
-                $this->query ['where'];
+                $this->parts['mainTableName'] . "." . $this->parts['countField'] . ")
+                                 AS total " . $this->query['table'] . $this->query['joins'] .
+                $this->query['where'];
         }
         $this->notify('NOTIFY_QUERYBUILDER_SETFINALQUERY_END');
     }
+
     /**
      * preprocess joins
      *
      * @since ZC v1.5.7
      */
-    protected function preProcessJoins()
+    protected function preProcessJoins(): void
     {
         $this->notify('NOTIFY_QUERYBUILDER_PREPROCESSJOINS_START');
-        if (count($this->parts ['joinTables']) == 0) {
+        if (count($this->parts['joinTables']) === 0) {
             return;
         }
-        $this->query ['joins'] = '';
+        $this->query['joins'] = '';
         $this->notify('NOTIFY_QUERYBUILDER_PREPROCESSJOINS_END');
     }
 
@@ -132,20 +120,20 @@ class QueryBuilder extends \base
      *
      * @since ZC v1.5.7
      */
-    protected function processJoins()
+    protected function processJoins(): void
     {
         $this->notify('NOTIFY_QUERYBUILDER_PROCESSJOINS_START');
-        if (count($this->parts ['joinTables']) == 0) {
+        if (count($this->parts['joinTables']) === 0) {
             return;
         }
-        foreach ($this->parts ['joinTables'] as $joinTable) {
-            $this->query ['joins'] .= strtoupper($joinTable ['type']) . " JOIN " . $joinTable ['table'] . ' AS ' . $joinTable ['table'];
+        foreach ($this->parts['joinTables'] as $joinTable) {
+            $this->query['joins'] .= strtoupper($joinTable ['type']) . " JOIN " . $joinTable ['table'] . ' AS ' . $joinTable ['table'];
             $this->processJoinFkeyField($joinTable);
             $this->processJoinCustomAnd($joinTable);
             $this->processJoinAddColumns($joinTable);
         }
-        $this->query ['table'] .= "(";
-        $this->query ['joins'] .= ")";
+        $this->query['table'] .= "(";
+        $this->query['joins'] .= ")";
         $this->notify('NOTIFY_QUERYBUILDER_PROCESSJOINS_END');
     }
 
@@ -155,11 +143,11 @@ class QueryBuilder extends \base
      * @param $joinTable
      * @since ZC v1.5.7
      */
-    protected function processJoinCustomAnd($joinTable)
+    protected function processJoinCustomAnd($joinTable): void
     {
         $this->notify('NOTIFY_QUERYBUILDER_PROCESSJOINSCUSTOMAND_START');
         if (isset($joinTable ['customAnd'])) {
-            $this->query ['joins'] .= " " . $joinTable ['customAnd'] . " ";
+            $this->query['joins'] .= " " . $joinTable ['customAnd'] . " ";
         }
         $this->notify('NOTIFY_QUERYBUILDER_PROCESSJOINSCUSTOMAND_END');
     }
@@ -170,15 +158,16 @@ class QueryBuilder extends \base
      * @param $joinTable
      * @since ZC v1.5.7
      */
-    protected function processJoinAddColumns($joinTable)
+    protected function processJoinAddColumns($joinTable): void
     {
         $this->notify('NOTIFY_QUERYBUILDER_PROCESSJOINADDCOLUMN_START');
         if (isset($joinTable ['addColumns']) && $joinTable ['addColumns']) {
-            $this->query ['select'] .= ", " . $joinTable ['table'] . ".*";
+            $this->query['select'] .= ", " . $joinTable ['table'] . ".*";
         }
         if (isset($joinTable ['selectColumns'])) {
-            foreach ($joinTable ['selectColumns'] as $column)
-            $this->query ['select'] .= ", " . $joinTable ['table'] . "." . $column;
+            foreach ($joinTable ['selectColumns'] as $column) {
+                $this->query['select'] .= ", " . $joinTable ['table'] . "." . $column;
+            }
         }
         $this->notify('NOTIFY_QUERYBUILDER_PROCESSJOINADDCOLUMN_ENDT');
     }
@@ -189,25 +178,24 @@ class QueryBuilder extends \base
      * @param $joinTable
      * @since ZC v1.5.7
      */
-    protected function processJoinFkeyField($joinTable)
+    protected function processJoinFkeyField($joinTable): void
     {
         $this->notify('NOTIFY_QUERYBUILDER_PROCESSJOINFKEYFIELD_START');
-        $fkeyFieldLeft = $this->parts ['mainTableName'] . '.' . $this->parts ['countField'];
-        $fkeyFieldRight = $joinTable ['table'] . '.' . $this->parts ['countField'];
+        $fkeyFieldLeft = $this->parts['mainTableName'] . '.' . $this->parts['countField'];
+        $fkeyFieldRight = $joinTable ['table'] . '.' . $this->parts['countField'];
         if (!isset($joinTable ['fkeyFieldLeft'])) {
-            $this->query ['joins'] .= " ON " . $fkeyFieldLeft . " = " . $fkeyFieldRight . " ";
+            $this->query['joins'] .= " ON " . $fkeyFieldLeft . " = " . $fkeyFieldRight . " ";
             return;
-
         }
-        $fkeyFieldLeft = $this->parts ['mainTableName'] . '.' . $joinTable ['fkeyFieldLeft'];
+        $fkeyFieldLeft = $this->parts['mainTableName'] . '.' . $joinTable ['fkeyFieldLeft'];
         if (isset($joinTable ['fkeyTable'])) {
-            $fkeyFieldLeft =  constant($joinTable ['fkeyTable']) . '.' . $joinTable ['fkeyFieldLeft'];
+            $fkeyFieldLeft = constant($joinTable ['fkeyTable']) . '.' . $joinTable ['fkeyFieldLeft'];
         }
         $fkeyFieldRight = $joinTable ['table'] . '.' . $joinTable ['fkeyFieldLeft'];
         if (isset($joinTable ['fkeyFieldRight'])) {
             $fkeyFieldRight = $joinTable ['table'] . '.' . $joinTable ['fkeyFieldRight'];
         }
-        $this->query ['joins'] .= " ON " . $fkeyFieldLeft . " = " . $fkeyFieldRight . " ";
+        $this->query['joins'] .= " ON " . $fkeyFieldLeft . " = " . $fkeyFieldRight . " ";
         $this->notify('NOTIFY_QUERYBUILDER_PROCESSJOINFKEYFIELD_END');
     }
 
@@ -215,16 +203,16 @@ class QueryBuilder extends \base
      * process where clauses
      * @since ZC v1.5.7
      */
-    protected function processWhereClause()
+    protected function processWhereClause(): void
     {
         $this->notify('NOTIFY_QUERYBUILDER_PROCESSWHERECLAUSE_START');
-        $this->query ['where'] = ' WHERE 1';
-        if (count($this->parts ['whereClauses']) == 0) {
+        $this->query['where'] = ' WHERE 1';
+        if (count($this->parts['whereClauses']) === 0) {
             return;
         }
-        foreach ($this->parts ['whereClauses'] as $whereClause) {
+        foreach ($this->parts['whereClauses'] as $whereClause) {
             if (isset($whereClause ['custom'])) {
-                $this->query ['where'] .= " " . trim($whereClause ['custom']) . " ";
+                $this->query['where'] .= " " . trim($whereClause ['custom']) . " ";
                 continue;
             }
             $this->processWhereClauseTest($whereClause);
@@ -238,7 +226,7 @@ class QueryBuilder extends \base
      * @param $whereClause
      * @since ZC v1.5.7
      */
-    protected function processWhereClauseTest($whereClause)
+    protected function processWhereClauseTest($whereClause): void
     {
         $this->notify('NOTIFY_QUERYBUILDER_PROCESSWHERECLAUSETEST_START');
         if (!isset($whereClause ['test'])) {
@@ -248,10 +236,12 @@ class QueryBuilder extends \base
             $whereClause ['type'] = 'AND';
         }
         $default = ' ' . $whereClause ['test'] . ' ' . $whereClause ['value'];
-        $hashMap = array('IN' => " IN ( " . $whereClause ['value'] . " ) ",
-                         'LIKE' => " LIKE " . $whereClause ['value'] . " ");
+        $hashMap = [
+            'IN' => " IN ( " . $whereClause ['value'] . " ) ",
+            'LIKE' => " LIKE " . $whereClause ['value'] . " ",
+        ];
 
-        $addTest = (isset($hashMap[strtoupper($whereClause ['test'])])) ? $hashMap[strtoupper($whereClause ['test'])] : $default;
+        $addTest = $hashMap[strtoupper($whereClause ['test'])] ?? $default;
         $this->query['where'] .= " " . $whereClause ['type'] . " " . $whereClause ['table'] . "." . $whereClause ['field'] . $addTest;
         $this->notify('NOTIFY_QUERYBUILDER_PROCESSWHERECLAUSETEST_END');
     }
@@ -260,22 +250,22 @@ class QueryBuilder extends \base
      * process orderBy clauses
      * @since ZC v1.5.7
      */
-    protected function processOrderBys()
+    protected function processOrderBys(): void
     {
         $this->notify('NOTIFY_QUERYBUILDER_PROCESSORDERBYS_START');
-        $this->query ['orderBy'] = "";
-        if (count($this->parts ['orderBys']) == 0) {
+        $this->query['orderBy'] = "";
+        if (count($this->parts['orderBys']) === 0) {
             return;
         }
-        $this->query ['orderBy'] = " ORDER BY ";
-        foreach ($this->parts ['orderBys'] as $orderBy) {
+        $this->query['orderBy'] = " ORDER BY ";
+        foreach ($this->parts['orderBys'] as $orderBy) {
             $result = $this->processOrderByEntry($orderBy);
             if ($result) {
                 continue;
             }
         }
-        if (substr($this->query ['orderBy'], strlen($this->query ['orderBy']) - 2) == ', ') {
-            $this->query ['orderBy'] = substr($this->query ['orderBy'], 0, strlen($this->query ['orderBy']) - 2) . " ";
+        if (str_ends_with($this->query['orderBy'], ', ')) {
+            $this->query['orderBy'] = substr($this->query['orderBy'], 0, -2) . " ";
         }
         $this->notify('NOTIFY_QUERYBUILDER_PROCESSORDERBYS_END');
     }
@@ -284,22 +274,22 @@ class QueryBuilder extends \base
      * process orderBy clauses
      * @since ZC v1.5.7
      */
-    protected function processGroupBys()
+    protected function processGroupBys(): void
     {
         $this->notify('NOTIFY_QUERYBUILDER_PROCESSGROUPBYS_START');
-        $this->query ['groupBy'] = "";
-        if (count($this->parts ['groupBys']) == 0) {
+        $this->query['groupBy'] = "";
+        if (count($this->parts['groupBys']) === 0) {
             return;
         }
-        $this->query ['groupBy'] = " GROUP BY ";
-        foreach ($this->parts ['groupBys'] as $groupBy) {
+        $this->query['groupBy'] = " GROUP BY ";
+        foreach ($this->parts['groupBys'] as $groupBy) {
             $result = $this->processGroupByEntry($groupBy);
             if ($result) {
                 continue;
             }
         }
-        if (substr($this->query ['groupBy'], strlen($this->query ['groupBy']) - 2) == ', ') {
-            $this->query ['groupBy'] = substr($this->query ['groupBy'], 0, strlen($this->query ['groupBy']) - 2) . " ";
+        if (str_ends_with($this->query['groupBy'], ', ')) {
+            $this->query['groupBy'] = substr($this->query['groupBy'], 0, -2) . " ";
         }
         $this->notify('NOTIFY_QUERYBUILDER_PROCESSGROUPBYS_END');
     }
@@ -307,25 +297,25 @@ class QueryBuilder extends \base
     /**
      * @since ZC v1.5.7
      */
-    protected function processGroupByEntry($groupBy)
+    protected function processGroupByEntry($groupBy): false
     {
-        $this->query ['groupBy'] .= $groupBy . ", ";
+        $this->query['groupBy'] .= $groupBy . ", ";
         return false;
     }
 
     /**
      * @since ZC v1.5.7
      */
-    protected function processOrderByEntry($orderBy)
+    protected function processOrderByEntry($orderBy): bool
     {
-        if ($orderBy ['type'] == 'mysql') {
-            $this->query ['orderBy'] .= ' ' . $orderBy ['field'] . ', ';
+        if ($orderBy['type'] === 'mysql') {
+            $this->query['orderBy'] .= ' ' . $orderBy['field'] . ', ';
             return true;
         }
-        if (isset($orderBy ['table'])) {
-            $this->query ['orderBy'] .= $orderBy ['table'] . ".";
+        if (isset($orderBy['table'])) {
+            $this->query['orderBy'] .= $orderBy['table'] . ".";
         }
-        $this->query ['orderBy'] .= $orderBy ['field'] . ", ";
+        $this->query['orderBy'] .= $orderBy['field'] . ", ";
         return false;
     }
 
@@ -333,15 +323,17 @@ class QueryBuilder extends \base
      * process select list entries
      * @since ZC v1.5.7
      */
-    protected function processSelectList()
+    protected function processSelectList(): void
     {
         $this->notify('NOTIFY_QUERYBUILDER_PROCESSSELECTLIST_START');
-        if (count($this->parts ['selectList']) == 0) {
+        if (count($this->parts['selectList']) === 0) {
             return;
         }
-        foreach ($this->parts ['selectList'] as $selectList) {
-            if (trim($this->query ['select']) != 'SELECT') $this->query ['select'] .= ", ";
-            $this->query ['select'] .= $selectList;
+        foreach ($this->parts['selectList'] as $selectList) {
+            if (trim($this->query['select']) !== 'SELECT') {
+                $this->query['select'] .= ", ";
+            }
+            $this->query['select'] .= $selectList;
         }
         $this->notify('NOTIFY_QUERYBUILDER_PROCESSSELECTLIST_END');
     }
@@ -350,50 +342,41 @@ class QueryBuilder extends \base
      * process bindVars clauses
      * @since ZC v1.5.7
      */
-    protected function processBindVars()
+    protected function processBindVars(): void
     {
         $this->notify('NOTIFY_QUERYBUILDER_PROCESSBINDVARS_START');
-        if (count($this->parts ['bindVars']) == 0) {
+        if (count($this->parts['bindVars']) === 0) {
             return;
         }
-        foreach ($this->parts ['bindVars'] as $bindVars) {
-            $this->query['mainSql'] = $this->dbConn->bindVars($this->query['mainSql'], $bindVars [0], $bindVars [1], $bindVars [2]);
+        foreach ($this->parts['bindVars'] as $bindVars) {
+            $this->query['mainSql'] = $this->dbConn->bindVars($this->query['mainSql'], $bindVars[0], $bindVars[1], $bindVars[2]);
             if (isset($this->query['countSql'])) {
-                $this->query['countSql'] = $this->dbConn->bindVars($this->query['countSql'], $bindVars [0], $bindVars [1], $bindVars [2]);
+                $this->query['countSql'] = $this->dbConn->bindVars($this->query['countSql'], $bindVars[0], $bindVars[1], $bindVars[2]);
             }
         }
         $this->notify('NOTIFY_QUERYBUILDER_PROCESSBINDVARS_END');
     }
 
     /**
-     * getter
-     *
-     * @return mixed
      * @since ZC v1.5.7
      */
-    public function getParts()
+    public function getParts(): ?array
     {
         return $this->parts;
     }
 
     /**
-     * getter
-     *
-     * @return mixed
      * @since ZC v1.5.7
      */
-    public function getQuery()
+    public function getQuery(): ?array
     {
         return $this->query;
     }
 
     /**
-     * setter
-     *
-     * @param $value
      * @since ZC v1.5.7
      */
-    public function setParts($value)
+    public function setParts($value): void
     {
         $this->parts = $value;
         $this->notify('NOTIFY_QUERYBUILDER_SETPARTS_START');

--- a/includes/classes/Request.php
+++ b/includes/classes/Request.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -19,10 +21,9 @@ class Request
     protected array $paramBag;
 
     /**
-     * @return mixed|Request
      * @since ZC v1.5.8
      */
-    public static function capture(): mixed
+    public static function capture(): self
     {
         $self = self::getInstance();
         $self->paramBag = $_REQUEST;
@@ -30,9 +31,6 @@ class Request
     }
 
     /**
-     * @param $key
-     * @param null $default
-     * @return mixed|null
      * @since ZC v1.5.8
      */
     public function input($key, $default = null): mixed
@@ -41,8 +39,6 @@ class Request
     }
 
     /**
-     * @param $key
-     * @return bool
      * @since ZC v1.5.8
      */
     public function has($key): bool
@@ -54,16 +50,18 @@ class Request
     {
         /**
          * Detect the type of request received (secure or not)
+         *
+         * NOTE: there are some intentional loose-comparisons here for numeric strings.
          */
-        return ((isset($_SERVER['HTTPS']) && (strtolower((string)$_SERVER['HTTPS']) !== 'off' || $_SERVER['HTTPS'] == '1'))) ||
-            (isset($_SERVER['HTTP_X_FORWARDED_BY']) && str_contains(strtoupper((string)$_SERVER['HTTP_X_FORWARDED_BY']), 'SSL')) ||
-            (isset($_SERVER['HTTP_X_FORWARDED_HOST']) && (str_contains(strtoupper((string)$_SERVER['HTTP_X_FORWARDED_HOST']), 'SSL') || str_contains(strtolower((string)$_SERVER['HTTP_X_FORWARDED_HOST']), str_replace('https://', '', HTTP_SERVER)))) ||
-            (isset($_SERVER['HTTP_X_FORWARDED_SERVER']) && str_contains(strtolower((string)$_SERVER['HTTP_X_FORWARDED_SERVER']), str_replace('https://', '', HTTP_SERVER))) ||
-            (isset($_SERVER['SCRIPT_URI']) && stripos((string)$_SERVER['SCRIPT_URI'], 'https:') === 0) ||
-            (isset($_SERVER['HTTP_X_FORWARDED_SSL']) && ($_SERVER['HTTP_X_FORWARDED_SSL'] == '1' || strtolower((string)$_SERVER['HTTP_X_FORWARDED_SSL']) === 'on')) ||
-            (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && (strtolower((string)$_SERVER['HTTP_X_FORWARDED_PROTO']) === 'ssl' || strtolower((string)$_SERVER['HTTP_X_FORWARDED_PROTO']) === 'https')) ||
-            (isset($_SERVER['HTTP_SSLSESSIONID']) && $_SERVER['HTTP_SSLSESSIONID'] !== '') ||
-            (isset($_SERVER['HTTP_X_FORWARDED_PORT']) && $_SERVER['HTTP_X_FORWARDED_PORT'] == '443') ||
-            (isset($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] == '443');
+        return ((isset($_SERVER['HTTPS']) && (strtolower((string)$_SERVER['HTTPS']) !== 'off' || $_SERVER['HTTPS'] == '1')))
+            || (isset($_SERVER['HTTP_X_FORWARDED_BY']) && str_contains(strtoupper((string)$_SERVER['HTTP_X_FORWARDED_BY']), 'SSL'))
+            || (isset($_SERVER['HTTP_X_FORWARDED_HOST']) && (str_contains(strtoupper((string)$_SERVER['HTTP_X_FORWARDED_HOST']), 'SSL') || str_contains(strtolower((string)$_SERVER['HTTP_X_FORWARDED_HOST']), str_replace('https://', '', HTTP_SERVER))))
+            || (isset($_SERVER['HTTP_X_FORWARDED_SERVER']) && str_contains(strtolower((string)$_SERVER['HTTP_X_FORWARDED_SERVER']), str_replace('https://', '', HTTP_SERVER)))
+            || (isset($_SERVER['SCRIPT_URI']) && stripos((string)$_SERVER['SCRIPT_URI'], 'https:') === 0)
+            || (isset($_SERVER['HTTP_X_FORWARDED_SSL']) && ($_SERVER['HTTP_X_FORWARDED_SSL'] == '1' || strtolower((string)$_SERVER['HTTP_X_FORWARDED_SSL']) === 'on'))
+            || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && (strtolower((string)$_SERVER['HTTP_X_FORWARDED_PROTO']) === 'ssl' || strtolower((string)$_SERVER['HTTP_X_FORWARDED_PROTO']) === 'https'))
+            || (isset($_SERVER['HTTP_SSLSESSIONID']) && $_SERVER['HTTP_SSLSESSIONID'] !== '')
+            || (isset($_SERVER['HTTP_X_FORWARDED_PORT']) && $_SERVER['HTTP_X_FORWARDED_PORT'] == '443')
+            || (isset($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] == '443');
     }
 }

--- a/includes/classes/ResourceLoaders/AdminArraysLanguageLoader.php
+++ b/includes/classes/ResourceLoaders/AdminArraysLanguageLoader.php
@@ -1,10 +1,13 @@
 <?php
+
+declare(strict_types=1);
 /**
  *
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: DrByte 2025 Sep 18 Modified in v2.2.0 $
  */
+
 namespace Zencart\LanguageLoader;
 
 /**
@@ -64,7 +67,7 @@ class AdminArraysLanguageLoader extends ArraysLanguageLoader
     /**
      * @since ZC v2.1.0
      */
-    protected function loadBaseLanguageFiles()
+    protected function loadBaseLanguageFiles(): void
     {
         // -----
         // First, load the main language file(). The 'lang.english.php' file is always

--- a/includes/classes/ResourceLoaders/ArraysLanguageLoader.php
+++ b/includes/classes/ResourceLoaders/ArraysLanguageLoader.php
@@ -1,10 +1,13 @@
 <?php
+
+declare(strict_types=1);
 /**
  *
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: DrByte 2025 Sep 29 Modified in v2.2.0 $
  */
+
 namespace Zencart\LanguageLoader;
 
 use Zencart\FileSystem\FileSystem;
@@ -31,7 +34,7 @@ class ArraysLanguageLoader extends BaseLanguageLoader
                 $constants_made = true;
                 continue;
             }
-            preg_match_all('/%{2}([^%]+)%{2}/', $defineValue, $matches, PREG_PATTERN_ORDER);
+            preg_match_all('/%{2}([^%]+)%{2}/', $defineValue, $matches, \PREG_PATTERN_ORDER);
             if (count($matches[1])) {
                 foreach ($matches[1] as $index => $match) {
                     if (isset($defines[$match])) {
@@ -215,7 +218,7 @@ class ArraysLanguageLoader extends BaseLanguageLoader
     protected function loadDefinesFromArrayFile(string $rootPath, string $language, string $fileName, string $extraPath = ''): array
     {
         $arrayFileName = 'lang.' . $fileName;
-        $mainFile = $rootPath . $language . $extraPath. '/' . $arrayFileName;
+        $mainFile = $rootPath . $language . $extraPath . '/' . $arrayFileName;
         $fallbackFile = $rootPath . $language . '/' . $arrayFileName;
         $defineList = $this->loadDefinesWithFallback($mainFile, $fallbackFile);
         return $defineList;

--- a/includes/classes/ResourceLoaders/BaseLanguageLoader.php
+++ b/includes/classes/ResourceLoaders/BaseLanguageLoader.php
@@ -1,10 +1,13 @@
 <?php
+
+declare(strict_types=1);
 /**
  *
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: DrByte 2025 Sep 18 Modified in v2.2.0 $
  */
+
 namespace Zencart\LanguageLoader;
 
 use Zencart\FileSystem\FileSystem;

--- a/includes/classes/ResourceLoaders/CatalogArraysLanguageLoader.php
+++ b/includes/classes/ResourceLoaders/CatalogArraysLanguageLoader.php
@@ -1,10 +1,13 @@
 <?php
+
+declare(strict_types=1);
 /**
  *
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: DrByte 2025 Sep 18 Modified in v2.2.0 $
  */
+
 namespace Zencart\LanguageLoader;
 
 use Zencart\FileSystem\FileSystem;
@@ -153,7 +156,7 @@ class CatalogArraysLanguageLoader extends ArraysLanguageLoader
         // difference with the 'base' file for the page.  For example, lang.account_information.php
         // but not lang.account.php for the 'account' page.
         //
-        $files_regex = '~^lang.' . $this->currentPage  . '(.+)\.php$~i';
+        $files_regex = '~^lang.' . $this->currentPage . '(.+)\.php$~i';
 
         $defines = [];
         $files = $this->fileSystem->listFilesFromDirectoryAlphaSorted($directory, $files_regex);

--- a/includes/classes/ResourceLoaders/HtmlIncludesFinder.php
+++ b/includes/classes/ResourceLoaders/HtmlIncludesFinder.php
@@ -1,9 +1,12 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: DrByte 2025 Sep 18 Modified in v2.2.0 $
  */
+
 namespace Zencart\ResourceLoaders;
 
 /**
@@ -12,20 +15,14 @@ namespace Zencart\ResourceLoaders;
 class HtmlIncludesFinder
 {
     private $filesystem;
-    private array $installedPlugins;
-    private string $language;
     private string $fallback = 'english';
-    private string $templateDir;
     private TemplateResolver $templateResolver;
 
     private static array $files = [];
 
-    public function __construct($filesystem, array $installedPlugins, string $language, string $templateDir)
+    public function __construct($filesystem, private array $installedPlugins, private string $language, private string $templateDir)
     {
         $this->filesystem = $filesystem;
-        $this->installedPlugins = $installedPlugins;
-        $this->language = $language;
-        $this->templateDir = $templateDir;
         $this->templateResolver = new TemplateResolver(null, null, null, $installedPlugins);
     }
 

--- a/includes/classes/ResourceLoaders/LanguageLoader.php
+++ b/includes/classes/ResourceLoaders/LanguageLoader.php
@@ -1,10 +1,13 @@
 <?php
+
+declare(strict_types=1);
 /**
  *
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: DrByte 2025 Sep 29 Modified in v2.2.0 $
  */
+
 namespace Zencart\LanguageLoader;
 
 /**
@@ -149,7 +152,7 @@ class LanguageLoader
         $fileInfo = pathinfo($defineFile);
         $searchFile = $fileInfo['basename'];
         if (!str_starts_with($searchFile, 'lang.')) {
-             $searchFile = 'lang.' . $searchFile;
+            $searchFile = 'lang.' . $searchFile;
         }
         $searchFile = $fileInfo['dirname'] . '/' . $searchFile;
         if (in_array($searchFile, $this->languageFilesLoaded['arrays'])) {

--- a/includes/classes/ResourceLoaders/LanguageLoaderFactory.php
+++ b/includes/classes/ResourceLoaders/LanguageLoaderFactory.php
@@ -1,10 +1,13 @@
 <?php
+
+declare(strict_types=1);
 /**
  *
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: DrByte 2025 Sep 18 Modified in v2.2.0 $
  */
+
 namespace Zencart\LanguageLoader;
 
 use Zencart\LanguageLoader\LanguageLoader;

--- a/includes/classes/ResourceLoaders/ModuleFinder.php
+++ b/includes/classes/ResourceLoaders/ModuleFinder.php
@@ -1,11 +1,13 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: DrByte 2025 Sep 18 Modified in v2.2.0 $
  */
-namespace Zencart\ResourceLoaders;
 
+namespace Zencart\ResourceLoaders;
 
 use Zencart\FileSystem\FileSystem;
 

--- a/includes/classes/ResourceLoaders/PageLoader.php
+++ b/includes/classes/ResourceLoaders/PageLoader.php
@@ -1,10 +1,13 @@
 <?php
+
+declare(strict_types=1);
 /**
  *
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: DrByte 2025 Sep 18 Modified in v2.2.0 $
  */
+
 namespace Zencart\PageLoader;
 
 use Zencart\FileSystem\FileSystem as FileSystem;
@@ -32,8 +35,7 @@ class PageLoader
         string $mainPage,
         FileSystem $fileSystem,
         ?TemplateResolver $templateResolver = null
-    ): void
-    {
+    ): void {
         $this->installedPlugins = $installedPlugins;
         $this->mainPage = $mainPage;
         $this->fileSystem = $fileSystem;
@@ -87,10 +89,10 @@ class PageLoader
      */
     public function getTemplatePart(string $pageDirectory, string $templatePart, string $fileExtension = '.php'): array
     {
-        if ($this->isTemplatePath($pageDirectory)) {
+        if (self::isTemplatePath($pageDirectory)) {
             $directoryArray = [];
             foreach ($this->getTemplateSearchDirectoriesFromPath($pageDirectory) as $directory) {
-                $directoryArray = $this->getTemplatePartFromDirectory(
+                $directoryArray = self::getTemplatePartFromDirectory(
                     $directoryArray,
                     $directory,
                     $templatePart,
@@ -102,7 +104,7 @@ class PageLoader
             return $directoryArray;
         }
 
-        $directoryArray = $this->getTemplatePartFromDirectory(
+        $directoryArray = self::getTemplatePartFromDirectory(
             [],
             $pageDirectory,
             $templatePart,
@@ -112,7 +114,7 @@ class PageLoader
         foreach ($this->installedPlugins as $plugin) {
             $checkDir = 'zc_plugins/' . $plugin['unique_key'] . '/' . $plugin['version'] . '/catalog/';
             $checkDir .= $pageDirectory;
-            $directoryArray = $this->getTemplatePartFromDirectory(
+            $directoryArray = self::getTemplatePartFromDirectory(
                 $directoryArray,
                 $checkDir,
                 $templatePart,
@@ -128,7 +130,7 @@ class PageLoader
      *
      * @since ZC v1.5.7
      */
-    private function getTemplatePartFromDirectory(array $directoryArray, string $pageDirectory, string $templatePart, string $fileExtension): array
+    private static function getTemplatePartFromDirectory(array $directoryArray, string $pageDirectory, string $templatePart, string $fileExtension): array
     {
         if ($dir = @dir($pageDirectory)) {
             while ($file = $dir->read()) {
@@ -168,7 +170,7 @@ class PageLoader
     public function getTemplateDirectory(string $fileName, string $currentTemplateDir, string $currentPage, string $templateSubDir): string
     {
         $fileName = str_replace("/", '', $fileName);
-        foreach ($this->getTemplateSearchDirectories($this->getCurrentTemplateKey($currentTemplateDir), $currentPage, $templateSubDir) as $directory) {
+        foreach ($this->getTemplateSearchDirectories(self::getCurrentTemplateKey($currentTemplateDir), $currentPage, $templateSubDir) as $directory) {
             if ($this->fileSystem->fileExistsInDirectory($directory, $fileName)) {
                 return rtrim($directory, '/');
             }
@@ -186,7 +188,7 @@ class PageLoader
                 continue;
             }
 
-            foreach ($this->getPluginOverlayDirectories($plugin, $templateDir) as $checkDir) {
+            foreach (self::getPluginOverlayDirectories($plugin, $templateDir) as $checkDir) {
                 if ($this->fileSystem->fileExistsInDirectory($checkDir, preg_replace('/\//', '', $fileName))) {
                     return $checkDir;
                 }
@@ -278,7 +280,7 @@ class PageLoader
      */
     private function getTemplateSearchDirectoriesFromPath(string $pageDirectory): array
     {
-        $normalized = $this->normalizeDirectory($pageDirectory);
+        $normalized = self::normalizeDirectory($pageDirectory);
         if (!preg_match('~includes/templates/([^/]+)/(.+)$~', $normalized, $matches)) {
             return [$pageDirectory];
         }
@@ -298,7 +300,7 @@ class PageLoader
             return [];
         }
 
-        $templateRoot = $this->getRelativeCatalogPath($record['template_path']);
+        $templateRoot = self::getRelativeCatalogPath($record['template_path']);
         if ($templateRoot === null) {
             return [];
         }
@@ -315,7 +317,7 @@ class PageLoader
     {
         $directories = [];
         foreach ($this->installedPlugins as $plugin) {
-            foreach ($this->getPluginOverlayDirectories($plugin, $subDirectory, ['default']) as $directory) {
+            foreach (self::getPluginOverlayDirectories($plugin, $subDirectory, ['default']) as $directory) {
                 $directories[] = $directory;
             }
         }
@@ -335,7 +337,7 @@ class PageLoader
     {
         $directories = [];
         foreach ($this->installedPlugins as $plugin) {
-            foreach ($this->getPluginOverlayDirectories($plugin, $templateSubDir, [$targetTemplate]) as $directory) {
+            foreach (self::getPluginOverlayDirectories($plugin, $templateSubDir, [$targetTemplate]) as $directory) {
                 $directories[] = $directory;
             }
         }
@@ -346,14 +348,14 @@ class PageLoader
     /**
      * @since ZC v3.0.0
      */
-    private function getPluginOverlayDirectories(array $plugin, string $templateSubDir, ?array $targets = null): array
+    private static function getPluginOverlayDirectories(array $plugin, string $templateSubDir, ?array $targets = null): array
     {
         $templatesRoot = 'zc_plugins/' . $plugin['unique_key'] . '/' . $plugin['version'] . '/catalog/includes/templates/';
         if (!is_dir(DIR_FS_CATALOG . $templatesRoot)) {
             return [];
         }
 
-        $availableTargets = $targets ?? $this->getPluginTemplateTargets($templatesRoot);
+        $availableTargets = $targets ?? self::getPluginTemplateTargets($templatesRoot);
         $directories = [];
         foreach ($availableTargets as $target) {
             $directory = $templatesRoot . trim($target, '/') . '/' . trim($templateSubDir, '/') . '/';
@@ -368,7 +370,7 @@ class PageLoader
     /**
      * @since ZC v3.0.0
      */
-    private function getPluginTemplateTargets(string $templatesRoot): array
+    private static function getPluginTemplateTargets(string $templatesRoot): array
     {
         $targets = [];
         $directory = new \DirectoryIterator(DIR_FS_CATALOG . $templatesRoot);
@@ -398,9 +400,9 @@ class PageLoader
     /**
      * @since ZC v3.0.0
      */
-    private function getCurrentTemplateKey(string $currentTemplateDir): string
+    private static function getCurrentTemplateKey(string $currentTemplateDir): string
     {
-        $normalized = trim($this->normalizeDirectory($currentTemplateDir), '/');
+        $normalized = trim(self::normalizeDirectory($currentTemplateDir), '/');
         if ($normalized === '' || $normalized === 'template_default') {
             return 'template_default';
         }
@@ -424,10 +426,10 @@ class PageLoader
     /**
      * @since ZC v3.0.0
      */
-    private function getRelativeCatalogPath(string $path): ?string
+    private static function getRelativeCatalogPath(string $path): ?string
     {
         $normalizedCatalogRoot = rtrim(str_replace('\\', '/', DIR_FS_CATALOG), '/');
-        $normalizedPath = $this->normalizeDirectory($path);
+        $normalizedPath = self::normalizeDirectory($path);
         if (!str_starts_with($normalizedPath, $normalizedCatalogRoot . '/')) {
             return null;
         }
@@ -438,15 +440,15 @@ class PageLoader
     /**
      * @since ZC v3.0.0
      */
-    private function isTemplatePath(string $path): bool
+    private static function isTemplatePath(string $path): bool
     {
-        return str_contains($this->normalizeDirectory($path), 'includes/templates/');
+        return str_contains(self::normalizeDirectory($path), 'includes/templates/');
     }
 
     /**
      * @since ZC v3.0.0
      */
-    private function normalizeDirectory(string $path): string
+    private static function normalizeDirectory(string $path): string
     {
         return rtrim(str_replace('\\', '/', $path), '/');
     }

--- a/includes/classes/ResourceLoaders/SideboxFinder.php
+++ b/includes/classes/ResourceLoaders/SideboxFinder.php
@@ -1,9 +1,12 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: DrByte 2025 Sep 18 Modified in v2.2.0 $
  */
+
 namespace Zencart\ResourceLoaders;
 
 use Zencart\FileSystem\FileSystem as FileSystem;

--- a/includes/classes/ResourceLoaders/TemplateResolver.php
+++ b/includes/classes/ResourceLoaders/TemplateResolver.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -34,11 +36,10 @@ class TemplateResolver
         ?string $pluginsRoot = null,
         ?array $installedPlugins = null,
         ?PluginManager $pluginManager = null
-    )
-    {
-        $this->catalogRoot = $this->normalizeDirectory($catalogRoot ?? (defined('DIR_FS_CATALOG') ? DIR_FS_CATALOG : dirname(__DIR__, 2)));
-        $this->coreTemplatesPath = $this->normalizeDirectory($coreTemplatesPath ?? $this->catalogRoot . '/includes/templates');
-        $this->pluginsRoot = $this->normalizeDirectory($pluginsRoot ?? $this->catalogRoot . '/zc_plugins');
+    ) {
+        $this->catalogRoot = self::normalizeDirectory($catalogRoot ?? (defined('DIR_FS_CATALOG') ? DIR_FS_CATALOG : dirname(__DIR__, 2)));
+        $this->coreTemplatesPath = self::normalizeDirectory($coreTemplatesPath ?? $this->catalogRoot . '/includes/templates');
+        $this->pluginsRoot = self::normalizeDirectory($pluginsRoot ?? $this->catalogRoot . '/zc_plugins');
         $this->installedPlugins = $installedPlugins;
 
         if ($pluginManager !== null) {
@@ -209,9 +210,9 @@ class TemplateResolver
 
             if (!isset(self::$templateRecords[$contextKey])) {
                 self::$templateRecords[$contextKey] = array_merge(
-                $this->loadCoreTemplates(),
-                $this->loadPluginTemplates()
-            );
+                    $this->loadCoreTemplates(),
+                    $this->loadPluginTemplates()
+                );
             }
 
             foreach (self::$templateRecords[$contextKey] as $templateKey => $templateProperties) {
@@ -241,20 +242,20 @@ class TemplateResolver
             }
 
             $templateKey = $fileInfo->getFilename();
-            $templatePath = $this->normalizeDirectory($fileInfo->getPathname());
-            $templateInfo = $this->loadTemplateInfo($templatePath . '/template_info.php');
+            $templatePath = self::normalizeDirectory($fileInfo->getPathname());
+            $templateInfo = self::loadTemplateInfo($templatePath . '/template_info.php');
             if ($templateInfo === null) {
                 continue;
             }
 
             $templates[$templateKey] = array_merge($templateInfo, [
-                'template_base_fs' => $this->normalizeDirectory($this->catalogRoot) . '/',
+                'template_base_fs' => self::normalizeDirectory($this->catalogRoot) . '/',
                 'template_key' => $templateKey,
                 'template_path' => $templatePath . '/',
                 'template_catalog_path' => 'includes/templates/' . $templateKey . '/',
-                'template_web_path' => $this->buildCoreWebPath($templateKey),
+                'template_web_path' => self::buildCoreWebPath($templateKey),
                 'template_settings_path' => $templatePath . '/template_settings.php',
-                'base_template' => $this->normalizeBaseTemplate($templateInfo['base_template'] ?? null, $templateKey),
+                'base_template' => self::normalizeBaseTemplate($templateInfo['base_template'] ?? null, $templateKey),
                 'is_plugin_template' => false,
                 'template_source' => 'core',
             ]);
@@ -282,7 +283,7 @@ class TemplateResolver
                 continue;
             }
             $manifest = require $manifestFile;
-            if (!$this->isSelectableTemplateManifest($manifest)) {
+            if (!self::isSelectableTemplateManifest($manifest)) {
                 continue;
             }
 
@@ -302,7 +303,7 @@ class TemplateResolver
     private function getInstalledPlugins(): array
     {
         if ($this->installedPlugins !== null) {
-            return $this->normalizeInstalledPlugins($this->installedPlugins);
+            return self::normalizeInstalledPlugins($this->installedPlugins);
         }
 
         if ($this->pluginManager !== null) {
@@ -315,7 +316,7 @@ class TemplateResolver
     /**
      * @since ZC v3.0.0
      */
-    private function isSelectableTemplateManifest(mixed $manifest): bool
+    private static function isSelectableTemplateManifest(mixed $manifest): bool
     {
         if (!is_array($manifest) || empty($manifest['template']) || !is_array($manifest['template'])) {
             return false;
@@ -331,29 +332,29 @@ class TemplateResolver
     {
         $template = $manifest['template'];
         $templateKey = $template['key'];
-        $defaultTemplatePath = $this->normalizeDirectory($versionPath . '/catalog/includes/templates/' . $templateKey);
+        $defaultTemplatePath = self::normalizeDirectory($versionPath . '/catalog/includes/templates/' . $templateKey);
         $templateInfoFile = !empty($template['infoFile'])
             ? $versionPath . '/' . ltrim($template['infoFile'], '/')
             : $defaultTemplatePath . '/template_info.php';
-        $templateInfo = $this->loadTemplateInfo($templateInfoFile);
+        $templateInfo = self::loadTemplateInfo($templateInfoFile);
         if ($templateInfo === null) {
             return null;
         }
 
-        $templatePath = $this->normalizeDirectory(dirname($templateInfoFile)) . '/';
-        $templateCatalogPath = ltrim(str_replace($this->normalizeDirectory($this->catalogRoot) . '/', '', $this->normalizeDirectory($templatePath)), '/') . '/';
+        $templatePath = self::normalizeDirectory(dirname($templateInfoFile)) . '/';
+        $templateCatalogPath = ltrim(str_replace(self::normalizeDirectory($this->catalogRoot) . '/', '', self::normalizeDirectory($templatePath)), '/') . '/';
         $settingsFile = !empty($template['settingsFile'])
             ? $versionPath . '/' . ltrim($template['settingsFile'], '/')
             : $templatePath . 'template_settings.php';
 
         return array_merge($templateInfo, [
-            'template_base_fs' => $this->normalizeDirectory($versionPath . '/catalog/') . '/',
+            'template_base_fs' => self::normalizeDirectory($versionPath . '/catalog/') . '/',
             'template_key' => $templateKey,
             'template_path' => $templatePath,
             'template_catalog_path' => $templateCatalogPath,
-            'template_web_path' => $this->buildPluginWebPath($templateCatalogPath),
+            'template_web_path' => self::buildPluginWebPath($templateCatalogPath),
             'template_settings_path' => $settingsFile,
-            'base_template' => $this->normalizeBaseTemplate($template['baseTemplate'] ?? null, $templateKey),
+            'base_template' => self::normalizeBaseTemplate($template['baseTemplate'] ?? null, $templateKey),
             'is_plugin_template' => true,
             'template_source' => 'plugin',
             'plugin_key' => $pluginKey,
@@ -366,7 +367,7 @@ class TemplateResolver
     /**
      * @since ZC v3.0.0
      */
-    private function loadTemplateInfo(string $templateInfoFile): ?array
+    private static function loadTemplateInfo(string $templateInfoFile): ?array
     {
         if (!file_exists($templateInfoFile)) {
             return null;
@@ -400,7 +401,7 @@ class TemplateResolver
     /**
      * @since ZC v3.0.0
      */
-    private function buildCoreWebPath(string $templateKey): string
+    private static function buildCoreWebPath(string $templateKey): string
     {
         $catalogWebRoot = defined('DIR_WS_CATALOG') ? DIR_WS_CATALOG : '/';
         return rtrim($catalogWebRoot, '/') . '/includes/templates/' . $templateKey . '/';
@@ -409,7 +410,7 @@ class TemplateResolver
     /**
      * @since ZC v3.0.0
      */
-    private function buildPluginWebPath(string $templateCatalogPath): string
+    private static function buildPluginWebPath(string $templateCatalogPath): string
     {
         $catalogWebRoot = defined('DIR_WS_CATALOG') ? DIR_WS_CATALOG : '/';
         return rtrim($catalogWebRoot, '/') . '/' . trim($templateCatalogPath, '/') . '/';
@@ -418,7 +419,7 @@ class TemplateResolver
     /**
      * @since ZC v3.0.0
      */
-    private function normalizeBaseTemplate(?string $baseTemplate, string $templateKey): ?string
+    private static function normalizeBaseTemplate(?string $baseTemplate, string $templateKey): ?string
     {
         if (empty($baseTemplate)) {
             return $templateKey === 'template_default' ? null : 'template_default';
@@ -427,7 +428,7 @@ class TemplateResolver
         return $baseTemplate === $templateKey ? null : $baseTemplate;
     }
 
-    private function normalizeDirectory(string $path): string
+    private static function normalizeDirectory(string $path): string
     {
         return rtrim(str_replace('\\', '/', $path), '/');
     }
@@ -441,14 +442,14 @@ class TemplateResolver
             $this->catalogRoot,
             $this->coreTemplatesPath,
             $this->pluginsRoot,
-            md5(json_encode($this->normalizeInstalledPlugins($this->installedPlugins ?? [])) ?: '[]'),
+            md5(json_encode(self::normalizeInstalledPlugins($this->installedPlugins ?? [])) ?: '[]'),
         ]);
     }
 
     /**
      * @since ZC v3.0.0
      */
-    private function normalizeInstalledPlugins(array $installedPlugins): array
+    private static function normalizeInstalledPlugins(array $installedPlugins): array
     {
         $normalized = [];
         foreach ($installedPlugins as $key => $plugin) {

--- a/includes/classes/SessionHandler.php
+++ b/includes/classes/SessionHandler.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * Zen Cart Database Session Handler
  *
@@ -14,7 +16,6 @@ namespace Zencart;
  */
 class SessionHandler implements \SessionHandlerInterface
 {
-
     /**
      * @inheritDoc
      * @since ZC v2.0.0

--- a/includes/classes/Settings.php
+++ b/includes/classes/Settings.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0

--- a/includes/classes/TemplateDto.php
+++ b/includes/classes/TemplateDto.php
@@ -1,9 +1,12 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: DrByte 2025 Sep 18 Modified in v2.2.0 $
  */
+
 namespace Zencart\Templates;
 
 use Zencart\Traits\Singleton;

--- a/includes/classes/TemplateSelect.php
+++ b/includes/classes/TemplateSelect.php
@@ -1,9 +1,12 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: DrByte 2025 Sep 18 Modified in v2.2.0 $
  */
+
 namespace Zencart\Templates;
 
 /**

--- a/includes/classes/TemplateSettings.php
+++ b/includes/classes/TemplateSettings.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0

--- a/includes/classes/ViewBuilders/BaseController.php
+++ b/includes/classes/ViewBuilders/BaseController.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -40,7 +42,7 @@ class BaseController
     /**
      * @since ZC v1.5.8
      */
-    protected function getAction() : string
+    protected function getAction(): string
     {
         $action = $this->request->input('action', '');
         return $action;
@@ -98,7 +100,7 @@ class BaseController
     /**
      * @since ZC v1.5.8
      */
-    public function colKeyLink() : string
+    public function colKeyLink(): string
     {
         return $this->tableDefinition->colKeyName() . '=' . $this->currentFieldValue($this->tableDefinition->getParameter('colKey'));
     }

--- a/includes/classes/ViewBuilders/DataTableDataSource.php
+++ b/includes/classes/ViewBuilders/DataTableDataSource.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0

--- a/includes/classes/ViewBuilders/DerivedItemsManager.php
+++ b/includes/classes/ViewBuilders/DerivedItemsManager.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -53,7 +55,9 @@ class DerivedItemsManager
         $params = $columnInfo['derivedItem']['params'];
         $listValue = $tableRow[$colName];
         $result = $params['false'];
-        if ($listValue) $result = $params['true'];
+        if ($listValue) {
+            $result = $params['true'];
+        }
         return $result;
     }
 
@@ -74,7 +78,7 @@ class DerivedItemsManager
     protected function getPluginFileSize($tableRow, string $colName, array $columnInfo): string
     {
         $filePath = DIR_FS_CATALOG . 'zc_plugins/' . $tableRow['unique_key'] . '/';
-        $fs = new FileSystem;
+        $fs = new FileSystem();
         $dirSize = $fs->getDirectorySize($filePath);
         return $dirSize;
     }

--- a/includes/classes/ViewBuilders/NativePaginator.php
+++ b/includes/classes/ViewBuilders/NativePaginator.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0

--- a/includes/classes/ViewBuilders/PluginManagerController.php
+++ b/includes/classes/ViewBuilders/PluginManagerController.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -34,7 +36,7 @@ class PluginManagerController extends BaseController
     /**
      * @since ZC v2.2.0
      */
-    protected function getManifest(string $unique_key, string $version): null|array
+    protected function getManifest(string $unique_key, string $version): ?array
     {
         if (isset($this->manifests[$unique_key][$version])) {
             return $this->manifests[$unique_key][$version];
@@ -406,12 +408,12 @@ class PluginManagerController extends BaseController
         }
         $this->setBoxHeader('<h4>' . zen_lookup_admin_menu_language_override('plugin_name', $this->currentFieldValue('unique_key'), $this->currentFieldValue('name')) . '</h4>');
         $this->setBoxForm(zen_draw_form(
-                'pluginupgrade',
-                FILENAME_PLUGIN_MANAGER,
-                $this->pageLink() . '&' . $this->colKeyLink() . '&action=doUpgrade',
-                'post',
-                'class="form-horizontal"'
-            ) . zen_draw_hidden_field('version', $this->request->input('version')));
+            'pluginupgrade',
+            FILENAME_PLUGIN_MANAGER,
+            $this->pageLink() . '&' . $this->colKeyLink() . '&action=doUpgrade',
+            'post',
+            'class="form-horizontal"'
+        ) . zen_draw_hidden_field('version', $this->request->input('version')));
         $this->setBoxContent(
             '<br>' . TEXT_CONFIRM_UPGRADE . '<br>' . sprintf(TEXT_INFO_UPGRADE_CONFIRM, $this->request->input('version')) . '<br><br>' . TEXT_INFO_UPGRADE_WARNING
         );
@@ -573,12 +575,12 @@ class PluginManagerController extends BaseController
     {
         $this->setBoxHeader('<h4>' . zen_lookup_admin_menu_language_override('plugin_name', $this->currentFieldValue('unique_key'), $this->currentFieldValue('name')) . '</h4>');
         $this->setBoxForm(zen_draw_form(
-                'pluginuninstall',
-                FILENAME_PLUGIN_MANAGER,
-                $this->pageLink() . '&' . $this->colKeyLink() . '&action=doEnable',
-                'post',
-                'class="form-horizontal"'
-            ) . zen_draw_hidden_field('version', $this->currentFieldValue('version')));
+            'pluginuninstall',
+            FILENAME_PLUGIN_MANAGER,
+            $this->pageLink() . '&' . $this->colKeyLink() . '&action=doEnable',
+            'post',
+            'class="form-horizontal"'
+        ) . zen_draw_hidden_field('version', $this->currentFieldValue('version')));
         $this->setBoxContent('<br>' . TEXT_CONFIRM_ENABLE . '<br>');
 
         $installer = $this->installerFactory->make($this->currentFieldValue('unique_key'), $this->currentFieldValue('version'));
@@ -639,12 +641,12 @@ class PluginManagerController extends BaseController
     {
         $this->setBoxHeader('<h4>' . zen_lookup_admin_menu_language_override('plugin_name', $this->currentFieldValue('unique_key'), $this->currentFieldValue('name')) . '</h4>');
         $this->setBoxForm(zen_draw_form(
-                'pluginuninstall',
-                FILENAME_PLUGIN_MANAGER,
-                $this->pageLink() . '&' . $this->colKeyLink() . '&action=doDisable',
-                'post',
-                'class="form-horizontal"'
-            ) . zen_draw_hidden_field('version', $this->currentFieldValue('version')));
+            'pluginuninstall',
+            FILENAME_PLUGIN_MANAGER,
+            $this->pageLink() . '&' . $this->colKeyLink() . '&action=doDisable',
+            'post',
+            'class="form-horizontal"'
+        ) . zen_draw_hidden_field('version', $this->currentFieldValue('version')));
         $this->setBoxContent('<br>' . TEXT_CONFIRM_DISABLE . '<br>');
 
         $installer = $this->installerFactory->make($this->currentFieldValue('unique_key'), $this->currentFieldValue('version'));

--- a/includes/classes/ViewBuilders/PluginManagerDataSource.php
+++ b/includes/classes/ViewBuilders/PluginManagerDataSource.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0

--- a/includes/classes/ViewBuilders/SimpleDataFormatter.php
+++ b/includes/classes/ViewBuilders/SimpleDataFormatter.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -186,11 +188,11 @@ class SimpleDataFormatter
      */
     public function hasButtonActions()
     {
-         $buttonActions = $this->getRawButtonActions();
-         if (count($buttonActions) == 0) {
-             return false;
-         }
-         return (count($buttonActions) > 0);
+        $buttonActions = $this->getRawButtonActions();
+        if (count($buttonActions) == 0) {
+            return false;
+        }
+        return (count($buttonActions) > 0);
     }
 
     /**
@@ -282,7 +284,7 @@ class SimpleDataFormatter
     {
         $pagerVar = $this->tableDefinition->getParameter('pagerVariable');
         $link = $pagerVar . '=' . $this->request->input($pagerVar, 1);
-        $link .= '&action='  . $rowAction['action'];
+        $link .= '&action=' . $rowAction['action'];
         $tableRowLink = $this->processRowActionTableRowLink($rowAction, $tableRow);
         $tableRowLink = rtrim($tableRowLink, '&');
         $link .= '&' . $tableRowLink;
@@ -299,7 +301,9 @@ class SimpleDataFormatter
             return $link;
         }
         foreach ($rowAction['linkParams'] as $linkParams) {
-            if ($linkParams['source'] !== 'tableRow') continue;
+            if ($linkParams['source'] !== 'tableRow') {
+                continue;
+            }
             $link .= $linkParams['param'] . '=' . $tableRow[$linkParams['field']]['original'] . '&';
         }
         return $link;

--- a/includes/classes/ViewBuilders/TableViewDefinition.php
+++ b/includes/classes/ViewBuilders/TableViewDefinition.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -26,7 +28,7 @@ class TableViewDefinition
     /**
      * @since ZC v1.5.8
      */
-    public function getDefinition() : array
+    public function getDefinition(): array
     {
         return $this->definition;
     }
@@ -34,7 +36,7 @@ class TableViewDefinition
     /**
      * @since ZC v1.5.8
      */
-    public function setParameter(string $field, $definition) : TableViewDefinition
+    public function setParameter(string $field, $definition): TableViewDefinition
     {
         $this->definition[$field] = $definition;
         return $this;
@@ -52,7 +54,7 @@ class TableViewDefinition
     /**
      * @since ZC v1.5.8
      */
-    public function addButtonAction($definition) : TableViewDefinition
+    public function addButtonAction($definition): TableViewDefinition
     {
         $this->definition['buttonActions'][] = $definition;
         return $this;
@@ -61,7 +63,7 @@ class TableViewDefinition
     /**
      * @since ZC v1.5.8
      */
-    public function addRowAction($definition) : TableViewDefinition
+    public function addRowAction($definition): TableViewDefinition
     {
         $this->definition['rowActions'][] = $definition;
         return $this;
@@ -70,7 +72,7 @@ class TableViewDefinition
     /**
      * @since ZC v1.5.8
      */
-    public function addColumn(string $field, $definition) : TableViewDefinition
+    public function addColumn(string $field, $definition): TableViewDefinition
     {
         $this->definition['columns'][$field] = $definition;
         return $this;
@@ -79,7 +81,7 @@ class TableViewDefinition
     /**
      * @since ZC v1.5.8
      */
-    public function addColumnBefore($index, $newKey, $data) : TableViewDefinition
+    public function addColumnBefore($index, $newKey, $data): TableViewDefinition
     {
         $columns = $this->definition['columns'];
         $columns = $this->insertBefore($columns, $index, $newKey, $data);
@@ -90,7 +92,7 @@ class TableViewDefinition
     /**
      * @since ZC v1.5.8
      */
-    public function addColumnAfter($index, $newKey, $data) : TableViewDefinition
+    public function addColumnAfter($index, $newKey, $data): TableViewDefinition
     {
         $columns = $this->definition['columns'];
         $columns = $this->insertAfter($columns, $index, $newKey, $data);
@@ -113,7 +115,7 @@ class TableViewDefinition
     /**
      * @since ZC v1.5.8
      */
-    public function isPaginated() : bool
+    public function isPaginated(): bool
     {
         return ($this->definition['paginated']);
     }
@@ -121,7 +123,7 @@ class TableViewDefinition
     /**
      * @since ZC v1.5.8
      */
-    public function colKeyName() : string
+    public function colKeyName(): string
     {
         return $this->definition['colKeyName'];
     }
@@ -129,15 +131,15 @@ class TableViewDefinition
     /**
      * @since ZC v1.5.8
      */
-    public function hasRowActions() : bool
+    public function hasRowActions(): bool
     {
-        return (count($this->definition['rowActions']) >0);
+        return (count($this->definition['rowActions']) > 0);
     }
 
     /**
      * @since ZC v1.5.8
      */
-    public function getRowActions() : array
+    public function getRowActions(): array
     {
         return $this->definition['rowActions'];
     }
@@ -145,7 +147,7 @@ class TableViewDefinition
     /**
      * @since ZC v1.5.8
      */
-    public function getButtonActions() : array
+    public function getButtonActions(): array
     {
         return $this->definition['buttonActions'];
     }
@@ -155,14 +157,14 @@ class TableViewDefinition
      */
     protected function setDefaults()
     {
-        $this->definition['paginated'] = $this->definition['paginated'] ?? true;
-        $this->definition['columns'] = $this->definition['columns'] ?? [];
-        $this->definition['buttonActions'] = $this->definition['buttonActions'] ?? [];
-        $this->definition['rowActions'] = $this->definition['rowActions'] ?? [];
-        $this->definition['maxRowCount'] = $this->definition['maxRowCount'] ?? 10;
-        $this->definition['colKeyName'] = $this->definition['colKeyName'] ?? 'colKey';
-        $this->definition['pagerVariable'] = $this->definition['pagerVariable'] ?? 'page';
-        $this->definition['colKey'] = $this->definition['colKey'] ?? 'id';
+        $this->definition['paginated'] ??= true;
+        $this->definition['columns'] ??= [];
+        $this->definition['buttonActions'] ??= [];
+        $this->definition['rowActions'] ??= [];
+        $this->definition['maxRowCount'] ??= 10;
+        $this->definition['colKeyName'] ??= 'colKey';
+        $this->definition['pagerVariable'] ??= 'page';
+        $this->definition['colKey'] ??= 'id';
     }
 
     /**
@@ -176,11 +178,12 @@ class TableViewDefinition
     /**
      * @since ZC v1.5.8
      */
-    protected function insertBefore($input, $index, $newKey, $element) {
+    protected function insertBefore($input, $index, $newKey, $element)
+    {
         if (!array_key_exists($index, $input)) {
             return $input;
         }
-        $tmpArray = array();
+        $tmpArray = [];
         foreach ($input as $key => $value) {
             if ($key === $index) {
                 $tmpArray[$newKey] = $element;
@@ -193,11 +196,12 @@ class TableViewDefinition
     /**
      * @since ZC v1.5.8
      */
-    protected function insertAfter($input, $index, $newKey, $element) {
+    protected function insertAfter($input, $index, $newKey, $element)
+    {
         if (!array_key_exists($index, $input)) {
             return $input;
         }
-        $tmpArray = array();
+        $tmpArray = [];
         foreach ($input as $key => $value) {
             $tmpArray[$key] = $value;
             if ($key === $index) {

--- a/includes/classes/ZenShipping.php
+++ b/includes/classes/ZenShipping.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @since ZC v2.1.0
  */

--- a/includes/classes/ajax/zcAjaxAdminDashboardWidgetArrange.php
+++ b/includes/classes/ajax/zcAjaxAdminDashboardWidgetArrange.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * zcAjaxAdminDashboardWidgetArrange
  *
@@ -44,8 +46,8 @@ class zcAjaxAdminDashboardWidgetArrange extends base
         $clean_layout = [];
 
         foreach ($allowed_zones as $zone) {
+            $clean_layout[$zone] = [];
             if (isset($layout[$zone]) && is_array($layout[$zone])) {
-                $clean_layout[$zone] = [];
                 foreach ($layout[$zone] as $widget) {
                     // filter out empty elements that the ajax drag-drop might send
                     if (!is_string($widget) || empty(trim($widget))) {
@@ -62,8 +64,6 @@ class zcAjaxAdminDashboardWidgetArrange extends base
                     }
                     $clean_layout[$zone][] = $clean_widget;
                 }
-            } else {
-                $clean_layout[$zone] = [];
             }
         }
 

--- a/includes/classes/ajax/zcAjaxAdminDatePickerDateCheck.php
+++ b/includes/classes/ajax/zcAjaxAdminDatePickerDateCheck.php
@@ -36,7 +36,7 @@ class zcAjaxAdminDatePickerDateCheck extends base
             $dt = DateTime::createFromFormat($local_fmt, $date_raw);
             $date_raw = false;
             if (!empty($dt)) {
-              $date_raw = $dt->format('Y-m-d');
+                $date_raw = $dt->format('Y-m-d');
             }
         }
         return ($date_raw !== false && zcDate::validateDate($date_raw) === true) ? 'true' : 'false';

--- a/includes/classes/ajax/zcAjaxAdminDatePickerDateCheck.php
+++ b/includes/classes/ajax/zcAjaxAdminDatePickerDateCheck.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * zcAjaxAdminDateCheck
  *
@@ -10,11 +12,12 @@
 class zcAjaxAdminDatePickerDateCheck extends base
 {
     /**
-     * check.  Checks a 'datepicker' date for validity
+     * Checks a 'datepicker' date for validity
      *
+     * @return string 'true' or 'false' (as a string for ease of use in JavaScript)
      * @since ZC v2.0.0
      */
-    public function check()
+    public function check(): string
     {
         // -----
         // Deny access unless running under the admin.
@@ -33,9 +36,9 @@ class zcAjaxAdminDatePickerDateCheck extends base
 
         if (DATE_FORMAT_DATE_PICKER !== 'yy-mm-dd') {
             $local_fmt = zen_datepicker_format_fordate();
-            $dt = DateTime::createFromFormat($local_fmt, $date_raw);
+            $dt = DateTimeImmutable::createFromFormat($local_fmt, $date_raw);
             $date_raw = false;
-            if (!empty($dt)) {
+            if ($dt !== false) {
                 $date_raw = $dt->format('Y-m-d');
             }
         }

--- a/includes/classes/ajax/zcAjaxAdminNotifications.php
+++ b/includes/classes/ajax/zcAjaxAdminNotifications.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * zcAjaxAdminNotifications
  *
@@ -12,7 +14,7 @@ class zcAjaxAdminNotifications extends base
     /**
      * @since ZC v1.5.6
      */
-    public function forget()
+    public function forget(): array
     {
         global $db;
 

--- a/includes/classes/ajax/zcAjaxAdminNotifications.php
+++ b/includes/classes/ajax/zcAjaxAdminNotifications.php
@@ -9,7 +9,6 @@
  */
 class zcAjaxAdminNotifications extends base
 {
-
     /**
      * @since ZC v1.5.6
      */
@@ -18,9 +17,9 @@ class zcAjaxAdminNotifications extends base
         global $db;
 
         if (!isset($_POST['key'])) {
-            return (array(
-                'data' => false
-            ));
+            return ([
+                'data' => false,
+            ]);
         }
 
         $sql = "INSERT INTO " . TABLE_ADMIN_NOTIFICATIONS . "(notification_key, admin_id, dismissed) VALUE (:nKey:,:adminId:, 1)
@@ -30,9 +29,9 @@ class zcAjaxAdminNotifications extends base
         $sql = $db->bindVars($sql, ':nKey:', $_POST['key'], 'string');
         $result = $db->Execute($sql);
 
-        return (array(
-            'data' => $result
-        ));
+        return ([
+            'data' => $result,
+        ]);
     }
 
 }

--- a/includes/classes/ajax/zcAjaxAdminSessionChange.php
+++ b/includes/classes/ajax/zcAjaxAdminSessionChange.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -8,14 +10,14 @@
 
 class zcAjaxAdminSessionChange extends base
 {
-    protected $supportedNames = [
+    protected array $supportedNames = [
         'imageView',
     ];
 
     /**
      * @since ZC v2.0.0
      */
-    public function change()
+    public function change(): string
     {
         // -----
         // Deny access unless running under the admin.
@@ -25,8 +27,8 @@ class zcAjaxAdminSessionChange extends base
         }
 
         // -----
-        // Give an observer the opportunity to add other supported names.  Each
-        // name can contain *only* alphanumeric characters.
+        // Give an observer the opportunity to add other supported names.
+        // Each name can contain *only* alphanumeric characters.
         //
         $other_names = [];
         $this->notify('NOTIFY_AJAX_ADMIN_NOTIFICATIONS', '', $other_names);
@@ -39,7 +41,7 @@ class zcAjaxAdminSessionChange extends base
         // -----
         // No action if the 'name' isn't recognized.
         //
-        if (!in_array($_POST['name'], $this->supportedNames)) {
+        if (!in_array($_POST['name'], $this->supportedNames, true)) {
             return '';
         }
 

--- a/includes/classes/ajax/zcAjaxPayment.php
+++ b/includes/classes/ajax/zcAjaxPayment.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * zcAjaxPayment
  *
@@ -12,195 +14,202 @@ use Zencart\LanguageLoader\LanguageLoaderFactory;
 
 class zcAjaxPayment extends base
 {
-  /**
-   * Test whether the selected payment module "does" the "CollectsCardDataOnsite" method
-   * @since ZC v1.5.4
-   */
-  public function doesCollectsCardDataOnsite()
-  {
-    require_once (DIR_WS_CLASSES.'payment.php');
-    $retVal = false;
-    $payment = new payment ($_POST['paymentValue']);
-    if (isset ($payment->selected_module)) {
-      if ($payment->paymentClass->collectsCardDataOnsite===true) {
-        $retVal = true;
-      }
-    }
-    return (array(
-        'data' => $retVal
-    ));
-  }
-
-  /**
-   * Build replacement confirmation page, which doesn't transmit sensitive CHD
-   * @since ZC v1.5.4
-   */
-  public function prepareConfirmation()
-  {
-    global $messageStack, $template, $breadcrumb, $template_dir_select, $template_dir, $language_page_directory, $currencies, $order, $zco_notifier, $db, $current_page_base, $order_total_modules, $credit_covers;
-    $_GET['main_page'] = $current_page_base = $current_page = FILENAME_CHECKOUT_CONFIRMATION;
-    if ($_SESSION['cart']->count_contents ()<=0) {
-      zen_redirect (zen_href_link (FILENAME_TIME_OUT));
-    }
-    if (!zen_is_logged_in()) {
-      $_SESSION['navigation']->set_snapshot (array(
-          'mode' => 'SSL',
-          'page' => FILENAME_CHECKOUT_PAYMENT
-      ));
-      zen_redirect (zen_href_link (FILENAME_LOGIN, '', 'SSL'));
-    } else {
-      // validate customer
-      if (zen_get_customer_validate_session ($_SESSION['customer_id'])==false) {
-        $_SESSION['navigation']->set_snapshot ();
-        zen_redirect (zen_href_link (FILENAME_LOGIN, '', 'SSL'));
-      }
-    }
-
-    // avoid hack attempts during the checkout procedure by checking the internal cartID
-    if (isset ($_SESSION['cart']->cartID)&&$_SESSION['cartID']) {
-      if ($_SESSION['cart']->cartID!=$_SESSION['cartID']) {
-        zen_redirect (zen_href_link (FILENAME_CHECKOUT_SHIPPING, '', 'SSL'));
-      }
-    }
-
-    // if no shipping method has been selected, redirect the customer to the shipping method selection page
-    if (!isset ($_SESSION['shipping'])) {
-      zen_redirect (zen_href_link (FILENAME_CHECKOUT_SHIPPING, '', 'SSL'));
-    }
-    if (isset ($_SESSION['shipping']['id']) && $_SESSION['shipping']['id']=='free_free'
-      && $_SESSION['cart']->get_content_type () != 'virtual'
-      && zen_config('MODULE_ORDER_TOTAL_SHIPPING_FREE_SHIPPING') === 'true'
-      && zen_config('MODULE_ORDER_TOTAL_SHIPPING_FREE_SHIPPING_OVER') && $_SESSION['cart']->show_total () < zen_config('MODULE_ORDER_TOTAL_SHIPPING_FREE_SHIPPING_OVER')) {
-      zen_redirect (zen_href_link (FILENAME_CHECKOUT_SHIPPING, '', 'SSL'));
-    }
-
-    if (isset ($_POST['payment'])) $_SESSION['payment'] = $_POST['payment'];
-
-    $_SESSION['comments'] = $_POST['comments'];
-
-    if (zen_config('DISPLAY_CONDITIONS_ON_CHECKOUT') === 'true') {
-        $_SESSION['conditions'] = $_POST['conditions'] ?? NULL;
-    }
-    // load the selected payment module
-    require (DIR_WS_CLASSES.'payment.php');
-    $payment_modules = new payment ($_POST['payment']);
-    $payment_modules->update_status ();
-    if (($_POST['payment']==''||!is_object ($payment_modules->paymentClass))&&$credit_covers===FALSE) {
-      $messageStack->add_session ('checkout_payment', ERROR_NO_PAYMENT_MODULE_SELECTED, 'error');
-    }
-    $GLOBALS[$_POST['payment']] = $payment_modules->paymentClass;
-
-    require (DIR_WS_CLASSES.'order.php');
-    $order = new order ();
-    // load the selected shipping module
-    require (DIR_WS_CLASSES.'shipping.php');
-    $shipping_modules = new shipping ($_SESSION['shipping']);
-
-    require (DIR_WS_CLASSES.'order_total.php');
-    $order_total_modules = new order_total ();
-    $order_total_modules->collect_posts ();
-    $order_total_modules->pre_confirmation_check ();
-
-    if (!isset ($credit_covers)) $credit_covers = FALSE;
-    if ($credit_covers) {
-      unset ($_SESSION['payment']);
-      $_SESSION['payment'] = '';
-    }
-
-    if (is_array ($payment_modules->modules)) {
-      $payment_modules->pre_confirmation_check ();
-    }
-
-    if ($messageStack->size ('checkout_payment')>0) {
-      zen_redirect (zen_href_link (FILENAME_CHECKOUT_PAYMENT, '', 'SSL'));
-    }
-
-    // Stock Check
-    $flagAnyOutOfStock = false;
-    $stock_check = array();
-    if (zen_config('STOCK_CHECK') === 'true') {
-      for($i = 0, $n = sizeof ($order->products); $i<$n; $i++) {
-        if ($stock_check[$i] = zen_check_stock ($order->products[$i]['id'], $order->products[$i]['qty'])) {
-          $flagAnyOutOfStock = true;
+    /**
+     * Test whether the selected payment module "does" the "CollectsCardDataOnsite" method
+     * @since ZC v1.5.4
+     */
+    public function doesCollectsCardDataOnsite(): array
+    {
+        require_once DIR_WS_CLASSES . 'payment.php';
+        $retVal = false;
+        $payment = new payment($_POST['paymentValue']);
+        if (isset($payment->selected_module)) {
+            if ($payment->paymentClass->collectsCardDataOnsite === true) {
+                $retVal = true;
+            }
         }
-      }
-      // Out of Stock
-      if ((zen_config('STOCK_ALLOW_CHECKOUT') !== 'true') && ($flagAnyOutOfStock==true)) {
-        zen_redirect (zen_href_link (FILENAME_SHOPPING_CART));
-      }
+        return ([
+            'data' => $retVal,
+        ]);
     }
 
-    // update customers_referral with $_SESSION['gv_id']
-    if (!empty($_SESSION['cc_id'])) {
-      $discount_coupon_query = "SELECT coupon_code
-                            FROM ".TABLE_COUPONS."
+    /**
+     * Build replacement confirmation page, which doesn't transmit sensitive CHD
+     * @since ZC v1.5.4
+     */
+    public function prepareConfirmation(): array
+    {
+        global $messageStack, $template, $breadcrumb, $template_dir_select, $template_dir, $language_page_directory, $currencies, $order, $zco_notifier, $db, $current_page_base, $order_total_modules, $credit_covers;
+        $_GET['main_page'] = $current_page_base = $current_page = FILENAME_CHECKOUT_CONFIRMATION;
+        if ($_SESSION['cart']->count_contents() <= 0) {
+            zen_redirect(zen_href_link(FILENAME_TIME_OUT));
+        }
+        if (!zen_is_logged_in()) {
+            $_SESSION['navigation']->set_snapshot([
+                'mode' => 'SSL',
+                'page' => FILENAME_CHECKOUT_PAYMENT,
+            ]);
+            zen_redirect(zen_href_link(FILENAME_LOGIN, '', 'SSL'));
+        } else {
+            // validate customer
+            if (zen_get_customer_validate_session($_SESSION['customer_id']) === false) {
+                $_SESSION['navigation']->set_snapshot();
+                zen_redirect(zen_href_link(FILENAME_LOGIN, '', 'SSL'));
+            }
+        }
+
+        // avoid hack attempts during the checkout procedure by checking the internal cartID
+        if (isset($_SESSION['cart']->cartID) && $_SESSION['cartID']) {
+            if ($_SESSION['cart']->cartID !== $_SESSION['cartID']) {
+                zen_redirect(zen_href_link(FILENAME_CHECKOUT_SHIPPING, '', 'SSL'));
+            }
+        }
+
+        // if no shipping method has been selected, redirect the customer to the shipping method selection page
+        if (!isset($_SESSION['shipping'])) {
+            zen_redirect(zen_href_link(FILENAME_CHECKOUT_SHIPPING, '', 'SSL'));
+        }
+        if (isset($_SESSION['shipping']['id']) && $_SESSION['shipping']['id'] === 'free_free'
+          && $_SESSION['cart']->get_content_type() !== 'virtual'
+          && zen_config('MODULE_ORDER_TOTAL_SHIPPING_FREE_SHIPPING') === 'true'
+          && zen_config('MODULE_ORDER_TOTAL_SHIPPING_FREE_SHIPPING_OVER')
+          && $_SESSION['cart']->show_total() < zen_config('MODULE_ORDER_TOTAL_SHIPPING_FREE_SHIPPING_OVER'))
+        {
+            zen_redirect(zen_href_link(FILENAME_CHECKOUT_SHIPPING, '', 'SSL'));
+        }
+
+        if (isset($_POST['payment'])) {
+            $_SESSION['payment'] = $_POST['payment'];
+        }
+
+        $_SESSION['comments'] = $_POST['comments'];
+
+        if (zen_config('DISPLAY_CONDITIONS_ON_CHECKOUT') === 'true') {
+            $_SESSION['conditions'] = $_POST['conditions'] ?? null;
+        }
+        // load the selected payment module
+        require DIR_WS_CLASSES . 'payment.php';
+        $payment_modules = new payment($_POST['payment']);
+        $payment_modules->update_status();
+        if (($_POST['payment'] === '' || !is_object($payment_modules->paymentClass)) && $credit_covers === false) {
+            $messageStack->add_session('checkout_payment', ERROR_NO_PAYMENT_MODULE_SELECTED, 'error');
+        }
+        $GLOBALS[$_POST['payment']] = $payment_modules->paymentClass;
+
+        require DIR_WS_CLASSES . 'order.php';
+        $order = new order();
+        // load the selected shipping module
+        require DIR_WS_CLASSES . 'shipping.php';
+        $shipping_modules = new shipping($_SESSION['shipping']);
+
+        require DIR_WS_CLASSES . 'order_total.php';
+        $order_total_modules = new order_total();
+        $order_total_modules->collect_posts();
+        $order_total_modules->pre_confirmation_check();
+
+        if (!isset($credit_covers)) {
+            $credit_covers = false;
+        }
+        if ($credit_covers) {
+            unset($_SESSION['payment']);
+            $_SESSION['payment'] = '';
+        }
+
+        if (is_array($payment_modules->modules)) {
+            $payment_modules->pre_confirmation_check();
+        }
+
+        if ($messageStack->size('checkout_payment') > 0) {
+            zen_redirect(zen_href_link(FILENAME_CHECKOUT_PAYMENT, '', 'SSL'));
+        }
+
+        // Stock Check
+        $flagAnyOutOfStock = false;
+        $stock_check = [];
+        if (zen_config('STOCK_CHECK') === 'true') {
+            for ($i = 0, $n = count($order->products); $i < $n; $i++) {
+                if ($stock_check[$i] = zen_check_stock($order->products[$i]['id'], $order->products[$i]['qty'])) {
+                    $flagAnyOutOfStock = true;
+                }
+            }
+            // Out of Stock
+            if (zen_config('STOCK_ALLOW_CHECKOUT') !== 'true' && $flagAnyOutOfStock === true) {
+                zen_redirect(zen_href_link(FILENAME_SHOPPING_CART));
+            }
+        }
+
+        // update customers_referral with $_SESSION['gv_id']
+        if (!empty($_SESSION['cc_id'])) {
+            $discount_coupon_query = "SELECT coupon_code
+                            FROM " . TABLE_COUPONS . "
                             WHERE coupon_id = :couponID";
 
-      $discount_coupon_query = $db->bindVars ($discount_coupon_query, ':couponID', $_SESSION['cc_id'], 'integer');
-      $discount_coupon = $db->Execute ($discount_coupon_query);
+            $discount_coupon_query = $db->bindVars($discount_coupon_query, ':couponID', $_SESSION['cc_id'], 'integer');
+            $discount_coupon = $db->Execute($discount_coupon_query);
 
-      $customers_referral_query = "SELECT customers_referral
-                               FROM ".TABLE_CUSTOMERS."
+            $customers_referral_query = "SELECT customers_referral
+                               FROM " . TABLE_CUSTOMERS . "
                                WHERE customers_id = :customersID";
 
-      $customers_referral_query = $db->bindVars ($customers_referral_query, ':customersID', $_SESSION['customer_id'], 'integer');
-      $customers_referral = $db->Execute ($customers_referral_query);
+            $customers_referral_query = $db->bindVars($customers_referral_query, ':customersID', $_SESSION['customer_id'], 'integer');
+            $customers_referral = $db->Execute($customers_referral_query);
 
-      // only use discount coupon if set by coupon
-      if ($customers_referral->fields['customers_referral']=='' && (int)zen_config('CUSTOMERS_REFERRAL_STATUS') === 1) {
-        $sql = "UPDATE ".TABLE_CUSTOMERS."
+            // only use discount coupon if set by coupon
+            if ($customers_referral->fields['customers_referral'] === '' && (int)zen_config('CUSTOMERS_REFERRAL_STATUS') === 1) {
+                $sql = "UPDATE " . TABLE_CUSTOMERS . "
             SET customers_referral = :customersReferral
             WHERE customers_id = :customersID";
 
-        $sql = $db->bindVars ($sql, ':customersID', $_SESSION['customer_id'], 'integer');
-        $sql = $db->bindVars ($sql, ':customersReferral', $discount_coupon->fields['coupon_code'], 'string');
-        $db->Execute ($sql);
-      } else {
-        // do not update referral was added before
-      }
+                $sql = $db->bindVars($sql, ':customersID', $_SESSION['customer_id'], 'integer');
+                $sql = $db->bindVars($sql, ':customersReferral', $discount_coupon->fields['coupon_code'], 'string');
+                $db->Execute($sql);
+            } else {
+                // do not update referral was added before
+            }
+        }
+
+        if (isset(${$_SESSION['payment']}->form_action_url)) {
+            $form_action_url = ${$_SESSION['payment']}->form_action_url;
+        } else {
+            $form_action_url = zen_href_link(FILENAME_CHECKOUT_PROCESS, '', 'SSL');
+        }
+
+        // if shipping-edit button should be overridden, do so
+        $editShippingButtonLink = zen_href_link(FILENAME_CHECKOUT_SHIPPING, '', 'SSL');
+        if (!empty($_SESSION['payment']) && !empty(${$_SESSION['payment']}) && is_object(${$_SESSION['payment']}) && method_exists(${$_SESSION['payment']}, 'alterShippingEditButton')) {
+            $theLink = ${$_SESSION['payment']}->alterShippingEditButton();
+            if ($theLink) {
+                $editShippingButtonLink = $theLink;
+            }
+        }
+        // deal with billing address edit button
+        $flagDisablePaymentAddressChange = false;
+        if (isset(${$_SESSION['payment']}->flagDisablePaymentAddressChange)) {
+            $flagDisablePaymentAddressChange = ${$_SESSION['payment']}->flagDisablePaymentAddressChange;
+        }
+
+        $current_page_base = FILENAME_CHECKOUT_CONFIRMATION;
+        $languageLoaderFactory = new LanguageLoaderFactory();
+        $languageLoader = $languageLoaderFactory->make('catalog', [], $current_page, $template_dir);
+        $languageLoader->loadInitialLanguageDefines();
+        $languageLoader->finalizeLanguageDefines();
+
+        require_once DIR_WS_MODULES . zen_get_module_directory('require_languages.php');
+        require_once DIR_WS_MODULES . zen_get_module_directory('meta_tags.php');
+        $breadcrumb->add(NAVBAR_TITLE_1, zen_href_link(FILENAME_CHECKOUT_SHIPPING, '', 'SSL'));
+        $breadcrumb->add(NAVBAR_TITLE_2);
+
+        $breadCrumbHtml = $breadcrumb->trail(zen_config('BREAD_CRUMBS_SEPARATOR'));
+        $body_code = DIR_FS_CATALOG . $template->get_template_dir('tpl_ajax_checkout_confirmation_default.php', DIR_WS_TEMPLATE, $current_page_base, 'templates') . '/tpl_ajax_checkout_confirmation_default.php';
+        ob_start();
+        require_once $body_code;
+        $confirmationHtml = ob_get_clean();
+        ob_flush();
+
+        return ([
+            'breadCrumbHtml' => $breadCrumbHtml,
+            'confirmationHtml' => $confirmationHtml,
+            'pageTitle' => META_TAG_TITLE,
+        ]);
     }
-
-    if (isset (${$_SESSION['payment']}->form_action_url)) {
-      $form_action_url = ${$_SESSION['payment']}->form_action_url;
-    } else {
-      $form_action_url = zen_href_link (FILENAME_CHECKOUT_PROCESS, '', 'SSL');
-    }
-
-    // if shipping-edit button should be overridden, do so
-    $editShippingButtonLink = zen_href_link (FILENAME_CHECKOUT_SHIPPING, '', 'SSL');
-    if (!empty($_SESSION['payment']) && !empty(${$_SESSION['payment']}) && is_object(${$_SESSION['payment']}) && method_exists(${$_SESSION['payment']}, 'alterShippingEditButton')) {
-      $theLink = ${$_SESSION['payment']}->alterShippingEditButton ();
-      if ($theLink)
-        $editShippingButtonLink = $theLink;
-    }
-    // deal with billing address edit button
-    $flagDisablePaymentAddressChange = false;
-    if (isset (${$_SESSION['payment']}->flagDisablePaymentAddressChange)) {
-      $flagDisablePaymentAddressChange = ${$_SESSION['payment']}->flagDisablePaymentAddressChange;
-    }
-
-    $current_page_base = FILENAME_CHECKOUT_CONFIRMATION;
-    $languageLoaderFactory = new LanguageLoaderFactory();
-    $languageLoader = $languageLoaderFactory->make('catalog', [], $current_page, $template_dir);
-    $languageLoader->loadInitialLanguageDefines();
-    $languageLoader->finalizeLanguageDefines();
-
-    require_once (DIR_WS_MODULES.zen_get_module_directory ('require_languages.php'));
-    require_once (DIR_WS_MODULES.zen_get_module_directory ('meta_tags.php'));
-    $breadcrumb->add (NAVBAR_TITLE_1, zen_href_link (FILENAME_CHECKOUT_SHIPPING, '', 'SSL'));
-    $breadcrumb->add (NAVBAR_TITLE_2);
-
-    $breadCrumbHtml = $breadcrumb->trail (zen_config('BREAD_CRUMBS_SEPARATOR'));
-    $body_code = DIR_FS_CATALOG.$template->get_template_dir ('tpl_ajax_checkout_confirmation_default.php', DIR_WS_TEMPLATE, $current_page_base, 'templates').'/tpl_ajax_checkout_confirmation_default.php';
-    ob_start ();
-    require_once ($body_code);
-    $confirmationHtml = ob_get_clean ();
-    ob_flush ();
-
-    return (array(
-        'breadCrumbHtml' => $breadCrumbHtml,
-        'confirmationHtml' => $confirmationHtml,
-        'pageTitle' => META_TAG_TITLE
-    ));
-  }
 }

--- a/includes/classes/ajax/zcAjaxSelect2Lookups.php
+++ b/includes/classes/ajax/zcAjaxSelect2Lookups.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0

--- a/includes/classes/ajax/zcAjaxSelect2Lookups.php
+++ b/includes/classes/ajax/zcAjaxSelect2Lookups.php
@@ -70,9 +70,9 @@ class zcAjaxSelect2Lookups extends base
             $exclude_gv = " AND p.products_model NOT LIKE 'GIFT%' ";
         }
 
-// @TODO:optionally offer exclusion of products that cannot be added to cart:
-//        LEFT JOIN " . TABLE_PRODUCT_TYPES . " pt ON p.products_type = pt.type_id
-//        WHERE pt.allow_add_to_cart = 'N'
+        // @TODO:optionally offer exclusion of products that cannot be added to cart:
+        //        LEFT JOIN " . TABLE_PRODUCT_TYPES . " pt ON p.products_type = pt.type_id
+        //        WHERE pt.allow_add_to_cart = 'N'
 
         $search_query = '';
         if ($lookup !== '') {
@@ -104,8 +104,7 @@ class zcAjaxSelect2Lookups extends base
                 'text' => ($this->stripTags ? strip_tags($result['products_name']) : $result['products_name']) .
                     ' (' . $currencies->format($display_price) . ')' .
                     ($show_model ? ' [' . $result['products_model'] . '] ' : '') .
-                    ($show_id ? ' - ID# ' . $result['products_id'] : '')
-                ,
+                    ($show_id ? ' - ID# ' . $result['products_id'] : ''),
             ];
         }
 

--- a/includes/classes/breadcrumb.php
+++ b/includes/classes/breadcrumb.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * breadcrumb Class.
  *
@@ -26,7 +28,7 @@ if (!defined('DISABLE_BREADCRUMB_LINKS_ON_LAST_ITEM')) {
  */
 class breadcrumb extends base
 {
-    protected $_trail = [];
+    protected array $_trail = [];
 
     public function __construct()
     {
@@ -36,7 +38,7 @@ class breadcrumb extends base
     /**
      * @since ZC v1.0.3
      */
-    public function reset()
+    public function reset(): void
     {
         $this->_trail = [];
     }
@@ -44,7 +46,7 @@ class breadcrumb extends base
     /**
      * @since ZC v1.0.3
      */
-    public function add($title, $link = '')
+    public function add(string $title, string $link = ''): void
     {
         $this->_trail[] = ['title' => $title, 'link' => $link];
     }
@@ -52,19 +54,19 @@ class breadcrumb extends base
     /**
      * @since ZC v1.0.3
      */
-    public function trail($separator = '&nbsp;&nbsp;', $prefix = '', $suffix = '')
+    public function trail(string $separator = '&nbsp;&nbsp;', string $prefix = '', string $suffix = ''): string
     {
         $trail_string = '';
 
         for ($i = 0, $n = count($this->_trail); $i < $n; $i++) {
             // echo 'breadcrumb ' . $i . ' of ' . $n . ': ' . $this->_trail[$i]['title'] . '<br>';
             $skip_link = false;
-            if ($i == ($n - 1) && DISABLE_BREADCRUMB_LINKS_ON_LAST_ITEM == 'true') {
+            if ($i === ($n - 1) && DISABLE_BREADCRUMB_LINKS_ON_LAST_ITEM === 'true') {
                 $skip_link = true;
             }
             if (!empty($this->_trail[$i]['link']) && !$skip_link) {
                 // this line simply sets the "Home" link to be the domain/url, not main_page=index?blahblah:
-                if ($this->_trail[$i]['title'] == HEADER_TITLE_CATALOG) {
+                if ($this->_trail[$i]['title'] === HEADER_TITLE_CATALOG) {
                     $trail_string .= '  ' . $prefix . '<a href="' . zen_href_link('/', '', 'SSL', false, true, true) . '">' . $this->_trail[$i]['title'] . '</a>' . $suffix;
                 } else {
                     $trail_string .= '  ' . $prefix . '<a href="' . $this->_trail[$i]['link'] . '">' . $this->_trail[$i]['title'] . '</a>' . $suffix;
@@ -96,7 +98,7 @@ class breadcrumb extends base
     /**
      * @since ZC v1.5.7c
      */
-    public function removeLast()
+    public function removeLast(): void
     {
         $trail_size = count($this->_trail);
         unset($this->_trail[$trail_size - 1]);
@@ -105,10 +107,11 @@ class breadcrumb extends base
     /**
      * @since ZC v1.5.7c
      */
-    public function replaceLast($title = null, $link = null)
+    public function replaceLast(?string $title = null, ?string $link = null): void
     {
         if ($title === null && $link === null) {
-            return $this->removeLast();
+            $this->removeLast();
+            return;
         }
 
         $trail_size = count($this->_trail);
@@ -123,7 +126,7 @@ class breadcrumb extends base
     /**
      * @since ZC v1.5.7
      */
-    public function isEmpty()
+    public function isEmpty(): bool
     {
         return empty($this->_trail);
     }
@@ -131,14 +134,14 @@ class breadcrumb extends base
     /**
      * @since ZC v1.5.7
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_trail);
     }
     /**
      * @since ZC v1.5.8a
      */
-    public function getTrail()
+    public function getTrail(): array
     {
         return $this->_trail;
     }

--- a/includes/classes/cache.php
+++ b/includes/classes/cache.php
@@ -72,7 +72,7 @@ class cache
                 }
                 break;
             case 'database':
-                $sql = "SELECT * FROM " . TABLE_DB_CACHE . " WHERE cache_entry_name = '" . $zp_cache_name ."'";
+                $sql = "SELECT * FROM " . TABLE_DB_CACHE . " WHERE cache_entry_name = '" . $zp_cache_name . "'";
                 $cache_result = $db->Execute($sql);
                 if (!$cache_result->EOF) {
                     $start_time = $cache_result->fields['cache_entry_created'];

--- a/includes/classes/cache.php
+++ b/includes/classes/cache.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * cache Class.
  *
@@ -124,7 +126,7 @@ class cache
     /**
      * @since ZC v1.2.0d
      */
-    public function sql_cache_store($zf_query, $zf_result_array): void
+    public function sql_cache_store(string $zf_query, array $zf_result_array): void
     {
         global $db;
         $zp_cache_name = $this->cache_generate_cache_name($zf_query);

--- a/includes/classes/categories_ul_generator.php
+++ b/includes/classes/categories_ul_generator.php
@@ -41,7 +41,7 @@ class zen_categories_ul_generator
     /**
      * @since ZC v1.5.5
      */
-    public function buildBranch($parent_id, $level = 0, $submenu = true, string $parent_link = ''): string
+    public function buildBranch($parent_id, $level = 0, bool $submenu = true, string $parent_link = ''): string
     {
         $parent_id = (int)$parent_id;
         $level = (int)$level;
@@ -75,7 +75,7 @@ class zen_categories_ul_generator
     /**
      * @since ZC v1.5.5
      */
-    public function buildTree($submenu = false, ?int $max_levels = null): string
+    public function buildTree(bool $submenu = false, ?int $max_levels = null): string
     {
         if (empty($this->data)) {
             return '';

--- a/includes/classes/category_tree.php
+++ b/includes/classes/category_tree.php
@@ -20,7 +20,6 @@ if (!defined('IS_ADMIN_FLAG')) {
  */
 class category_tree extends base
 {
-
     /**
      * Array of category details for display
      */

--- a/includes/classes/category_tree.php
+++ b/includes/classes/category_tree.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * category_tree Class.
  *
@@ -25,9 +27,7 @@ class category_tree extends base
      */
     private array $box_categories_array = [];
     /**
-     * String containing concatenated list of categories with separator.
-     *
-     * @since ZC v1.2.0d
+     * String containing a concatenated list of categories with separator.
      */
     private string $categories_string;
     /*
@@ -35,117 +35,129 @@ class category_tree extends base
      */
     private array $tree = [];
 
-    public function zen_category_tree($product_type = "all"): array
+    /**
+     * @var int|string $product_type int = product type id, 0 = all, 'all' = all (for legacy support)
+     *
+     * @since ZC v1.2.0d
+     */
+    public function zen_category_tree(int|string $product_type = 0): array
     {
         global $db, $cPath, $cPath_array;
-        if ($product_type !== 'all') {
-            $sql = "select type_master_type from " . TABLE_PRODUCT_TYPES . "
-                    where type_master_type = " . $product_type;
+        if ($product_type !== 0 && $product_type !== 'all') {
+            $sql = "SELECT type_master_type FROM " . TABLE_PRODUCT_TYPES . "
+                    WHERE type_master_type = " . (int)$product_type;
             $master_type_result = $db->Execute($sql);
-            $master_type = $master_type_result->fields['type_master_type'];
+            $master_type = (int)$master_type_result->fields['type_master_type'];
         }
         $this->tree = [];
-        if ($product_type === 'all') {
-            $categories_query = "select c.categories_id, cd.categories_name, c.parent_id, c.categories_image
-                             from " . TABLE_CATEGORIES . " c, " . TABLE_CATEGORIES_DESCRIPTION . " cd
-                             where c.parent_id = " . (int)TOPMOST_CATEGORY_PARENT_ID . "
-                             and c.categories_id = cd.categories_id
-                             and cd.language_id='" . (int)$_SESSION['languages_id'] . "'
-                             and c.categories_status= 1
-                             order by sort_order, cd.categories_name";
+        if ($product_type === 0 || $product_type === 'all') {
+            $categories_query = "SELECT c.categories_id, cd.categories_name, c.parent_id, c.categories_image
+                             FROM " . TABLE_CATEGORIES . " c, " . TABLE_CATEGORIES_DESCRIPTION . " cd
+                             WHERE c.parent_id = " . (int)TOPMOST_CATEGORY_PARENT_ID . "
+                             AND c.categories_id = cd.categories_id
+                             AND cd.language_id='" . (int)$_SESSION['languages_id'] . "'
+                             AND c.categories_status= 1
+                             ORDER BY sort_order, cd.categories_name";
         } else {
-            $categories_query = "select ptc.category_id as categories_id, cd.categories_name, c.parent_id, c.categories_image
-                             from " . TABLE_CATEGORIES . " c, " . TABLE_CATEGORIES_DESCRIPTION . " cd, " . TABLE_PRODUCT_TYPES_TO_CATEGORY . " ptc
-                             where c.parent_id = " . (int)TOPMOST_CATEGORY_PARENT_ID . "
-                             and ptc.category_id = cd.categories_id
-                             and ptc.product_type_id = " . $master_type . "
-                             and c.categories_id = ptc.category_id
-                             and cd.language_id=" . (int)$_SESSION['languages_id'] . "
-                             and c.categories_status= 1
-                             order by sort_order, cd.categories_name";
+            $categories_query = "SELECT ptc.category_id as categories_id, cd.categories_name, c.parent_id, c.categories_image
+                             FROM " . TABLE_CATEGORIES . " c, " . TABLE_CATEGORIES_DESCRIPTION . " cd, " . TABLE_PRODUCT_TYPES_TO_CATEGORY . " ptc
+                             WHERE c.parent_id = " . (int)TOPMOST_CATEGORY_PARENT_ID . "
+                             AND ptc.category_id = cd.categories_id
+                             AND ptc.product_type_id = " . (int)$master_type . "
+                             AND c.categories_id = ptc.category_id
+                             AND cd.language_id=" . (int)$_SESSION['languages_id'] . "
+                             AND c.categories_status= 1
+                             ORDER BY sort_order, cd.categories_name";
         }
         $categories = $db->Execute($categories_query, '', true, 150);
-        while (!$categories->EOF) {
-            $this->tree[$categories->fields['categories_id']] = [
-                'name' => $categories->fields['categories_name'],
-                'parent' => $categories->fields['parent_id'],
+
+        $parent_id = null;
+        $first_element = null;
+
+        foreach ($categories as $category) {
+            $categoryId = $category['categories_id'];
+
+            $this->tree[$categoryId] = [
+                'name' => $category['categories_name'],
+                'parent' => $category['parent_id'],
                 'level' => 0,
-                'path' => $categories->fields['categories_id'],
-                'image' => $categories->fields['categories_image'],
+                'path' => $categoryId,
+                'image' => $category['categories_image'],
                 'next_id' => false,
             ];
 
             if (isset($parent_id)) {
-                $this->tree[$parent_id]['next_id'] = $categories->fields['categories_id'];
+                $this->tree[$parent_id]['next_id'] = $categoryId;
             }
 
-            $parent_id = $categories->fields['categories_id'];
+            $parent_id = $categoryId;
 
             if (!isset($first_element)) {
-                $first_element = $categories->fields['categories_id'];
+                $first_element = $categoryId;
             }
-            $categories->MoveNext();
         }
+
         if (zen_not_null($cPath)) {
             $new_path = '';
             foreach ($cPath_array as $key => $value) {
                 unset($parent_id);
                 unset($first_id);
-                if ($product_type == 'all') {
-                    $categories_query = "select c.categories_id, cd.categories_name, c.parent_id, c.categories_image
-                               from " . TABLE_CATEGORIES . " c, " . TABLE_CATEGORIES_DESCRIPTION . " cd
-                               where c.parent_id = " . (int)$value . "
-                               and c.categories_id = cd.categories_id
-                               and cd.language_id=" . (int)$_SESSION['languages_id'] . "
-                               and c.categories_status= 1
-                               order by sort_order, cd.categories_name";
+                if ($product_type === 0 || $product_type === 'all') {
+                    $categories_query = "SELECT c.categories_id, cd.categories_name, c.parent_id, c.categories_image
+                               FROM " . TABLE_CATEGORIES . " c, " . TABLE_CATEGORIES_DESCRIPTION . " cd
+                               WHERE c.parent_id = " . (int)$value . "
+                               AND c.categories_id = cd.categories_id
+                               AND cd.language_id=" . (int)$_SESSION['languages_id'] . "
+                               AND c.categories_status= 1
+                               ORDER BY sort_order, cd.categories_name";
                 } else {
                     /*
-                    $categories_query = "select ptc.category_id as categories, cd.categories_name, c.parent_id, c.categories_image
-                    from " . TABLE_CATEGORIES . " c, " . TABLE_CATEGORIES_DESCRIPTION . " cd, " . TABLE_PRODUCT_TYPES_TO_CATEGORY . " ptc
-                    where c.parent_id = '" . (int)$value . "'
-                    and ptc.category_id = cd.categories_id
-                    and ptc.product_type_id = '" . $master_type . "'
-                    and cd.language_id='" . (int)$_SESSION['languages_id'] . "'
-                    and c.categories_status= '1'
-                    order by sort_order, cd.categories_name";
+                    $categories_query = "SELECT ptc.category_id as categories, cd.categories_name, c.parent_id, c.categories_image
+                    FROM " . TABLE_CATEGORIES . " c, " . TABLE_CATEGORIES_DESCRIPTION . " cd, " . TABLE_PRODUCT_TYPES_TO_CATEGORY . " ptc
+                    WHERE c.parent_id = '" . (int)$value . "'
+                    AND ptc.category_id = cd.categories_id
+                    AND ptc.product_type_id = '" . $master_type . "'
+                    AND cd.language_id='" . (int)$_SESSION['languages_id'] . "'
+                    AND c.categories_status= '1'
+                    ORDER BY sort_order, cd.categories_name";
                     */
-                    $categories_query = "select ptc.category_id as categories_id, cd.categories_name, c.parent_id, c.categories_image
-                             from " . TABLE_CATEGORIES . " c, " . TABLE_CATEGORIES_DESCRIPTION . " cd, " . TABLE_PRODUCT_TYPES_TO_CATEGORY . " ptc
-                             where c.parent_id = " . (int)$value . "
-                             and ptc.category_id = cd.categories_id
-                             and ptc.product_type_id = " . $master_type . "
-                             and c.categories_id = ptc.category_id
-                             and cd.language_id=" . (int)$_SESSION['languages_id'] . "
-                             and c.categories_status= 1
-                             order by sort_order, cd.categories_name";
+                    $categories_query = "SELECT ptc.category_id as categories_id, cd.categories_name, c.parent_id, c.categories_image
+                             FROM " . TABLE_CATEGORIES . " c, " . TABLE_CATEGORIES_DESCRIPTION . " cd, " . TABLE_PRODUCT_TYPES_TO_CATEGORY . " ptc
+                             WHERE c.parent_id = " . (int)$value . "
+                             AND ptc.category_id = cd.categories_id
+                             AND ptc.product_type_id = " . $master_type . "
+                             AND c.categories_id = ptc.category_id
+                             AND cd.language_id=" . (int)$_SESSION['languages_id'] . "
+                             AND c.categories_status= 1
+                             ORDER BY sort_order, cd.categories_name";
                 }
 
                 $rows = $db->Execute($categories_query);
 
                 if ($rows->RecordCount() > 0) {
                     $new_path .= $value;
-                    while (!$rows->EOF) {
-                        $this->tree[$rows->fields['categories_id']] = [
-                            'name' => $rows->fields['categories_name'],
-                            'parent' => $rows->fields['parent_id'],
+                    foreach ($rows as $row) {
+                        $categoryId = $row['categories_id'];
+
+                        $this->tree[$categoryId] = [
+                            'name' => $row['categories_name'],
+                            'parent' => $row['parent_id'],
                             'level' => $key + 1,
-                            'path' => $new_path . '_' . $rows->fields['categories_id'],
-                            'image' => $categories->fields['categories_image'],
+                            'path' => $new_path . '_' . $categoryId,
+                            'image' => $row['categories_image'],
                             'next_id' => false,
                         ];
 
                         if (isset($parent_id)) {
-                            $this->tree[$parent_id]['next_id'] = $rows->fields['categories_id'];
+                            $this->tree[$parent_id]['next_id'] = $categoryId;
                         }
 
-                        $parent_id = $rows->fields['categories_id'];
+                        $parent_id = $categoryId;
                         if (!isset($first_id)) {
-                            $first_id = $rows->fields['categories_id'];
+                            $first_id = $categoryId;
                         }
 
-                        $last_id = $rows->fields['categories_id'];
-                        $rows->MoveNext();
+                        $last_id = $categoryId;
                     }
                     if (!empty($value) && !empty($this->tree[$value]) /* Needed to thwart notice */) {
                         $this->tree[$last_id]['next_id'] = $this->tree[$value]['next_id'];
@@ -214,7 +226,7 @@ class category_tree extends base
             }
         }
 
-        if ($this->tree[$counter]['next_id'] != false) {
+        if ($this->tree[$counter]['next_id'] !== false) {
             $ii++;
             $this->zen_show_category($this->tree[$counter]['next_id'], $ii);
         }

--- a/includes/classes/cc_validation.php
+++ b/includes/classes/cc_validation.php
@@ -8,7 +8,7 @@
  * @version $Id: DrByte 2025 Sep 18 Modified in v2.2.0 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
-  die('Illegal Access');
+    die('Illegal Access');
 }
 /**
  * cc_validation Class.
@@ -18,7 +18,10 @@ if (!defined('IS_ADMIN_FLAG')) {
  */
 class cc_validation
 {
-    public $cc_type, $cc_number, $cc_expiry_month, $cc_expiry_year;
+    public $cc_type;
+    public $cc_number;
+    public $cc_expiry_month;
+    public $cc_expiry_year;
 
     /**
     * @since ZC v1.0.3
@@ -72,7 +75,7 @@ class cc_validation
 
         $current_year = date('Y');
         if (strlen($expiry_y) === 2) {
-            $expiry_y = intval(substr($current_year, 0, 2) . $expiry_y);
+            $expiry_y = (int)(substr($current_year, 0, 2) . $expiry_y);
         }
         if (is_numeric($expiry_y) && $expiry_y >= $current_year && $expiry_y <= ($current_year + 10)) {
             $this->cc_expiry_year = $expiry_y;
@@ -94,9 +97,9 @@ class cc_validation
 
             if (strlen($start_y) === 2) {
                 if ($start_y > 80) {
-                    $start_y = intval('19' . $start_y);
+                    $start_y = (int)('19' . $start_y);
                 } else {
-                    $start_y = intval('20' . $start_y);
+                    $start_y = (int)('20' . $start_y);
                 }
             }
 

--- a/includes/classes/cc_validation.php
+++ b/includes/classes/cc_validation.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * cc_validation Class.
  *
@@ -12,16 +14,16 @@ if (!defined('IS_ADMIN_FLAG')) {
 }
 /**
  * cc_validation Class.
- * Class to validate credit card numbers etc
+ * Class to validate credit card numbers against the Luhn algorithm.
  *
  * @since ZC v1.0.3
  */
 class cc_validation
 {
-    public $cc_type;
-    public $cc_number;
-    public $cc_expiry_month;
-    public $cc_expiry_year;
+    public string $cc_type;
+    public string $cc_number;
+    public string|int $cc_expiry_month;
+    public string|int $cc_expiry_year;
 
     /**
     * @since ZC v1.0.3
@@ -77,13 +79,13 @@ class cc_validation
         if (strlen($expiry_y) === 2) {
             $expiry_y = (int)(substr($current_year, 0, 2) . $expiry_y);
         }
-        if (is_numeric($expiry_y) && $expiry_y >= $current_year && $expiry_y <= ($current_year + 10)) {
+        if (is_numeric($expiry_y) && $expiry_y >= $current_year && $expiry_y <= ((int)$current_year + 10)) {
             $this->cc_expiry_year = $expiry_y;
         } else {
             return -3;
         }
 
-        if ($expiry_y == $current_year) {
+        if ((int)$expiry_y === (int)$current_year) {
             if ($expiry_m < date('n')) {
                 return -4;
             }
@@ -121,11 +123,11 @@ class cc_validation
         $cardNumber = strrev($this->cc_number);
         $numSum = 0;
 
-        for ($i = 0; $i < strlen($cardNumber); $i++) {
+        for ($i = 0, $j = strlen($cardNumber); $i < $j; $i++) {
             $currentNum = substr($cardNumber, $i, 1);
 
             // Double every second digit
-            if ($i % 2 == 1) {
+            if ($i % 2 === 1) {
                 $currentNum *= 2;
             }
 

--- a/includes/classes/class.base.php
+++ b/includes/classes/class.base.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * This \base class is sometimes used as a parent class for other classes, but it is not intended to be instantiated on its own.
  * It provides some common functionality that can be shared to child classes, such as the ability to manage observers and notifiers.
@@ -26,16 +28,18 @@ class base
     use ObserverManager;
 
     /**
+     * Convert a string to camel case format
+     *
      * @since ZC v1.5.2
      */
-    public static function camelize($rawName, $camelFirst = false)
+    public static function camelize(string $rawName, bool $camelFirst = false): array|string|null
     {
-        if ($rawName == "") {
+        if ($rawName === '') {
             return $rawName;
         }
         if ($camelFirst) {
             $rawName[0] = strtoupper($rawName[0]);
         }
-        return preg_replace_callback('/[_-]([0-9,a-z])/', fn($matches) => strtoupper($matches[1]), $rawName);
+        return preg_replace_callback('/[_-]([0-9,a-z])/', static fn($matches) => strtoupper($matches[1]), $rawName);
     }
 }

--- a/includes/classes/class.base.php
+++ b/includes/classes/class.base.php
@@ -30,13 +30,12 @@ class base
      */
     public static function camelize($rawName, $camelFirst = false)
     {
-        if ($rawName == "")
+        if ($rawName == "") {
             return $rawName;
+        }
         if ($camelFirst) {
             $rawName[0] = strtoupper($rawName[0]);
         }
-        return preg_replace_callback('/[_-]([0-9,a-z])/', function ($matches) {
-            return strtoupper($matches[1]);
-        }, $rawName);
+        return preg_replace_callback('/[_-]([0-9,a-z])/', fn($matches) => strtoupper($matches[1]), $rawName);
     }
 }

--- a/includes/classes/class.notifier.php
+++ b/includes/classes/class.notifier.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * File contains just the notifier class
  *
@@ -11,9 +13,7 @@
  * NOTE: It is preferred to use Zencart\Traits\NotifierManager trait instead of extending this class.
  *
  * class notifier is a concrete implemetation of the abstract base class
- *
  * it can be used in procedural (non OOP) code to set up an observer.
- *
  * see the observer/notifier tutorial for more details.
  *
  * @since ZC v1.3.0

--- a/includes/classes/class.notifier.php
+++ b/includes/classes/class.notifier.php
@@ -22,6 +22,4 @@ if (!defined('IS_ADMIN_FLAG')) {
     die('Illegal Access');
 }
 
-class notifier extends base
-{
-}
+class notifier extends base {}

--- a/includes/classes/class.search.php
+++ b/includes/classes/class.search.php
@@ -175,7 +175,7 @@ class Search extends \base
             'PRODUCT_LIST_PRICE' => zen_config('PRODUCT_LIST_PRICE'),
             'PRODUCT_LIST_QUANTITY' => zen_config('PRODUCT_LIST_QUANTITY'),
             'PRODUCT_LIST_WEIGHT' => zen_config('PRODUCT_LIST_WEIGHT'),
-            'PRODUCT_LIST_IMAGE' => zen_config('PRODUCT_LIST_IMAGE')
+            'PRODUCT_LIST_IMAGE' => zen_config('PRODUCT_LIST_IMAGE'),
         ];
 
         asort($define_list);

--- a/includes/classes/class.search.php
+++ b/includes/classes/class.search.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * Product search SQL operations.
  *
@@ -96,7 +98,7 @@ class Search extends \base
      * @return void
      * @since ZC v2.0.0
      */
-    public function setSearchOptions(SearchOptions $searchOptions)
+    public function setSearchOptions(SearchOptions $searchOptions): void
     {
         $this->searchOptions = $searchOptions;
     }
@@ -109,7 +111,7 @@ class Search extends \base
      * @return string The built SQL.
      * @since ZC v2.0.0
      */
-    public function buildSearchSQL()
+    public function buildSearchSQL(): string
     {
         global $db, $messageStack, $currencies, $column_list;
 
@@ -124,47 +126,47 @@ class Search extends \base
         $search_additional_clause = false;
         $this->notify('NOTIFY_ADVANCED_SEARCH_RESULTS_ADDL_CLAUSE', [], $search_additional_clause);
 
-        if ($search_additional_clause === false &&
-            empty($this->searchOptions->keywords) &&
-            (
-                (empty($this->searchOptions->dfrom) && empty($this->searchOptions->dto)) &&
-                (empty($this->searchOptions->pfrom) || $this->searchOptions->pfrom <= 0) &&
-                (empty($this->searchOptions->pto) || $this->searchOptions->pto <= 0)
+        if ($search_additional_clause === false
+            && empty($this->searchOptions->keywords)
+            && (
+                (empty($this->searchOptions->dfrom) && empty($this->searchOptions->dto))
+                && (empty($this->searchOptions->pfrom) || $this->searchOptions->pfrom <= 0)
+                && (empty($this->searchOptions->pto) || $this->searchOptions->pto <= 0)
             )) {
             throw new SearchException(ERROR_AT_LEAST_ONE_INPUT);
-        } else {
-            $dfrom_array = [];
-            $dto_array = [];
+        }
 
-            if (!empty($this->searchOptions->dfrom) &&
-                !zen_checkdate($this->searchOptions->dfrom, DOB_FORMAT_STRING, $dfrom_array)) {
-                throw new SearchException(ERROR_INVALID_FROM_DATE);
-            }
+        $dfrom_array = [];
+        $dto_array = [];
 
-            if (!empty($this->searchOptions->dto) &&
-                !zen_checkdate($this->searchOptions->dto, DOB_FORMAT_STRING, $dto_array)) {
-                throw new SearchException(ERROR_INVALID_TO_DATE);
-            }
+        if (!empty($this->searchOptions->dfrom)
+            && !zen_checkdate($this->searchOptions->dfrom, DOB_FORMAT_STRING, $dfrom_array)) {
+            throw new SearchException(ERROR_INVALID_FROM_DATE);
+        }
 
-            if (!empty($this->searchOptions->dfrom) && !empty($this->searchOptions->dto)) {
-                if (mktime(0, 0, 0, $dfrom_array[1], $dfrom_array[2], $dfrom_array[0]) > mktime(0, 0, 0, $dto_array[1], $dto_array[2], $dto_array[0])) {
-                    throw new SearchException(ERROR_TO_DATE_LESS_THAN_FROM_DATE);
-                }
-            }
+        if (!empty($this->searchOptions->dto)
+            && !zen_checkdate($this->searchOptions->dto, DOB_FORMAT_STRING, $dto_array)) {
+            throw new SearchException(ERROR_INVALID_TO_DATE);
+        }
 
-            if ($this->searchOptions->pfrom > $this->searchOptions->pto) {
-                throw new SearchException(ERROR_PRICE_TO_LESS_THAN_PRICE_FROM);
-            }
-
-            if (!empty($this->searchOptions->keywords) &&
-                !zen_parse_search_string(stripslashes($this->searchOptions->keywords), $search_keywords)) {
-                throw new SearchException(ERROR_INVALID_KEYWORDS);
+        if (!empty($this->searchOptions->dfrom) && !empty($this->searchOptions->dto)) {
+            if (mktime(0, 0, 0, $dfrom_array[1], $dfrom_array[2], $dfrom_array[0]) > mktime(0, 0, 0, $dto_array[1], $dto_array[2], $dto_array[0])) {
+                throw new SearchException(ERROR_TO_DATE_LESS_THAN_FROM_DATE);
             }
         }
 
-        if (empty($this->searchOptions->dfrom) && empty($this->searchOptions->dto) &&
-            empty($this->searchOptions->pfrom) && empty($this->searchOptions->pto) &&
-            empty($this->searchOptions->keywords) && $search_additional_clause === false) {
+        if ($this->searchOptions->pfrom > $this->searchOptions->pto) {
+            throw new SearchException(ERROR_PRICE_TO_LESS_THAN_PRICE_FROM);
+        }
+
+        if (!empty($this->searchOptions->keywords)
+            && !zen_parse_search_string(stripslashes($this->searchOptions->keywords), $search_keywords)) {
+            throw new SearchException(ERROR_INVALID_KEYWORDS);
+        }
+
+        if (empty($this->searchOptions->dfrom) && empty($this->searchOptions->dto)
+            && empty($this->searchOptions->pfrom) && empty($this->searchOptions->pto)
+            && empty($this->searchOptions->keywords) && $search_additional_clause === false) {
             throw new SearchException(ERROR_AT_LEAST_ONE_INPUT);
         }
 
@@ -416,31 +418,31 @@ class Search extends \base
             global $order_by;   //- Set in modules/listing_display_order.php
 
             $order_str = $order_by;
-        // -----
-        // Otherwise, use the legacy ordering identified by $_GET['sort']
-        //
+            // -----
+            // Otherwise, use the legacy ordering identified by $_GET['sort']
+            //
         } else {
             // set the default sort order setting from the Admin when not defined by customer
             if (empty($this->searchOptions->sort) && zen_config('PRODUCT_LISTING_DEFAULT_SORT_ORDER') !== '') {
                 $this->searchOptions->sort = zen_config('PRODUCT_LISTING_DEFAULT_SORT_ORDER');
             }
-            if (empty($this->searchOptions->sort) ||
-                !preg_match('/[1-8][ad]/', $this->searchOptions->sort) ||
-                substr($this->searchOptions->sort, 0, 1) > count($column_list)) {
+            if (empty($this->searchOptions->sort)
+                || !preg_match('/[1-8][ad]/', $this->searchOptions->sort)
+                || substr($this->searchOptions->sort, 0, 1) > count($column_list)) {
                 for ($col = 0, $n = count($column_list); $col < $n; $col++) {
                     if ($column_list[$col] === 'PRODUCT_LIST_NAME') {
                         $this->searchOptions->sort = $col + 1 . 'a';
                         $order_str .= ' ORDER BY pd.products_name';
                         break;
-                    } else {
-                        // sort by products_sort_order when PRODUCT_LISTING_DEFAULT_SORT_ORDER ia left blank
-                        // for reverse, descending order use:
-                        //       $listing_sql .= " order by p.products_sort_order desc, pd.products_name";
-                        $order_str .= " ORDER BY p.products_sort_order, pd.products_name";
-                        break;
                     }
+
+                    // sort by products_sort_order when PRODUCT_LISTING_DEFAULT_SORT_ORDER ia left blank
+                    // for reverse, descending order use:
+                    //       $listing_sql .= " order by p.products_sort_order desc, pd.products_name";
+                    $order_str .= " ORDER BY p.products_sort_order, pd.products_name";
+                    break;
                 }
-                // if set to nothing use products_sort_order and PRODUCTS_LIST_NAME is off
+                // if set to nothing, use products_sort_order and PRODUCTS_LIST_NAME is off
                 if (zen_config('PRODUCT_LISTING_DEFAULT_SORT_ORDER') === '') {
                     $this->searchOptions->sort = '20a';
                 }

--- a/includes/classes/class.zcPassword.php
+++ b/includes/classes/class.zcPassword.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * File contains just the zcPassword class
  *
@@ -6,6 +8,7 @@
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: DrByte 2025 Sep 18 Modified in v2.2.0 $
  */
+
 /**
  * class zcPassword
  *
@@ -17,172 +20,156 @@
  */
 class zcPassword extends base
 {
-  /**
-   *
-   * @var $instance object
-   */
-  protected static $instance = null;
-  /**
-   * enforce singleton
-   *
-   * @param string $phpVersion
-   * @since ZC v1.5.3
-   */
-  public static function getInstance($phpVersion)
-  {
-    if (! self::$instance) {
-      $class = __CLASS__;
-      self::$instance = new $class($phpVersion);
-    }
-    return self::$instance;
-  }
-  /**
-   * constructor
-   *
-   * @param string $phpVersion
-   */
-  public function __construct($phpVersion = PHP_VERSION)
-  {
-  }
-  /**
-   * Determine the password type
-   *
-   * Legacy passwords were hash:salt with a salt of length 2
-   * php < 5.3.7 updated passwords are hash:salt with salt of length > 2
-   * php >= 5.3.7 passwords are BMCF format
-   *
-   * @param string $encryptedPassword
-   * @return string
-   * @since ZC v1.5.3
-   */
-  function detectPasswordType($encryptedPassword)
-  {
-    $type = 'unknown';
-    $tmp = explode(':', $encryptedPassword);
-    if (count($tmp) == 2) {
-      if (strlen($tmp [1]) > 2) {
-        $type = 'compatSha256';
-      } elseif (strlen($tmp [1]) == 2) {
-        $type = 'oldMd5';
-      }
-    }
-    return $type;
-  }
-  /**
-   * validate a password where format is unknown
-   *
-   * @param string $plain
-   * @param string $encrypted
-   * @return boolean
-   * @since ZC v1.5.3
-   */
-  public function validatePassword($plain, $encrypted)
-  {
-    $type = $this->detectPasswordType($encrypted);
-    if ($type != 'unknown') {
-      $method = 'validatePassword' . ucfirst($type);
-      return $this->{$method}($plain, $encrypted);
-    }
-    $result = password_verify($plain, $encrypted);
-    return $result;
-  }
-  /**
-   * validate a legacy md5 type password
-   *
-   * @param string $plain
-   * @param string $encrypted
-   * @return boolean
-   * @since ZC v1.5.3
-   */
-  public function validatePasswordOldMd5($plain, $encrypted)
-  {
-    if (zen_not_null($plain) && zen_not_null($encrypted)) {
-      $stack = explode(':', $encrypted);
-      if (sizeof($stack) != 2)
-        return false;
-      if (hash('md5', $stack [1] . $plain) == $stack [0]) {
-        return true;
-      }
-    }
-    return false;
-  }
-  /**
-   * validate a SHA256 type password
-   *
-   * @param string $plain
-   * @param string $encrypted
-   * @return boolean
-   * @since ZC v1.5.3
-   */
-  public function validatePasswordCompatSha256($plain, $encrypted)
-  {
-    if (zen_not_null($plain) && zen_not_null($encrypted)) {
-      $stack = explode(':', $encrypted);
-      if (sizeof($stack) != 2)
-        return false;
-      if (hash('sha256', $stack [1] . $plain) == $stack [0]) {
-        return true;
-      }
-    }
-    return false;
-  }
+    protected static ?object $instance = null;
 
-  /**
-   * Update a not logged in Admin password.
-   *
-   * @param string $plain
-   * @param string $admin
-   * @return string
-   * @since ZC v1.5.3
-   */
-  public function updateNotLoggedInAdminPassword($plain, $admin)
-  {
-    $this->confirmDbSchema('admin');
-    global $db;
-    $updatedPassword = password_hash($plain, PASSWORD_DEFAULT);
-    $sql = "UPDATE " . TABLE_ADMIN . "
+    /**
+     * enforce singleton
+     * @since ZC v1.5.3
+     */
+    public static function getInstance(string $phpVersion)
+    {
+        if (!self::$instance) {
+            $class = __CLASS__;
+            self::$instance = new $class($phpVersion);
+        }
+        return self::$instance;
+    }
+
+    public function __construct(string $phpVersion = \PHP_VERSION) {}
+
+    /**
+     * Determine the password type
+     *
+     * Legacy passwords were hash:salt with a salt of length 2
+     * php < 5.3.7 updated passwords are hash:salt with salt of length > 2
+     * php >= 5.3.7 passwords are BMCF format
+     *
+     * @since ZC v1.5.3
+     */
+    public function detectPasswordType(string $encryptedPassword): string
+    {
+        $type = 'unknown';
+        $tmp = explode(':', $encryptedPassword);
+        if (count($tmp) === 2) {
+            if (strlen($tmp [1]) > 2) {
+                $type = 'compatSha256';
+            } elseif (strlen($tmp [1]) === 2) {
+                $type = 'oldMd5';
+            }
+        }
+        return $type;
+    }
+
+    /**
+     * validate a password where format is unknown
+     *
+     * @since ZC v1.5.3
+     */
+    public function validatePassword(string $plain, string $encrypted): bool
+    {
+        $type = $this->detectPasswordType($encrypted);
+        if ($type !== 'unknown') {
+            $method = 'validatePassword' . ucfirst($type);
+            return $this->{$method}($plain, $encrypted);
+        }
+        return password_verify($plain, $encrypted);
+    }
+
+    /**
+     * validate a legacy md5 type password
+     *
+     * @since ZC v1.5.3
+     */
+    public function validatePasswordOldMd5(string $plain, string $encrypted): bool
+    {
+        if (zen_not_null($plain) && zen_not_null($encrypted)) {
+            $stack = explode(':', $encrypted);
+            if (count($stack) !== 2) {
+                return false;
+            }
+            if (hash('md5', $stack [1] . $plain) == $stack [0]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * validate a SHA256 type password
+     *
+     * @param string $plain
+     * @param string $encrypted
+     * @return boolean
+     * @since ZC v1.5.3
+     */
+    public function validatePasswordCompatSha256($plain, $encrypted)
+    {
+        if (zen_not_null($plain) && zen_not_null($encrypted)) {
+            $stack = explode(':', $encrypted);
+            if (count($stack) !== 2) {
+                return false;
+            }
+            if (hash('sha256', $stack [1] . $plain) == $stack [0]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Update a not logged in Admin password.
+     *
+     * @since ZC v1.5.3
+     */
+    public function updateNotLoggedInAdminPassword(string $plain, string $admin): string
+    {
+        $this->confirmDbSchema('admin');
+        global $db;
+        $updatedPassword = password_hash($plain, \PASSWORD_DEFAULT);
+        $sql = "UPDATE " . TABLE_ADMIN . "
               SET admin_pass = :password:
               WHERE admin_name = :adminName:";
 
-    $sql = $db->bindVars($sql, ':adminName:', $admin, 'string');
-    $sql = $db->bindVars($sql, ':password:', $updatedPassword, 'string');
-    $db->Execute($sql);
-    return $updatedPassword;
-  }
-  /**
-   * Ensure db schema has been updated to support the required password lengths
-   * @param string $mode
-   * @since ZC v1.5.3
-   */
-  public function confirmDbSchema($mode = '') {
-    global $db;
-    if ($mode == '' || $mode == 'admin') {
-      $sql = "ALTER TABLE " . TABLE_ADMIN . " MODIFY admin_pass VARCHAR( 255 ) NOT NULL DEFAULT ''";
-      $db->Execute($sql);
-      $sql = "ALTER TABLE " . TABLE_ADMIN . " MODIFY prev_pass1 VARCHAR( 255 ) NOT NULL DEFAULT ''";
-      $db->Execute($sql);
-      $sql = "ALTER TABLE " . TABLE_ADMIN . " MODIFY prev_pass2 VARCHAR( 255 ) NOT NULL DEFAULT ''";
-      $db->Execute($sql);
-      $sql = "ALTER TABLE " . TABLE_ADMIN . " MODIFY prev_pass3 VARCHAR( 255 ) NOT NULL DEFAULT ''";
-      $db->Execute($sql);
-      $sql = "ALTER TABLE " . TABLE_ADMIN . " MODIFY reset_token VARCHAR( 255 ) NOT NULL DEFAULT ''";
-      $db->Execute($sql);
-    }
-    if ($mode == '' || $mode == 'customer') {
-      $found = false;
-      $sql = "show fields from " . TABLE_CUSTOMERS;
-      $result = $db->Execute($sql);
-      while (!$result->EOF && !$found) {
-        if ($result->fields['Field'] == 'customers_password' && strtoupper($result->fields['Type']) == 'VARCHAR(255)') {
-          $found = true;
-        }
-        $result->MoveNext();
-      }
-      if (!$found) {
-        $sql = "ALTER TABLE " . TABLE_CUSTOMERS . " MODIFY customers_password VARCHAR( 255 ) NOT NULL DEFAULT ''";
+        $sql = $db->bindVars($sql, ':adminName:', $admin, 'string');
+        $sql = $db->bindVars($sql, ':password:', $updatedPassword, 'string');
         $db->Execute($sql);
-      }
+        return $updatedPassword;
     }
-    return;
-  }
+
+    /**
+     * Ensure db schema has been updated to support the required password lengths
+     *
+     * @since ZC v1.5.3
+     */
+    public function confirmDbSchema(string $mode = ''): void
+    {
+        global $db;
+        if ($mode === '' || $mode === 'admin') {
+            $sql = "ALTER TABLE " . TABLE_ADMIN . " MODIFY admin_pass VARCHAR( 255 ) NOT NULL DEFAULT ''";
+            $db->Execute($sql);
+            $sql = "ALTER TABLE " . TABLE_ADMIN . " MODIFY prev_pass1 VARCHAR( 255 ) NOT NULL DEFAULT ''";
+            $db->Execute($sql);
+            $sql = "ALTER TABLE " . TABLE_ADMIN . " MODIFY prev_pass2 VARCHAR( 255 ) NOT NULL DEFAULT ''";
+            $db->Execute($sql);
+            $sql = "ALTER TABLE " . TABLE_ADMIN . " MODIFY prev_pass3 VARCHAR( 255 ) NOT NULL DEFAULT ''";
+            $db->Execute($sql);
+            $sql = "ALTER TABLE " . TABLE_ADMIN . " MODIFY reset_token VARCHAR( 255 ) NOT NULL DEFAULT ''";
+            $db->Execute($sql);
+        }
+        if ($mode === '' || $mode === 'customer') {
+            $found = false;
+            $sql = "SHOW FIELDS FROM " . TABLE_CUSTOMERS;
+            $result = $db->Execute($sql);
+            while (!$result->EOF && !$found) {
+                if ($result->fields['Field'] === 'customers_password' && strtoupper($result->fields['Type']) === 'VARCHAR(255)') {
+                    $found = true;
+                }
+                $result->MoveNext();
+            }
+            if (!$found) {
+                $sql = "ALTER TABLE " . TABLE_CUSTOMERS . " MODIFY customers_password VARCHAR( 255 ) NOT NULL DEFAULT ''";
+                $db->Execute($sql);
+            }
+        }
+    }
 }

--- a/includes/classes/currencies.php
+++ b/includes/classes/currencies.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * currencies class
  *
@@ -80,7 +82,7 @@ class currencies extends base
 
         if ($calculate_using_exchange_rate === true) {
             // Special Case: if the selected currency is in the european euro-conversion and the default currency is euro,
-            // then the currency will displayed in both the national currency and euro currency
+            // then the currency will be displayed in both the national currency and euro currency
             if (zen_config('DEFAULT_CURRENCY') === 'EUR' && in_array($currency_code, ['DEM', 'BEF', 'LUF', 'ESP', 'FRF', 'IEP', 'ITL', 'NLG', 'ATS', 'PTE', 'FIM', 'GRD'])) {
                 $formatted_string .= ' <small>[' . $this->format($number, true, 'EUR') . ']</small>';
             }
@@ -90,7 +92,7 @@ class currencies extends base
     }
 
     /**
-     * Convert amount based on currency values and round it to the relevant decimal places
+     * Convert the amount based on currency values and round it to the relevant decimal places
      *
      * @param numeric $number
      * @param bool $calculate_using_exchange_rate
@@ -105,10 +107,10 @@ class currencies extends base
 
         if ($calculate_using_exchange_rate === true) {
             $rate = !empty($currency_value) ? $currency_value : $currency_info['value'];
-            $number = $number * $rate;
+            $number *= $rate;
         }
 
-        return zen_round($number, $currency_info['decimal_places']);
+        return zen_round(zen_str_to_numeric($number), $currency_info['decimal_places']);
     }
 
     /**
@@ -129,10 +131,10 @@ class currencies extends base
         if ($calculate_using_exchange_rate === true) {
             $multiplier = ($currency_code === zen_config('DEFAULT_CURRENCY')) ? 1 / $this->currencies[$_SESSION['currency']]['value'] : $currency_info['value'];
             $rate = !empty($currency_value) ? $currency_value : $multiplier;
-            $number = $number * $rate;
+            $number *= $rate;
         }
 
-        return zen_round($number, $currency_info['decimal_places']);
+        return zen_round(zen_str_to_numeric($number), $currency_info['decimal_places']);
     }
 
     /**
@@ -166,7 +168,7 @@ class currencies extends base
     public function get_value(string $currency_code): float
     {
         $currency_info = $this->getCurrencyInfo($currency_code);
-        return $currency_info['value'];
+        return zen_str_to_numeric($currency_info['value']);
     }
 
     /**
@@ -177,7 +179,7 @@ class currencies extends base
     public function get_decimal_places(string $currency_code): int
     {
         $currency_info = $this->getCurrencyInfo($currency_code);
-        return $currency_info['decimal_places'];
+        return (int)$currency_info['decimal_places'];
     }
 
     /**
@@ -253,7 +255,7 @@ class currencies extends base
      */
     public function display_price(mixed $product_price, mixed $product_tax, mixed $quantity = 1): string
     {
-        return $this->format(zen_add_tax($product_price, $product_tax) * $quantity);
+        return $this->format(zen_add_tax(zen_str_to_numeric($product_price), zen_str_to_numeric($product_tax)) * $quantity);
     }
 
     /**

--- a/includes/classes/currencies.php
+++ b/includes/classes/currencies.php
@@ -233,7 +233,7 @@ class currencies extends base
             $this->currencies[$currency_code]['symbol_left'] = $currency_code . ' ';
             $this->currencies[$currency_code]['symbol_right'] = '';
             if ($this->debug === true) {
-                trigger_error("Creating currency settings for $currency_code, based on " . zen_config('DEFAULT_CURRENCY') . " settings.", E_USER_NOTICE);
+                trigger_error("Creating currency settings for $currency_code, based on " . zen_config('DEFAULT_CURRENCY') . " settings.", \E_USER_NOTICE);
             }
         }
 

--- a/includes/classes/db/mysql/define_queries.php
+++ b/includes/classes/db/mysql/define_queries.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * define_queries
  * defines queries used in various codeblocks
@@ -9,13 +11,13 @@
  * @version $Id: torvista 2026 Mar 17 Modified in v2.2.1 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
-  die('Illegal Access');
+    die('Illegal Access');
 }
 define('SQL_CC_ENABLED', "SELECT configuration_key FROM " . TABLE_CONFIGURATION . " WHERE configuration_key RLIKE 'CC_ENABLED' AND configuration_value= '1'");
 define('SQL_SHOW_PRODUCT_INFO_CATEGORY', "SELECT configuration_key, configuration_value FROM " . TABLE_CONFIGURATION . " WHERE configuration_key RLIKE 'SHOW_PRODUCT_INFO_CATEGORY' AND configuration_value > 0 ORDER BY configuration_value");
-define('SQL_SHOW_PRODUCT_INFO_MAIN',"SELECT configuration_key, configuration_value FROM " . TABLE_CONFIGURATION . " WHERE configuration_key RLIKE 'SHOW_PRODUCT_INFO_MAIN' AND configuration_value > 0 ORDER BY configuration_value");
-define('SQL_SHOW_PRODUCT_INFO_MISSING',"SELECT configuration_key, configuration_value FROM " . TABLE_CONFIGURATION  . " WHERE configuration_key RLIKE 'SHOW_PRODUCT_INFO_MISSING' AND configuration_value > 0 ORDER BY configuration_value");
-define('SQL_SHOW_PRODUCT_INFO_LISTING_BELOW',"SELECT configuration_key, configuration_value FROM " . TABLE_CONFIGURATION . " WHERE configuration_key RLIKE 'SHOW_PRODUCT_INFO_LISTING_BELOW' AND configuration_value > 0 ORDER BY configuration_value");
+define('SQL_SHOW_PRODUCT_INFO_MAIN', "SELECT configuration_key, configuration_value FROM " . TABLE_CONFIGURATION . " WHERE configuration_key RLIKE 'SHOW_PRODUCT_INFO_MAIN' AND configuration_value > 0 ORDER BY configuration_value");
+define('SQL_SHOW_PRODUCT_INFO_MISSING', "SELECT configuration_key, configuration_value FROM " . TABLE_CONFIGURATION . " WHERE configuration_key RLIKE 'SHOW_PRODUCT_INFO_MISSING' AND configuration_value > 0 ORDER BY configuration_value");
+define('SQL_SHOW_PRODUCT_INFO_LISTING_BELOW', "SELECT configuration_key, configuration_value FROM " . TABLE_CONFIGURATION . " WHERE configuration_key RLIKE 'SHOW_PRODUCT_INFO_LISTING_BELOW' AND configuration_value > 0 ORDER BY configuration_value");
 define('SQL_BANNER_CHECK_QUERY', "SELECT count(*) AS count FROM " . TABLE_BANNERS_HISTORY . " WHERE banners_id = '%s' AND DATE_FORMAT(banners_history_date, '%%Y%%m%%d') = DATE_FORMAT(NOW(), '%%Y%%m%%d')");
 define('SQL_BANNER_CHECK_UPDATE', "update " . TABLE_BANNERS_HISTORY . " SET banners_shown = banners_shown +1 WHERE banners_id = '%s' AND DATE_FORMAT(banners_history_date, '%%Y%%m%%d') = DATE_FORMAT(NOW(), '%%Y%%m%%d')");
 define('SQL_BANNER_UPDATE_CLICK_COUNT', "UPDATE " . TABLE_BANNERS_HISTORY . " SET banners_clicked = banners_clicked + 1 WHERE banners_id = '%s' AND DATE_FORMAT(banners_history_date, '%%Y%%m%%d') = DATE_FORMAT(NOW(), '%%Y%%m%%d')");
@@ -30,4 +32,4 @@ define('SQL_ALSO_PURCHASED', "SELECT p.products_id, p.products_image, MAX(o.date
     GROUP BY p.products_id, p.products_image
     ORDER BY date_purchased desc, p.products_id");
 
-define('SQL_SHOW_SHOPPING_CART_EMPTY',"SELECT configuration_key, configuration_value FROM " . TABLE_CONFIGURATION . " WHERE configuration_key RLIKE 'SHOW_SHOPPING_CART_EMPTY' AND configuration_value > 0 ORDER BY configuration_value");
+define('SQL_SHOW_SHOPPING_CART_EMPTY', "SELECT configuration_key, configuration_value FROM " . TABLE_CONFIGURATION . " WHERE configuration_key RLIKE 'SHOW_SHOPPING_CART_EMPTY' AND configuration_value > 0 ORDER BY configuration_value");

--- a/includes/classes/db/mysql/query_factory.php
+++ b/includes/classes/db/mysql/query_factory.php
@@ -93,11 +93,11 @@ class queryFactory extends base
         $dbCharset = $options['dbCharset'] ?? (defined('DB_CHARSET') ? DB_CHARSET : null);
 
         if (!function_exists('mysqli_connect')) {
-            die ('Call to undefined function: mysqli_connect().  Please install the MySQL Connector for PHP');
+            die('Call to undefined function: mysqli_connect().  Please install the MySQL Connector for PHP');
         }
 
         // use default reporting setting, so exceptions aren't thrown, since we attempt to catch errors here procedurally.
-        mysqli_report(MYSQLI_REPORT_OFF);
+        mysqli_report(\MYSQLI_REPORT_OFF);
 
         $connectionRetry = 10;
         while ($this->link === false && $connectionRetry > 0) {
@@ -171,7 +171,7 @@ class queryFactory extends base
     public function simpleConnect(string $db_host, string $db_user, string $db_password, string $db_name): bool
     {
         // use default reporting setting, so exceptions aren't thrown, since we attempt to catch errors here procedurally.
-        mysqli_report(MYSQLI_REPORT_OFF);
+        mysqli_report(\MYSQLI_REPORT_OFF);
 
         $this->database = $db_name;
         $this->user = $db_user;
@@ -179,7 +179,7 @@ class queryFactory extends base
         $this->password = $db_password;
 
         // temporarily suppress E_WARNING in case of connection failure
-        $error_level = error_reporting(E_ERROR | E_PARSE);
+        $error_level = error_reporting(\E_ERROR | \E_PARSE);
         $this->link = mysqli_connect($db_host, $db_user, $db_password, $db_name, (defined('DB_PORT') ? DB_PORT : null), (defined('DB_SOCKET') ? DB_SOCKET : null));
         error_reporting($error_level);
 
@@ -247,7 +247,7 @@ class queryFactory extends base
      * @see $this->prepare_input()
      * @since ZC v1.3.0
      */
-    function prepareInput(string $string)
+    public function prepareInput(string $string)
     {
         return $this->prepare_input($string);
     }
@@ -464,9 +464,9 @@ class queryFactory extends base
      * @deprecated since 1.5.8 use ExecuteRandomMulti
      * @since ZC v1.5.5f
      */
-    function ExecuteRandomMultiNoCache($sqlQuery)
+    public function ExecuteRandomMultiNoCache($sqlQuery)
     {
-        trigger_error('Call to deprecated function ExecuteRandomMultiNoCache. Use ExecuteRandomMulti() instead', E_USER_DEPRECATED);
+        trigger_error('Call to deprecated function ExecuteRandomMultiNoCache. Use ExecuteRandomMulti() instead', \E_USER_DEPRECATED);
 
         return $this->ExecuteRandomMulti($sqlQuery, 0);
     }
@@ -618,8 +618,9 @@ class queryFactory extends base
         switch (strtolower($performType)) {
             case 'insertignore':
                 $insertString = 'INSERT IGNORE';
+                // no break
             case 'insert':
-                $insertString = $insertString ?? 'INSERT';
+                $insertString ??= 'INSERT';
                 $insertString .= " INTO $tableName (";
                 foreach ($tableData as $key => $value) {
                     if ($debug === true) {
@@ -644,8 +645,9 @@ class queryFactory extends base
 
             case 'updateignore':
                 $updateString = 'UPDATE IGNORE ';
+                // no break
             case 'update':
-                $updateString = $updateString ?? 'UPDATE ';
+                $updateString ??= 'UPDATE ';
                 $updateString .= " $tableName SET ";
                 foreach ($tableData as $key => $value) {
                     $bindVarValue = $this->getBindVarValue($value['value'], $value['type']);
@@ -698,18 +700,14 @@ class queryFactory extends base
         switch ($type) {
             case 'inConstructInteger':
                 $list = explode(',', $value);
-                $newList = array_map(function ($value) {
-                    return (int)$value;
-                }, $list);
+                $newList = array_map(fn($value) => (int)$value, $list);
                 $value = implode(',', $newList);
 
                 return $value;
 
             case 'inConstructString':
                 $list = explode(',', $value);
-                $newList = array_map(function ($value) {
-                    return '\'' . $this->prepare_input($value) . '\'';
-                }, $list);
+                $newList = array_map(fn($value) => '\'' . $this->prepare_input($value) . '\'', $list);
                 $value = implode(',', $newList);
 
                 return $value;
@@ -761,7 +759,7 @@ class queryFactory extends base
                 return $this->prepare_input($value);
 
             default:
-                trigger_error("FATAL ERROR: var-type undefined: $type ($value).", E_USER_WARNING);
+                trigger_error("FATAL ERROR: var-type undefined: $type ($value).", \E_USER_WARNING);
                 exit();
         }
     }
@@ -844,7 +842,7 @@ class queryFactory extends base
         if (file_exists(FILENAME_DATABASE_TEMPORARILY_DOWN)) {
             if (($this->error_number == 0 && $this->error_text == DB_ERROR_NOT_CONNECTED)
                 || in_array($this->error_number, [2002, 2003])) {
-                include(FILENAME_DATABASE_TEMPORARILY_DOWN);
+                include FILENAME_DATABASE_TEMPORARILY_DOWN;
             }
         }
 
@@ -875,7 +873,7 @@ class queryFactory extends base
                 break;
             }
         }
-        trigger_error('FATAL MySQL error ' . $this->error_number . ': ' . $this->error_text . ' :: ' . $this->zf_sql . $query_factory_caller, E_USER_WARNING);
+        trigger_error('FATAL MySQL error ' . $this->error_number . ': ' . $this->error_text . ' :: ' . $this->zf_sql . $query_factory_caller, \E_USER_WARNING);
         exit();
     }
 
@@ -922,10 +920,10 @@ class queryFactory extends base
         if (strtoupper(substr($sqlQuery, 0, 6)) !== 'SELECT' /*&& strstr($sqlQuery,'products_id')*/) {
             return;
         }
-// optional isolation
-//        if (strpos($sqlQuery, 'products_id') === false) {
-//            return;
-//        }
+        // optional isolation
+        //        if (strpos($sqlQuery, 'products_id') === false) {
+        //            return;
+        //        }
 
         $f = @fopen(DIR_FS_LOGS . '/query_selects_' . $current_page_base . '_' . time() . '.txt', 'ab');
         if ($f) {
@@ -933,7 +931,7 @@ class queryFactory extends base
 
             if (STORE_DB_TRANSACTIONS === 'backtrace') {
                 ob_start();
-                debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+                debug_print_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS);
                 $backtrace = ob_get_clean();
                 $backtrace = preg_replace('/^#0\s+' . __FUNCTION__ . '[^\n]*\n/', '', $backtrace, 1);
                 $backtrace = 'query trace: ' . "\n" . $backtrace . "\n";
@@ -1002,9 +1000,7 @@ class queryFactoryResult implements Countable, Iterator
 
     public string $sql_query = '';
 
-    public function __construct(public ?mysqli $link)
-    {
-    }
+    public function __construct(public ?mysqli $link) {}
 
     /* (non-PHPdoc)
      * @see Iterator::current()

--- a/includes/classes/db/mysql/query_factory.php
+++ b/includes/classes/db/mysql/query_factory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * MySQL query_factory class.
  * Class used for database abstraction to MySQL via mysqli procedural interface.
@@ -681,7 +683,7 @@ class queryFactory extends base
     public function bindVars(string $sql, string $parameterToReplace, $valueToBind, string $bindingRule): string
     {
         $sqlNew = $this->getBindVarValue($valueToBind, $bindingRule);
-        $sqlNew = str_replace($parameterToReplace, $sqlNew, $sql);
+        $sqlNew = str_replace($parameterToReplace, (string)$sqlNew, $sql);
         return $sqlNew;
     }
 
@@ -699,14 +701,14 @@ class queryFactory extends base
         $type = $typeArray[0];
         switch ($type) {
             case 'inConstructInteger':
-                $list = explode(',', $value);
-                $newList = array_map(fn($value) => (int)$value, $list);
+                $list = explode(',', (string)$value);
+                $newList = array_map(static fn($value) => (int)$value, $list);
                 $value = implode(',', $newList);
 
                 return $value;
 
             case 'inConstructString':
-                $list = explode(',', $value);
+                $list = explode(',', (string)$value);
                 $newList = array_map(fn($value) => '\'' . $this->prepare_input($value) . '\'', $list);
                 $value = implode(',', $newList);
 
@@ -719,31 +721,31 @@ class queryFactory extends base
                 return $value;
 
             case 'float':
-                return (!zen_not_null($value) || $value == '' || $value == 0) ? 0 : (float)$value;
+                return (!zen_not_null($value) || $value === '' || $value === 0) ? 0 : (float)$value;
 
             case 'integer':
                 return (int)$value;
 
             case 'string':
-                if (preg_match('/NULL/', $value)) {
+                if (preg_match('/NULL/', (string)$value)) {
                     return 'null';
                 }
-                return '\'' . $this->prepare_input($value) . '\'';
+                return '\'' . $this->prepare_input((string)$value) . '\'';
 
             case 'stringIgnoreNull':
-                return '\'' . $this->prepare_input($value) . '\'';
+                return '\'' . $this->prepare_input((string)$value) . '\'';
 
             case 'noquotestring':
-                return $this->prepare_input($value);
+                return $this->prepare_input((string)$value);
 
             case 'currency':
-                return '\'' . $this->prepare_input($value) . '\'';
+                return '\'' . $this->prepare_input((string)$value) . '\'';
 
             case 'date':
-                if (preg_match('/null/i', $value)) {
+                if (preg_match('/null/i', (string)$value)) {
                     return 'null';
                 }
-                return '\'' . $this->prepare_input($value) . '\'';
+                return '\'' . $this->prepare_input((string)$value) . '\'';
 
             case 'enum':
                 if (isset($typeArray[1])) {
@@ -1137,6 +1139,7 @@ class queryFactoryResult implements Countable, Iterator
         if (!empty($this->resource) && $this->resource instanceof mysqli_result) {
             return @mysqli_num_rows($this->resource);
         }
+
         return 0;
     }
 

--- a/includes/classes/http_client.php
+++ b/includes/classes/http_client.php
@@ -33,7 +33,7 @@ class httpClient extends base
     public array $responseHeaders;
     /** @var resource|bool */
     public $socket = false;
-// proxy stuff
+    // proxy stuff
     public bool $useProxy = false;
     public string $proxyHost;
     public string|int $proxyPort;
@@ -219,8 +219,8 @@ class httpClient extends base
      * @return string response status code (200 if ok)
      * @since ZC v1.0.3
      **/
-// * $params = array( "login" => "tiger", "password" => "secret" );
-// * $http->post( "/login.php", $params );
+    // * $params = array( "login" => "tiger", "password" => "secret" );
+    // * $http->post( "/login.php", $params );
     public function Post(string $uri, array $query_params = []): string
     {
         $uri = $this->makeUri($uri);
@@ -456,7 +456,7 @@ class httpClient extends base
                     continue;
                 }
                 [$hdr, $value] = $parts;
-// nasty workaround broken multiple same headers (eg. Set-Cookie headers) @FIXME
+                // nasty workaround broken multiple same headers (eg. Set-Cookie headers) @FIXME
                 if (isset($headers[$hdr])) {
                     $headers[$hdr] .= '; ' . trim($value);
                 } else {

--- a/includes/classes/http_client.php
+++ b/includes/classes/http_client.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * httpClient Class.
  *
@@ -378,7 +380,7 @@ class httpClient extends base
             }
 
             if (!empty($this->requestBody)) {
-                $this->addHeader('Content-Length', strlen($this->requestBody));
+                $this->addHeader('Content-Length', (string)strlen($this->requestBody));
             }
 
             $this->request = $command;
@@ -449,7 +451,7 @@ class httpClient extends base
                 break;
             }
 
-            $finished = ($str == $lastLine);
+            $finished = ($str === $lastLine);
             if (!$finished) {
                 $parts = explode(': ', $str, 2);
                 if (count($parts) < 2) {

--- a/includes/classes/language.php
+++ b/includes/classes/language.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * language Class.
  *
@@ -140,7 +142,7 @@ class language extends base
     public function set_language(string $language): void
     {
         if (empty($language) || !isset($this->languages_by_code[$language])) {
-            $language = DEFAULT_LANGUAGE;
+            $language = zen_config('DEFAULT_LANGUAGE');
         }
 
         $this->language = $this->languages_by_code[$language];

--- a/includes/classes/message_stack.php
+++ b/includes/classes/message_stack.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * messageStack Class.
  *
@@ -46,7 +48,7 @@ class messageStack extends base
         $message = trim($message);
         $duplicate = false;
 
-        if (strlen($message) > 0) {
+        if ($message !== '') {
 
             $theAlert['class'] = $class;
 

--- a/includes/classes/message_stack.php
+++ b/includes/classes/message_stack.php
@@ -27,7 +27,7 @@ class messageStack extends base
             return $this->size('default');
         }
 
-        trigger_error('Undefined property: ' . static::class . '::$' . $name, E_USER_WARNING);
+        trigger_error('Undefined property: ' . static::class . '::$' . $name, \E_USER_WARNING);
 
         return null;
     }
@@ -87,7 +87,7 @@ class messageStack extends base
         $messageToStack[] = [
             'class' => $class,
             'text' => $message,
-            'type' => $type
+            'type' => $type,
         ];
         $_SESSION['messageToStack'] = $messageToStack;
         $this->add($class, $message, $type);
@@ -228,22 +228,22 @@ class messageStack extends base
         return [
             'error' => [
                 'params' => 'class="messageStackError larger"',
-                'icon' => zen_image($template->get_template_dir(ICON_IMAGE_ERROR, DIR_WS_TEMPLATE, $current_page_base,'images/icons'). '/' . ICON_IMAGE_ERROR, ICON_ERROR_ALT),
+                'icon' => zen_image($template->get_template_dir(ICON_IMAGE_ERROR, DIR_WS_TEMPLATE, $current_page_base, 'images/icons') . '/' . ICON_IMAGE_ERROR, ICON_ERROR_ALT),
             ],
             'success' => [
                 'params' => 'class="messageStackSuccess larger"',
-                'icon' => zen_image($template->get_template_dir(ICON_IMAGE_SUCCESS, DIR_WS_TEMPLATE, $current_page_base,'images/icons'). '/' . ICON_IMAGE_SUCCESS, ICON_SUCCESS_ALT),
+                'icon' => zen_image($template->get_template_dir(ICON_IMAGE_SUCCESS, DIR_WS_TEMPLATE, $current_page_base, 'images/icons') . '/' . ICON_IMAGE_SUCCESS, ICON_SUCCESS_ALT),
             ],
             'warning' => [
                 'params' => 'class="messageStackWarning larger"',
-                'icon' => zen_image($template->get_template_dir(ICON_IMAGE_WARNING, DIR_WS_TEMPLATE, $current_page_base,'images/icons'). '/' . ICON_IMAGE_WARNING, ICON_WARNING_ALT),
+                'icon' => zen_image($template->get_template_dir(ICON_IMAGE_WARNING, DIR_WS_TEMPLATE, $current_page_base, 'images/icons') . '/' . ICON_IMAGE_WARNING, ICON_WARNING_ALT),
             ],
             'caution' => [
                 'params' => 'class="messageStackCaution larger"',
-                'icon' => zen_image($template->get_template_dir(ICON_IMAGE_WARNING, DIR_WS_TEMPLATE, $current_page_base,'images/icons'). '/' . ICON_IMAGE_WARNING, ICON_WARNING_ALT),
+                'icon' => zen_image($template->get_template_dir(ICON_IMAGE_WARNING, DIR_WS_TEMPLATE, $current_page_base, 'images/icons') . '/' . ICON_IMAGE_WARNING, ICON_WARNING_ALT),
             ],
             'default' => [
                 'params' => 'class="messageStackError larger"'],
-            ];
+        ];
     }
 }

--- a/includes/classes/navigation_history.php
+++ b/includes/classes/navigation_history.php
@@ -18,9 +18,8 @@ if (!defined('IS_ADMIN_FLAG')) {
  */
 class navigationHistory extends base
 {
-    public
-        $path,
-        $snapshot;
+    public $path;
+    public $snapshot;
 
     public function __construct()
     {
@@ -74,7 +73,7 @@ class navigationHistory extends base
                         continue;
                     } else {
                         if ($this->path[$i]['get']['cPath'] == $cPath) {
-                            array_splice($this->path, ($i+1));
+                            array_splice($this->path, ($i + 1));
                             $set = 'false';
                             break;
                         } else {
@@ -82,7 +81,7 @@ class navigationHistory extends base
                             $new_cPath = explode('_', $cPath);
 
                             $exit_loop = false;
-                            for ($j=0, $n2=sizeof($old_cPath); $j<$n2; $j++) {
+                            for ($j = 0, $n2 = count($old_cPath); $j < $n2; $j++) {
                                 if ($old_cPath[$j] != $new_cPath[$j]) {
                                     array_splice($this->path, ($i));
                                     $set = 'true';
@@ -105,11 +104,11 @@ class navigationHistory extends base
 
         if ($set === 'true') {
             $page = (isset($_GET['main_page'])) ? $_GET['main_page'] : FILENAME_DEFAULT;
-             $this->path[] = [
+            $this->path[] = [
                 'page' => $page,
                 'mode' => $request_type,
                 'get' => $get_vars,
-                'post' => [] /*$_POST*/
+                'post' => [], /*$_POST*/
             ];
         }
     }
@@ -143,7 +142,7 @@ class navigationHistory extends base
                 'page' => $page,
                 'mode' => $request_type,
                 'get' => $get_vars,
-                'post' => [] /*$_POST*/
+                'post' => [], /*$_POST*/
             ];
         }
     }
@@ -168,7 +167,7 @@ class navigationHistory extends base
             'page' => $this->path[$pos]['page'],
             'mode' => $this->path[$pos]['mode'],
             'get' => $this->path[$pos]['get'],
-            'post' => $this->path[$pos]['post']
+            'post' => $this->path[$pos]['post'],
         ];
     }
 

--- a/includes/classes/navigation_history.php
+++ b/includes/classes/navigation_history.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * Navigation_history Class.
  *
@@ -18,8 +20,8 @@ if (!defined('IS_ADMIN_FLAG')) {
  */
 class navigationHistory extends base
 {
-    public $path;
-    public $snapshot;
+    public array $path = [];
+    public array $snapshot = [];
 
     public function __construct()
     {
@@ -29,7 +31,7 @@ class navigationHistory extends base
     /**
      * @since ZC v1.0.3
      */
-    public function reset()
+    public function reset(): void
     {
         $this->path = [];
         $this->snapshot = [];
@@ -55,7 +57,7 @@ class navigationHistory extends base
     public function add_current_page()
     {
         // check whether there are pages which should be blacklisted against entering navigation history
-        if (preg_match('|ajax\.php$|', $_SERVER['SCRIPT_NAME']) && $_GET['act'] !== '') {
+        if (preg_match('|ajax\.php$|', $_SERVER['SCRIPT_NAME'] ?? '') && ($_GET['act'] ?? '') !== '') {
             return;
         }
 
@@ -65,45 +67,45 @@ class navigationHistory extends base
         $get_vars = $_GET;
         unset($get_vars['main_page']);
 
-        $set = 'true';
-        for ($i = 0, $n = count($this->path); $i < $n; $i++) {
-            if (isset($_GET['main_page']) && $this->path[$i]['page'] === $_GET['main_page']) {
+        $set = true;
+        foreach ($this->path as $outerKey => $outerValue) {
+            if (isset($_GET['main_page']) && $outerValue['page'] === $_GET['main_page']) {
                 if (isset($cPath)) {
-                    if (!isset($this->path[$i]['get']['cPath'])) {
+                    if (!isset($outerValue['get']['cPath'])) {
                         continue;
-                    } else {
-                        if ($this->path[$i]['get']['cPath'] == $cPath) {
-                            array_splice($this->path, ($i + 1));
-                            $set = 'false';
-                            break;
-                        } else {
-                            $old_cPath = explode('_', $this->path[$i]['get']['cPath']);
-                            $new_cPath = explode('_', $cPath);
+                    }
 
-                            $exit_loop = false;
-                            for ($j = 0, $n2 = count($old_cPath); $j < $n2; $j++) {
-                                if ($old_cPath[$j] != $new_cPath[$j]) {
-                                    array_splice($this->path, ($i));
-                                    $set = 'true';
-                                    $exit_loop = true;
-                                    break;
-                                }
-                            }
-                            if ($exit_loop == true) {
-                                break;
-                            }
+                    if ($outerValue['get']['cPath'] === $cPath) {
+                        array_splice($this->path, ($outerKey + 1));
+                        $set = false;
+                        break;
+                    }
+
+                    $old_cPath = explode('_', $outerValue['get']['cPath']);
+                    $new_cPath = explode('_', $cPath);
+
+                    $exit_loop = false;
+                    for ($j = 0, $n2 = count($old_cPath); $j < $n2; $j++) {
+                        if ($old_cPath[$j] !== $new_cPath[$j]) {
+                            array_splice($this->path, ($outerKey));
+                            $set = true;
+                            $exit_loop = true;
+                            break;
                         }
                     }
+                    if ($exit_loop === true) {
+                        break;
+                    }
                 } else {
-                    array_splice($this->path, ($i));
-                    $set = 'true';
+                    array_splice($this->path, ($outerKey));
+                    $set = true;
                     break;
                 }
             }
         }
 
-        if ($set === 'true') {
-            $page = (isset($_GET['main_page'])) ? $_GET['main_page'] : FILENAME_DEFAULT;
+        if ($set === true) {
+            $page = $_GET['main_page'] ?? FILENAME_DEFAULT;
             $this->path[] = [
                 'page' => $page,
                 'mode' => $request_type,
@@ -116,12 +118,12 @@ class navigationHistory extends base
     /**
      * @since ZC v1.0.3
      */
-    public function remove_current_page()
+    public function remove_current_page(): void
     {
         $this->checkProperties();
 
         $last_entry_position = count($this->path) - 1;
-        if (isset($this->path[$last_entry_position]['page']) && isset($_GET['main_page']) && $this->path[$last_entry_position]['page'] === $_GET['main_page']) {
+        if (isset($this->path[$last_entry_position]['page'], $_GET['main_page']) && $this->path[$last_entry_position]['page'] === $_GET['main_page']) {
             unset($this->path[$last_entry_position]);
         }
     }
@@ -129,7 +131,7 @@ class navigationHistory extends base
     /**
      * @since ZC v1.0.3
      */
-    public function set_snapshot($page = '')
+    public function set_snapshot(string|array $page = ''): void
     {
         global $request_type;
         if (is_array($page)) {
@@ -137,7 +139,7 @@ class navigationHistory extends base
         } else {
             $get_vars = $_GET;
             unset($get_vars['main_page']);
-            $page = (isset($_GET['main_page'])) ? $_GET['main_page'] : FILENAME_DEFAULT;
+            $page = $_GET['main_page'] ?? FILENAME_DEFAULT;
             $this->snapshot = [
                 'page' => $page,
                 'mode' => $request_type,
@@ -150,7 +152,7 @@ class navigationHistory extends base
     /**
      * @since ZC v1.0.3
      */
-    public function clear_snapshot()
+    public function clear_snapshot(): void
     {
         $this->snapshot = [];
     }
@@ -158,7 +160,7 @@ class navigationHistory extends base
     /**
      * @since ZC v1.0.3
      */
-    public function set_path_as_snapshot($history = 0)
+    public function set_path_as_snapshot($history = 0): void
     {
         $this->checkProperties();
 
@@ -174,18 +176,18 @@ class navigationHistory extends base
     /**
      * @since ZC v1.0.3
      */
-    public function debug()
+    public function debug(): void
     {
         $this->checkProperties();
 
-        for ($i = 0, $n = count($this->path); $i < $n; $i++) {
-            echo $this->path[$i]['page'] . '?';
-            foreach ($this->path[$i]['get'] as $key => $value) {
+        foreach ($this->path as $pathValue) {
+            echo $pathValue['page'] . '?';
+            foreach ($pathValue['get'] as $key => $value) {
                 echo $key . '=' . $value . '&';
             }
-            if (count($this->path[$i]['post']) !== 0) {
+            if (count($pathValue['post']) !== 0) {
                 echo '<br>';
-                foreach ($this->path[$i]['post'] as $key => $value) {
+                foreach ($pathValue['post'] as $key => $value) {
                     echo '&nbsp;&nbsp;<strong>' . $key . '=' . $value . '</strong><br>';
                 }
             }
@@ -202,7 +204,7 @@ class navigationHistory extends base
     /**
      * @since ZC v1.0.3
      */
-    public function unserialize($broken)
+    public function unserialize($broken): void
     {
         foreach ($broken as $kv) {
             $key = $kv['key'];

--- a/includes/classes/navigation_history.php
+++ b/includes/classes/navigation_history.php
@@ -13,8 +13,7 @@ if (!defined('IS_ADMIN_FLAG')) {
     die('Illegal Access');
 }
 /**
- * Navigation_history Class.
- * This class is used to manage navigation snapshots
+ * Manage navigation snapshots
  *
  * @since ZC v1.0.3
  */
@@ -86,7 +85,7 @@ class navigationHistory extends base
 
                     $exit_loop = false;
                     for ($j = 0, $n2 = count($old_cPath); $j < $n2; $j++) {
-                        if ($old_cPath[$j] !== $new_cPath[$j]) {
+                        if (!isset($new_cPath[$j]) || $old_cPath[$j] !== $new_cPath[$j]) {
                             array_splice($this->path, ($outerKey));
                             $set = true;
                             $exit_loop = true;

--- a/includes/classes/observers/auto.non_captcha_observer.php
+++ b/includes/classes/observers/auto.non_captcha_observer.php
@@ -132,10 +132,10 @@ class zcObserverNonCaptchaObserver extends base
         foreach ($fields as $field) {
             if (!empty($_POST[$field])) {
                 if (is_array($_POST[$field])) {
-                   $array_found = true;
-                   $_POST[$field] = '';
+                    $array_found = true;
+                    $_POST[$field] = '';
                 } else {
-                   $test_string .= $_POST[$field];
+                    $test_string .= $_POST[$field];
                 }
             }
         }

--- a/includes/classes/observers/class.products_viewed_counter.php
+++ b/includes/classes/observers/class.products_viewed_counter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Zencart\Traits\ObserverManager;
 
 /**

--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -18,7 +18,6 @@ if (!defined('IS_ADMIN_FLAG')) {
 
 class order extends base
 {
-
     /**
      * $attachArray is an array of file names to be attached to the email
      */
@@ -151,12 +150,16 @@ class order extends base
 
         $this->queryReturnFlag = null;
         $this->notify('NOTIFY_ORDER_BEFORE_QUERY', [], $order_id);
-        if ($this->queryReturnFlag === true) return;
+        if ($this->queryReturnFlag === true) {
+            return;
+        }
 
         $order_query = "SELECT * FROM " . TABLE_ORDERS . " where orders_id = " . (int)$order_id;
         $order = $db->Execute($order_query);
 
-        if ($order->EOF) return;
+        if ($order->EOF) {
+            return;
+        }
 
         $this->orderId = $order_id = (int)$order_id;
 
@@ -261,8 +264,8 @@ class order extends base
         ];
         $this->delivery['zone_id'] = $this->getCountryZoneId((int)$this->delivery['country']['id'], $this->delivery['state']);
 
-        if (($order->fields['shipping_module_code'] === 'storepickup') ||
-            (empty($this->delivery['name']) && empty($this->delivery['street_address']))) {
+        if (($order->fields['shipping_module_code'] === 'storepickup')
+            || (empty($this->delivery['name']) && empty($this->delivery['street_address']))) {
             $this->delivery = false;
         }
 
@@ -381,11 +384,11 @@ class order extends base
         global $db;
 
         if (empty($language_id)) {
-// @TODO - provide lookup in language class
-//          if (!empty($this->info['language_code'])) {
-//              global $lng;
-//              $language_id = $lng->getLanguageIdFromCode($this->info['language_code']);
-//          }
+            // @TODO - provide lookup in language class
+            //          if (!empty($this->info['language_code'])) {
+            //              global $lng;
+            //              $language_id = $lng->getLanguageIdFromCode($this->info['language_code']);
+            //          }
             if (empty($language_id)) {
                 $language_id = $_SESSION['languages_id'];
             }
@@ -497,7 +500,7 @@ class order extends base
             if (!empty($_SESSION['shipping']['id']) && strpos((string)$_SESSION['shipping']['id'], '_')) {
                 $shipping_module_code = $_SESSION['shipping']['id'];
             } else {
-                trigger_error('Malformed value for session-based shipping module; customer will need to re-select: ' . json_encode($_SESSION['shipping']), E_USER_NOTICE);
+                trigger_error('Malformed value for session-based shipping module; customer will need to re-select: ' . json_encode($_SESSION['shipping']), \E_USER_NOTICE);
                 unset($_SESSION['shipping']);
             }
         }
@@ -509,11 +512,11 @@ class order extends base
             'payment_method' => (isset($GLOBALS[$paymentModule]) && is_object($GLOBALS[$paymentModule])) ? $GLOBALS[$paymentModule]->title : '',
             'payment_module_code' => (isset($GLOBALS[$paymentModule]) && is_object($GLOBALS[$paymentModule])) ? $GLOBALS[$paymentModule]->code : '',
             'coupon_code' => $coupon_code->fields['coupon_code'] ?? '',
-//            'cc_type' => $GLOBALS['cc_type'] ?? '',
-//            'cc_owner' => $GLOBALS['cc_owner'] ?? '',
-//            'cc_number' => $GLOBALS['cc_number'] ?? '',
-//            'cc_expires' => $GLOBALS['cc_expires'] ?? '',
-//            'cc_cvv' => $GLOBALS['cc_cvv'] ?? '',
+            //            'cc_type' => $GLOBALS['cc_type'] ?? '',
+            //            'cc_owner' => $GLOBALS['cc_owner'] ?? '',
+            //            'cc_number' => $GLOBALS['cc_number'] ?? '',
+            //            'cc_expires' => $GLOBALS['cc_expires'] ?? '',
+            //            'cc_cvv' => $GLOBALS['cc_cvv'] ?? '',
             'shipping_method' => $_SESSION['shipping']['title'] ?? '',
             'shipping_module_code' => $shipping_module_code,
             'shipping_cost' => !empty($_SESSION['shipping']['cost']) ? $_SESSION['shipping']['cost'] : 0,
@@ -539,12 +542,12 @@ class order extends base
         $deliveryKey = null;
         $billKey = null;
         if (!empty($customerAddresses)) {
-            $deliveryKey = $this->getAddressKey($customerAddresses, $sendto);
-            $billKey = $this->getAddressKey($customerAddresses, $billto);
+            $deliveryKey = self::getAddressKey($customerAddresses, $sendto);
+            $billKey = self::getAddressKey($customerAddresses, $billto);
         }
 
         if (!empty($customer->getData('customers_firstname'))) {
-            $this->customer = $this->getAddress($customerAddresses, $this->getAddressKey($customerAddresses, $customer->getData('customers_default_address_id')));
+            $this->customer = self::getAddress($customerAddresses, self::getAddressKey($customerAddresses, $customer->getData('customers_default_address_id')));
             $this->customer['telephone'] = $customer->getData('customers_telephone');
             $this->customer['email_address'] = $customer->getData('customers_email_address');
         }
@@ -564,17 +567,17 @@ class order extends base
                     'id' => 0,
                     'title' => '',
                     'iso_code_2' => '',
-                    'iso_code_3' => ''
+                    'iso_code_3' => '',
                 ],
                 'country_id' => 0,
                 'format_id' => 0,
             ];
         } elseif (!is_null($deliveryKey)) {
-            $this->delivery = $this->getAddress($customerAddresses, $deliveryKey);
+            $this->delivery = self::getAddress($customerAddresses, $deliveryKey);
         }
 
         if (!is_null($billKey)) {
-            $this->billing = $this->getAddress($customerAddresses, $billKey);
+            $this->billing = self::getAddress($customerAddresses, $billKey);
         }
 
         // -----
@@ -675,7 +678,7 @@ class order extends base
                     if ($value == PRODUCTS_OPTIONS_VALUES_TEXT_ID) {
                         $attr_value = $products[$i]['attributes_values'][$option];
                     } else {
-                        $attr_value = htmlspecialchars_decode($attributes->fields['products_options_values_name'], ENT_COMPAT);
+                        $attr_value = htmlspecialchars_decode($attributes->fields['products_options_values_name'], \ENT_COMPAT);
                     }
 
                     $this->products[$index]['attributes'][$subindex] = [
@@ -865,7 +868,7 @@ class order extends base
      * @return int|null
      * @since ZC v1.2.2d
      */
-    public function create(array $zf_ot_modules): int|null
+    public function create(array $zf_ot_modules): ?int
     {
         global $db;
 
@@ -1049,7 +1052,9 @@ class order extends base
     {
         global $db, $currencies, $order_total_modules, $order_totals;
 
-        if ($zf_insert_id === null) $zf_insert_id = $this->orderId;
+        if ($zf_insert_id === null) {
+            $zf_insert_id = $this->orderId;
+        }
 
         // initialized for the email confirmation
         $this->products_ordered = '';
@@ -1059,7 +1064,7 @@ class order extends base
         // lowstock email report
         $this->email_low_stock = '';
 
-        for ($i = 0, $n = sizeof($this->products); $i < $n; $i++) {
+        for ($i = 0, $n = count($this->products); $i < $n; $i++) {
             $custom_insertable_text = '';
 
             $this->doStockDecrement = (zen_config('STOCK_LIMITED') === 'true');
@@ -1107,7 +1112,7 @@ class order extends base
                     // for low stock email
                     if ($stock_left <= zen_config('STOCK_REORDER_LEVEL')) {
                         // add product to low stock email content
-                        $this->email_low_stock .= ($this->products[$i]['model'] === '' ? ''  : $this->products[$i]['model'] . "\t\t") . ' "' . $this->products[$i]['name'] . '" (#' . zen_get_prid($this->products[$i]['id']) . ')'. "\t\t" . ' ' . TEXT_PRODUCTS_QUANTITY . ' ' . $stock_left . "\n";
+                        $this->email_low_stock .= ($this->products[$i]['model'] === '' ? '' : $this->products[$i]['model'] . "\t\t") . ' "' . $this->products[$i]['name'] . '" (#' . zen_get_prid($this->products[$i]['id']) . ')' . "\t\t" . ' ' . TEXT_PRODUCTS_QUANTITY . ' ' . $stock_left . "\n";
                     }
                 }
             }
@@ -1161,7 +1166,7 @@ class order extends base
             $this->products_ordered_attributes = '';
             if (isset($this->products[$i]['attributes'])) {
                 $attributes_exist = '1';
-                for ($j = 0, $n2 = sizeof($this->products[$i]['attributes']); $j < $n2; $j++) {
+                for ($j = 0, $n2 = count($this->products[$i]['attributes']); $j < $n2; $j++) {
                     if (zen_config('DOWNLOAD_ENABLED') === 'true') {
                         $attributes_query = "SELECT popt.products_options_name, poval.products_options_values_name,
                                  pa.options_values_price, pa.price_prefix,
@@ -1292,9 +1297,15 @@ class order extends base
             /* END: ADD MY CUSTOM DETAILS */
 
             // update totals counters
-            if (!isset($this->total_weight)) $this->total_weight = 0.0;
-            if (!isset($this->total_tax)) $this->total_tax = 0.0;
-            if (!isset($this->total_cost)) $this->total_cost = 0.0;
+            if (!isset($this->total_weight)) {
+                $this->total_weight = 0.0;
+            }
+            if (!isset($this->total_tax)) {
+                $this->total_tax = 0.0;
+            }
+            if (!isset($this->total_cost)) {
+                $this->total_cost = 0.0;
+            }
             $this->total_weight += ($this->products[$i]['qty'] * $this->products[$i]['weight']);
             $this->total_tax += zen_calculate_tax($this->products[$i]['final_price'] * $this->products[$i]['qty'], $this->products[$i]['tax']);
             $this->total_cost += $this->products[$i]['final_price'] + $this->products[$i]['onetime_charges'];
@@ -1315,8 +1326,8 @@ class order extends base
                 '<td class="product-details-num" valign="top" align="right">' .
                 $currencies->display_price($this->products[$i]['final_price'], $this->products[$i]['tax'], $this->products[$i]['qty']) . '</td>' . "\n" . '</tr>' . "\n" .
                 ($this->products[$i]['onetime_charges'] != 0 ?
-                    '<tr>'. "\n" . '<td class="product-details" colspan="2">' . nl2br(TEXT_ONETIME_CHARGES_EMAIL) . '</td>' . "\n" .
-                    '<td valign="top" align="right">' . $currencies->display_price($this->products[$i]['onetime_charges'], $this->products[$i]['tax'], 1) . '</td>' . "\n" . '</tr>' . "\n": '');
+                    '<tr>' . "\n" . '<td class="product-details" colspan="2">' . nl2br(TEXT_ONETIME_CHARGES_EMAIL) . '</td>' . "\n" .
+                    '<td valign="top" align="right">' . $currencies->display_price($this->products[$i]['onetime_charges'], $this->products[$i]['tax'], 1) . '</td>' . "\n" . '</tr>' . "\n" : '');
         }
 
         $order_total_modules->apply_credit();//ICW ADDED FOR CREDIT CLASS SYSTEM
@@ -1332,7 +1343,9 @@ class order extends base
     {
         global $order_totals, $zcDate;
 
-        if ($zf_insert_id === null) $zf_insert_id = $this->orderId;
+        if ($zf_insert_id === null) {
+            $zf_insert_id = $this->orderId;
+        }
 
         $this->notify('NOTIFY_ORDER_SEND_EMAIL_INITIALIZE', [], $zf_insert_id, $order_totals, $zf_mode);
 
@@ -1394,7 +1407,7 @@ class order extends base
 
         //order totals area
         $html_ot = '<tr><td class="order-totals-text" align="right" width="100%">' . '&nbsp;' . '</td> ' . "\n" . '<td class="order-totals-num" align="right" nowrap="nowrap">' . '---------' . '</td> </tr>' . "\n";
-        for ($i = 0, $n = sizeof($order_totals); $i < $n; $i++) {
+        for ($i = 0, $n = count($order_totals); $i < $n; $i++) {
             $email_order .= strip_tags($order_totals[$i]['title']) . ' ' . strip_tags($order_totals[$i]['text']) . "\n";
             $html_ot .= '<tr><td class="order-totals-text" align="right" width="100%">' . $order_totals[$i]['title'] . '</td> ' . "\n" . '<td class="order-totals-num" align="right" nowrap="nowrap">' . ($order_totals[$i]['text']) . '</td> </tr>' . "\n";
         }
@@ -1445,8 +1458,8 @@ class order extends base
         }
         $html_msg['PAYMENT_METHOD_TITLE'] = EMAIL_TEXT_PAYMENT_METHOD;
         $html_msg['PAYMENT_METHOD_DETAIL'] = (isset($GLOBALS[$_SESSION['payment']]) && is_object($GLOBALS[$_SESSION['payment']]) ? $GLOBALS[$payment_class]->title : PAYMENT_METHOD_GV);
-        $html_msg['PAYMENT_METHOD_FOOTER'] = (!empty($payment_class) && isset($GLOBALS[$payment_class]->email_footer) && is_object($GLOBALS[$_SESSION['payment']]) &&
-    $GLOBALS[$payment_class]->email_footer !== '') ? nl2br($GLOBALS[$payment_class]->email_footer) : (isset($this->info['cc_type']) && $this->info['cc_type'] !== '' ? $this->info['cc_type'] . ' ' . $cc_num_display : '');
+        $html_msg['PAYMENT_METHOD_FOOTER'] = (!empty($payment_class) && isset($GLOBALS[$payment_class]->email_footer) && is_object($GLOBALS[$_SESSION['payment']])
+    && $GLOBALS[$payment_class]->email_footer !== '') ? nl2br($GLOBALS[$payment_class]->email_footer) : (isset($this->info['cc_type']) && $this->info['cc_type'] !== '' ? $this->info['cc_type'] . ' ' . $cc_num_display : '');
 
         // Add in store specific order message
         $this->email_order_message = defined('EMAIL_ORDER_MESSAGE') ? constant('EMAIL_ORDER_MESSAGE') : '';
@@ -1457,9 +1470,13 @@ class order extends base
         $html_msg['EMAIL_ORDER_MESSAGE'] = $this->email_order_message;
 
         // include disclaimer
-        if (defined('EMAIL_DISCLAIMER') && EMAIL_DISCLAIMER != '') $email_order .= "\n-----\n" . sprintf(EMAIL_DISCLAIMER, zen_config('STORE_OWNER_EMAIL_ADDRESS')) . "\n\n";
+        if (defined('EMAIL_DISCLAIMER') && EMAIL_DISCLAIMER != '') {
+            $email_order .= "\n-----\n" . sprintf(EMAIL_DISCLAIMER, zen_config('STORE_OWNER_EMAIL_ADDRESS')) . "\n\n";
+        }
         // include copyright
-        if (defined('EMAIL_FOOTER_COPYRIGHT')) $email_order .= "\n-----\n" . EMAIL_FOOTER_COPYRIGHT . "\n\n";
+        if (defined('EMAIL_FOOTER_COPYRIGHT')) {
+            $email_order .= "\n-----\n" . EMAIL_FOOTER_COPYRIGHT . "\n\n";
+        }
 
         $email_order = str_replace('&nbsp;', ' ', $email_order);
 
@@ -1501,11 +1518,19 @@ class order extends base
             $html_msg['EMAIL_TEXT_HEADER'] = nl2br($this->extra_header_text) . $html_msg['EMAIL_TEXT_HEADER'];
 
             if ($sendExtraOrderEmail) {
-                zen_mail('', zen_config('SEND_EXTRA_ORDER_EMAILS_TO'),
+                zen_mail(
+                    '',
+                    zen_config('SEND_EXTRA_ORDER_EMAILS_TO'),
                     SEND_EXTRA_NEW_ORDERS_EMAILS_TO_SUBJECT . ' ' . EMAIL_TEXT_SUBJECT . EMAIL_ORDER_NUMBER_SUBJECT . $zf_insert_id,
-                    $email_order . $extra_info['TEXT'], zen_config('STORE_NAME'), zen_config('EMAIL_FROM'), $html_msg, 'checkout_extra',
-                    $this->attachArray, $this->customer['firstname'] . ' ' . $this->customer['lastname'],
-                    $this->customer['email_address']);
+                    $email_order . $extra_info['TEXT'],
+                    zen_config('STORE_NAME'),
+                    zen_config('EMAIL_FROM'),
+                    $html_msg,
+                    'checkout_extra',
+                    $this->attachArray,
+                    $this->customer['firstname'] . ' ' . $this->customer['lastname'],
+                    $this->customer['email_address']
+                );
             }
         }
         $this->notify('NOTIFY_ORDER_AFTER_SEND_ORDER_EMAIL', $zf_insert_id, $email_order, $extra_info, $html_msg);
@@ -1514,7 +1539,7 @@ class order extends base
     /**
      * @since ZC v2.2.0
      */
-    private function getAddressKey(array $customerAddresses, int $bookId): null|int
+    private static function getAddressKey(array $customerAddresses, int $bookId): ?int
     {
         foreach ($customerAddresses as $k => $address) {
             if (isset($address['address_book_id']) && $bookId === (int)$address['address_book_id']) {
@@ -1527,7 +1552,7 @@ class order extends base
     /**
      * @since ZC v2.2.0
      */
-    private function getAddress(array $customerAddresses, int $arrayKey): array
+    private static function getAddress(array $customerAddresses, int $arrayKey): array
     {
         $address = $customerAddresses[$arrayKey]['address'];
         return [

--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -41,9 +43,8 @@ class order extends base
     public array $customer = [];
     /**
      * $delivery is an array containing delivery details for the order
-     * @var array
      */
-    public $delivery = [];
+    public array|false $delivery = [];
     /**
      * $doStockDecrement is a flag used by a notifier to prevent the default stock decrement processing
      */
@@ -340,21 +341,20 @@ class order extends base
             $attributes = $db->Execute($attributes_query);
             if ($attributes->RecordCount()) {
                 $this->products[$index]['attributes'] = [];
-                while (!$attributes->EOF) {
+                foreach ($attributes as $attribute) {
                     $this->products[$index]['attributes'][$subindex] = [
-                        'option' => $attributes->fields['products_options'],
-                        'value' => $attributes->fields['products_options_values'],
-                        'option_id' => $attributes->fields['products_options_id'],
-                        'value_id' => $attributes->fields['products_options_values_id'],
-                        'prefix' => $attributes->fields['price_prefix'],
-                        'price' => $attributes->fields['options_values_price'],
-                        'product_attribute_is_free' => (int)$attributes->fields['product_attribute_is_free'],
-                        'weight' => $attributes->fields['products_attributes_weight'],
-                        'weight_prefix' => $attributes->fields['products_attributes_weight_prefix'],
+                        'option' => $attribute['products_options'],
+                        'value' => $attribute['products_options_values'],
+                        'option_id' => $attribute['products_options_id'],
+                        'value_id' => $attribute['products_options_values_id'],
+                        'prefix' => $attribute['price_prefix'],
+                        'price' => $attribute['options_values_price'],
+                        'product_attribute_is_free' => (int)$attribute['product_attribute_is_free'],
+                        'weight' => $attribute['products_attributes_weight'],
+                        'weight_prefix' => $attribute['products_attributes_weight_prefix'],
                     ];
 
                     $subindex++;
-                    $attributes->MoveNext();
                 }
             }
 
@@ -448,7 +448,7 @@ class order extends base
     /**
      * @since ZC v1.5.8
      */
-    protected function getCountryZoneId(int $countries_id, string $state)
+    protected function getCountryZoneId(int $countries_id, string $state): int|string
     {
         global $db;
 
@@ -512,11 +512,6 @@ class order extends base
             'payment_method' => (isset($GLOBALS[$paymentModule]) && is_object($GLOBALS[$paymentModule])) ? $GLOBALS[$paymentModule]->title : '',
             'payment_module_code' => (isset($GLOBALS[$paymentModule]) && is_object($GLOBALS[$paymentModule])) ? $GLOBALS[$paymentModule]->code : '',
             'coupon_code' => $coupon_code->fields['coupon_code'] ?? '',
-            //            'cc_type' => $GLOBALS['cc_type'] ?? '',
-            //            'cc_owner' => $GLOBALS['cc_owner'] ?? '',
-            //            'cc_number' => $GLOBALS['cc_number'] ?? '',
-            //            'cc_expires' => $GLOBALS['cc_expires'] ?? '',
-            //            'cc_cvv' => $GLOBALS['cc_cvv'] ?? '',
             'shipping_method' => $_SESSION['shipping']['title'] ?? '',
             'shipping_module_code' => $shipping_module_code,
             'shipping_cost' => !empty($_SESSION['shipping']['cost']) ? $_SESSION['shipping']['cost'] : 0,
@@ -675,7 +670,7 @@ class order extends base
                     }
 
                     //clr 030714 Account for text attributes
-                    if ($value == PRODUCTS_OPTIONS_VALUES_TEXT_ID) {
+                    if ($value == (int)zen_config('PRODUCTS_OPTIONS_VALUES_TEXT_ID')) {
                         $attr_value = $products[$i]['attributes_values'][$option];
                     } else {
                         $attr_value = htmlspecialchars_decode($attributes->fields['products_options_values_name'], \ENT_COMPAT);
@@ -757,7 +752,7 @@ class order extends base
                     $address_book_id = $billToAddressId;
                     break;
                 case 'Store':
-                    if (isset($this->billing['zone_id']) && $this->billing['zone_id'] == zen_config('STORE_ZONE')) {
+                    if (isset($this->billing['zone_id']) && $this->billing['zone_id'] == (int)zen_config('STORE_ZONE')) {
                         $address_book_id = $billToAddressId;
                     } else {
                         $address_book_id = ($this->content_type === 'virtual' ? $billToAddressId : $shipToAddressId);
@@ -769,7 +764,7 @@ class order extends base
                                   WHERE ab.customers_id = " . (int)$_SESSION['customer_id'] . "
                                   AND ab.address_book_id = " . $address_book_id;
 
-            if ($tax_address_query != '') {
+            if ($tax_address_query !== '') {
                 $tax_address = $db->Execute($tax_address_query);
                 if ($tax_address->RecordCount() > 0) {
                     $taxCountryId = $tax_address->fields['entry_country_id'];
@@ -878,7 +873,7 @@ class order extends base
             if ((int)zen_config('DEFAULT_ZERO_BALANCE_ORDERS_STATUS_ID') === 0) {
                 $this->info['order_status'] = (int)zen_config('DEFAULT_ORDERS_STATUS_ID');
             } else {
-                if ($_SESSION['payment'] != 'freecharger') {
+                if ($_SESSION['payment'] !== 'freecharger') {
                     $this->info['order_status'] = (int)zen_config('DEFAULT_ZERO_BALANCE_ORDERS_STATUS_ID');
                 }
             }
@@ -1010,35 +1005,35 @@ class order extends base
         global $db;
         $this->notify('NOTIFIER_ADMIN_ZEN_REMOVE_ORDER', [], $this->orderId, $restock);
         if ($restock || $restock === 'on') {
-            $order_products = $db->Execute("select products_id, products_quantity
-                                from " . TABLE_ORDERS_PRODUCTS . "
-                                where orders_id = " . (int)$this->orderId);
+            $order_products = $db->Execute("SELECT products_id, products_quantity
+                                FROM " . TABLE_ORDERS_PRODUCTS . "
+                                WHERE orders_id = " . (int)$this->orderId);
 
-            while (!$order_products->EOF) {
-                $db->Execute("update " . TABLE_PRODUCTS . "
-                        set products_quantity = products_quantity + " . $order_products->fields['products_quantity'] . ", products_ordered = products_ordered - " . $order_products->fields['products_quantity'] . " where products_id = " . $order_products->fields['products_id']);
-                $order_products->MoveNext();
+            foreach ($order_products as $product) {
+                $db->Execute("UPDATE " . TABLE_PRODUCTS . "
+                        SET products_quantity = products_quantity + " . $product['products_quantity'] . ", products_ordered = products_ordered - " . $product['products_quantity'] . "
+                        WHERE products_id = " . $product['products_id']);
             }
         }
 
-        $db->Execute("delete from " . TABLE_ORDERS . " where orders_id = " . (int)$this->orderId);
-        $db->Execute("delete from " . TABLE_ORDERS_PRODUCTS . "
-                                    where orders_id = " . (int)$this->orderId);
+        $db->Execute("DELETE FROM " . TABLE_ORDERS . " WHERE orders_id = " . (int)$this->orderId);
+        $db->Execute("DELETE FROM " . TABLE_ORDERS_PRODUCTS . "
+                                WHERE orders_id = " . (int)$this->orderId);
 
-        $db->Execute("delete from " . TABLE_ORDERS_PRODUCTS_ATTRIBUTES . "
-                                    where orders_id = " . (int)$this->orderId);
+        $db->Execute("DELETE FROM " . TABLE_ORDERS_PRODUCTS_ATTRIBUTES . "
+                                WHERE orders_id = " . (int)$this->orderId);
 
-        $db->Execute("delete from " . TABLE_ORDERS_PRODUCTS_DOWNLOAD . "
-                                    where orders_id = " . (int)$this->orderId);
+        $db->Execute("DELETE FROM " . TABLE_ORDERS_PRODUCTS_DOWNLOAD . "
+                                WHERE orders_id = " . (int)$this->orderId);
 
-        $db->Execute("delete from " . TABLE_ORDERS_STATUS_HISTORY . "
-                                    where orders_id = " . (int)$this->orderId);
+        $db->Execute("DELETE FROM " . TABLE_ORDERS_STATUS_HISTORY . "
+                                WHERE orders_id = " . (int)$this->orderId);
 
-        $db->Execute("delete from " . TABLE_ORDERS_TOTAL . "
-                                    where orders_id = " . (int)$this->orderId);
+        $db->Execute("DELETE FROM " . TABLE_ORDERS_TOTAL . "
+                                WHERE orders_id = " . (int)$this->orderId);
 
-        $db->Execute("delete from " . TABLE_COUPON_GV_QUEUE . "
-                                    where order_id = " . (int)$this->orderId . " and release_flag = 'N'");
+        $db->Execute("DELETE FROM " . TABLE_COUPON_GV_QUEUE . "
+                                WHERE order_id = " . (int)$this->orderId . " AND release_flag = 'N'");
 
         zen_record_admin_activity('Deleted order ' . (int)$this->orderId . ' from database via admin console.', 'warning');
 
@@ -1458,8 +1453,8 @@ class order extends base
         }
         $html_msg['PAYMENT_METHOD_TITLE'] = EMAIL_TEXT_PAYMENT_METHOD;
         $html_msg['PAYMENT_METHOD_DETAIL'] = (isset($GLOBALS[$_SESSION['payment']]) && is_object($GLOBALS[$_SESSION['payment']]) ? $GLOBALS[$payment_class]->title : PAYMENT_METHOD_GV);
-        $html_msg['PAYMENT_METHOD_FOOTER'] = (!empty($payment_class) && isset($GLOBALS[$payment_class]->email_footer) && is_object($GLOBALS[$_SESSION['payment']])
-    && $GLOBALS[$payment_class]->email_footer !== '') ? nl2br($GLOBALS[$payment_class]->email_footer) : (isset($this->info['cc_type']) && $this->info['cc_type'] !== '' ? $this->info['cc_type'] . ' ' . $cc_num_display : '');
+        $html_msg['PAYMENT_METHOD_FOOTER'] = (!empty($payment_class) && isset($GLOBALS[$payment_class]->email_footer) && is_object($GLOBALS[$_SESSION['payment']]) && $GLOBALS[$payment_class]->email_footer !== '')
+            ? nl2br($GLOBALS[$payment_class]->email_footer) : (isset($this->info['cc_type']) && $this->info['cc_type'] !== '' ? $this->info['cc_type'] . ' ' . $cc_num_display : '');
 
         // Add in store specific order message
         $this->email_order_message = defined('EMAIL_ORDER_MESSAGE') ? constant('EMAIL_ORDER_MESSAGE') : '';
@@ -1470,7 +1465,7 @@ class order extends base
         $html_msg['EMAIL_ORDER_MESSAGE'] = $this->email_order_message;
 
         // include disclaimer
-        if (defined('EMAIL_DISCLAIMER') && EMAIL_DISCLAIMER != '') {
+        if (defined('EMAIL_DISCLAIMER') && EMAIL_DISCLAIMER !== '') {
             $email_order .= "\n-----\n" . sprintf(EMAIL_DISCLAIMER, zen_config('STORE_OWNER_EMAIL_ADDRESS')) . "\n\n";
         }
         // include copyright

--- a/includes/classes/order_total.php
+++ b/includes/classes/order_total.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * File contains the order-totals-processing class ("order_total")
  *
@@ -77,7 +79,7 @@ class order_total
 
                 if (isset($modules_found[$value])) {
                     include_once DIR_FS_CATALOG . $modules_found[$value] . $value;
-                    $class = pathinfo($value, PATHINFO_FILENAME);
+                    $class = pathinfo($value, \PATHINFO_FILENAME);
                     $GLOBALS[$class] = new $class();
                     $this->modules[] = $value;
                     $this->module_order_total_installed = true;
@@ -102,7 +104,7 @@ class order_total
         if ($this->module_order_total_installed === true) {
             $this->notify('NOTIFY_ORDER_TOTAL_PROCESS_STARTS', ['order_info' => $order->info]);
             foreach ($this->modules as $value) {
-                $class = pathinfo($value, PATHINFO_FILENAME);
+                $class = pathinfo($value, \PATHINFO_FILENAME);
                 if (!isset($GLOBALS[$class])) {
                     continue;
                 }
@@ -144,10 +146,10 @@ class order_total
         $output_string = '';
         if ($this->module_order_total_installed === true) {
             foreach ($this->modules as $value) {
-                $class = pathinfo($value, PATHINFO_FILENAME);
+                $class = pathinfo($value, \PATHINFO_FILENAME);
 
                 // ideally, the first part of this IF statement should be dropped, and the ELSE portion is all that should be kept
-                if ($return_html == true) {
+                if ($return_html === true) {
                     $class_code = str_replace('_', '-', $GLOBALS[$class]->code);
                     foreach ($GLOBALS[$class]->output as $next_output) {
                         $output_string .=
@@ -184,7 +186,7 @@ class order_total
         $selection_array = [];
         if ($this->module_order_total_installed === true) {
             foreach ($this->modules as $value) {
-                $class = pathinfo($value, PATHINFO_FILENAME);
+                $class = pathinfo($value, \PATHINFO_FILENAME);
                 if (!empty($GLOBALS[$class]->credit_class)) {
                     $selection = $GLOBALS[$class]->credit_selection();
                     if (is_array($selection)) {
@@ -208,7 +210,7 @@ class order_total
     {
         if ($this->module_order_total_installed === true) {
             foreach ($this->modules as $value) {
-                $class = pathinfo($value, PATHINFO_FILENAME);
+                $class = pathinfo($value, \PATHINFO_FILENAME);
                 if (!empty($GLOBALS[$class]->credit_class)) {
                     $GLOBALS[$class]->update_credit_account($i);
                 }
@@ -229,7 +231,7 @@ class order_total
     {
         if ($this->module_order_total_installed === true) {
             foreach ($this->modules as $value) {
-                $class = pathinfo($value, PATHINFO_FILENAME);
+                $class = pathinfo($value, \PATHINFO_FILENAME);
                 if (!empty($GLOBALS[$class]->credit_class)) {
                     $post_var = 'c' . $GLOBALS[$class]->code;
                     if (!empty($_POST[$post_var])) {
@@ -260,7 +262,7 @@ class order_total
             $orderInfoSaved = $order->info;
             $this->notify('NOTIFY_ORDER_TOTAL_PRE_CONFIRMATION_CHECK_STARTS', ['order_info' => $orderInfoSaved]);
             foreach ($this->modules as $value) {
-                $class = pathinfo($value, PATHINFO_FILENAME);
+                $class = pathinfo($value, \PATHINFO_FILENAME);
                 $GLOBALS[$class]->process();
                 $this->notify('NOTIFY_ORDER_TOTAL_PRE_CONFIRMATION_CHECK_NEXT', ['class' => $class, 'order_info' => $order->info, 'ot_output' => $GLOBALS[$class]->output]);
                 $GLOBALS[$class]->output = [];
@@ -292,7 +294,7 @@ class order_total
     {
         if ($this->module_order_total_installed === true) {
             foreach ($this->modules as $value) {
-                $class = pathinfo($value, PATHINFO_FILENAME);
+                $class = pathinfo($value, \PATHINFO_FILENAME);
                 if (!empty($GLOBALS[$class]->credit_class)) {
                     $GLOBALS[$class]->apply_credit();
                 }
@@ -309,7 +311,7 @@ class order_total
     {
         if ($this->module_order_total_installed === true) {
             foreach ($this->modules as $value) {
-                $class = pathinfo($value, PATHINFO_FILENAME);
+                $class = pathinfo($value, \PATHINFO_FILENAME);
                 if (!empty($GLOBALS[$class]->credit_class) && method_exists($GLOBALS[$class], 'clear_posts')) {
                     $GLOBALS[$class]->clear_posts();
                 }

--- a/includes/classes/order_total.php
+++ b/includes/classes/order_total.php
@@ -32,7 +32,7 @@ class order_total
     /**
      * $modules is an array of installed order totals module names
      */
-    public array $modules;
+    public array $modules = [];
 
     /**
      * $module_order_total_installed indicates whether at least one order-total module is installed.

--- a/includes/classes/payment.php
+++ b/includes/classes/payment.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * Payment Class.
  *
@@ -27,31 +29,26 @@ class payment
 
     /**
      * $doesCollectsCardDataOnsite is a flag to indicate if card details are collected on site
-     * @var boolean
      */
     public bool $doesCollectsCardDataOnsite;
     /**
      * $form_action_url is the URL to process the payment or not set for local processing
-     * @var string
      */
     public string $form_action_url;
     /**
      * $modules array of payment module names
-     * @var array
      */
     public array $modules;
     /**
      * $paymentClass is a payment class
-     * @var class
      */
-    public $paymentClass;
+    public object $paymentClass;
     /**
      * $selected_module is the selected payment module
-     * @var string
      */
     public string $selected_module;
 
-    public function __construct($module = '')
+    public function __construct(string $module = '')
     {
         global $language, $credit_covers, $messageStack, $languageLoader, $installedPlugins;
 
@@ -76,14 +73,14 @@ class payment
 
         $include_modules = [];
 
-        if (!empty($module) && in_array($module . '.php', $this->modules) && isset($modules_found[$module . '.php'])) {
+        if (!empty($module) && in_array($module . '.php', $this->modules, true) && isset($modules_found[$module . '.php'])) {
             $this->selected_module = $module;
 
             $include_modules[] = ['class' => $module, 'file' => $module . '.php'];
         } else {
             // Free Payment Only shows
             $freecharger_enabled = (zen_config('MODULE_PAYMENT_FREECHARGER_STATUS') === 'True' && isset($modules_found['freecharger.php']));
-            if ($freecharger_enabled && $_SESSION['cart']->show_total() == 0 && (!isset($_SESSION['shipping']['cost']) || $_SESSION['shipping']['cost'] == 0)) {
+            if ($freecharger_enabled && empty($_SESSION['cart']->show_total()) && empty($_SESSION['shipping']['cost'])) {
                 $this->selected_module = $module;
                 $include_modules[] = ['class' => 'freecharger', 'file' => 'freecharger.php'];
             } else {
@@ -91,7 +88,7 @@ class payment
                 foreach ($this->modules as $value) {
                     // double check that the module really exists before adding to the array
                     if (isset($modules_found[$value])) {
-                        $class = pathinfo($value, PATHINFO_FILENAME);
+                        $class = pathinfo($value, \PATHINFO_FILENAME);
                         // Don't show Free Payment Module
                         if ($class !== 'freecharger') {
                             $include_modules[] = ['class' => $class, 'file' => $value];
@@ -142,13 +139,13 @@ class payment
         // if there is only one payment method, select it as default because in
         // checkout_confirmation.php the $payment variable is being assigned the
         // $_POST['payment'] value which will be empty (no radio button selection possible)
-        if (zen_count_payment_modules() == 1 && (!isset($_SESSION['payment']) || !is_object($_SESSION['payment']))) {
+        if (zen_count_payment_modules() === 1 && (!isset($_SESSION['payment']) || !is_object($_SESSION['payment']))) {
             if (empty($credit_covers)) {
                 $_SESSION['payment'] = $include_modules[0]['class'];
             }
         }
 
-        if (!empty($module) && in_array($module, $this->modules) && isset($GLOBALS[$module]->form_action_url)) {
+        if (!empty($module) && in_array($module, $this->modules, true) && isset($GLOBALS[$module]->form_action_url)) {
             $this->form_action_url = $GLOBALS[$module]->form_action_url;
         }
     }
@@ -169,12 +166,10 @@ class payment
         return $credit_is_covered;
     }
 
-    // -----
-    // This protected method is used by various public methods to
-    // perform common determination of whether the currently-selected
-    // module is present, enabled and includes the submitted method.
-    //
     /**
+     * This protected method is used by various public methods to
+     * perform common determination of whether the currently-selected
+     * module is present AND enabled AND includes the submitted method.
      * @since ZC v2.1.0
      */
     protected function isPaymentModuleMethodPresent(string $method): bool
@@ -235,7 +230,7 @@ class payment
             '  }' . "\n\n";
 
         foreach ($this->modules as $value) {
-            $class = pathinfo($value, PATHINFO_FILENAME);
+            $class = pathinfo($value, \PATHINFO_FILENAME);
             if (!empty($GLOBALS[$class]->enabled)) {
                 $js .= $GLOBALS[$class]->javascript_validation();
             }
@@ -271,7 +266,7 @@ class payment
 
         $selection_array = [];
         foreach ($this->modules as $value) {
-            $class = pathinfo($value, PATHINFO_FILENAME);
+            $class = pathinfo($value, \PATHINFO_FILENAME);
             if (empty($GLOBALS[$class]->enabled)) {
                 continue;
             }
@@ -303,7 +298,7 @@ class payment
 
         $result = false;
         foreach ($this->modules as $value) {
-            $class = pathinfo($value, PATHINFO_FILENAME);
+            $class = pathinfo($value, \PATHINFO_FILENAME);
             if (isset($GLOBALS[$class]) && is_object($GLOBALS[$class]) && $GLOBALS[$class]->enabled && method_exists($GLOBALS[$class], 'in_special_checkout')) {
                 $module_result = $GLOBALS[$class]->in_special_checkout();
                 if ($module_result === true) {

--- a/includes/classes/payment.php
+++ b/includes/classes/payment.php
@@ -30,23 +30,23 @@ class payment
     /**
      * $doesCollectsCardDataOnsite is a flag to indicate if card details are collected on site
      */
-    public bool $doesCollectsCardDataOnsite;
+    public bool $doesCollectsCardDataOnsite = false;
     /**
      * $form_action_url is the URL to process the payment or not set for local processing
      */
-    public string $form_action_url;
+    public string $form_action_url = '';
     /**
      * $modules array of payment module names
      */
-    public array $modules;
+    public array $modules = [];
     /**
      * $paymentClass is a payment class
      */
-    public object $paymentClass;
+    public ?object $paymentClass = null;
     /**
      * $selected_module is the selected payment module
      */
-    public string $selected_module;
+    public string $selected_module = '';
 
     public function __construct(string $module = '')
     {
@@ -105,8 +105,8 @@ class payment
                 $lang_file = zen_get_file_directory(DIR_WS_LANGUAGES . $_SESSION['language'] . '/modules/payment/', $next_module['file'], 'false');
 
                 // -----
-                // If the language file's name doesn't start with 'lang.' (which they do,
-                // as of zc300), add that prefix for the cautionary message.
+                // If the language file's name doesn't start with 'lang.' (which they do, as of zc300),
+                // add that prefix for the cautionary message.
                 //
                 if (!str_starts_with($next_module['file'], 'lang.')) {
                     $lang_file = str_replace($lang_file, $next_module['file'], 'lang.' . $next_module['file']);

--- a/includes/classes/query_cache.php
+++ b/includes/classes/query_cache.php
@@ -78,7 +78,7 @@ class QueryCache
             $this->queries = [];
             return false;
         }
-        unset ($this->queries[$query]);
+        unset($this->queries[$query]);
         return true;
     }
 }

--- a/includes/classes/query_cache.php
+++ b/includes/classes/query_cache.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * Memoization cache for MySQL SELECT queries
  *
@@ -59,6 +61,7 @@ class QueryCache
 
     /**
      * ensure the query is a SELECT query
+     * (Technically, other "read" queries include SHOW, DESCRIBE, EXPLAIN, but we're not caching those.)
      *
      * @since ZC v1.5.1
      */

--- a/includes/classes/shipping.php
+++ b/includes/classes/shipping.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * shipping class
  *
@@ -42,10 +44,10 @@ class shipping
      */
     protected array $initialized_modules = [];
 
-    public function __construct($module = null)
+    public function __construct(?array $module = null)
     {
         if (!empty(zen_config('MODULE_SHIPPING_INSTALLED'))) {
-            $this->modules = explode(';', zen_config('MODULE_SHIPPING_INSTALLED'));
+            $this->modules = explode(';', zen_config('MODULE_SHIPPING_INSTALLED', ''));
         }
         $this->notify('NOTIFY_SHIPPING_CLASS_GET_INSTALLED_MODULES', $module);
 
@@ -61,7 +63,7 @@ class shipping
      * If $module is specified, limits the initialization to just that module; else processes all "installed" modules listed in Admin.
      * @since ZC v2.0.0
      */
-    protected function initialize_modules($module = null): void
+    protected function initialize_modules(?array $module = null): void
     {
         global $messageStack, $languageLoader, $installedPlugins;
 
@@ -76,14 +78,14 @@ class shipping
         $modules_to_quote = [];
 
         $module_name = (empty($module)) ? '0' : substr($module['id'], 0, strpos($module['id'], '_'));
-        if (!empty($module) && in_array($module_name . '.php', $this->modules) && isset($modules_found[$module_name])) {
+        if (!empty($module) && in_array($module_name . '.php', $this->modules, true) && isset($modules_found[$module_name])) {
             $modules_to_quote[] = [
                 'class' => $module_name,
                 'file' => $module_name . '.php',
             ];
         } else {
             foreach ($this->modules as $value) {
-                $class = pathinfo($value, PATHINFO_FILENAME);
+                $class = pathinfo($value, \PATHINFO_FILENAME);
                 $modules_to_quote[] = [
                     'class' => $class,
                     'file' => $value,
@@ -151,7 +153,7 @@ class shipping
      * Check whether a module is enabled for the active checkout zone
      * @since ZC v1.5.5
      */
-    public function check_enabled($module_class): bool
+    public function check_enabled(object $module_class): bool
     {
         $enabled = $module_class->enabled;
         if (method_exists($module_class, 'check_enabled_for_zone') && $module_class->enabled) {
@@ -174,7 +176,7 @@ class shipping
      * DOES NOT TAKE PACKAGE DIMENSIONS INTO ACCOUNT.
      * @since ZC v1.3.8
      */
-    public function calculate_boxes_weight_and_tare()
+    public function calculate_boxes_weight_and_tare(): void
     {
         global $total_weight, $shipping_weight, $shipping_quoted, $shipping_num_boxes;
 
@@ -204,12 +206,12 @@ class shipping
             switch (true) {
                 // large box add padding
                 case (zen_config('SHIPPING_MAX_WEIGHT') <= $shipping_weight):
-                    $shipping_weight = $shipping_weight + ($shipping_weight * ($zc_large_percent / 100)) + $zc_large_weight;
+                    $shipping_weight += ($shipping_weight * ($zc_large_percent / 100)) + $zc_large_weight;
                     break;
 
                 default:
                     // add tare weight < large
-                    $shipping_weight = $shipping_weight + ($shipping_weight * ($zc_tare_percent / 100)) + $zc_tare_weight;
+                    $shipping_weight += ($shipping_weight * ($zc_tare_percent / 100)) + $zc_tare_weight;
                     break;
             }
 
@@ -218,7 +220,7 @@ class shipping
             if ($shipping_weight > zen_config('SHIPPING_MAX_WEIGHT')) { // Split into many boxes
                 $zc_boxes = zen_round(($shipping_weight / zen_config('SHIPPING_MAX_WEIGHT')), 2);
                 $shipping_num_boxes = ceil($zc_boxes);
-                $shipping_weight = $shipping_weight / $shipping_num_boxes;
+                $shipping_weight /= $shipping_num_boxes;
             }
         }
         $this->notify('NOTIFY_SHIPPING_MODULE_CALCULATE_BOXES_AND_TARE', [], $total_weight, $shipping_weight, $shipping_quoted, $shipping_num_boxes);
@@ -234,7 +236,7 @@ class shipping
      * @return array
      * @since ZC v1.0.3
      */
-    public function quote($method = '', $module = '', $calc_boxes_weight_tare = true, $insurance_exclusions = []): array
+    public function quote(string $method = '', string $module = '', bool $calc_boxes_weight_tare = true, array $insurance_exclusions = []): array
     {
         global $shipping_weight, $uninsurable_value;
 
@@ -244,6 +246,8 @@ class shipping
             $this->calculate_boxes_weight_and_tare();
         }
 
+
+        // @TODO - Check whether $this should still be used here, or if it needs to relate to $GLOBALS[$class] instead
         // calculate amount not to be insured on shipping
         $uninsurable_value = (method_exists($this, 'get_uninsurable_value')) ? $this->get_uninsurable_value($insurance_exclusions) : 0;
 
@@ -251,7 +255,7 @@ class shipping
             $modules_to_quote = [];
 
             foreach ($this->modules as $value) {
-                $class = pathinfo($value, PATHINFO_FILENAME);
+                $class = pathinfo($value, \PATHINFO_FILENAME);
                 if (!empty($module)) {
                     if ($module === $class && isset($GLOBALS[$class]) && $GLOBALS[$class]->enabled) {
                         $modules_to_quote[] = $class;
@@ -298,7 +302,7 @@ class shipping
         $rates = [];
         $exclude_storepickup_module = false;
         foreach ($this->modules as $value) {
-            $class = pathinfo($value, PATHINFO_FILENAME);
+            $class = pathinfo($value, \PATHINFO_FILENAME);
             if (isset($GLOBALS[$class]) && is_object($GLOBALS[$class]) && $GLOBALS[$class]->enabled) {
                 $quotes = $GLOBALS[$class]->quotes ?? null;
                 if (empty($quotes['methods']) || isset($quotes['error'])) {

--- a/includes/classes/shipping.php
+++ b/includes/classes/shipping.php
@@ -18,8 +18,7 @@ if (!defined('IS_ADMIN_FLAG')) {
 }
 
 /**
- * shipping class
- * Class used for interfacing with shipping modules
+ * This class proxies methods for configured shipping modules
  *
  * @since ZC v1.0.3
  */
@@ -30,15 +29,15 @@ class shipping
     /**
      * $enabled public property used by notifiers to allow notifier to turn off a shipping method when querying available modules
      */
-    public bool $enabled;
+    public bool $enabled = false;
     /**
      * $modules is an array of installed shipping module names; notifier hook exists to alter if needed
      */
-    public array $modules;
+    public array $modules = [];
     /**
      * $abort_legacy_calculations public property allows a notifier to intercept the calculate_boxes_weight_and_tare method
      */
-    public bool $abort_legacy_calculations;
+    public bool $abort_legacy_calculations = false;
     /**
      * Initialized modules whose status is "enabled"
      */

--- a/includes/classes/shopping_cart.php
+++ b/includes/classes/shopping_cart.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * Class for managing the Shopping Cart
  *
@@ -17,66 +19,54 @@ class shoppingCart extends base
 {
     /**
      * shopping cart contents
-     * @var array
      */
-    public $contents;
+    public array $contents;
     /**
      * shopping cart total price
-     * @var float
      */
-    public $total;
+    public float $total;
     /**
      * shopping cart total weight
-     * @var float
      */
-    public $weight;
+    public float $weight;
     /**
      * cart identifier
-     * @var integer
      */
-    public $cartID;
+    public ?string $cartID;
     /**
      * overall content type of shopping cart
-     * @var string
      */
-    protected $content_type;
+    protected string|bool $content_type;
     /**
      * number of free shipping items in cart
-     * @var float|int
      */
-    protected $free_shipping_item;
+    protected float|int $free_shipping_item;
     /**
      * total weight of free shipping items in cart
-     * @var float|int
      */
-    protected $free_shipping_weight;
+    protected float|int $free_shipping_weight;
     /**
      * total price of free shipping items in cart
-     * @var float|int
      */
-    protected $free_shipping_price;
+    protected float|int $free_shipping_price;
     /**
      * total downloads in cart
-     * @var float|int
      */
-    protected $download_count;
+    protected float|int $download_count;
     /**
      * shopping cart total price before Specials, Sales and Discounts
-     * @var float|int
      */
-    protected $total_before_discounts;
+    protected float|int $total_before_discounts;
     /**
-     * set to TRUE to see debug messages for developer use when troubleshooting add/update cart
+     * set to true to see debug messages for developer use when troubleshooting add/update cart
      * Then, Logout/Login to reset cart for change
-     * @var boolean
      */
-    protected $display_debug_messages = false;
-    protected $flag_duplicate_msgs_set = false;
+    protected bool $display_debug_messages = false;
+    protected bool $flag_duplicate_msgs_set = false;
     /**
-     * array of flag to indicate if quantity ordered is outside product min/max order values
-     * @var array
+     * array of flags to indicate if quantity ordered is outside product min/max order values
      */
-    protected $flag_duplicate_quantity_msgs_set = [];
+    protected array $flag_duplicate_quantity_msgs_set = [];
 
     /**
      * Instantiate a new shopping cart object
@@ -207,7 +197,7 @@ class shoppingCart extends base
      * @return void
      * @since ZC v1.0.3
      */
-    public function reset($reset_database = false)
+    public function reset(bool $reset_database = false): void
     {
         global $db;
         $this->notify('NOTIFIER_CART_RESET_START', null, $reset_database);
@@ -230,7 +220,7 @@ class shoppingCart extends base
             $db->Execute($sql);
         }
 
-        unset($this->cartID);
+        $this->cartID = null;
         $_SESSION['cartID'] = '';
         $_SESSION['cart_errors'] = '';
         $_SESSION['valid_to_checkout'] = true;
@@ -245,13 +235,12 @@ class shoppingCart extends base
      * and if the customer is logged in, also adds to the database stored cart.
      *
      * @param int $product_id the product ID of the item to be added
-     * @param float $qty the quantity of the item to be added
+     * @param float|int $qty the quantity of the item to be added
      * @param array $attributes any attributes that are attached to the product
      * @param bool $notify whether to add the product to the notify list
-     * @return void
      * @since ZC v1.0.3
      */
-    public function add_cart($product_id, $qty = 1, $attributes = [], $notify = true)
+    public function add_cart(int|string $product_id, float|int|string $qty = 1, array $attributes = [], bool $notify = true): void
     {
         global $db, $messageStack;
         if ($this->display_debug_messages) {
@@ -391,11 +380,11 @@ class shoppingCart extends base
      * logged in.
      *
      * @param mixed $uprid product 'uprid' of item to update
-     * @param int|float $quantity the quantity to update the item to
+     * @param float|int $quantity the quantity to update the item to
      * @param array $attributes product attributes attached to the item
      * @since ZC v1.0.3
      */
-    function update_quantity($uprid, $quantity = 0, $attributes = []): ?bool
+    public function update_quantity(mixed $uprid, float|int|string $quantity = 0, array $attributes = []): ?bool
     {
         global $db, $messageStack;
         if ($this->display_debug_messages) {
@@ -506,10 +495,9 @@ class shoppingCart extends base
      * all items that have reached this state. The database-stored cart
      * is also updated where necessary
      *
-     * @return void
      * @since ZC v1.0.3
      */
-    function cleanup()
+    public function cleanup(): void
     {
         $this->notify('NOTIFIER_CART_CLEANUP_START');
         foreach ($this->contents as $key => $data) {
@@ -523,11 +511,10 @@ class shoppingCart extends base
     /**
      * Protected method that removes a uprid from the cart.
      *
-     * @param string|int $uprid 'uprid' of product to remove
-     * @return void
+     * @param int|string $uprid 'uprid' of product to remove
      * @since ZC v2.0.0
      */
-    protected function removeUprid($uprid)
+    protected function removeUprid(int|string $uprid): void
     {
         global $db;
 
@@ -559,7 +546,7 @@ class shoppingCart extends base
      * @return int|float total number of items in cart
      * @since ZC v1.0.3
      */
-    public function count_contents()
+    public function count_contents(): float|int
     {
         $this->notify('NOTIFIER_CART_COUNT_CONTENTS_START');
         $total_items = 0;
@@ -582,12 +569,12 @@ class shoppingCart extends base
      * @return int|float the quantity of the item
      * @since ZC v1.0.3
      */
-    public function get_quantity($uprid)
+    public function get_quantity(int|string $uprid): float|int
     {
         $this->notify('NOTIFIER_CART_GET_QUANTITY_START', null, $uprid);
         if (isset($this->contents[$uprid])) {
             $this->notify('NOTIFIER_CART_GET_QUANTITY_END_QTY', null, $uprid);
-            return $this->contents[$uprid]['qty'];
+            return zen_str_to_numeric($this->contents[$uprid]['qty']);
         }
 
         $this->notify('NOTIFIER_CART_GET_QUANTITY_END_FALSE', $uprid);
@@ -598,10 +585,9 @@ class shoppingCart extends base
      * Check whether a product exists in the cart
      *
      * @param mixed $uprid product ID of product to check
-     * @return boolean
      * @since ZC v1.0.3
      */
-    public function in_cart($uprid)
+    public function in_cart(mixed $uprid): bool
     {
         $this->notify('NOTIFIER_CART_IN_CART_START', null, $uprid);
         if (isset($this->contents[$uprid])) {
@@ -616,11 +602,10 @@ class shoppingCart extends base
     /**
      * Remove a product from the cart
      *
-     * @param string|int $uprid product ID of product to remove
-     * @return void
+     * @param int|string $uprid product ID of product to remove
      * @since ZC v1.0.3
      */
-    public function remove($uprid)
+    public function remove(int|string $uprid): void
     {
         $this->notify('NOTIFIER_CART_REMOVE_START', null, $uprid);
         $this->removeUprid(zen_db_input($uprid));
@@ -634,7 +619,7 @@ class shoppingCart extends base
      * Remove all products from the cart
      * @since ZC v1.0.3
      */
-    public function remove_all()
+    public function remove_all(): void
     {
         $this->notify('NOTIFIER_CART_REMOVE_ALL_START');
         $this->reset();
@@ -648,7 +633,7 @@ class shoppingCart extends base
      * @return string csv
      * @since ZC v1.0.3
      */
-    public function get_product_id_list()
+    public function get_product_id_list(): string
     {
         if (!is_array($this->contents)) {
             return '';
@@ -676,8 +661,8 @@ class shoppingCart extends base
             return 0;
         }
 
-// By default, Price Factor is based on Price and is called from function zen_get_attributes_price_factor
-// Setting a define for ATTRIBUTES_PRICE_FACTOR_FROM_SPECIAL to 1 to calculate the Price Factor from Special rather than Price switches this to be based on Special, if it exists
+        // By default, Price Factor is based on Price and is called from function zen_get_attributes_price_factor
+        // Setting a define for ATTRIBUTES_PRICE_FACTOR_FROM_SPECIAL to 1 to calculate the Price Factor from Special rather than Price switches this to be based on Special, if it exists
         zen_define_default('ATTRIBUTES_PRICE_FACTOR_FROM_SPECIAL', 1);
         foreach ($this->contents as $uprid => $data) {
             $total_before_discounts = 0;
@@ -742,7 +727,7 @@ class shoppingCart extends base
             $productTotal += $products_price;
             $this->weight += ($qty * $products_weight);
 
-// ****** WARNING NEED TO ADD ATTRIBUTES AND QTY
+            // ****** WARNING NEED TO ADD ATTRIBUTES AND QTY
             // calculate Product Price without Specials, Sales or Discounts
             $total_before_discounts += zen_str_to_numeric($products_raw_price);
 
@@ -994,7 +979,7 @@ class shoppingCart extends base
                 $this->free_shipping_price += zen_add_tax($totalOnetimeCharge, $products_tax);
             }
 
-// ******* WARNING ADD ONE TIME ATTRIBUTES, PRICE FACTOR
+            // ******* WARNING ADD ONE TIME ATTRIBUTES, PRICE FACTOR
             // calculate Product Price without Specials, Sales or Discounts
             $total_before_discounts = $total_before_discounts * $qty;
             $total_before_discounts += $totalOnetimeChargeNoDiscount;
@@ -1010,7 +995,7 @@ class shoppingCart extends base
      * @return float the price of the item's attributes
      * @since ZC v1.0.3
      */
-    public function attributes_price($uprid)
+    public function attributes_price(mixed $uprid): float|int
     {
         global $db, $currencies;
 
@@ -1133,7 +1118,7 @@ class shoppingCart extends base
      * @return float the price of the items attributes
      * @since ZC v1.2.0d
      */
-    public function attributes_price_onetime_charges($uprid, $qty)
+    public function attributes_price_onetime_charges(mixed $uprid, float $qty): float|int
     {
         $this->notify('NOTIFY_CART_ATTRIBUTES_PRICE_ONETIME_CHARGES_START', $uprid);
 
@@ -1191,11 +1176,11 @@ class shoppingCart extends base
     /**
      * Calculate weight of attributes for a given item
      *
-     * @param mixed $product_id the product ID of the item to check
+     * @param string|int $uprid the product ID of the item to check
      * @return float the weight of the items attributes
      * @since ZC v1.0.3
      */
-    public function attributes_weight($uprid)
+    public function attributes_weight(string|int $uprid): float|int
     {
         if (!isset($this->contents[$uprid]['attributes'])) {
             return 0;
@@ -1234,7 +1219,7 @@ class shoppingCart extends base
      * @return array|false
      * @since ZC v1.0.3
      */
-    public function get_products(bool $check_for_valid_cart = false)
+    public function get_products(bool $check_for_valid_cart = false): false|array
     {
         global $db;
 
@@ -1436,10 +1421,9 @@ class shoppingCart extends base
     /**
      * Calculate total price of items in cart
      *
-     * @return float Total Price
      * @since ZC v1.0.3
      */
-    public function show_total()
+    public function show_total(): float
     {
         $this->notify('NOTIFIER_CART_SHOW_TOTAL_START');
         $this->calculate();
@@ -1453,7 +1437,7 @@ class shoppingCart extends base
      * @return float Total Price before Specials, Sales, Discounts
      * @since ZC v1.5.2
      */
-    public function show_total_before_discounts()
+    public function show_total_before_discounts(): float|int
     {
         $this->notify('NOTIFIER_CART_SHOW_TOTAL_BEFORE_DISCOUNT_START');
         $this->calculate();
@@ -1464,10 +1448,9 @@ class shoppingCart extends base
     /**
      * Calculate total weight of items in cart
      *
-     * @return float Total Weight
      * @since ZC v1.0.3
      */
-    public function show_weight()
+    public function show_weight(): float
     {
         $this->calculate();
         return $this->weight;
@@ -1476,11 +1459,9 @@ class shoppingCart extends base
     /**
      * Generate a cart ID, used to ensure contents have not been altered unexpectedly
      *
-     * @param int $length length of ID to generate
-     * @return string cart ID
      * @since ZC v1.0.3
      */
-    public function generate_cart_id($length = 5)
+    public function generate_cart_id(int $length = 5): string
     {
         return zen_create_random_value($length, 'digits');
     }
@@ -1489,10 +1470,9 @@ class shoppingCart extends base
      * Calculate the content type of a cart
      *
      * @param bool $gv_only whether to test for Gift Vouchers only
-     * @return string
      * @since ZC v1.0.3
      */
-    public function get_content_type($gv_only = false)
+    public function get_content_type(bool $gv_only = false): string|float|int|false
     {
         global $db;
 
@@ -1514,7 +1494,7 @@ class shoppingCart extends base
                 $free_ship_check = (new Product($prid))->withDefaultLanguage()->getData();
 
                 if (str_starts_with($free_ship_check['products_model'] ?? '', 'GIFT')) {
-// @TODO - fix GIFT price in cart special/attribute
+                    // @TODO - fix GIFT price in cart special/attribute
                     $gift_special = zen_get_products_special_price($prid, true);
                     $gift_pba = zen_get_products_price_is_priced_by_attributes($prid);
                     $gift_price = zen_get_retail_or_wholesale_price($free_ship_check['products_price'], $free_ship_check['products_price_w']);
@@ -1641,10 +1621,9 @@ class shoppingCart extends base
      * @NOTE: NOT USED IN CORE CODE
      *
      * @param int|string $uprid_to_check product id of item to check
-     * @return float
      * @since ZC v1.2.0d
      */
-    public function in_cart_mixed_discount_quantity($uprid_to_check)
+    public function in_cart_mixed_discount_quantity(int|string $uprid_to_check): float|int
     {
         // if nothing is in cart return 0
         if (!is_array($this->contents)) {
@@ -1683,7 +1662,7 @@ class shoppingCart extends base
      * @return int number of items matching constraint
      * @since ZC v1.1.0
      */
-    public function in_cart_check($check_what, $check_value = '1')
+    public function in_cart_check(string $check_what, mixed $check_value = '1'): int
     {
         // if nothing is in cart return 0
         if (!is_array($this->contents)) {
@@ -1708,7 +1687,7 @@ class shoppingCart extends base
      * @return float|bool value of Gift Vouchers in cart
      * @since ZC v1.2.0d
      */
-    public function gv_only()
+    public function gv_only(): float|bool
     {
         return $this->get_content_type(true);
     }
@@ -1716,10 +1695,9 @@ class shoppingCart extends base
     /**
      * Return the number of free shipping items in the cart
      *
-     * @return float
      * @since ZC v1.2.2d
      */
-    public function free_shipping_items()
+    public function free_shipping_items(): float|int
     {
         $this->calculate();
         return $this->free_shipping_item;
@@ -1728,10 +1706,9 @@ class shoppingCart extends base
     /**
      * Return the total price of free shipping items in the cart
      *
-     * @return float
      * @since ZC v1.2.2d
      */
-    public function free_shipping_prices()
+    public function free_shipping_prices(): float|int
     {
         $this->calculate();
         return $this->free_shipping_price;
@@ -1740,10 +1717,9 @@ class shoppingCart extends base
     /**
      * Return the total weight of free shipping items in the cart
      *
-     * @return float
      * @since ZC v1.2.2d
      */
-    public function free_shipping_weight()
+    public function free_shipping_weight(): float|int
     {
         $this->calculate();
         return $this->free_shipping_weight;
@@ -1752,10 +1728,9 @@ class shoppingCart extends base
     /**
      * Return the total number of downloads in the cart
      *
-     * @return int|float
      * @since ZC v1.5.2
      */
-    public function download_counts()
+    public function download_counts(): float|int
     {
         $this->calculate();
         return $this->download_count;
@@ -1768,7 +1743,7 @@ class shoppingCart extends base
      * @param array $parameters URL parameters to ignore
      * @since ZC v1.3.0
      */
-    public function actionUpdateProduct($goto, $parameters)
+    public function actionUpdateProduct(string $goto, array $parameters): void
     {
         global $messageStack;
         if ($this->display_debug_messages) {
@@ -1935,7 +1910,7 @@ class shoppingCart extends base
      * @param array $parameters URL parameters to ignore
      * @since ZC v1.3.0
      */
-    public function actionAddProduct($goto, $parameters = [])
+    public function actionAddProduct(string $goto, array $parameters = []): void
     {
         global $db, $messageStack;
         if ($this->display_debug_messages) {
@@ -2068,7 +2043,7 @@ class shoppingCart extends base
                                 if (!$products_options_file->parse($text_prefix)) {
                                     continue;
                                 }
-                                $products_image_extension = '.' . pathinfo($products_options_file->filename, PATHINFO_EXTENSION);
+                                $products_image_extension = '.' . pathinfo($products_options_file->filename, \PATHINFO_EXTENSION);
                                 if (zen_is_logged_in()) {
                                     $db->Execute("INSERT INTO " . TABLE_FILES_UPLOADED . " (sesskey, customers_id, files_uploaded_name) VALUES ('" . zen_session_id() . "', " . (int)$_SESSION['customer_id'] . ", '" . zen_db_input($products_options_file->filename) . "')");
                                 } else {
@@ -2114,7 +2089,7 @@ class shoppingCart extends base
                 } // eof: set error message
             } // eof: quantity maximum = 1
 
-            if ($adjust_max == 'true') {
+            if ($adjust_max === 'true') {
                 $messageStack->add_session('shopping_cart', ERROR_MAXIMUM_QTY . zen_get_products_name($_POST['products_id']), 'caution');
                 if ($this->display_debug_messages) {
                     $messageStack->add_session('header', 'E: FUNCTION ' . __FUNCTION__ . '<br>' . ERROR_MAXIMUM_QTY . zen_get_products_name($_POST['products_id']), 'caution');
@@ -2145,7 +2120,7 @@ class shoppingCart extends base
      * @param array $parameters URL parameters to ignore
      * @since ZC v1.3.0
      */
-    public function actionBuyNow($goto, $parameters = [])
+    public function actionBuyNow(string $goto, array $parameters = []): void
     {
         global $messageStack;
         if ($this->display_debug_messages) {
@@ -2210,7 +2185,7 @@ class shoppingCart extends base
      * @param array $parameters URL parameters to ignore
      * @since ZC v1.3.0
      */
-    public function actionMultipleAddProduct($goto, $parameters = [])
+    public function actionMultipleAddProduct(string $goto, array $parameters = []): void
     {
         global $messageStack;
         if ($this->display_debug_messages) {
@@ -2300,7 +2275,7 @@ class shoppingCart extends base
      * @param array $parameters URL parameters to ignore
      * @since ZC v1.3.0
      */
-    public function actionNotify($goto, $parameters = ['ignored'])
+    public function actionNotify(string $goto, array $parameters = ['ignored']): void
     {
         global $db;
         if (zen_is_logged_in() && !zen_in_guest_checkout()) {
@@ -2336,7 +2311,7 @@ class shoppingCart extends base
      * @param array $parameters URL parameters to ignore
      * @since ZC v1.3.0
      */
-    public function actionNotifyRemove($goto, $parameters = ['ignored'])
+    public function actionNotifyRemove(string $goto, array $parameters = ['ignored']): void
     {
         global $db;
         if (zen_is_logged_in() && !zen_in_guest_checkout() && isset($_GET['products_id'])) {
@@ -2359,7 +2334,7 @@ class shoppingCart extends base
      * @param array $parameters URL parameters to ignore
      * @since ZC v1.3.0
      */
-    public function actionCustomerOrder($goto, $parameters)
+    public function actionCustomerOrder(string $goto, array $parameters): void
     {
         global $messageStack;
         if ($this->display_debug_messages) {
@@ -2392,7 +2367,7 @@ class shoppingCart extends base
      * @param array $parameters URL parameters to ignore
      * @since ZC v1.3.0
      */
-    public function actionRemoveProduct($goto, $parameters)
+    public function actionRemoveProduct(string $goto, array $parameters): void
     {
         if (!empty($_GET['product_id'])) {
             $this->remove($_GET['product_id']);
@@ -2409,7 +2384,7 @@ class shoppingCart extends base
      * @param array $parameters URL parameters to ignore
      * @since ZC v1.3.0
      */
-    public function actionCartUserAction($goto, $parameters)
+    public function actionCartUserAction(string $goto, array $parameters): void
     {
         $this->notify('NOTIFY_CART_USER_ACTION', null, $goto, $parameters);
     }
@@ -2424,7 +2399,7 @@ class shoppingCart extends base
      * @return float|int
      * @since ZC v1.3.6
      */
-    public function adjust_quantity($check_qty, $product_id, $messageStackPosition = 'shopping_cart')
+    public function adjust_quantity(float|string $check_qty, int|string $product_id, string $messageStackPosition = 'shopping_cart'): float|int|string
     {
         global $messageStack;
         if (empty($messageStackPosition)) {
@@ -2454,15 +2429,12 @@ class shoppingCart extends base
 
     /**
      * calculate the number of items in a cart based on an attribute option_id and option_values_id combo
-     * USAGE:  $chk_attrib_1_16 = $this->in_cart_check_attrib_quantity(1, 16);
-     * USAGE:  $chk_attrib_1_16 = $_SESSION['cart']->in_cart_check_attrib_quantity(1, 16);
+     * USAGE: $chk_attrib_1_16 = $this->in_cart_check_attrib_quantity(1, 16);
+     * USAGE: $chk_attrib_1_16 = $_SESSION['cart']->in_cart_check_attrib_quantity(1, 16);
      *
-     * @param int $check_option_id
-     * @param int $check_option_values_id
-     * @return float
      * @since ZC v1.5.5b
      */
-    public function in_cart_check_attrib_quantity($check_option_id, $check_option_values_id)
+    public function in_cart_check_attrib_quantity(int $check_option_id, int $check_option_values_id): float|int
     {
         // if nothing is in cart return 0
         if (!is_array($this->contents)) {
@@ -2490,11 +2462,9 @@ class shoppingCart extends base
      * USAGE:  $product_total_price = $this->in_cart_product_total_price(12);
      * USAGE:  $chk_product_cart_total_price = $_SESSION['cart']->in_cart_product_total_price(12);
      *
-     * @param mixed $product_id
-     * @return float
      * @since ZC v1.5.5b
      */
-    public function in_cart_product_total_price($product_id)
+    public function in_cart_product_total_price(int|string $product_id): float|int
     {
         $products = $this->get_products();
         $in_cart_product_price = 0;
@@ -2512,11 +2482,9 @@ class shoppingCart extends base
      * USAGE:  $product_total_quantity = $this->in_cart_product_total_quantity(12);
      * USAGE:  $chk_product_cart_total_quantity = $_SESSION['cart']->in_cart_product_total_quantity(12);
      *
-     * @param mixed $product_id
-     * @return int|mixed
      * @since ZC v1.5.5b
      */
-    public function in_cart_product_total_quantity($product_id)
+    public function in_cart_product_total_quantity(int|string $product_id): mixed
     {
         $products = $this->get_products();
 
@@ -2534,11 +2502,9 @@ class shoppingCart extends base
      * USAGE:  $product_total_weight = $this->in_cart_product_total_weight(12);
      * USAGE:  $chk_product_cart_total_weight = $_SESSION['cart']->in_cart_product_total_weight(12);
      *
-     * @param mixed $product_id
-     * @return float
      * @since ZC v1.5.5b
      */
-    public function in_cart_product_total_weight($product_id)
+    public function in_cart_product_total_weight(int|string $product_id): float|int
     {
         $products = $this->get_products();
         $in_cart_product_weight = 0;
@@ -2555,11 +2521,9 @@ class shoppingCart extends base
      * USAGE:  $category_total_weight_cat = $this->in_cart_product_total_weight_category(9);
      * USAGE:  $chk_category_cart_total_weight_cat = $_SESSION['cart']->in_cart_product_total_weight_category(9);
      *
-     * @param int $category_id
-     * @return float
      * @since ZC v1.5.5b
      */
-    public function in_cart_product_total_weight_category($category_id)
+    public function in_cart_product_total_weight_category(int $category_id): float|int
     {
         $products = $this->get_products();
         $in_cart_product_weight = 0;
@@ -2576,11 +2540,9 @@ class shoppingCart extends base
      * USAGE:  $category_total_price_cat = $this->in_cart_product_total_price_category(9);
      * USAGE:  $chk_category_cart_total_price_cat = $_SESSION['cart']->in_cart_product_total_price_category(9);
      *
-     * @param int $category_id
-     * @return float|int
      * @since ZC v1.5.5b
      */
-    public function in_cart_product_total_price_category($category_id)
+    public function in_cart_product_total_price_category(int $category_id): float|int
     {
         $products = $this->get_products();
         $in_cart_product_price = 0;
@@ -2598,11 +2560,9 @@ class shoppingCart extends base
      * USAGE:  $category_total_quantity_cat = $this->in_cart_product_total_quantity_category(9);
      * USAGE:  $chk_category_cart_total_quantity_cat = $_SESSION['cart']->in_cart_product_total_quantity_category(9);
      *
-     * @param int $category_id
-     * @return float
      * @since ZC v1.5.5b
      */
-    public function in_cart_product_total_quantity_category($category_id)
+    public function in_cart_product_total_quantity_category(int $category_id): float|int
     {
         $products = $this->get_products();
 
@@ -2620,14 +2580,12 @@ class shoppingCart extends base
      * USAGE:  $category_total_weight_cat = $this->in_cart_product_total_weight_category_sub(3);
      * USAGE:  $chk_category_cart_total_weight_cat = $_SESSION['cart']->in_cart_product_total_weight_category_sub(3);
      *
-     * @param int $category_id
-     * @return float
      * @since ZC v1.5.5b
      */
-    public function in_cart_product_total_weight_category_sub($category_id)
+    public function in_cart_product_total_weight_category_sub(int $category_id): float|int
     {
         if (!zen_has_category_subcategories($category_id)) {
-           return $this->in_cart_product_total_weight_category($category_id);
+            return $this->in_cart_product_total_weight_category($category_id);
         }
 
         $subcategories_array = [];
@@ -2644,11 +2602,9 @@ class shoppingCart extends base
      * USAGE:  $category_total_price_cat = $this->in_cart_product_total_price_category_sub(3);
      * USAGE:  $chk_category_cart_total_price_cat = $_SESSION['cart']->in_cart_product_total_price_category_sub(3);
      *
-     * @param int $category_id
-     * @return float
      * @since ZC v1.5.5b
      */
-    public function in_cart_product_total_price_category_sub($category_id)
+    public function in_cart_product_total_price_category_sub(int $category_id): float|int
     {
         if (!zen_has_category_subcategories($category_id)) {
             return $this->in_cart_product_total_price_category($category_id);
@@ -2668,11 +2624,9 @@ class shoppingCart extends base
      * USAGE:  $category_total_quantity_cat = $this->in_cart_product_total_quantity_category_sub(3);
      * USAGE:  $chk_category_cart_total_quantity_cat = $_SESSION['cart']->in_cart_product_total_quantity_category_sub(3);
      *
-     * @param int $category_id
-     * @return float
      * @since ZC v1.5.5b
      */
-    public function in_cart_product_total_quantity_category_sub($category_id)
+    public function in_cart_product_total_quantity_category_sub(int $category_id): float|int
     {
         if (!zen_has_category_subcategories($category_id)) {
             return $this->in_cart_product_total_quantity_category($category_id);
@@ -2694,12 +2648,9 @@ class shoppingCart extends base
      * USAGE:  $mix_all = in_cart_product_mixed_changed($product_id);
      * USAGE:  $mix_all = in_cart_product_mixed_changed($product_id, 'all'); (Second value anything other than 'increase' or 'decrease')
      *
-     * @param int|string $product_id
-     * @param bool $chk
-     * @return array|bool
      * @since ZC v1.5.6
      */
-    public function in_cart_product_mixed_changed($product_id, $chk = false)
+    public function in_cart_product_mixed_changed(int|string $product_id, string|bool $chk = false): bool|array
     {
         global $db;
 
@@ -2785,13 +2736,13 @@ class shoppingCart extends base
         ];
 
         if (array_key_exists($product_id, $product_changed)) {
-            if ($product_total_change[$pr_id] == 0) {
+            if ($product_total_change[$pr_id] === 0) {
                 $changed_array['state'] = 'netzero';
                 return $changed_array;
             }
 
             if (array_key_exists($product_id, $product_tracked_changed)) {
-                if ($product_last_changed[$pr_id] == $product_id) {
+                if ($product_last_changed[$pr_id] === $product_id) {
                     $changed_array['state'] = true;
                     return $changed_array;
                 }

--- a/includes/classes/shopping_cart.php
+++ b/includes/classes/shopping_cart.php
@@ -1366,10 +1366,10 @@ class shoppingCart extends base
             if ($precision < 0) {
                 $precision = 0;
             }
-            if ($precision === 0 || !str_contains($data['qty'], '.')) {
+            if ($precision === 0 || !str_contains((string)$data['qty'], '.')) {
                 $new_qty = $data['qty'];
             } else {
-                $new_qty = rtrim($data['qty'], '0');
+                $new_qty = rtrim((string)$data['qty'], '0');
             }
             $check_unit_decimals = $product['products_quantity_order_units'];
             if (!str_contains($check_unit_decimals, '.')) {

--- a/includes/classes/shopping_cart.php
+++ b/includes/classes/shopping_cart.php
@@ -2434,7 +2434,7 @@ class shoppingCart extends base
      *
      * @since ZC v1.5.5b
      */
-    public function in_cart_check_attrib_quantity(int $check_option_id, int $check_option_values_id): float|int
+    public function in_cart_check_attrib_quantity(int|string $check_option_id, int|string $check_option_values_id): float|int
     {
         // if nothing is in cart return 0
         if (!is_array($this->contents)) {
@@ -2523,12 +2523,12 @@ class shoppingCart extends base
      *
      * @since ZC v1.5.5b
      */
-    public function in_cart_product_total_weight_category(int $category_id): float|int
+    public function in_cart_product_total_weight_category(int|string $category_id): float|int
     {
         $products = $this->get_products();
         $in_cart_product_weight = 0;
         foreach ($products as $product) {
-            if ($product['category'] === $category_id) {
+            if ((int)$product['category'] === (int)$category_id) {
                 $in_cart_product_weight += $product['weight'] * $product['quantity'];
             }
         }
@@ -2542,7 +2542,7 @@ class shoppingCart extends base
      *
      * @since ZC v1.5.5b
      */
-    public function in_cart_product_total_price_category(int $category_id): float|int
+    public function in_cart_product_total_price_category(int|string $category_id): float|int
     {
         $products = $this->get_products();
         $in_cart_product_price = 0;
@@ -2562,7 +2562,7 @@ class shoppingCart extends base
      *
      * @since ZC v1.5.5b
      */
-    public function in_cart_product_total_quantity_category(int $category_id): float|int
+    public function in_cart_product_total_quantity_category(int|string $category_id): float|int
     {
         $products = $this->get_products();
 
@@ -2582,7 +2582,7 @@ class shoppingCart extends base
      *
      * @since ZC v1.5.5b
      */
-    public function in_cart_product_total_weight_category_sub(int $category_id): float|int
+    public function in_cart_product_total_weight_category_sub(int|string $category_id): float|int
     {
         if (!zen_has_category_subcategories($category_id)) {
             return $this->in_cart_product_total_weight_category($category_id);
@@ -2604,7 +2604,7 @@ class shoppingCart extends base
      *
      * @since ZC v1.5.5b
      */
-    public function in_cart_product_total_price_category_sub(int $category_id): float|int
+    public function in_cart_product_total_price_category_sub(int|string $category_id): float|int
     {
         if (!zen_has_category_subcategories($category_id)) {
             return $this->in_cart_product_total_price_category($category_id);
@@ -2626,7 +2626,7 @@ class shoppingCart extends base
      *
      * @since ZC v1.5.5b
      */
-    public function in_cart_product_total_quantity_category_sub(int $category_id): float|int
+    public function in_cart_product_total_quantity_category_sub(int|string $category_id): float|int
     {
         if (!zen_has_category_subcategories($category_id)) {
             return $this->in_cart_product_total_quantity_category($category_id);

--- a/includes/classes/site_map.php
+++ b/includes/classes/site_map.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * site_map.php
  *
@@ -21,10 +23,8 @@ class zen_SiteMapTree
 {
     /**
      * The root category name
-     *
-     * @var string|int
      */
-    protected $root_category_id = TOPMOST_CATEGORY_PARENT_ID;
+    protected int|string $root_category_id = 0;
     /**
      * The maximum number of levels to display 0 = all;
      */
@@ -76,14 +76,18 @@ class zen_SiteMapTree
 
     public function __construct()
     {
+        if (zen_config('TOPMOST_CATEGORY_PARENT_ID', 0) > 0) {
+            $this->root_category_id = zen_config('TOPMOST_CATEGORY_PARENT_ID');
+        }
+
         global $db;
         $this->data = [];
-        $categories_query = "select c.categories_id, cd.categories_name, c.parent_id
-                      from " . TABLE_CATEGORIES . " c, " . TABLE_CATEGORIES_DESCRIPTION . " cd
-                      where c.categories_id = cd.categories_id
-                      and cd.language_id = '" . (int)$_SESSION['languages_id'] . "'
-                      and c.categories_status != '0'
-                      order by c.parent_id, c.sort_order, cd.categories_name";
+        $categories_query = "SELECT c.categories_id, cd.categories_name, c.parent_id
+                      FROM " . TABLE_CATEGORIES . " c, " . TABLE_CATEGORIES_DESCRIPTION . " cd
+                      WHERE c.categories_id = cd.categories_id
+                      AND cd.language_id = '" . (int)$_SESSION['languages_id'] . "'
+                      AND c.categories_status != '0'
+                      ORDER BY c.parent_id, c.sort_order, cd.categories_name";
         $categories = $db->Execute($categories_query);
         while (!$categories->EOF) {
             $this->data[$categories->fields['parent_id']][$categories->fields['categories_id']] = ['name' => $categories->fields['categories_name'], 'count' => 0];
@@ -123,9 +127,9 @@ class zen_SiteMapTree
                     $result .= $this->parent_end_string;
                 }
 
-//        $result .= $this->child_end_string;
+                //        $result .= $this->child_end_string;
 
-                if (isset($this->data[$category_id]) && (($this->max_level == '0') || ($this->max_level > $level + 1))) {
+                if (isset($this->data[$category_id]) && (empty($this->max_level) || ($this->max_level > $level + 1))) {
                     $result .= $this->buildBranch($category_id, $level + 1, $category_link . '_');
                 }
                 $result .= $this->child_end_string;

--- a/includes/classes/site_map.php
+++ b/includes/classes/site_map.php
@@ -19,7 +19,6 @@ if (!defined('IS_ADMIN_FLAG')) {
  */
 class zen_SiteMapTree
 {
-
     /**
      * The root category name
      *

--- a/includes/classes/sniffer.php
+++ b/includes/classes/sniffer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Database-Sniffer Class.
  *

--- a/includes/classes/sniffer.php
+++ b/includes/classes/sniffer.php
@@ -88,7 +88,7 @@ class sniffer
         global $db;
         $sql = "SHOW FIELDS FROM " . $db->prepare_input($table_name);
         $result = $db->Execute($sql);
-        foreach($result as $record) {
+        foreach ($result as $record) {
             if ($record['Field'] === $field_name) {
                 if ($record['Type'] === $field_type) {
                     return true; // exists and matches required type, so return with no error

--- a/includes/classes/split_page_results.php
+++ b/includes/classes/split_page_results.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * split_page_results Class.
  *
@@ -9,7 +11,7 @@
  */
 
 if (!defined('IS_ADMIN_FLAG')) {
-  die('Illegal Access');
+    die('Illegal Access');
 }
 /**
  * Split Page Result Class
@@ -18,289 +20,317 @@ if (!defined('IS_ADMIN_FLAG')) {
  * Overhaul scheduled for subsequent release
  *
  */
-class splitPageResults extends base {
-
+class splitPageResults extends base
+{
     /**
      * Database field used to define unique item to count. Becomes the sql query.
      */
-    private $countQuery;
+    private string $countQuery;
     /**
      * Current page number
      */
-    public $current_page_number;
+    public int $current_page_number;
     /**
      * Total number of pages;
      */
-    public $number_of_pages;
+    public int $number_of_pages;
     /**
      * Total Number of unique rows from $countQuery
      */
-    public $number_of_rows;
+    public int $number_of_rows;
     /**
      * maximum number of rows to display on a page
      */
-    private $number_of_rows_per_page;
+    private int $number_of_rows_per_page;
     /**
      *  The form name of field that holds the current page number
      */
-    private $page_name;
+    private ?string $page_name;
     /**
      * Query used to select items for page
      */
-    public $sql_query;
+    public string $sql_query;
 
     private bool $legacyArgumentMode = false;
 
-  /* class constructor */
-  function __construct($query, $max_rows, $count_key = '*', $page_holder = 'page', $debug = false, $countQuery = "") {
-    global $db;
-    $max_rows = ($max_rows == '' || $max_rows == 0) ? 20 : $max_rows;
+    public function __construct(?string $query, int $max_rows, string $count_key = '*', ?string $page_holder = 'page', bool $debug = false, string $countQuery = "")
+    {
+        global $db;
+        $max_rows = empty($max_rows) ? 20 : (int)$max_rows;
 
-    $legacyPageNumber = null;
-    if ($this->isLegacyConstructorCall($query, $count_key)) {
-      $this->legacyArgumentMode = true;
-      $legacyPageNumber = $query;
-      $query = is_string($count_key) ? $count_key : '';
-      $count_key = is_string($debug) && $debug !== '' ? $debug : '*';
-      $page_holder = 'page';
-      $debug = is_bool($countQuery) ? $countQuery : ((int)$countQuery === 1);
-      $countQuery = '';
+        $legacyPageNumber = null;
+        if (self::isLegacyConstructorCall($query, $count_key)) {
+            $this->legacyArgumentMode = true;
+            $legacyPageNumber = $query;
+            $query = is_string($count_key) ? $count_key : '';
+            $count_key = is_string($debug) && $debug !== '' ? $debug : '*';
+            $page_holder = 'page';
+            $debug = is_bool($countQuery) ? $countQuery : ((int)$countQuery === 1);
+            $countQuery = '';
+        }
+
+        $query = (string)$query;
+        $this->sql_query = preg_replace("/\n\r|\r\n|\n|\r/", " ", $query);
+        if ($countQuery !== "") {
+            $countQuery = preg_replace("/\n\r|\r\n|\n|\r/", " ", (string)$countQuery);
+        }
+        $this->countQuery = ($countQuery !== "") ? $countQuery : $this->sql_query;
+        $this->page_name = $page_holder;
+
+        if ($debug) {
+            echo '<br><br>';
+            echo 'original_query=' . $query . '<br><br>';
+            echo 'original_count_query=' . $countQuery . '<br><br>';
+            echo 'sql_query=' . $this->sql_query . '<br><br>';
+            echo 'count_query=' . $this->countQuery . '<br><br>';
+        }
+        if ($legacyPageNumber !== null && $legacyPageNumber !== '' && is_numeric($legacyPageNumber)) {
+            $page = $legacyPageNumber;
+        } elseif (isset($_GET[$page_holder])) {
+            $page = $_GET[$page_holder];
+        } elseif (isset($_POST[$page_holder])) {
+            $page = $_POST[$page_holder];
+        } else {
+            $page = '';
+        }
+
+        if (empty($page) || !is_numeric($page)) {
+            $page = 1;
+        }
+        $this->current_page_number = (int)$page;
+
+        $this->number_of_rows_per_page = $max_rows;
+
+        $pos_to = strlen($this->countQuery);
+
+        $query_lower = strtolower($this->countQuery);
+        $pos_from = strpos($query_lower, ' from', 0);
+
+        $pos_group_by = strpos($query_lower, ' group by', $pos_from);
+        if (($pos_group_by < $pos_to) && ($pos_group_by !== false)) {
+            $pos_to = $pos_group_by;
+        }
+
+        $pos_having = strpos($query_lower, ' having', $pos_from);
+        if (($pos_having < $pos_to) && ($pos_having !== false)) {
+            $pos_to = $pos_having;
+        }
+
+        $pos_order_by = strrpos($query_lower, ' order by', $pos_from);
+        if (($pos_order_by < $pos_to) && ($pos_order_by !== false)) {
+            $pos_to = $pos_order_by;
+        }
+
+        if (strpos($query_lower, 'distinct') !== false || strpos($query_lower, 'group by') !== false || strpos($query_lower, ' having') !== false) {
+            $count_query = 'SELECT count(*) AS total FROM (' . substr($this->countQuery, 0, ($pos_order_by !== false ? $pos_order_by : strlen($this->countQuery))) . ') split_count';
+        } else {
+            $count_string = zen_db_input($count_key);
+            $count_query = "SELECT count(" . $count_string . ") AS total " . substr($this->countQuery, $pos_from, ($pos_to - $pos_from));
+        }
+        if ($debug) {
+            echo 'count_query=' . $count_query . '<br><br>';
+        }
+        $count = $db->Execute($count_query);
+
+        $this->number_of_rows = (int)$count->fields['total'];
+
+        $this->number_of_pages = (int)ceil($this->number_of_rows / $this->number_of_rows_per_page);
+
+        if ($this->current_page_number > $this->number_of_pages) {
+            $this->current_page_number = $this->number_of_pages;
+        }
+
+        $offset = ($this->number_of_rows_per_page * ($this->current_page_number - 1));
+
+        // fix offset error on some versions
+        if ($offset <= 0) {
+            $offset = 0;
+        }
+
+        $this->sql_query .= " limit " . ($offset > 0 ? $offset . ", " : '') . $this->number_of_rows_per_page;
+
     }
 
-    $query = (string)$query;
-    $this->sql_query = preg_replace("/\n\r|\r\n|\n|\r/", " ", $query);
-    if ($countQuery != "") {
-      $countQuery = preg_replace("/\n\r|\r\n|\n|\r/", " ", (string)$countQuery);
-    }
-    $this->countQuery = ($countQuery != "") ? $countQuery : $this->sql_query;
-    $this->page_name = $page_holder;
+    /**
+     * display split-page-number-links
+     */
+    public function display_links($max_page_links, $parameters = '', bool $outputAsUnorderedList = false, ?string $navElementLabel = ''): string
+    {
+        global $request_type;
+        $args = func_get_args();
 
-    if ($debug) {
-      echo '<br><br>';
-      echo 'original_query=' . $query . '<br><br>';
-      echo 'original_count_query=' . $countQuery . '<br><br>';
-      echo 'sql_query=' . $this->sql_query . '<br><br>';
-      echo 'count_query=' . $this->countQuery . '<br><br>';
-    }
-    if ($legacyPageNumber !== null && $legacyPageNumber !== '' && is_numeric($legacyPageNumber)) {
-      $page = $legacyPageNumber;
-    } elseif (isset($_GET[$page_holder])) {
-      $page = $_GET[$page_holder];
-    } elseif (isset($_POST[$page_holder])) {
-      $page = $_POST[$page_holder];
-    } else {
-      $page = '';
-    }
+        if ($this->legacyArgumentMode && count($args) >= 3) {
+            $max_page_links = $args[2] ?? 1;
+            $parameters = $args[4] ?? '';
+            $outputAsUnorderedList = false;
+            $navElementLabel = '';
 
-    if (empty($page) || !is_numeric($page)) $page = 1;
-    $this->current_page_number = $page;
+            if (!empty($args[5]) && is_string($args[5])) {
+                $this->page_name = $args[5];
+            }
+            if (isset($args[3]) && is_numeric($args[3]) && (int)$args[3] > 0) {
+                $this->current_page_number = (int)$args[3];
+            }
+        }
 
-    $this->number_of_rows_per_page = $max_rows;
+        if (empty($max_page_links)) {
+            $max_page_links = 1;
+        }
 
-    $pos_to = strlen($this->countQuery);
+        if ($this->number_of_pages <= 1) {
+            return '';
+        }
 
-    $query_lower = strtolower($this->countQuery);
-    $pos_from = strpos($query_lower, ' from', 0);
+        $display_links_string = $ul_elements = '';
+        $counter_actual_page_links = 0;
 
-    $pos_group_by = strpos($query_lower, ' group by', $pos_from);
-    if (($pos_group_by < $pos_to) && ($pos_group_by != false)) $pos_to = $pos_group_by;
+        $class = '';
 
-    $pos_having = strpos($query_lower, ' having', $pos_from);
-    if (($pos_having < $pos_to) && ($pos_having != false)) $pos_to = $pos_having;
+        if (!empty($parameters) && !str_ends_with($parameters, '&') && $this->current_page_number > 1) {
+            $parameters .= '&';
+        }
 
-    $pos_order_by = strrpos($query_lower, ' order by', $pos_from);
-    if (($pos_order_by < $pos_to) && ($pos_order_by != false)) $pos_to = $pos_order_by;
-
-    if (strpos($query_lower, 'distinct') !== false || strpos($query_lower, 'group by') !== false || strpos($query_lower, ' having') !== false) {
-      $count_query = 'select count(*) as total from (' . substr($this->countQuery, 0, ($pos_order_by !== false ? $pos_order_by : strlen($this->countQuery))) . ') split_count';
-    } else {
-      $count_string = zen_db_input($count_key);
-      $count_query = "select count(" . $count_string . ") as total " . substr($this->countQuery, $pos_from, ($pos_to - $pos_from));
-    }
-    if ($debug) {
-      echo 'count_query=' . $count_query . '<br><br>';
-    }
-    $count = $db->Execute($count_query);
-
-    $this->number_of_rows = $count->fields['total'];
-
-    $this->number_of_pages = ceil($this->number_of_rows / $this->number_of_rows_per_page);
-
-    if ($this->current_page_number > $this->number_of_pages) {
-      $this->current_page_number = $this->number_of_pages;
-    }
-
-    $offset = ($this->number_of_rows_per_page * ($this->current_page_number - 1));
-
-    // fix offset error on some versions
-    if ($offset <= 0) { $offset = 0; }
-
-    $this->sql_query .= " limit " . ($offset > 0 ? $offset . ", " : '') . $this->number_of_rows_per_page;
-
-  }
-
-  /* class functions */
-
-  // display split-page-number-links
-  function display_links($max_page_links, $parameters = '', $outputAsUnorderedList = false, $navElementLabel = '') {
-    global $request_type;
-    $args = func_get_args();
-
-    if ($this->legacyArgumentMode && count($args) >= 3) {
-      $max_page_links = $args[2] ?? 1;
-      $parameters = $args[4] ?? '';
-      $outputAsUnorderedList = false;
-      $navElementLabel = '';
-
-      if (!empty($args[5]) && is_string($args[5])) {
-        $this->page_name = $args[5];
-      }
-      if (isset($args[3]) && is_numeric($args[3]) && (int)$args[3] > 0) {
-        $this->current_page_number = (int)$args[3];
-      }
-    }
-
-    if ($max_page_links == '') $max_page_links = 1;
-
-    if ($this->number_of_pages <= 1) return;
-
-    $display_links_string = $ul_elements = '';
-    $counter_actual_page_links = 0;
-
-    $class = '';
-
-    if (!empty($parameters) && (substr($parameters, -1) != '&') && ($this->current_page_number > 1)) $parameters .= '&';
-
-    // previous button - not displayed on first page
-    $link = '<a href="' . zen_href_link($_GET['main_page'], $parameters . ($this->current_page_number > 2 ? $this->page_name . '=' . ($this->current_page_number - 1) : ''), $request_type) . '" title="' . PREVNEXT_TITLE_PREVIOUS_PAGE . '">' . PREVNEXT_BUTTON_PREV . '</a>';
-    if ($this->current_page_number > 1) {
-      $display_links_string .= $link . '&nbsp;&nbsp;';
-      $ul_elements .= '  <li class="pagination-previous" aria-label="' . ARIA_PAGINATION_PREVIOUS_PAGE . '">' . $link . '</li>' . "\n";
-    } else {
-      // $ul_elements .= '  <li class="disabled pagination-previous">' . $link . '</li>' . "\n";
-    }
+        // previous button - not displayed on first page
+        $link = '<a href="' . zen_href_link($_GET['main_page'], $parameters . ($this->current_page_number > 2 ? $this->page_name . '=' . ($this->current_page_number - 1) : ''), $request_type) . '" title="' . PREVNEXT_TITLE_PREVIOUS_PAGE . '">' . PREVNEXT_BUTTON_PREV . '</a>';
+        if ($this->current_page_number > 1) {
+            $display_links_string .= $link . '&nbsp;&nbsp;';
+            $ul_elements .= '  <li class="pagination-previous" aria-label="' . ARIA_PAGINATION_PREVIOUS_PAGE . '">' . $link . '</li>' . "\n";
+        } else {
+            // $ul_elements .= '  <li class="disabled pagination-previous">' . $link . '</li>' . "\n";
+        }
 
 
-    // check if number_of_pages > $max_page_links
-    $cur_window_num = intval($this->current_page_number / $max_page_links);
-    if ($this->current_page_number % $max_page_links) $cur_window_num++;
+        // check if number_of_pages > $max_page_links
+        $cur_window_num = (int)($this->current_page_number / $max_page_links);
+        if ($this->current_page_number % $max_page_links) {
+            $cur_window_num++;
+        }
 
-    $max_window_num = intval($this->number_of_pages / $max_page_links);
-    if ($this->number_of_pages % $max_page_links) $max_window_num++;
+        $max_window_num = (int)($this->number_of_pages / $max_page_links);
+        if ($this->number_of_pages % $max_page_links) {
+            $max_window_num++;
+        }
 
-    // previous group of pages
-    $link = '<a href="' . zen_href_link($_GET['main_page'], $parameters . ((($cur_window_num - 1) * $max_page_links) > 1 ? $this->page_name . '=' . (($cur_window_num - 1) * $max_page_links) : ''), $request_type) . '" title="' . sprintf(PREVNEXT_TITLE_PREV_SET_OF_NO_PAGE, $max_page_links) . '" aria-label="' . ARIA_PAGINATION_ELLIPSIS_PREVIOUS . '">...</a>';
-    if ($cur_window_num > 1) {
-      $display_links_string .= $link;
-      $ul_elements .= '  <li class="ellipsis">' . $link . '</li>' . "\n";
-    } else {
-      // $ul_elements .= '  <li class="ellipsis" aria-hidden="true">' . $link . '</li>' . "\n";
+        // previous group of pages
+        $link = '<a href="' . zen_href_link($_GET['main_page'], $parameters . ((($cur_window_num - 1) * $max_page_links) > 1 ? $this->page_name . '=' . (($cur_window_num - 1) * $max_page_links) : ''), $request_type) . '" title="' . sprintf(PREVNEXT_TITLE_PREV_SET_OF_NO_PAGE, $max_page_links) . '" aria-label="' . ARIA_PAGINATION_ELLIPSIS_PREVIOUS . '">...</a>';
+        if ($cur_window_num > 1) {
+            $display_links_string .= $link;
+            $ul_elements .= '  <li class="ellipsis">' . $link . '</li>' . "\n";
+        } else {
+            // $ul_elements .= '  <li class="ellipsis" aria-hidden="true">' . $link . '</li>' . "\n";
+        }
+
+        // page nn button
+        for ($jump_to_page = 1 + (($cur_window_num - 1) * $max_page_links); ($jump_to_page <= ($cur_window_num * $max_page_links)) && ($jump_to_page <= $this->number_of_pages); $jump_to_page++) {
+            if ($jump_to_page === $this->current_page_number) {
+                $display_links_string .= '&nbsp;<strong class="current" aria-current="true" aria-label="' . ARIA_PAGINATION_CURRENT_PAGE . ', ' . sprintf(ARIA_PAGINATION_PAGE_NUM, $jump_to_page) . '">' . $jump_to_page . '</strong>&nbsp;';
+                $ul_elements .= '  <li class="current active">' . $jump_to_page . '</li>' . "\n";
+                $counter_actual_page_links++;
+            } else {
+                $link = '<a href="' . zen_href_link($_GET['main_page'], $parameters . ($jump_to_page > 1 ? $this->page_name . '=' . $jump_to_page : ''), $request_type) . '" title="' . sprintf(PREVNEXT_TITLE_PAGE_NO, $jump_to_page) . '" aria-label="' . ARIA_PAGINATION_GOTO . sprintf(ARIA_PAGINATION_PAGE_NUM, $jump_to_page) . '">' . $jump_to_page . '</a>';
+                $display_links_string .= '&nbsp;' . $link . '&nbsp;';
+                $ul_elements .= '  <li>' . $link . '</li>' . "\n";
+                $counter_actual_page_links++;
+            }
+        }
+
+        // next group of pages
+        if ($cur_window_num < $max_window_num) {
+            $link = '<a href="' . zen_href_link($_GET['main_page'], $parameters . $this->page_name . '=' . (($cur_window_num) * $max_page_links + 1), $request_type) . '" title="' . sprintf(PREVNEXT_TITLE_NEXT_SET_OF_NO_PAGE, $max_page_links) . '" aria-label="' . ARIA_PAGINATION_ELLIPSIS_NEXT . '">...</a>';
+            $display_links_string .= $link . '&nbsp;';
+            $ul_elements .= '  <li class="ellipsis">' . $link . '</li>' . "\n";
+        } else {
+            // $ul_elements .= '  <li class="ellipsis" aria-hidden="true">' . $link . '</li>' . "\n";
+        }
+
+        // next button
+        if (($this->current_page_number < $this->number_of_pages) && ($this->number_of_pages !== 1)) {
+            $link = '<a href="' . zen_href_link($_GET['main_page'], $parameters . $this->page_name . '=' . ($this->current_page_number + 1), $request_type) . '" title="' . PREVNEXT_TITLE_NEXT_PAGE . '" aria-label="' . ARIA_PAGINATION_NEXT_PAGE . '">' . PREVNEXT_BUTTON_NEXT . '</a>';
+            $display_links_string .= '&nbsp;' . $link . '&nbsp;';
+            $ul_elements .= '  <li class="pagination-next">' . $link . '</li>' . "\n";
+        } else {
+            // $ul_elements .= '  <li class="disabled pagination-next">' . $link . '</li>' . "\n";
+        }
+
+        // if no pagination needed, return blank
+        if ($counter_actual_page_links === 0) {
+            return '';
+        }
+
+        // return <nav><ul> format with a-hrefs wrapped in <li>
+        // not setting role="navigation" because we're using a <nav> element already.
+        if ($outputAsUnorderedList) {
+            $aria_label = empty($navElementLabel) ? ARIA_PAGINATION_ROLE_LABEL_GENERAL : sprintf(ARIA_PAGINATION_ROLE_LABEL_FOR, zen_output_string_protected($navElementLabel));
+            $aria_label .= sprintf(ARIA_PAGINATION_CURRENTLY_ON, $this->current_page_number);
+            return  '<nav class="pagination" aria-label="' . $aria_label . '">' . "\n" .
+                '<ul class="pagination">' . "\n" .
+                $ul_elements .
+                '</ul>' . "\n" .
+                '</nav>';
+        }
+        // return unformatted collection of a-hrefs
+        return $display_links_string;
     }
 
-    // page nn button
-    for ($jump_to_page = 1 + (($cur_window_num - 1) * $max_page_links); ($jump_to_page <= ($cur_window_num * $max_page_links)) && ($jump_to_page <= $this->number_of_pages); $jump_to_page++) {
-      if ($jump_to_page == $this->current_page_number) {
-        $display_links_string .= '&nbsp;<strong class="current" aria-current="true" aria-label="' . ARIA_PAGINATION_CURRENT_PAGE . ', ' . sprintf(ARIA_PAGINATION_PAGE_NUM, $jump_to_page) . '">' . $jump_to_page . '</strong>&nbsp;';
-        $ul_elements .= '  <li class="current active">' . $jump_to_page . '</li>' . "\n";
-        $counter_actual_page_links++;
-      } else {
-        $link = '<a href="' . zen_href_link($_GET['main_page'], $parameters . ($jump_to_page > 1 ? $this->page_name . '=' . $jump_to_page : ''), $request_type) . '" title="' . sprintf(PREVNEXT_TITLE_PAGE_NO, $jump_to_page) . '" aria-label="' . ARIA_PAGINATION_GOTO . sprintf(ARIA_PAGINATION_PAGE_NUM, $jump_to_page) . '">' . $jump_to_page . '</a>';
-        $display_links_string .= '&nbsp;' . $link . '&nbsp;';
-        $ul_elements .= '  <li>' . $link . '</li>' . "\n";
-        $counter_actual_page_links++;
-      }
+    /**
+     * display number of total products found
+     */
+    public function display_count($text_output): string
+    {
+        $args = func_get_args();
+        if ($this->legacyArgumentMode && count($args) >= 4) {
+            $text_output = $args[3];
+            if (isset($args[2]) && is_numeric($args[2]) && (int)$args[2] > 0) {
+                $this->current_page_number = (int)$args[2];
+            }
+        }
+
+        $to_num = ($this->number_of_rows_per_page * $this->current_page_number);
+        if ($to_num > $this->number_of_rows) {
+            $to_num = $this->number_of_rows;
+        }
+
+        $from_num = ($this->number_of_rows_per_page * ($this->current_page_number - 1));
+
+        if ($to_num == 0) {
+            $from_num = 0;
+        } else {
+            $from_num++;
+        }
+
+        if ($to_num <= 1) {
+            // don't show count when 1
+            return '';
+        }
+
+        return sprintf($text_output, $from_num, $to_num, $this->number_of_rows);
     }
 
-    // next group of pages
-    if ($cur_window_num < $max_window_num) {
-      $link = '<a href="' . zen_href_link($_GET['main_page'], $parameters . $this->page_name . '=' . (($cur_window_num) * $max_page_links + 1), $request_type) . '" title="' . sprintf(PREVNEXT_TITLE_NEXT_SET_OF_NO_PAGE, $max_page_links) . '" aria-label="' . ARIA_PAGINATION_ELLIPSIS_NEXT . '">...</a>';
-      $display_links_string .= $link . '&nbsp;';
-      $ul_elements .= '  <li class="ellipsis">' . $link . '</li>' . "\n";
-    } else {
-      // $ul_elements .= '  <li class="ellipsis" aria-hidden="true">' . $link . '</li>' . "\n";
+    /**
+     * @since ZC v1.5.7
+     */
+    public function getSqlQuery(): string
+    {
+        return $this->sql_query;
     }
 
-    // next button
-    if (($this->current_page_number < $this->number_of_pages) && ($this->number_of_pages != 1)) {
-      $link = '<a href="' . zen_href_link($_GET['main_page'], $parameters . $this->page_name . '=' . ($this->current_page_number + 1), $request_type) . '" title="' . PREVNEXT_TITLE_NEXT_PAGE . '" aria-label="' . ARIA_PAGINATION_NEXT_PAGE . '">' . PREVNEXT_BUTTON_NEXT . '</a>';
-      $display_links_string .= '&nbsp;' . $link . '&nbsp;';
-      $ul_elements .= '  <li class="pagination-next">' . $link . '</li>' . "\n";
-    } else {
-      // $ul_elements .= '  <li class="disabled pagination-next">' . $link . '</li>' . "\n";
+    private static function isLegacyConstructorCall($query, $count_key): bool
+    {
+        if (!is_string($count_key)) {
+            return false;
+        }
+
+        $trimmedCountKey = ltrim($count_key);
+        if ($trimmedCountKey === '' || stripos($trimmedCountKey, 'select') !== 0) {
+            return false;
+        }
+
+        if (!is_scalar($query) && $query !== null) {
+            return false;
+        }
+
+        $queryString = ltrim((string)$query);
+
+        return $queryString === '' || stripos($queryString, 'select') !== 0;
     }
-
-    // if no pagination needed, return blank
-    if ($counter_actual_page_links == 0) return;
-
-    // return <nav><ul> format with a-hrefs wrapped in <li>
-    // not setting role="navigation" because we're using a <nav> element already.
-    if ($outputAsUnorderedList) {
-        $aria_label = empty($navElementLabel) ? ARIA_PAGINATION_ROLE_LABEL_GENERAL : sprintf(ARIA_PAGINATION_ROLE_LABEL_FOR, zen_output_string_protected($navElementLabel));
-        $aria_label .= sprintf(ARIA_PAGINATION_CURRENTLY_ON, $this->current_page_number);
-        return  '<nav class="pagination" aria-label="' . $aria_label . '">' . "\n" .
-            '<ul class="pagination">' . "\n" .
-            $ul_elements .
-            '</ul>' . "\n" .
-            '</nav>';
-    }
-    // return unformatted collection of a-hrefs
-    return $display_links_string;
-  }
-
-  // display number of total products found
-  function display_count($text_output) {
-    $args = func_get_args();
-    if ($this->legacyArgumentMode && count($args) >= 4) {
-      $text_output = $args[3];
-      if (isset($args[2]) && is_numeric($args[2]) && (int)$args[2] > 0) {
-        $this->current_page_number = (int)$args[2];
-      }
-    }
-
-    $to_num = ($this->number_of_rows_per_page * $this->current_page_number);
-    if ($to_num > $this->number_of_rows) $to_num = $this->number_of_rows;
-
-    $from_num = ($this->number_of_rows_per_page * ($this->current_page_number - 1));
-
-    if ($to_num == 0) {
-      $from_num = 0;
-    } else {
-      $from_num++;
-    }
-
-    if ($to_num <= 1) {
-      // don't show count when 1
-      return '';
-    } else {
-      return sprintf($text_output, $from_num, $to_num, $this->number_of_rows);
-    }
-  }
-
-  /**
-   * @since ZC v1.5.7
-   */
-  public function getSqlQuery()
-  {
-      return $this->sql_query;
-  }
-
-  private function isLegacyConstructorCall($query, $count_key): bool
-  {
-      if (!is_string($count_key)) {
-          return false;
-      }
-
-      $trimmedCountKey = ltrim($count_key);
-      if ($trimmedCountKey === '' || stripos($trimmedCountKey, 'select') !== 0) {
-          return false;
-      }
-
-      if (!is_scalar($query) && $query !== null) {
-          return false;
-      }
-
-      $queryString = ltrim((string)$query);
-
-      return $queryString === '' || stripos($queryString, 'select') !== 0;
-  }
 }

--- a/includes/classes/template_func.php
+++ b/includes/classes/template_func.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * template_func Class.
  *

--- a/includes/classes/traits/InteractsWithPlugins.php
+++ b/includes/classes/traits/InteractsWithPlugins.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -87,7 +89,7 @@ trait InteractsWithPlugins
      */
     protected function linkCatalogStylesheet(string $stylesheet_filename, ?string $current_page): bool
     {
-        global $template, $pageLoader;
+        global $template, $pageLoader, $current_page_base;
         if (!$pageLoader) {
             $pageLoader = PageLoader::getInstance();
         }
@@ -102,7 +104,7 @@ trait InteractsWithPlugins
         }
 
         // if catalog template contains a stylesheet of the same name, load it as well, to apply any overrides it may contain
-        $stylesheet_dir = $template->get_template_dir($stylesheet_filename, DIR_WS_TEMPLATE, $current_page, 'css') . '/';
+        $stylesheet_dir = $template->get_template_dir($stylesheet_filename, DIR_WS_TEMPLATE, $current_page ?? $current_page_base, 'css') . '/';
         if (!str_contains($stylesheet_dir, $this->zcPluginCatalogPath) && file_exists($stylesheet_dir . $stylesheet_filename)) {
             echo '<link rel="stylesheet" href="' . $stylesheet_dir . $stylesheet_filename . '">' . "\n";
             $found = true;

--- a/includes/classes/traits/InteractsWithPlugins.php
+++ b/includes/classes/traits/InteractsWithPlugins.php
@@ -79,16 +79,14 @@ trait InteractsWithPlugins
     }
 
     /**
-     * @param string $stylesheet_filename
-     * @param string|null $current_page
-     * @return bool
+     * Link/output a stylesheet file from the plugin's css directory.
+     * Checks first in the plugin's own css directory, then in the active template's css directory.
      *
-     * @var \template_func $template
-     * @var PageLoader $pageLoader
      * @since ZC v2.1.0
      */
     protected function linkCatalogStylesheet(string $stylesheet_filename, ?string $current_page): bool
     {
+        /** @var \template_func $template */
         global $template, $pageLoader, $current_page_base;
         if (!$pageLoader) {
             $pageLoader = PageLoader::getInstance();

--- a/includes/classes/traits/NotifierManager.php
+++ b/includes/classes/traits/NotifierManager.php
@@ -62,8 +62,7 @@ trait NotifierManager
         mixed &$param7 = null,
         mixed &$param8 = null,
         mixed &$param9 = null
-    ): void
-    {
+    ): void {
         // first log that the notifier was triggered:
         $this->logNotifier($eventID, $param1, $param2, $param3, $param4, $param5, $param6, $param7, $param8, $param9);
 
@@ -115,7 +114,7 @@ trait NotifierManager
             }
             // If no update handler method exists then trigger an error so the problem is logged
             $className = (is_object($obs['obs'])) ? get_class($obs['obs']) : $obs['obs'];
-            trigger_error('WARNING: No update() method (or matching alternative) found in the ' . $className . ' class for event ' . $actualEventId, E_USER_WARNING);
+            trigger_error('WARNING: No update() method (or matching alternative) found in the ' . $className . ' class for event ' . $actualEventId, \E_USER_WARNING);
         }
     }
 

--- a/includes/classes/traits/ObserverManager.php
+++ b/includes/classes/traits/ObserverManager.php
@@ -37,7 +37,7 @@ trait ObserverManager
 
             // handle deprecations
             if (array_key_exists($eventID, self::$deprecatedNotifications)) {
-                trigger_error("Use of deprecated notification '$eventID'.  Consider using '" . self::$deprecatedNotifications[$eventID] . "' instead.", E_USER_WARNING);
+                trigger_error("Use of deprecated notification '$eventID'.  Consider using '" . self::$deprecatedNotifications[$eventID] . "' instead.", \E_USER_WARNING);
                 continue;
             }
 

--- a/includes/classes/traits/Singleton.php
+++ b/includes/classes/traits/Singleton.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  *
  * @copyright Copyright 2003-2025 Zen Cart Development Team
@@ -43,7 +45,7 @@ trait Singleton
      */
     public static function getInstance()
     {
-        $cls = get_called_class(); // late-static-bound class name
+        $cls = static::class; // late-static-bound class name
         if (!isset(self::$instances[$cls])) {
             self::$instances[$cls] = new static();
         }

--- a/includes/classes/upload.php
+++ b/includes/classes/upload.php
@@ -17,7 +17,7 @@ if (!defined('IS_ADMIN_FLAG')) {
  *
  * @since ZC v1.0.3
  */
- //
+//
 // This is the old UPLOAD_FILENAME_EXTENSIONS which was in the database
 zen_define_default('UPLOAD_FILENAME_EXTENSIONS_LIST', 'jpg,jpeg,gif,png,eps,cdr,ai,pdf,tif,tiff,bmp,zip');
 
@@ -123,7 +123,7 @@ class upload
             return false;
         }
 
-        $file_extension = pathinfo($file['name'], PATHINFO_EXTENSION);
+        $file_extension = pathinfo($file['name'], \PATHINFO_EXTENSION);
         if (str_ends_with($file['name'], '.htaccess') || (count($this->extensions) !== 0 && !in_array(strtolower($file_extension), $this->extensions))) {
             $this->message_stack(sprintf(ERROR_FILETYPE_NOT_ALLOWED, $file_extension, '.' . implode(', .', $this->extensions)), 'error');
             return false;
@@ -140,11 +140,11 @@ class upload
      */
     protected function fileError(array $file): bool
     {
-        if ((int)$file['error'] === UPLOAD_ERR_OK) {
+        if ((int)$file['error'] === \UPLOAD_ERR_OK) {
             return false;
         }
         switch ((int)$file['error']) {  //- See for details: https://www.php.net/manual/en/filesystem.constants.php#constant.upload-err-form-size
-            case UPLOAD_ERR_INI_SIZE:   //- 1
+            case \UPLOAD_ERR_INI_SIZE:   //- 1
                 if (IS_ADMIN_FLAG === true) {
                     $this->message_stack(sprintf(ERROR_FILE_TOO_BIG_INI, ini_get('upload_max_filesize')), 'error'); //- TODO: Check post_max_size, too
                 } else {
@@ -152,7 +152,7 @@ class upload
                 }
                 break;
 
-            case UPLOAD_ERR_FORM_SIZE:  //- 2
+            case \UPLOAD_ERR_FORM_SIZE:  //- 2
                 if (IS_ADMIN_FLAG === true) {
                     $this->message_stack(sprintf(ERROR_FILE_TOO_BIG_MAXSIZE, $_POST['MAX_FILE_SIZE']), 'error');
                 } else {
@@ -160,10 +160,10 @@ class upload
                 }
                 break;
 
-            // -----
-            // Note: No message here, intentionally.
-            //
-            case UPLOAD_ERR_NO_FILE:    //- 4
+                // -----
+                // Note: No message here, intentionally.
+                //
+            case \UPLOAD_ERR_NO_FILE:    //- 4
                 $this->fileUploaded = false;
                 break;
 
@@ -262,7 +262,7 @@ class upload
      * @param array $extensions
      * @since ZC v1.0.3
      */
-    function set_extensions(array|string $extensions): void
+    public function set_extensions(array|string $extensions): void
     {
         if (!empty($extensions)) {
             if (is_array($extensions)) {
@@ -280,7 +280,7 @@ class upload
      */
     public function check_destination(): bool
     {
-        if (!is_writeable($this->destination)) {
+        if (!is_writable($this->destination)) {
             if (is_dir($this->destination)) {
                 $this->message_stack(sprintf(ERROR_DESTINATION_NOT_WRITEABLE, $this->destination), 'error');
             } else {

--- a/includes/classes/upload.php
+++ b/includes/classes/upload.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * upload Class.
  *
@@ -124,7 +126,7 @@ class upload
         }
 
         $file_extension = pathinfo($file['name'], \PATHINFO_EXTENSION);
-        if (str_ends_with($file['name'], '.htaccess') || (count($this->extensions) !== 0 && !in_array(strtolower($file_extension), $this->extensions))) {
+        if (str_ends_with($file['name'], '.htaccess') || (count($this->extensions) !== 0 && !in_array(strtolower($file_extension), $this->extensions, true))) {
             $this->message_stack(sprintf(ERROR_FILETYPE_NOT_ALLOWED, $file_extension, '.' . implode(', .', $this->extensions)), 'error');
             return false;
         }
@@ -154,7 +156,7 @@ class upload
 
             case \UPLOAD_ERR_FORM_SIZE:  //- 2
                 if (IS_ADMIN_FLAG === true) {
-                    $this->message_stack(sprintf(ERROR_FILE_TOO_BIG_MAXSIZE, $_POST['MAX_FILE_SIZE']), 'error');
+                    $this->message_stack(sprintf(ERROR_FILE_TOO_BIG_MAXSIZE, (int)($_POST['MAX_FILE_SIZE'] ?? 0)), 'error');
                 } else {
                     $this->message_stack(ERROR_FILE_TOO_BIG, 'error');
                 }
@@ -175,8 +177,6 @@ class upload
     }
 
     /**
-     * @param bool $overwrite
-     * @return bool
      * @since ZC v1.0.3
      */
     public function save(bool $overwrite = true): bool
@@ -210,7 +210,6 @@ class upload
     }
 
     /**
-     * @param string $file
      * @since ZC v1.0.3
      */
     public function set_file(string $file): void
@@ -219,7 +218,6 @@ class upload
     }
 
     /**
-     * @param string $destination
      * @since ZC v1.0.3
      */
     public function set_destination(string $destination): void
@@ -232,7 +230,6 @@ class upload
     }
 
     /**
-     * @param string $permissions
      * @since ZC v1.0.3
      */
     public function set_permissions(string $permissions): void
@@ -241,7 +238,6 @@ class upload
     }
 
     /**
-     * @param string $filename
      * @since ZC v1.0.3
      */
     public function set_filename(string $filename): void
@@ -250,7 +246,6 @@ class upload
     }
 
     /**
-     * @param string $filename
      * @since ZC v1.0.3
      */
     public function set_tmp_filename(string $filename): void
@@ -259,7 +254,6 @@ class upload
     }
 
     /**
-     * @param array $extensions
      * @since ZC v1.0.3
      */
     public function set_extensions(array|string $extensions): void
@@ -294,7 +288,6 @@ class upload
     }
 
     /**
-     * @param string $location
      * @since ZC v1.0.3
      */
     public function set_output_messages(string $location): void

--- a/includes/classes/zcDate.php
+++ b/includes/classes/zcDate.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
@@ -7,16 +9,24 @@
  */
 class zcDate extends base
 {
-    protected $useIntlDate = false;
-    protected $useStrftime = false;
-    protected $locale;
-    //- Only used when $this->useIntlDate is true
-    protected $strftime2date;
-    //- Only used when $this->useStrftime is false
-    protected $strftime2intl;
-    //- Only used when $this->useStrftime is false
-    protected $debug = false;
-    protected $dateObject;
+    protected bool $useIntlDate = false;
+    protected bool $useStrftime = false;
+
+    /**
+     * Only used when $this->useIntlDate is true
+     */
+    protected string $locale;
+    /**
+     * Only used when $this->useStrftime is false
+     */
+    protected array $strftime2date;
+    /**
+     * Only used when $this->useStrftime is false
+     */
+    protected array $strftime2intl;
+
+    protected bool $debug = false;
+    protected IntlDateFormatter $dateObject;
 
     // -----
     // Initial construction; initializes the conversion arrays and determines which PHP
@@ -33,7 +43,7 @@ class zcDate extends base
             $this->debug = true;
         }
 
-        if (version_compare(\PHP_VERSION, '8.1', '<')) {
+        if (PHP_VERSION_ID < 80100) {
             $this->useStrftime = true;
         } else {
             if (function_exists('datefmt_create')) {
@@ -60,7 +70,7 @@ class zcDate extends base
     /**
      * @since ZC v1.5.8
      */
-    protected function initializeConversionArrays()
+    protected function initializeConversionArrays(): void
     {
         $strftime2date = [
             '%a' => 'D',
@@ -144,7 +154,7 @@ class zcDate extends base
     /**
      * @since ZC v1.5.8
      */
-    public function enableDebug()
+    public function enableDebug(): void
     {
         $this->debug = true;
         $this->debug('Debug enabled: ' . \PHP_EOL . var_export($this, true));
@@ -152,20 +162,20 @@ class zcDate extends base
     /**
      * @since ZC v1.5.8
      */
-    public function disableDebug()
+    public function disableDebug(): void
     {
         $this->debug = false;
     }
 
     /**
-     * @param string $format  output method should start with a strftime-format string
-     * @param int    $timestamp
+     * @param string $format output method should start with a strftime-format string
+     * @param int $timestamp
      * @param string|null $calendar_locale Optional calendar-related locale. eg: 'ja_JP@calendar=japanese'
      *
      * @return false|string
      * @since ZC v1.5.8
      */
-    public function output(string $format, int $timestamp = 0, ?string $calendar_locale = null)
+    public function output(string $format, int $timestamp = 0, ?string $calendar_locale = null): false|string
     {
         if ($timestamp === 0) {
             $timestamp = time();
@@ -224,7 +234,7 @@ class zcDate extends base
     /**
      * @since ZC v1.5.8
      */
-    protected function convertFormat(string $format, array $replacements)
+    protected function convertFormat(string $format, array $replacements): array|string
     {
         return str_replace($replacements['from'], $replacements['to'], $format);
     }
@@ -245,7 +255,7 @@ class zcDate extends base
     /**
      * @since ZC v1.5.8
      */
-    protected function debug(string $message)
+    protected function debug(string $message): void
     {
         if ($this->debug === true) {
             error_log($message . \PHP_EOL);

--- a/includes/classes/zcDate.php
+++ b/includes/classes/zcDate.php
@@ -15,26 +15,33 @@ class zcDate extends base
     /**
      * Only used when $this->useIntlDate is true
      */
-    protected string $locale;
+    protected string $locale = '0';
     /**
      * Only used when $this->useStrftime is false
      */
-    protected array $strftime2date;
+    protected array $strftime2date = ['from' => [], 'to' => []];
     /**
      * Only used when $this->useStrftime is false
      */
-    protected array $strftime2intl;
+    protected array $strftime2intl = ['from' => [], 'to' => []];
 
     protected bool $debug = false;
-    protected IntlDateFormatter $dateObject;
 
-    // -----
-    // Initial construction; initializes the conversion arrays and determines which PHP
-    // base function will be used by the output method.
-    //
-    // The $zen_date_debug is a "soft" configuration setting that can be forced (defaults to false)
-    // via the site's /includes/extra_datafiles/site_specific_overrides.php
-    //
+    /** @var object|null */
+    protected ?object $dateObject = null;
+
+    /**
+     * Initializes the conversion arrays and determines which PHP
+     * base function will be used by the output method.
+     *
+     * 1. If PHP 8.1 or greater, use the IntlDateFormatter class.
+     * 2. If PHP 8.0 or greater, use the datefmt_create function.
+     * 3. Otherwise, use the strftime function.
+     *
+     * The $zen_date_debug is a "soft" configuration setting that can be forced (defaults to false)
+     * via the site's /includes/extra_datafiles/site_specific_overrides.php
+     *
+    */
     public function __construct()
     {
         global $zen_date_debug;
@@ -198,8 +205,8 @@ class zcDate extends base
             //
         } else {
             // -----
-            // If the locale has changes (as it might between the class construction and
-            // this method, re-initialize the conversion arrays for the current locale.
+            // If the locale has changed (as it might between the class construction and
+            // this method), re-initialize the conversion arrays for the current locale.
             //
             if ($this->locale !== setlocale(\LC_TIME, '0')) {
                 $this->initializeConversionArrays();

--- a/includes/classes/zcDate.php
+++ b/includes/classes/zcDate.php
@@ -33,7 +33,7 @@ class zcDate extends base
             $this->debug = true;
         }
 
-        if (version_compare(phpversion(), '8.1', '<')) {
+        if (version_compare(\PHP_VERSION, '8.1', '<')) {
             $this->useStrftime = true;
         } else {
             if (function_exists('datefmt_create')) {
@@ -41,7 +41,7 @@ class zcDate extends base
             }
             $this->initializeConversionArrays();
         }
-        $this->debug('zcDate construction: ' . PHP_EOL . var_export($this, true));
+        $this->debug('zcDate construction: ' . \PHP_EOL . var_export($this, true));
     }
 
     // -----
@@ -91,7 +91,7 @@ class zcDate extends base
             // First, save the current locale; it's set by the main language file's (presumed) call to the
             // setlocale function.
             //
-            $this->locale = setlocale(LC_TIME, '0');
+            $this->locale = setlocale(\LC_TIME, '0');
 
             // -----
             // Using the current locale, retrieve the locale-specific 'short' date and time
@@ -147,7 +147,7 @@ class zcDate extends base
     public function enableDebug()
     {
         $this->debug = true;
-        $this->debug('Debug enabled: ' . PHP_EOL . var_export($this, true));
+        $this->debug('Debug enabled: ' . \PHP_EOL . var_export($this, true));
     }
     /**
      * @since ZC v1.5.8
@@ -191,7 +191,7 @@ class zcDate extends base
             // If the locale has changes (as it might between the class construction and
             // this method, re-initialize the conversion arrays for the current locale.
             //
-            if ($this->locale !== setlocale(LC_TIME, '0')) {
+            if ($this->locale !== setlocale(\LC_TIME, '0')) {
                 $this->initializeConversionArrays();
             }
 
@@ -211,7 +211,7 @@ class zcDate extends base
             );
             $output = $this->dateObject->format($timestamp);
             if ($output === false) {
-                trigger_error(sprintf("Formatting error using '%s': %s (%d)", $converted_format, $this->dateObject->getErrorMessage(), $this->dateObject->getErrorCode()), E_USER_WARNING);
+                trigger_error(sprintf("Formatting error using '%s': %s (%d)", $converted_format, $this->dateObject->getErrorMessage(), $this->dateObject->getErrorCode()), \E_USER_WARNING);
             }
         }
 
@@ -248,7 +248,7 @@ class zcDate extends base
     protected function debug(string $message)
     {
         if ($this->debug === true) {
-            error_log($message . PHP_EOL);
+            error_log($message . \PHP_EOL);
         }
     }
 }

--- a/includes/functions/functions_categories.php
+++ b/includes/functions/functions_categories.php
@@ -188,7 +188,7 @@ function zen_get_categories(array $categories_array = [], $parent_id = TOPMOST_C
  * @param int $parent_id
  * @since ZC v1.0.3
  */
-function zen_get_subcategories(array &$subcategories_array, $parent_id = TOPMOST_CATEGORY_PARENT_ID): void
+function zen_get_subcategories(array &$subcategories_array, int|string $parent_id = TOPMOST_CATEGORY_PARENT_ID): void
 {
     global $db;
     $subcategories_query = "SELECT categories_id

--- a/includes/functions/functions_general.php
+++ b/includes/functions/functions_general.php
@@ -30,21 +30,22 @@ function zen_create_sort_heading($sortby, $colnum, $heading)
 }
 
 /**
- * Count number of modules of a certain type are enabled
- * @param string $modules
- * @return int
+ * Count the number of modules of a certain type which are enabled
+ *
  * @since ZC v1.0.3
  */
-function zen_count_modules($modules = '')
+function zen_count_modules(string $modules = ''): int
 {
     $count = 0;
 
-    if (empty($modules)) return $count;
+    if (empty($modules)) {
+        return 0;
+    }
 
     $modules_array = preg_split('/;/', $modules);
 
-    for ($i = 0, $n = count($modules_array); $i < $n; $i++) {
-        $class = substr($modules_array[$i], 0, strrpos($modules_array[$i], '.'));
+    foreach ($modules_array as $module) {
+        $class = substr($module, 0, strrpos($module, '.'));
 
         if (isset($GLOBALS[$class]) && is_object($GLOBALS[$class])) {
             if ($GLOBALS[$class]->enabled) {
@@ -58,7 +59,7 @@ function zen_count_modules($modules = '')
 /**
  * @since ZC v1.0.3
  */
-function zen_count_payment_modules()
+function zen_count_payment_modules(): int
 {
     return zen_count_modules(zen_config('MODULE_PAYMENT_INSTALLED'));
 }
@@ -66,7 +67,7 @@ function zen_count_payment_modules()
 /**
  * @since ZC v1.0.3
  */
-function zen_count_shipping_modules()
+function zen_count_shipping_modules(): int
 {
     return zen_count_modules(zen_config('MODULE_SHIPPING_INSTALLED'));
 }
@@ -75,12 +76,9 @@ function zen_count_shipping_modules()
 /**
  * Checks to see if the currency code exists as a currency
  * @TODO - move into currencies class
- * @param string $code
- * @param bool $getFirstDefault
- * @return false|string
  * @since ZC v1.0.3
  */
-function zen_currency_exists(string $code, bool $getFirstDefault = false)
+function zen_currency_exists(string $code, bool $getFirstDefault = false): false|string
 {
     global $db;
 

--- a/includes/functions/functions_general_shared.php
+++ b/includes/functions/functions_general_shared.php
@@ -19,37 +19,36 @@ function zen_get_zcversion(): string
 
 /**
  * Set timeout for the current script.
- * @param int $limit seconds
+ * Usually only used to extend for things that might be longer-running than PHP's default (which is often 30 seconds)
+ *
  * @since ZC v1.0.3
  */
-function zen_set_time_limit($limit)
+function zen_set_time_limit(int $seconds = 120): void
 {
-    @set_time_limit((int)$limit);
+    @set_time_limit((int)$seconds);
 }
 
 /**
- * @param string $ip
- * @return boolean
  * @since ZC v1.5.7
  */
-function zen_is_whitelisted_admin_ip($ip = null)
+function zen_is_whitelisted_admin_ip(?string $ip = null): bool
 {
     if (empty($ip)) {
         $ip = $_SERVER['REMOTE_ADDR'];
     }
-    return strpos(zen_config('EXCLUDE_ADMIN_IP_FOR_MAINTENANCE'), $ip) !== false;
+    return str_contains(zen_config('EXCLUDE_ADMIN_IP_FOR_MAINTENANCE'), $ip);
 }
 
 
-////
-// Wrapper function for round()
 /**
+ * Wrapper function for round()
+ *
  * @since ZC v1.0.3
  */
-function zen_round($value, $precision)
+function zen_round($value, int $precision = 0): float|int
 {
-    $value = round($value * pow(10, $precision), 0);
-    $value = $value / pow(10, $precision);
+    $value = round($value * (10 ** $precision), 0);
+    $value /= 10 ** $precision;
     return $value;
 }
 
@@ -119,7 +118,7 @@ function convertToFloat($input = 0): float|int
  */
 function issetorArray(array $array, $key, $default = null)
 {
-    return isset($array[$key]) ? $array[$key] : $default;
+    return $array[$key] ?? $default;
 }
 
 /**

--- a/includes/functions/functions_prices.php
+++ b/includes/functions/functions_prices.php
@@ -1193,23 +1193,17 @@ function zen_get_products_actual_price($product_id)
 
 /**
  * Calculate attribute price based on specified factors
- * @param float $price
- * @param float $special
- * @param float $factor
- * @param float $offset
- * @return float|int
  * @since ZC v1.2.0d
  */
-function zen_get_attributes_price_factor($price, $special, $factor, $offset)
+function zen_get_attributes_price_factor(float $price, float|false $special, float $factor, float $offset): float|int
 {
     if (defined('ATTRIBUTES_PRICE_FACTOR_FROM_SPECIAL') && ATTRIBUTES_PRICE_FACTOR_FROM_SPECIAL == 1 && $special) {
         // calculate from specials_new_products_price
-        $calculated_price = $special * ($factor - $offset);
-    } else {
-        // calculate from products_price
-        $calculated_price = $price * ($factor - $offset);
+        return $calculated_price = $special * ($factor - $offset);
     }
-    return $calculated_price;
+
+    // calculate from products_price
+    return $price * ($factor - $offset);
 }
 
 /**

--- a/not_for_release/testFramework/Unit/testsAdminNotifications/AdminNotificationsTest.php
+++ b/not_for_release/testFramework/Unit/testsAdminNotifications/AdminNotificationsTest.php
@@ -91,55 +91,55 @@ class AdminNotificationsTest extends zcUnitTestCase
     }
 
 
-    public function testBasicMock()
+    public function testBasicMock(): void
     {
         $r = $this->an->getNotifications('', 1);
         // no store country will be set as we are not mocking it so result will only return
         // notifications with no countries.
-        $this->assertTrue(count($r) == 0);
+        $this->assertEmpty($r);
     }
 
-    public function testWithSimpleLocationNoCountry()
+    public function testWithSimpleLocationNoCountry(): void
     {
         $r = $this->an->getNotifications('payment', 1);
         // no store country will be set as we are not mocking it so result will only return
         // notifications with no countries.
-        $this->assertTrue(count($r) == 1);
+        $this->assertCount(1, $r);
     }
 
-    public function testWithSimpleLocationWithCountry()
+    public function testWithSimpleLocationWithCountry(): void
     {
         $this->an->method('getStoreCountryIso3')->willReturn('USA');
         $this->an->method('getCurrentDate')->willReturn(new DateTime("now"));
         $r = $this->an->getNotifications('payment', 1);
-        $this->assertTrue(count($r) == 5);
+        $this->assertCount(5, $r);
     }
 
-    public function testWithComplexLocationWithCountry()
+    public function testWithComplexLocationWithCountry(): void
     {
         $this->an->method('getStoreCountryIso3')->willReturn('USA');
         $this->an->method('getCurrentDate')->willReturn(new DateTime("now"));
 
         $r = $this->an->getNotifications('payment-square', 1);
 
-        $this->assertTrue(count($r) == 1);
+        $this->assertCount(1, $r);
     }
 
-    public function testWithDateYesterday()
+    public function testWithDateYesterday(): void
     {
-        $datetime = (new DateTime())->sub(new DateInterval('P1D'));
+        $yesterday = (new DateTime())->sub(new DateInterval('P1D'));
         $this->an->method('getStoreCountryIso3')->willReturn('USA');
-        $this->an->method('getCurrentDate')->willReturn($datetime);
+        $this->an->method('getCurrentDate')->willReturn($yesterday);
         $r = $this->an->getNotifications('payment', 1);
-        $this->assertTrue(count($r) == 6);
+        $this->assertCount(6, $r);
     }
 
-    public function testWithDateTomorrow()
+    public function testWithDateTomorrow(): void
     {
-        $datetime = (new DateTime())->add(new DateInterval('P1D'));
+        $tomorrow = (new DateTime())->add(new DateInterval('P1D'));
         $this->an->method('getStoreCountryIso3')->willReturn('USA');
-        $this->an->method('getCurrentDate')->willReturn($datetime);
+        $this->an->method('getCurrentDate')->willReturn($tomorrow);
         $r = $this->an->getNotifications('payment', 1);
-        $this->assertTrue(count($r) == 4);
+        $this->assertCount(4, $r);
     }
 }

--- a/zc_cli.php
+++ b/zc_cli.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * Zen Cart console entry point.
  *
@@ -21,9 +23,7 @@ $pluginDiscovery = new \Zencart\Console\PluginCommandDiscovery(
     $psr4Autoloader,
     $trustedPluginContext['plugins']
 );
-$pluginListProvider = static function () use ($pluginRepositoryContext): ?array {
-    return $pluginRepositoryContext['repository']?->getAll();
-};
+$pluginListProvider = static fn(): ?array => $pluginRepositoryContext['repository']?->getAll();
 $versionProvider = static function () use ($dbContext): array {
     if ($dbContext['db'] === null) {
         return [];


### PR DESCRIPTION
This is a first round of reformatting.
- PSR-12
- alias functions renamed
- strict-types
- short-echo

Only touching classes and a couple function files in this round.

(files that combine a lot of HTML+PHP intermingled are much harder to reformat programmatically, which means templates and admin files are the most challenging ... they're lower on the priority list for that reason)

In this pull, probably the biggest risk is having added a lot of types to the shopping_cart class.