### PR TITLE
Admin split_pages_results; $query_num_rows initially null

### DIFF
--- a/admin/includes/classes/split_page_results.php
+++ b/admin/includes/classes/split_page_results.php
@@ -54,7 +54,7 @@ class splitPageResults
      * @param string $letterGroupColumn column name to build letter-nav from (optional)
      * @param int $letterGroupLength number of characters to sort/filter on for letterGroupColumn
      */
-    public function __construct(int|string &$current_page_number, int $max_rows_per_page, string &$sql_query, int &$query_num_rows, string $letterGroupColumn = '', int $letterGroupLength = 0)
+    public function __construct(int|string &$current_page_number, int $max_rows_per_page, string &$sql_query, ?int &$query_num_rows, string $letterGroupColumn = '', int $letterGroupLength = 0)
     {
         global $db;
 


### PR DESCRIPTION
... so I'm seeing logs like the following when viewing an admin product listing
```
[13-Jun-2026 08:22:55 America/New_York] PHP Fatal error:  Uncaught TypeError: splitPageResults::__construct(): Argument #4 ($query_num_rows) must be of type int, null given, called in C:\xampp\htdocs\zc300\admin\category_product_listing.php on line 951 and defined in C:\xampp\htdocs\zc300\admin\includes\classes\split_page_results.php:57
Stack trace:
#0 C:\xampp\htdocs\zc300\admin\category_product_listing.php(951): splitPageResults->__construct(1, 5, 'SELECT DISTINCT...', NULL)
#1 C:\xampp\htdocs\zc300\admin\index.php(16): require('C:\\xampp\\htdocs...')
#2 {main}
  thrown in C:\xampp\htdocs\zc300\admin\includes\classes\split_page_results.php on line 57

[13-Jun-2026 08:22:55 America/New_York] Request URI: /zc300/admin/index.php?cmd=category_product_listing&cPath=2_18, IP address: 127.0.0.1
--> PHP Fatal error: Uncaught TypeError: splitPageResults::__construct(): Argument #4 ($query_num_rows) must be of type int, null given, called in C:\xampp\htdocs\zc300\admin\category_product_listing.php on line 951 and defined in C:\xampp\htdocs\zc300\admin\includes\classes\split_page_results.php:57
Stack trace:
#0 C:\xampp\htdocs\zc300\admin\category_product_listing.php(951): splitPageResults->__construct(1, 5, 'SELECT DISTINCT...', NULL)
#1 C:\xampp\htdocs\zc300\admin\index.php(16): require('C:\\xampp\\htdocs...')
#2 {main}
  thrown in C:\xampp\htdocs\zc300\admin\includes\classes\split_page_results.php on line 57.

[13-Jun-2026 08:22:55 America/New_York] Request URI: /zc300/admin/index.php?cmd=category_product_listing&cPath=2_18, IP address: 127.0.0.1
--> PHP Fatal error: Uncaught TypeError: splitPageResults::__construct(): Argument #4 ($query_num_rows) must be of type int, null given, called in C:\xampp\htdocs\zc300\admin\category_product_listing.php on line 951 and defined in C:\xampp\htdocs\zc300\admin\includes\classes\split_page_results.php:57
Stack trace:
#0 C:\xampp\htdocs\zc300\admin\category_product_listing.php(951): splitPageResults->__construct(1, 5, 'SELECT DISTINCT...', NULL)
#1 C:\xampp\htdocs\zc300\admin\index.php(16): require('C:\\xampp\\htdocs...')
#2 {main}
  thrown in C:\xampp\htdocs\zc300\admin\includes\classes\split_page_results.php on line 57.
```