### PR TITLE
Add `null` type-hint to split_page_results constructor

### DIFF
--- a/admin/includes/classes/split_page_results.php
+++ b/admin/includes/classes/split_page_results.php
@@ -54,7 +54,7 @@ class splitPageResults
      * @param string $letterGroupColumn column name to build letter-nav from (optional)
      * @param int $letterGroupLength number of characters to sort/filter on for letterGroupColumn
      */
-    public function __construct(int|string &$current_page_number, int $max_rows_per_page, string &$sql_query, ?int &$query_num_rows, string $letterGroupColumn = '', int $letterGroupLength = 0)
+    public function __construct(int|string|null &$current_page_number, int $max_rows_per_page, string &$sql_query, ?int &$query_num_rows, string $letterGroupColumn = '', int $letterGroupLength = 0)
     {
         global $db;
 


### PR DESCRIPTION
I'm seeing failure-to-load on paged admin pages, with logs similar to
```
[14-Jun-2026 12:51:49 America/New_York] PHP Fatal error:  Uncaught TypeError: splitPageResults::display_count(): Argument #3 ($current_page_number) must be of type string|int, null given, called in C:\xampp\htdocs\zc300\admin\gv_queue.php on line 186 and defined in C:\xampp\htdocs\zc300\admin\includes\classes\split_page_results.php:338
Stack trace:
#0 C:\xampp\htdocs\zc300\admin\gv_queue.php(186): splitPageResults->display_count(1, 10, NULL, 'Displaying <b>%...')
#1 C:\xampp\htdocs\zc300\admin\index.php(16): require('C:\\xampp\\htdocs...')
#2 {main}
  thrown in C:\xampp\htdocs\zc300\admin\includes\classes\split_page_results.php on line 338
```