### PR TITLE
Ignore numeric language 'keys' to prevent whitepage

### DIFF
--- a/includes/classes/ResourceLoaders/ArraysLanguageLoader.php
+++ b/includes/classes/ResourceLoaders/ArraysLanguageLoader.php
@@ -30,6 +30,16 @@ class ArraysLanguageLoader extends BaseLanguageLoader
 
         $constants_made = false;
         foreach ($defines as $defineKey => $defineValue) {
+            // -----
+            // If the language-constant 'key' isn't a string, there's some problem
+            // with a loaded language file. Any non-string key is, thus, ignored
+            // here so that the code associated with the language file will error-out
+            // with an undefined-constant error rather than a hard-stop here.
+            //
+            if (!is_string($defineKey)) {
+                continue;
+            }
+
             if (defined($defineKey)) {
                 $constants_made = true;
                 continue;


### PR DESCRIPTION
There was an issue with one of my plugins where a language-constant entry was coded as
```php
    'VALUE', 'something',
```
that is, missing the ` => ` for the array-based definition.

That resulted in a storefront whitepage with the following error that took **FOREVER** to isolate. The array-loader is updated via this PR so that it will ignore any non-string 'key' values, letting the code associated with the errant language file attempt to use that constant and receive a 'undefined-constant' error.
```
[14-Jun-2026 08:36:31 America/New_York] Request URI: /zc300/index.php?main_page=index&cPath=22, IP address: 127.0.0.1
--> PHP Fatal error: Uncaught TypeError: defined(): Argument #1 ($constant_name) must be of type string, int given in C:\xampp\htdocs\zc300\includes\classes\ResourceLoaders\ArraysLanguageLoader.php:33
Stack trace:
#0 C:\xampp\htdocs\zc300\includes\classes\ResourceLoaders\ArraysLanguageLoader.php(33): defined(0)
#1 C:\xampp\htdocs\zc300\includes\classes\ResourceLoaders\LanguageLoader.php(41): Zencart\LanguageLoader\ArraysLanguageLoader->makeConstants(Array)
#2 C:\xampp\htdocs\zc300\includes\init_includes\init_templates.php(110): Zencart\LanguageLoader\LanguageLoader->finalizeLanguageDefines()
#3 C:\xampp\htdocs\zc300\includes\autoload_func.php(40): require_once('C:\\xampp\\htdocs...')
#4 C:\xampp\htdocs\zc300\includes\application_top.php(418): require('C:\\xampp\\htdocs...')
#5 C:\xampp\htdocs\zc300\index.php(27): require('C:\\xampp\\htdocs...')
#6 {main}
  thrown in C:\xampp\htdocs\zc300\includes\classes\ResourceLoaders\ArraysLanguageLoader.php on line 33.
```