### PR TITLE
`zen_ez_pages_link` is a storefront-only function; error thrown if admin usage is attempted

### DIFF
--- a/includes/functions/functions_ezpages.php
+++ b/includes/functions/functions_ezpages.php
@@ -8,55 +8,56 @@
  * @version $Id: DrByte 2025 Sep 18 Modified in v2.2.0 $
  */
 
-
 /**
- * look up page_id and create link for ez_pages
+ * look up page_id and create a storefront link for ez_pages
  * to use this link add '\<a href="' . zen_ez_pages_link($pages_id) . '">\</a>';
+ *
+ * Note that the $ez_pages_is_ssl input is no longer used, but is kept for backwards compatibility.
+ *
  * @since ZC v1.3.0
  */
-  function zen_ez_pages_link($ez_pages_id, $ez_pages_chapter = 0, $ez_pages_is_ssl = true, $ez_pages_open_new_window = false, $ez_pages_return_full_url = false) {
+function zen_ez_pages_link(
+    int|string $ez_pages_id,
+    int|string $ez_pages_chapter = 0,
+    bool $ez_pages_is_ssl = true,
+    bool $ez_pages_open_new_window = false,
+    bool $ez_pages_return_full_url = false
+): string {
     global $db;
     $ez_link = 'unknown';
     $ez_pages_name = 'Click Here';
 
-    if ($ez_pages_chapter == 0) {
-      $page_query = $db->Execute("SELECT * FROM " . TABLE_EZPAGES . " e, " . TABLE_EZPAGES_CONTENT . " ec WHERE e.pages_id = ec.pages_id AND ec.languages_id = " . (int)$_SESSION['languages_id'] . " AND e.pages_id='" . (int)$ez_pages_id . "' limit 1");
+    if ((int)$ez_pages_chapter === 0) {
+        $function_zen_href_link = (IS_ADMIN_FLAG === true) ? 'zen_catalog_href_link' : 'zen_href_link';
+        $page_query = $db->Execute(
+            "SELECT *
+               FROM " . TABLE_EZPAGES . " e, " . TABLE_EZPAGES_CONTENT . " ec
+              WHERE e.pages_id = ec.pages_id
+                AND ec.languages_id = " . (int)$_SESSION['languages_id'] . "
+                AND e.pages_id = " . (int)$ez_pages_id . "
+              LIMIT 1"
+        );
 
-      $ez_pages_id = $page_query->fields['pages_id'];
-      $ez_pages_name = $page_query->fields['pages_title'];
-      $ez_pages_alturl = $page_query->fields['alt_url'];
-      $ez_pages_chapter = $page_query->fields['toc_chapter'];
-      $ez_pages_linkto = "";
-      $ez_pages_external = $page_query->fields['alt_url_external'];
-      switch (true) {
-        // external link new window or same window
-        case ($ez_pages_external != ''):
-          $ez_pages_linkto  = $ez_pages_external;
-          break;
-          // internal link new window
-        case ($ez_pages_alturl != '' and $ez_pages_open_new_window == '1'):
-          $ez_pages_linkto  = (substr($ez_pages_alturl,0,4) == 'http') ?
-                              $ez_pages_alturl :
-                              ($ez_pages_alturl=='' ? '' : zen_href_link($ez_pages_alturl, '', 'SSL', true, true, true));
-          break;
-          // internal link same window
-        case ($ez_pages_alturl != '' and $ez_pages_open_new_window == '0'):
-          $ez_pages_linkto  = (substr($ez_pages_alturl,0,4) == 'http') ?
-                              $ez_pages_alturl :
-                              ($ez_pages_alturl=='' ? '' : zen_href_link($ez_pages_alturl, '', 'SSL', true, true, true));
-          break;
-      }
+        $ez_pages_name = $page_query->fields['pages_title'];
+        $ez_pages_alturl = $page_query->fields['alt_url'];
+        $ez_pages_chapter = $page_query->fields['toc_chapter'];
+        $ez_pages_external = $page_query->fields['alt_url_external'];
 
-      // if altURL is specified, use it; otherwise, use EZPage ID to create link
-      $ez_link = ($ez_pages_linkto =='') ?
-        zen_href_link(FILENAME_EZPAGES, 'id=' . $ez_pages_id . ((int)$ez_pages_chapter != 0 ? '&chapter=' . $ez_pages_chapter : ''), 'SSL') :
-        $ez_pages_linkto;
-      $ez_link .= ($ez_pages_open_new_window == '1' ? '" rel="noopener" target="_blank' : '');
+        $ez_link = '';
+        if ($ez_pages_external !== '') {
+            $ez_link = $ez_pages_external;
+        } elseif ($ez_pages_alturl !== '') {
+            $ez_link = (str_starts_with($ez_pages_alturl, 'http')) ? $ez_pages_alturl : $function_zen_href_link($ez_pages_alturl);
+        } else {
+            $ez_link = $function_zen_href_link(FILENAME_EZPAGES, 'id=' . $ez_pages_id . ((int)$ez_pages_chapter !== 0 ? '&chapter=' . $ez_pages_chapter : ''));
+        }
+
+        $ez_link .= ($ez_pages_open_new_window === '1' ? '" rel="noopener" target="_blank' : '');
     }
 
-    if ($ez_pages_return_full_url == false) {
-      return $ez_link;
+    if ($ez_pages_return_full_url === false) {
+        return $ez_link;
     } else {
-      return '<a href="' . $ez_link . '">' . $ez_pages_name . '</a>';
+        return '<a href="' . $ez_link . '">' . zen_output_string_protected($ez_pages_name) . '</a>';
     }
-  }
+}

--- a/includes/functions/functions_ezpages.php
+++ b/includes/functions/functions_ezpages.php
@@ -58,10 +58,10 @@ function zen_ez_pages_link(
         } elseif ($ez_pages_alturl !== '') {
             $ez_link = (str_starts_with($ez_pages_alturl, 'http')) ? $ez_pages_alturl : zen_href_link($ez_pages_alturl, '', 'SSL', true, true, true);
         } else {
-            $ez_link = zen_href_link(FILENAME_EZPAGES, 'id=' . $ez_pages_id . ((int)$ez_pages_chapter !== 0 ? '&chapter=' . $ez_pages_chapter : ''));
+            $ez_link = zen_href_link(FILENAME_EZPAGES, 'id=' . (int)$ez_pages_id . ((int)$ez_pages_chapter !== 0 ? '&chapter=' . (int)$ez_pages_chapter : ''));
         }
 
-        $ez_link .= ($ez_pages_open_new_window === '1' ? '" rel="noopener" target="_blank' : '');
+        $ez_link .= ($ez_pages_open_new_window === true ? '" rel="noopener" target="_blank' : '');
     }
 
     if ($ez_pages_return_full_url === false) {

--- a/includes/functions/functions_ezpages.php
+++ b/includes/functions/functions_ezpages.php
@@ -12,7 +12,9 @@
  * look up page_id and create a storefront link for ez_pages
  * to use this link add '\<a href="' . zen_ez_pages_link($pages_id) . '">\</a>';
  *
- * Note that the $ez_pages_is_ssl input is no longer used, but is kept for backwards compatibility.
+ * Note:
+ *   - The $ez_pages_is_ssl input is no longer used, but is kept for backwards compatibility.
+ *   - The function is valid **only** on the storefront; use in the admin will result in a FATAL error.
  *
  * @since ZC v1.3.0
  */
@@ -23,12 +25,19 @@ function zen_ez_pages_link(
     bool $ez_pages_open_new_window = false,
     bool $ez_pages_return_full_url = false
 ): string {
+    // -----
+    // Function is only available on the storefront.
+    //
+    if (IS_ADMIN_FLAG !== false) {
+        trigger_error("FATAL ERROR: zen_ez_pages_link is a storefront-only function.", \E_USER_WARNING);
+        zen_exit();
+    }
+
     global $db;
     $ez_link = 'unknown';
     $ez_pages_name = 'Click Here';
 
     if ((int)$ez_pages_chapter === 0) {
-        $function_zen_href_link = (IS_ADMIN_FLAG === true) ? 'zen_catalog_href_link' : 'zen_href_link';
         $page_query = $db->Execute(
             "SELECT *
                FROM " . TABLE_EZPAGES . " e, " . TABLE_EZPAGES_CONTENT . " ec
@@ -47,9 +56,9 @@ function zen_ez_pages_link(
         if ($ez_pages_external !== '') {
             $ez_link = $ez_pages_external;
         } elseif ($ez_pages_alturl !== '') {
-            $ez_link = (str_starts_with($ez_pages_alturl, 'http')) ? $ez_pages_alturl : $function_zen_href_link($ez_pages_alturl);
+            $ez_link = (str_starts_with($ez_pages_alturl, 'http')) ? $ez_pages_alturl : zen_href_link($ez_pages_alturl, '', 'SSL', true, true, true);
         } else {
-            $ez_link = $function_zen_href_link(FILENAME_EZPAGES, 'id=' . $ez_pages_id . ((int)$ez_pages_chapter !== 0 ? '&chapter=' . $ez_pages_chapter : ''));
+            $ez_link = zen_href_link(FILENAME_EZPAGES, 'id=' . $ez_pages_id . ((int)$ez_pages_chapter !== 0 ? '&chapter=' . $ez_pages_chapter : ''));
         }
 
         $ez_link .= ($ez_pages_open_new_window === '1' ? '" rel="noopener" target="_blank' : '');


### PR DESCRIPTION
Fixes #7814 ... and

- Provides PSR12 styling
- Adds input/output type-hints
- Simplifies external/alturl handling
- Uses a variable function-name so that admin accesses use `zen_catalog_href_link` while storefront accesses use `zen_href_link`