### PR TITLE
ot_gv: Validate submitted amount

### DIFF
--- a/includes/languages/english/modules/order_total/lang.ot_gv.php
+++ b/includes/languages/english/modules/order_total/lang.ot_gv.php
@@ -5,6 +5,7 @@ $define = [
     'MODULE_ORDER_TOTAL_GV_USER_PROMPT' => 'Apply Amount: ',
     'MODULE_ORDER_TOTAL_GV_TEXT_ENTER_CODE' => TEXT_GV_REDEEM,
     'TEXT_INVALID_REDEEM_AMOUNT' => 'It appears that the amount you have tried to apply and your Gift Certificate balance do not match. Please try again.',
+    'MODULE_ORDER_TOTAL_GV_INVALID_REDEEM_AMOUNT' => 'The Gift Certificate amount applied (%s) cannot be used. Enter a value that includes only numbers 0-9 and a decimal separator, either a dot (.) or a comma (,).',
     'MODULE_ORDER_TOTAL_GV_USER_BALANCE' => 'Available balance: ',
     'MODULE_ORDER_TOTAL_GV_REDEEM_INSTRUCTIONS' => '<p>To use Gift Certificate funds already in your account, type the amount you wish to apply in the box that says \'Apply Amount\'. You will need to choose a payment method,  then click the continue button to apply the funds to your shopping cart.</p><p>If you are redeeming a <em>new</em> Gift Certificate you should type the number into the box next to Redemption Code. The amount redeemed will be added to your account when you click the continue button.</p>',
     'MODULE_ORDER_TOTAL_GV_INCLUDE_ERROR' => ' Setting Include tax = true, should only happen when recalculate = None',

--- a/includes/modules/order_total/ot_gv.php
+++ b/includes/modules/order_total/ot_gv.php
@@ -17,15 +17,11 @@ class ot_gv
     /**
      * $_check is used to check that configuration keys are set up
      */
-    protected int $_check = 0;
+    protected int $_check;
     /**
      * $calculate_tax determines how tax should be applied to coupon Standard, Credit Note, None
      */
     protected string $calculate_tax;
-    /**
-     * $checkbox is the output to request the amount of gift vouchers the user wants to redeem
-     */
-    protected string $checkbox = '';
     /**
      * $code determines the internal 'code' name used to designate "this" order total module
      */
@@ -98,19 +94,6 @@ class ot_gv
 
         if (!(isset($_SESSION['cot_gv']) && !empty(ltrim($_SESSION['cot_gv'], ' 0'))) || $_SESSION['cot_gv'] == '0') {
             $_SESSION['cot_gv'] = '0.00';
-        }
-
-        if (IS_ADMIN_FLAG !== true && zen_is_logged_in() && !zen_in_guest_checkout()) {
-            $cot_gv = number_format($currencies->normalizeValue($_SESSION['cot_gv']), 2);
-            $gv_account_balance = $this->user_has_gv_account($_SESSION['customer_id']);
-            $this->checkbox =
-                MODULE_ORDER_TOTAL_GV_USER_PROMPT .
-                '<input type="text" size="6" onkeyup="submitFunction()" name="cot_gv" value="' . $cot_gv . '" onfocus="if (this.value == \'' . $cot_gv . '\') this.value = \'\';">' .
-                (
-                    $gv_account_balance > 0
-                    ? '<br>' . MODULE_ORDER_TOTAL_GV_USER_BALANCE . $currencies->format($gv_account_balance)
-                    : ''
-                );
         }
 
         $this->output = [];
@@ -210,12 +193,22 @@ class ot_gv
      * if customer has a GV balance, then we display the input field to allow entry of desired GV redemption amount
      * @since ZC v1.0.3
      */
-    public function use_credit_amount(): string
+    protected function use_credit_amount(): string
     {
-        if ($this->user_has_gv_account($_SESSION['customer_id'])) {
-            return $this->checkbox;
+        if (IS_ADMIN_FLAG === true || !zen_is_logged_in() || zen_in_guest_checkout() || !$this->user_has_gv_account($_SESSION['customer_id'])) {
+            return '';
         }
-        return '';
+
+        global $currencies;
+        $cot_gv = number_format($currencies->normalizeValue($_SESSION['cot_gv']), 2);
+        $gv_account_balance = $this->user_has_gv_account($_SESSION['customer_id']);
+        $checkbox =
+            MODULE_ORDER_TOTAL_GV_USER_PROMPT .
+            '<input type="text" size="6" onkeyup="submitFunction()" name="cot_gv" value="' . $cot_gv . '" onfocus="if (this.value == \'' . $cot_gv . '\') this.value = \'\';">';
+        if ($gv_account_balance > 0) {
+            $checkbox .= '<br>' . MODULE_ORDER_TOTAL_GV_USER_BALANCE . $currencies->format($gv_account_balance);
+        }
+        return $checkbox;
     }
 
     /**
@@ -302,7 +295,7 @@ class ot_gv
         $selection = [];
         $gv_query = $db->Execute("SELECT coupon_id FROM " . TABLE_COUPONS . " WHERE coupon_type = 'G' AND coupon_active = 'Y' LIMIT 1");
         // checks to see if any GVs are in the system and active or if the current customer has any GV balance
-        if (!$gv_query->EOF || $this->use_credit_amount()) {
+        if (!$gv_query->EOF || $this->use_credit_amount() !== '') {
             $selection = [
                 'id' => $this->code,
                 'module' => $this->title,
@@ -349,11 +342,26 @@ class ot_gv
 
     /**
      * Check to see if redemption code has been entered and redeem if valid
+     *
+     * NOTE: The order_total class' collect_posts method has already captured the
+     * contents of $_POST['cot_gv'] into $_SESSION['cot_gv'].
+     *
      * @since ZC v1.0.3
      */
     public function collect_posts(): void
     {
         global $db, $currencies, $messageStack;
+
+        // -----
+        // Check that any 'cot_gv' amount submitted is a valid numeric
+        // string. If not, reset the value, set a message and return to
+        // the checkout_payment phase.
+        //
+        if (isset($_SESSION['cot_gv']) && !preg_match('/^\d+[\.,]?\d*$/', $_SESSION['cot_gv'])) {
+            $messageStack->add_session('checkout_payment', sprintf(MODULE_ORDER_TOTAL_GV_INVALID_REDEEM_AMOUNT, zen_output_string_protected($_SESSION['cot_gv'])), 'error');
+            $_SESSION['cot_gv'] = '0';
+            zen_redirect(zen_href_link(FILENAME_CHECKOUT_PAYMENT));
+        }
 
         // if we have no GV amount selected, set it to 0
         // if requested redemption amount is greater than value of credits on account, throw error
@@ -446,7 +454,7 @@ class ot_gv
 
         // calculate value based on default currency
         $gv_payment_amount = $currencies->normalizeValue($_SESSION['cot_gv']);
-        $gv_payment_amount = $currencies->value($gv_payment_amount, true, DEFAULT_CURRENCY);
+        $gv_payment_amount = $currencies->value($gv_payment_amount, true, zen_config('DEFAULT_CURRENCY'));
         $full_cost = $save_total_cost - $gv_payment_amount;
         if ($full_cost < 0) {
             $gv_payment_amount = $save_total_cost;
@@ -657,7 +665,7 @@ class ot_gv
         global $db;
         if (!isset($this->_check)) {
             $check_query = $db->Execute("SELECT configuration_value FROM " . TABLE_CONFIGURATION . " WHERE configuration_key = 'MODULE_ORDER_TOTAL_GV_STATUS'");
-            $this->_check = $check_query->RecordCount();
+            $this->_check = (int)$check_query->RecordCount();
         }
 
         if ($this->_check) {

--- a/includes/modules/order_total/ot_gv.php
+++ b/includes/modules/order_total/ot_gv.php
@@ -92,8 +92,8 @@ class ot_gv
 
         $this->credit_class = true;
 
-        if (!(isset($_SESSION['cot_gv']) && !empty(ltrim($_SESSION['cot_gv'], ' 0'))) || $_SESSION['cot_gv'] == '0') {
-            $_SESSION['cot_gv'] = '0.00';
+        if (!isset($_SESSION['cot_gv']) || !is_string($_SESSION['cot_gv']) || empty(ltrim($_SESSION['cot_gv'], ' 0')) || $_SESSION['cot_gv'] === '0.00') {
+            $_SESSION['cot_gv'] = '0';
         }
 
         $this->output = [];
@@ -113,34 +113,36 @@ class ot_gv
     {
         global $order, $currencies;
 
-        if (!empty($_SESSION['cot_gv'])) {
-            $order_total_details = $this->get_order_total_details();
-            $od_amount = $this->calculate_deductions($order_total_details);
-            $this->deduction = $od_amount['total'];
-            if ($od_amount['total'] > 0) {
-                $tax = 0;
-                foreach ($order->info['tax_groups'] as $key => $value) {
-                    if (isset($od_amount['tax_groups'][$key])) {
-                        $order->info['tax_groups'][$key] -= $od_amount['tax_groups'][$key];
-                        $tax += $od_amount['tax_groups'][$key];
-                    }
+        if (empty($_SESSION['cot_gv'])) {
+            return;
+        }
+
+        $order_total_details = $this->get_order_total_details();
+        $od_amount = $this->calculate_deductions($order_total_details);
+        $this->deduction = $od_amount['total'];
+        if ($od_amount['total'] > 0) {
+            $tax = 0;
+            foreach ($order->info['tax_groups'] as $key => $value) {
+                if (isset($od_amount['tax_groups'][$key])) {
+                    $order->info['tax_groups'][$key] -= $od_amount['tax_groups'][$key];
+                    $tax += $od_amount['tax_groups'][$key];
                 }
-                $order->info['total'] -= $od_amount['total'];
-                if ($this->calculate_tax === 'Standard') {
-                    $order->info['total'] -= $tax;
-                }
-                if ($order->info['total'] < 0) {
-                    $order->info['total'] = 0;
-                }
-                $order->info['tax'] -= $od_amount['tax'];
-                // prepare order-total output for display and storing to invoice
-                $this->output[] = [
-                    'title' => $this->title . ':',
-                    // &#8209; is a non-break-hyphen so displays with number
-                    'text' => '&#8209;' . $currencies->format($od_amount['total']),
-                    'value' => $od_amount['total'],
-                ];
             }
+            $order->info['total'] -= $od_amount['total'];
+            if ($this->calculate_tax === 'Standard') {
+                $order->info['total'] -= $tax;
+            }
+            if ($order->info['total'] < 0) {
+                $order->info['total'] = 0;
+            }
+            $order->info['tax'] -= $od_amount['tax'];
+            // prepare order-total output for display and storing to invoice
+            $this->output[] = [
+                'title' => $this->title . ':',
+                // &#8209; is a non-break-hyphen so displays with number
+                'text' => '&#8209;' . $currencies->format($od_amount['total']),
+                'value' => $od_amount['total'],
+            ];
         }
     }
 
@@ -152,41 +154,34 @@ class ot_gv
     {
         unset($_SESSION['cot_gv']);
     }
-
+    
     /**
-     * Check for validity of redemption amounts and recalculate order totals to include proposed GV redemption deductions
-     *
-     * @TODO - Per order_total class, this function is not used. See process() instead.
-     * @since ZC v1.0.3
+     * Validate current $_SESSION['cot_gv'] value, redirecting to the
+     * checkout payment phase if an issue is detected. If the value **is**
+     * valid, return the session value with any ',' changed to a '.'
+     * so that the value is a valid numeric string.
      */
-    public function pre_confirmation_check($order_total): int|float
+    protected function getGvAmount(): string
     {
-        global $order, $currencies, $messageStack;
+        // -----
+        // Ensure that the session variable is set.
+        //
+        $_SESSION['cot_gv'] ??= '0';
+        $_SESSION['cot_gv'] = (string)$_SESSION['cot_gv'];
 
-        // clean out negative values and strip common currency symbols
-        $_SESSION['cot_gv'] = preg_replace('/[^0-9.,%]/', '', $_SESSION['cot_gv']);
-
-        if ($_SESSION['cot_gv'] > 0) {
-            // if cot_gv value contains any invalid characters, throw error
-            if (preg_match('/[^0-9\,.]/', trim($_SESSION['cot_gv']))) {
-                $messageStack->add_session('checkout_payment', TEXT_INVALID_REDEEM_AMOUNT, 'error');
-                zen_redirect(zen_href_link(FILENAME_CHECKOUT_PAYMENT, '', 'SSL'));
-            }
-
-            // if requested redemption amount is greater than value of credits on account, throw error
-            if ($_SESSION['cot_gv'] > $currencies->value($this->user_has_gv_account($_SESSION['customer_id']))) {
-                $messageStack->add_session('checkout_payment', TEXT_INVALID_REDEEM_AMOUNT, 'error');
-                zen_redirect(zen_href_link(FILENAME_CHECKOUT_PAYMENT, '', 'SSL'));
-            }
-
-            $od_amount = $this->calculate_deductions($this->get_order_total_details());
-            $order->info['total'] = $order->info['total'] - $od_amount['total'];
-            if (zen_config('DISPLAY_PRICE_WITH_TAX') !== 'true') {
-                $order->info['total'] -= $od_amount['tax'];
-            }
-            return $od_amount['total'] + $od_amount['tax'];
+        // -----
+        // Check that the session's 'cot_gv' value is a valid numeric
+        // string. If not, reset the value, set a message and return to
+        // the specified page.
+        //
+        if (!preg_match('/^\d+[\.,]?\d*$/', $_SESSION['cot_gv'])) {
+            global $messageStack;
+            $messageStack->add_session('checkout_payment', sprintf(MODULE_ORDER_TOTAL_GV_INVALID_REDEEM_AMOUNT, zen_output_string_protected($_SESSION['cot_gv'])), 'error');
+            $_SESSION['cot_gv'] = '0';
+            zen_redirect(zen_href_link(FILENAME_CHECKOUT_PAYMENT));
         }
-        return 0;
+
+        return str_replace(',', '.', $_SESSION['cot_gv']);
     }
 
     /**
@@ -200,7 +195,7 @@ class ot_gv
         }
 
         global $currencies;
-        $cot_gv = number_format($currencies->normalizeValue($_SESSION['cot_gv']), 2);
+        $cot_gv = number_format($currencies->normalizeValue($this->getGvAmount()), 2);
         $gv_account_balance = $this->user_has_gv_account($_SESSION['customer_id']);
         $checkbox =
             MODULE_ORDER_TOTAL_GV_USER_PROMPT .
@@ -324,7 +319,7 @@ class ot_gv
         $gv_payment_amount = 0;
         // check for valid redemption amount vs available credit for current customer
         if (!empty($_SESSION['cot_gv'])) {
-            $gv_result = $db->Execute("SELECT amount FROM " . TABLE_COUPON_GV_CUSTOMER . " WHERE customer_id = " . (int)$_SESSION['customer_id']);
+            $gv_result = $db->Execute("SELECT amount FROM " . TABLE_COUPON_GV_CUSTOMER . " WHERE customer_id = " . (int)$_SESSION['customer_id'], 1);
             // obtain final "deduction" amount
             $gv_payment_amount = $this->deduction;
             // determine amount of GV to redeem based on available balance minus qualified/calculated deduction suitable to this order
@@ -334,7 +329,7 @@ class ot_gv
         }
 
         // clear GV redemption flag since it's already been claimed and deducted
-        $_SESSION['cot_gv'] = false;
+        unset($_SESSION['cot_gv']);
 
         // send back the amount of GV used for payment on this order
         return $gv_payment_amount;
@@ -353,30 +348,26 @@ class ot_gv
         global $db, $currencies, $messageStack;
 
         // -----
-        // Check that any 'cot_gv' amount submitted is a valid numeric
-        // string. If not, reset the value, set a message and return to
-        // the checkout_payment phase.
+        // Retrieve the numeric string value associated with the session's
+        // 'cot_gv' value.  If the value's not numeric, the method will issue
+        // a message and redirect back to the checkout-payment page.
         //
-        if (isset($_SESSION['cot_gv']) && !preg_match('/^\d+[\.,]?\d*$/', $_SESSION['cot_gv'])) {
-            $messageStack->add_session('checkout_payment', sprintf(MODULE_ORDER_TOTAL_GV_INVALID_REDEEM_AMOUNT, zen_output_string_protected($_SESSION['cot_gv'])), 'error');
-            $_SESSION['cot_gv'] = '0';
-            zen_redirect(zen_href_link(FILENAME_CHECKOUT_PAYMENT));
-        }
+        $cot_gv = $this->getGvAmount();
 
         // if we have no GV amount selected, set it to 0
         // if requested redemption amount is greater than value of credits on account, throw error
-        if ($_SESSION['cot_gv'] > $currencies->value($this->user_has_gv_account($_SESSION['customer_id']))) {
-            $messageStack->add_session('checkout_payment', TEXT_INVALID_REDEEM_AMOUNT . ' - ' . number_format($_SESSION['cot_gv'], 2), 'error');
-            $_SESSION['cot_gv'] = 0.00;
-            zen_redirect(zen_href_link(FILENAME_CHECKOUT_PAYMENT, '', 'SSL'));
+        if ($cot_gv > $currencies->value($this->user_has_gv_account($_SESSION['customer_id']))) {
+            $messageStack->add_session('checkout_payment', TEXT_INVALID_REDEEM_AMOUNT . ' - ' . number_format($cot_gv, 2), 'error');
+            $_SESSION['cot_gv'] = '0';
+            zen_redirect(zen_href_link(FILENAME_CHECKOUT_PAYMENT));
         }
         if (isset($_POST['cot_gv']) && $_POST['cot_gv'] == 0) {
-            $_SESSION['cot_gv'] = '0.00';
+            $_SESSION['cot_gv'] = '0';
         }
 
         if (!empty($_POST['submit_redeem_x']) && empty($_POST['gv_redeem_code'])) {
             $messageStack->add_session('checkout_payment', ERROR_NO_REDEEM_CODE, 'error');
-            zen_redirect(zen_href_link(FILENAME_CHECKOUT_PAYMENT, '', 'SSL'));
+            zen_redirect(zen_href_link(FILENAME_CHECKOUT_PAYMENT));
         }
 
         // if we have a GV redemption code submitted, process it
@@ -390,16 +381,16 @@ class ot_gv
                     AND coupon_type = 'G'"
             );
             if (!$gv_result->EOF) {
-                $redeem_query = $db->Execute("SELECT * FROM " . TABLE_COUPON_REDEEM_TRACK . " WHERE coupon_id = '" . (int)$gv_result->fields['coupon_id'] . "'");
+                $redeem_query = $db->Execute("SELECT * FROM " . TABLE_COUPON_REDEEM_TRACK . " WHERE coupon_id = " . (int)$gv_result->fields['coupon_id'], 1);
                 // if already redeemed, throw error
                 if (!$redeem_query->EOF && $gv_result->fields['coupon_type'] === 'G') {
                     $messageStack->add_session('checkout_payment', ERROR_NO_INVALID_REDEEM_GV, 'error');
-                    zen_redirect(zen_href_link(FILENAME_CHECKOUT_PAYMENT, '', 'SSL'));
+                    zen_redirect(zen_href_link(FILENAME_CHECKOUT_PAYMENT));
                 }
             } else {
                 // if not valid redemption code, throw error
                 $messageStack->add_session('checkout_payment', ERROR_NO_INVALID_REDEEM_GV, 'error');
-                zen_redirect(zen_href_link(FILENAME_CHECKOUT_PAYMENT, '', 'SSL'));
+                zen_redirect(zen_href_link(FILENAME_CHECKOUT_PAYMENT));
             }
 
             // if valid, add redeemed amount to customer's GV balance and mark as redeemed
@@ -452,8 +443,15 @@ class ot_gv
     {
         global $db, $order, $currencies;
 
+        // -----
+        // Retrieve the numeric string value associated with the session's
+        // 'cot_gv' value.  If the value's not numeric, the method will issue
+        // a message and redirect back to the checkout-payment page.
+        //
+        $cot_gv = $this->getGvAmount();
+
         // calculate value based on default currency
-        $gv_payment_amount = $currencies->normalizeValue($_SESSION['cot_gv']);
+        $gv_payment_amount = $currencies->normalizeValue($cot_gv);
         $gv_payment_amount = $currencies->value($gv_payment_amount, true, zen_config('DEFAULT_CURRENCY'));
         $full_cost = $save_total_cost - $gv_payment_amount;
         if ($full_cost < 0) {

--- a/includes/modules/order_total/ot_gv.php
+++ b/includes/modules/order_total/ot_gv.php
@@ -167,7 +167,7 @@ class ot_gv
         // Ensure that the session variable is set.
         //
         $_SESSION['cot_gv'] ??= '0';
-        $_SESSION['cot_gv'] = (string)$_SESSION['cot_gv'];
+        $_SESSION['cot_gv'] = trim((string)$_SESSION['cot_gv']);
 
         // -----
         // Check that the session's 'cot_gv' value is a valid numeric
@@ -190,13 +190,18 @@ class ot_gv
      */
     protected function use_credit_amount(): string
     {
-        if (IS_ADMIN_FLAG === true || !zen_is_logged_in() || zen_in_guest_checkout() || !$this->user_has_gv_account($_SESSION['customer_id'])) {
+        if (IS_ADMIN_FLAG === true || !zen_is_logged_in() || zen_in_guest_checkout()) {
+            return '';
+        }
+
+        $gv_account_balance = $this->user_has_gv_account($_SESSION['customer_id']);
+        if (!$gv_account_balance) {
             return '';
         }
 
         global $currencies;
         $cot_gv = number_format($currencies->normalizeValue($this->getGvAmount()), 2);
-        $gv_account_balance = $this->user_has_gv_account($_SESSION['customer_id']);
+
         $checkbox =
             MODULE_ORDER_TOTAL_GV_USER_PROMPT .
             '<input type="text" size="6" onkeyup="submitFunction()" name="cot_gv" value="' . $cot_gv . '" onfocus="if (this.value == \'' . $cot_gv . '\') this.value = \'\';">';


### PR DESCRIPTION
Fixes #7800

This PR
- Removes the initialization of the `$_check` method, since it's checked for `isset` (i.e. null) in the `check` method.
- Removes the `checkbox` property, since it's only used once, moving its initialization from the constructor to the (now protected) `use_credit_amount` method.
- Updates the `collect_posts` method to validate any submitted gift-certificate value, requiring that the entry be a numeric string value, possibly with one decimal separator. If the validation fails, a message is set and control returns back to the checkout's payment phase.
- Uses the `zen_config` function to determine the site's "default currency"