### PR TITLE
Invalidate sessions after password changes

### DIFF
--- a/admin/includes/functions/admin_access.php
+++ b/admin/includes/functions/admin_access.php
@@ -37,8 +37,7 @@ function zen_is_admin_password_session_valid(): bool
     $currentPasswordHash = (string)$result->fields['admin_pass'];
 
     if (empty($_SESSION['admin_password_hash'])) {
-        zen_set_admin_session_password_hash($currentPasswordHash);
-        return true;
+        return false;
     }
 
     return hash_equals((string)$_SESSION['admin_password_hash'], $currentPasswordHash);

--- a/admin/includes/functions/admin_access.php
+++ b/admin/includes/functions/admin_access.php
@@ -11,11 +11,19 @@ zen_define_default('ADMIN_LOGIN_SLAMMING_THRESHOLD', 3);
 // Do you want warning/courtesy emails to be sent after several login failures have occurred (determined by the threshold above)?
 zen_define_default('ADMIN_SWITCH_SEND_LOGIN_FAILURE_EMAILS', 'Yes');
 
+/**
+ * Store the current admin user's password hash in the session so other sessions can be invalidated
+ * @since ZC v3.0.0
+ */
 function zen_set_admin_session_password_hash(string $passwordHash): void
 {
     $_SESSION['admin_password_hash'] = $passwordHash;
 }
 
+/**
+ * Validate that the logged-in admin session still matches the admin's current password hash.
+ * @since ZC v3.0.0
+ */
 function zen_is_admin_password_session_valid(): bool
 {
     global $db;

--- a/admin/includes/functions/admin_access.php
+++ b/admin/includes/functions/admin_access.php
@@ -36,7 +36,7 @@ function zen_is_admin_password_session_valid(): bool
 
     $currentPasswordHash = (string)$result->fields['admin_pass'];
 
-    if (empty($_SESSION['admin_password_hash'])) {
+    if (!array_key_exists('admin_password_hash', $_SESSION)) {
         return false;
     }
 

--- a/admin/includes/functions/admin_access.php
+++ b/admin/includes/functions/admin_access.php
@@ -11,6 +11,39 @@ zen_define_default('ADMIN_LOGIN_SLAMMING_THRESHOLD', 3);
 // Do you want warning/courtesy emails to be sent after several login failures have occurred (determined by the threshold above)?
 zen_define_default('ADMIN_SWITCH_SEND_LOGIN_FAILURE_EMAILS', 'Yes');
 
+function zen_set_admin_session_password_hash(string $passwordHash): void
+{
+    $_SESSION['admin_password_hash'] = $passwordHash;
+}
+
+function zen_is_admin_password_session_valid(): bool
+{
+    global $db;
+
+    if (empty($_SESSION['admin_id'])) {
+        return true;
+    }
+
+    $sql = "SELECT admin_pass
+            FROM " . TABLE_ADMIN . "
+            WHERE admin_id = :adminId:";
+    $sql = $db->bindVars($sql, ':adminId:', $_SESSION['admin_id'], 'integer');
+    $result = $db->Execute($sql, 1);
+
+    if ($result->EOF) {
+        return false;
+    }
+
+    $currentPasswordHash = (string)$result->fields['admin_pass'];
+
+    if (empty($_SESSION['admin_password_hash'])) {
+        zen_set_admin_session_password_hash($currentPasswordHash);
+        return true;
+    }
+
+    return hash_equals((string)$_SESSION['admin_password_hash'], $currentPasswordHash);
+}
+
 /**
  * Checks whether the currently logged on user has permission to access
  * the page passed as parameter $page, with GET $params . The function returns boolean
@@ -476,6 +509,7 @@ function zen_validate_user_login(string $admin_name, string $admin_pass): array
         $sql = $db->bindVars($sql, ':ip:', $_SERVER['REMOTE_ADDR'], 'string');
         $db->Execute($sql);
         $_SESSION['admin_id'] = $result['admin_id'];
+        zen_set_admin_session_password_hash($token);
         if (zen_config('SESSION_RECREATE') === 'True') {
             zen_session_recreate();
         }
@@ -579,6 +613,9 @@ function zen_reset_password($id, $password, $compare): array
         $sql = $db->bindVars($sql, ':adminID:', $id, 'integer');
         $sql = $db->bindVars($sql, ':newpwd:', $encryptedPassword, 'string');
         $db->Execute($sql);
+        if (isset($_SESSION['admin_id']) && (int)$_SESSION['admin_id'] === $id) {
+            zen_set_admin_session_password_hash($encryptedPassword);
+        }
         zen_record_admin_activity('Account password change saved.', 'warning');
     }
     return $errors;

--- a/admin/includes/init_includes/init_admin_auth.php
+++ b/admin/includes/init_includes/init_admin_auth.php
@@ -14,6 +14,22 @@ if (!defined('IS_ADMIN_FLAG')) {
 
 define('SUPERUSER_PROFILE', 1);
 
+if (!empty($_SESSION['admin_id']) && !zen_is_admin_password_session_valid()) {
+    if (basename($PHP_SELF) === FILENAME_AJAX . '.php') {
+        unset($_SESSION['admin_id'], $_SESSION['admin_password_hash'], $_SESSION['mfa']);
+        $ajax_response = [
+            'error' => 'logged_out',
+            'redirect' => zen_href_link(FILENAME_LOGIN, '', 'SSL'),
+        ];
+        echo json_encode($ajax_response);
+        exit;
+    }
+
+    $_SESSION['login_message'] = ERROR_ADMIN_SESSION_INVALID_DUE_TO_PASSWORD_CHANGE;
+    unset($_SESSION['admin_id'], $_SESSION['admin_password_hash'], $_SESSION['mfa']);
+    zen_redirect(zen_href_link(FILENAME_LOGIN, '', 'SSL'));
+}
+
 // -----
 // Special handling for AJAX requests.  Return a 'logged_out' error if no admin session
 // is active; otherwise, bypass the remainder of the authorization checks.

--- a/admin/includes/init_includes/init_admin_auth.php
+++ b/admin/includes/init_includes/init_admin_auth.php
@@ -19,7 +19,7 @@ if (!empty($_SESSION['admin_id']) && !zen_is_admin_password_session_valid()) {
         unset($_SESSION['admin_id'], $_SESSION['admin_password_hash'], $_SESSION['mfa']);
         $ajax_response = [
             'error' => 'logged_out',
-            'redirect' => zen_href_link(FILENAME_LOGIN, '', 'SSL'),
+            'redirect' => zen_href_link(FILENAME_LOGIN),
         ];
         echo json_encode($ajax_response);
         exit;
@@ -27,7 +27,7 @@ if (!empty($_SESSION['admin_id']) && !zen_is_admin_password_session_valid()) {
 
     $_SESSION['login_message'] = ERROR_ADMIN_SESSION_INVALID_DUE_TO_PASSWORD_CHANGE;
     unset($_SESSION['admin_id'], $_SESSION['admin_password_hash'], $_SESSION['mfa']);
-    zen_redirect(zen_href_link(FILENAME_LOGIN, '', 'SSL'));
+    zen_redirect(zen_href_link(FILENAME_LOGIN));
 }
 
 // -----

--- a/admin/includes/languages/english/lang.login.php
+++ b/admin/includes/languages/english/lang.login.php
@@ -16,6 +16,7 @@ $define = [
     'TEXT_ADMIN_CONFIRM_PASSWORD' => 'Confirm Password',
     'ERROR_WRONG_LOGIN' => 'You entered the wrong username or password.',
     'ERROR_SECURITY_ERROR' => 'There was a security error when trying to login.',
+    'ERROR_ADMIN_SESSION_INVALID_DUE_TO_PASSWORD_CHANGE' => 'Your session has expired because your password was changed. Please login again.',
     'TEXT_PASSWORD_FORGOTTEN' => 'Forgot Password?',
     'LOGIN_EXPIRY_NOTICE' => '',
     'ERROR_PASSWORD_EXPIRED' => 'NOTE: Your password has expired. Please select a new password. Your password <strong>must contain both NUMBERS and LETTERS and minimum 7 characters.</strong>',

--- a/admin/includes/languages/lang.english.php
+++ b/admin/includes/languages/lang.english.php
@@ -223,6 +223,7 @@ $define = [
     'ENTRY_TELEPHONE_NUMBER' => 'Telephone Number:',
     'ENTRY_TELEPHONE_NUMBER_ERROR' => '&nbsp;<span class="errorText">min ' . zen_config('ENTRY_TELEPHONE_MIN_LENGTH') . ' chars</span>',
     'ERROR_ADMIN_SECURITY_WARNING' => 'Warning: Your Admin login is not secure ... either you still have default login settings for: Admin admin or have not removed or changed: demo demoonly<br>The login(s) should be changed as soon as possible for the Security of your shop.',
+    'ERROR_ADMIN_SESSION_INVALID_DUE_TO_PASSWORD_CHANGE' => 'Your session has expired because your password was changed. Please login again.',
     'ERROR_CANNOT_DELETE_CUSTOMER_GROUP_DUE_TO_LINKED_CUSTOMERS' => 'ERROR: cannot delete group because %s customers are still assigned, and override was not specified.',
     'ERROR_CANNOT_LINK_TO_SAME_CATEGORY' => 'Error: a linked product cannot be created in the same category.',
     'ERROR_CANNOT_MOVE_CATEGORY_TO_CATEGORY_SELF' => 'Error: Cannot move Category to the same Category! ID#',

--- a/admin/login.php
+++ b/admin/login.php
@@ -9,6 +9,8 @@ require 'includes/application_top.php';
 
 //////////
 $admin_name = $admin_pass = $message = "";
+$message = $_SESSION['login_message'] ?? '';
+unset($_SESSION['login_message']);
 $errors = array();
 $error = $expired = false;
 if (isset($_POST['action']) && $_POST['action'] != '') {

--- a/includes/classes/Customer.php
+++ b/includes/classes/Customer.php
@@ -380,6 +380,11 @@ class Customer extends base
         $db->Execute($sql);
     }
 
+
+    /**
+     * Retrieves the password hash for the specified customer.
+     * @since ZC v3.0.0
+     */
     protected function getPasswordHash(int $customer_id): string
     {
         global $db;

--- a/includes/classes/Customer.php
+++ b/includes/classes/Customer.php
@@ -353,6 +353,7 @@ class Customer extends base
         $_SESSION['customer_country_id'] = (int)$this->data['country_id'];
         $_SESSION['customer_zone_id'] = (int)$this->data['zone_id'];
         $_SESSION['customers_authorization'] = (int)$this->data['customers_authorization'];
+        zen_set_customer_session_password_hash((string)$this->getPasswordHash($customer_id));
 
         // @TODO - should we add $this->data to a session var, and replace numerous other lookups?
 
@@ -377,6 +378,20 @@ class Customer extends base
               WHERE customer_id = :customerID";
         $sql = $db->bindVars($sql, ':customerID', $customers_id, 'integer');
         $db->Execute($sql);
+    }
+
+    protected function getPasswordHash(int $customer_id): string
+    {
+        global $db;
+
+        $sql =
+            "SELECT customers_password
+               FROM " . TABLE_CUSTOMERS . "
+              WHERE customers_id = :customersID";
+        $sql = $db->bindVars($sql, ':customersID', $customer_id, 'integer');
+        $result = $db->Execute($sql, 1);
+
+        return $result->EOF ? '' : (string)$result->fields['customers_password'];
     }
 
     /**
@@ -1116,12 +1131,13 @@ class Customer extends base
     public function setPassword(string $new_password): void
     {
         global $db;
+        $encryptedPassword = zen_encrypt_password($new_password);
         $sql =
             "UPDATE " . TABLE_CUSTOMERS . "
                 SET customers_password = :password
               WHERE customers_id = :customersID";
         $sql = $db->bindVars($sql, ':customersID', $this->customer_id, 'integer');
-        $sql = $db->bindVars($sql, ':password', zen_encrypt_password($new_password), 'string');
+        $sql = $db->bindVars($sql, ':password', $encryptedPassword, 'string');
         $db->Execute($sql, 1);
         $sql =
             "UPDATE " . TABLE_CUSTOMERS_INFO . "
@@ -1131,6 +1147,10 @@ class Customer extends base
         $db->Execute($sql, 1);
 
         $this->clearPasswordResetTokens($this->customer_id);
+
+        if ($this->isSameAsLoggedIn()) {
+            zen_set_customer_session_password_hash($encryptedPassword);
+        }
     }
 
     /**

--- a/includes/functions/functions_customers.php
+++ b/includes/functions/functions_customers.php
@@ -190,7 +190,7 @@ function zen_is_customer_password_session_valid(): bool
 
     $currentPasswordHash = (string)$result->fields['customers_password'];
 
-    if (empty($_SESSION['customer_password_hash'])) {
+    if (!array_key_exists('customer_password_hash', $_SESSION)) {
         return false;
     }
 

--- a/includes/functions/functions_customers.php
+++ b/includes/functions/functions_customers.php
@@ -159,6 +159,46 @@ function zen_get_customer_validate_session(int $customer_id): bool
 }
 
 /**
+ * Store the current customer's password hash in the session so other sessions can be invalidated
+ * when the password changes out-of-band.
+ */
+function zen_set_customer_session_password_hash(string $passwordHash): void
+{
+    $_SESSION['customer_password_hash'] = $passwordHash;
+}
+
+/**
+ * Validate that the logged-in session still matches the customer's current password hash.
+ */
+function zen_is_customer_password_session_valid(): bool
+{
+    global $db;
+
+    if (!zen_is_logged_in()) {
+        return true;
+    }
+
+    $sql = "SELECT customers_password
+            FROM " . TABLE_CUSTOMERS . "
+            WHERE customers_id = :customersID";
+    $sql = $db->bindVars($sql, ':customersID', $_SESSION['customer_id'], 'integer');
+    $result = $db->Execute($sql, 1);
+
+    if ($result->EOF) {
+        return false;
+    }
+
+    $currentPasswordHash = (string)$result->fields['customers_password'];
+
+    if (empty($_SESSION['customer_password_hash'])) {
+        zen_set_customer_session_password_hash($currentPasswordHash);
+        return true;
+    }
+
+    return hash_equals((string)$_SESSION['customer_password_hash'], $currentPasswordHash);
+}
+
+/**
  * This function identifies whether (true) or not (false) the current customer session is
  * associated with a guest-checkout process.
  * @alias Customer::isInGuestCheckout()

--- a/includes/functions/functions_customers.php
+++ b/includes/functions/functions_customers.php
@@ -191,8 +191,7 @@ function zen_is_customer_password_session_valid(): bool
     $currentPasswordHash = (string)$result->fields['customers_password'];
 
     if (empty($_SESSION['customer_password_hash'])) {
-        zen_set_customer_session_password_hash($currentPasswordHash);
-        return true;
+        return false;
     }
 
     return hash_equals((string)$_SESSION['customer_password_hash'], $currentPasswordHash);

--- a/includes/functions/functions_customers.php
+++ b/includes/functions/functions_customers.php
@@ -161,6 +161,7 @@ function zen_get_customer_validate_session(int $customer_id): bool
 /**
  * Store the current customer's password hash in the session so other sessions can be invalidated
  * when the password changes out-of-band.
+ * @since ZC v3.0.0
  */
 function zen_set_customer_session_password_hash(string $passwordHash): void
 {
@@ -169,6 +170,7 @@ function zen_set_customer_session_password_hash(string $passwordHash): void
 
 /**
  * Validate that the logged-in session still matches the customer's current password hash.
+ * @since ZC v3.0.0
  */
 function zen_is_customer_password_session_valid(): bool
 {

--- a/includes/functions/functions_email.php
+++ b/includes/functions/functions_email.php
@@ -22,6 +22,10 @@
 zen_define_default('EMAIL_SYSTEM_DEBUG', 0);
 zen_define_default('EMAIL_ATTACHMENTS_ENABLED', true);
 
+if (!class_exists(Email::class, false)) {
+    require_once DIR_FS_CATALOG . 'includes/classes/Email.php';
+}
+
 /**
  * enable embedded image support
  */

--- a/includes/functions/functions_email.php
+++ b/includes/functions/functions_email.php
@@ -22,10 +22,6 @@
 zen_define_default('EMAIL_SYSTEM_DEBUG', 0);
 zen_define_default('EMAIL_ATTACHMENTS_ENABLED', true);
 
-if (!class_exists(Email::class, false)) {
-    require_once DIR_FS_CATALOG . 'includes/classes/Email.php';
-}
-
 /**
  * enable embedded image support
  */

--- a/includes/init_includes/init_customer_auth.php
+++ b/includes/init_includes/init_customer_auth.php
@@ -21,6 +21,28 @@ if (zen_is_logged_in()) {
     zen_session_destroy();
     zen_redirect(zen_href_link(FILENAME_TIME_OUT));
   }
+
+  if (!zen_is_customer_password_session_valid()) {
+    global $messageStack, $customer;
+
+    $_SESSION['cart']->reset(true);
+    if (!isset($customer) || !is_a($customer, Customer::class)) {
+      $customer = new Customer($_SESSION['customer_id']);
+    }
+    $customer->forceLogout();
+    unset(
+      $_SESSION['customer_password_hash'],
+      $_SESSION['customers_email_address'],
+      $_SESSION['customer_first_name'],
+      $_SESSION['customer_last_name'],
+      $_SESSION['customer_default_address_id'],
+      $_SESSION['customer_country_id'],
+      $_SESSION['customer_zone_id'],
+      $_SESSION['customers_authorization']
+    );
+    $messageStack->add_session('header', ERROR_SESSION_INVALID_DUE_TO_PASSWORD_CHANGE, 'warning');
+    zen_redirect(zen_href_link(FILENAME_LOGIN, '', 'SSL'));
+  }
 }
 
 $down_for_maint_flag = false;

--- a/includes/init_includes/init_customer_auth.php
+++ b/includes/init_includes/init_customer_auth.php
@@ -25,7 +25,7 @@ if (zen_is_logged_in()) {
   if (!zen_is_customer_password_session_valid()) {
     global $messageStack, $customer;
 
-    $_SESSION['cart']->reset(true);
+    $_SESSION['cart']->reset(false);
     if (!isset($customer) || !is_a($customer, Customer::class)) {
       $customer = new Customer($_SESSION['customer_id']);
     }

--- a/includes/languages/lang.english.php
+++ b/includes/languages/lang.english.php
@@ -186,6 +186,7 @@ $define = [
     'ERROR_CORRECTIONS_HEADING' => 'Please correct the following: <br>',
     'ERROR_CUSTOMERS_ID_INVALID' => 'Customer information cannot be validated!<br>Please login or recreate your account ...',
     'ERROR_DATABASE_MAINTENANCE_NEEDED' => '<a href="https://docs.zen-cart.com/user/troubleshooting/error_71_maintenance_required/" rel="noopener" target="_blank">ERROR 0071 There appears to be a problem with the database. Maintenance is required.</a>',
+    'ERROR_SESSION_INVALID_DUE_TO_PASSWORD_CHANGE' => 'Your session has expired because your password was changed. Please login again.',
     'ERROR_DESTINATION_DOES_NOT_EXIST' => 'Error: destination does not exist.',
     'ERROR_DESTINATION_NOT_WRITEABLE' => 'Error:  destination not writeable.',
     'ERROR_FILETYPE_NOT_ALLOWED' => 'Error: An uploaded file type (%1$s) is not supported. Please try again.',

--- a/not_for_release/testFramework/FeatureAdmin/AdminEndpoints/AdminSessionInvalidationTest.php
+++ b/not_for_release/testFramework/FeatureAdmin/AdminEndpoints/AdminSessionInvalidationTest.php
@@ -33,4 +33,54 @@ class AdminSessionInvalidationTest extends zcInProcessFeatureTestCaseAdmin
             ->assertOk()
             ->assertSee('Your session has expired because your password was changed. Please login again.');
     }
+
+    public function testAdminSessionWithoutBaselineHashRequiresReauthentication(): void
+    {
+        TestDb::update(
+            'admin',
+            ['admin_pass' => password_hash('password', PASSWORD_DEFAULT)],
+            'admin_id = :admin_id',
+            [':admin_id' => 1]
+        );
+
+        $this->completeInitialAdminSetup();
+        $this->removeSessionValue('zenAdminID', 'admin_password_hash');
+
+        $response = $this->getAdmin('/admin/index.php?cmd=admin_account');
+        $response->assertRedirect('cmd=login');
+
+        $this->followAdminRedirect($response)
+            ->assertOk()
+            ->assertSee('Your session has expired because your password was changed. Please login again.');
+    }
+
+    private function removeSessionValue(string $sessionCookieName, string $sessionKey): void
+    {
+        $sessionId = $this->cookies[$sessionCookieName] ?? '';
+        $this->assertNotSame('', $sessionId);
+        $encodedSession = (string) TestDb::selectValue(
+            'SELECT value FROM sessions WHERE sesskey = :session_id',
+            [':session_id' => $sessionId]
+        );
+        $this->assertNotSame('', $encodedSession);
+
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_write_close();
+        }
+
+        session_id(bin2hex(random_bytes(8)));
+        session_start();
+        session_decode(base64_decode($encodedSession));
+        unset($_SESSION[$sessionKey]);
+        $updatedSession = session_encode();
+        session_write_close();
+        session_id('');
+
+        TestDb::update(
+            'sessions',
+            ['value' => base64_encode($updatedSession)],
+            'sesskey = :session_id',
+            [':session_id' => $sessionId]
+        );
+    }
 }

--- a/not_for_release/testFramework/FeatureAdmin/AdminEndpoints/AdminSessionInvalidationTest.php
+++ b/not_for_release/testFramework/FeatureAdmin/AdminEndpoints/AdminSessionInvalidationTest.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @copyright Copyright 2003-2026 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ */
+
+namespace Tests\FeatureAdmin\AdminEndpoints;
+
+use Tests\Support\Database\TestDb;
+use Tests\Support\zcInProcessFeatureTestCaseAdmin;
+
+#[\PHPUnit\Framework\Attributes\Group('parallel-candidate')]
+class AdminSessionInvalidationTest extends zcInProcessFeatureTestCaseAdmin
+{
+    protected $runTestInSeparateProcess = true;
+    protected $preserveGlobalState = false;
+
+    public function testAdminSessionIsInvalidatedAfterOutOfBandPasswordChange(): void
+    {
+        $this->completeInitialAdminSetup();
+
+        TestDb::update(
+            'admin',
+            ['admin_pass' => password_hash('Adminpass123', PASSWORD_DEFAULT)],
+            'admin_id = :admin_id',
+            [':admin_id' => 1]
+        );
+
+        $response = $this->getAdmin('/admin/index.php?cmd=admin_account');
+        $response->assertRedirect('cmd=login');
+
+        $this->followAdminRedirect($response)
+            ->assertOk()
+            ->assertSee('Your session has expired because your password was changed. Please login again.');
+    }
+}

--- a/not_for_release/testFramework/FeatureStore/StoreEndpoints/AccountSessionInvalidationInProcessTest.php
+++ b/not_for_release/testFramework/FeatureStore/StoreEndpoints/AccountSessionInvalidationInProcessTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @copyright Copyright 2003-2026 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ */
+
+namespace Tests\FeatureStore\StoreEndpoints;
+
+use Tests\Support\Database\TestDb;
+use Tests\Support\Traits\CustomerAccountConcerns;
+use Tests\Support\helpers\ProfileManager;
+use Tests\Support\zcInProcessFeatureTestCaseStore;
+
+#[\PHPUnit\Framework\Attributes\Group('parallel-candidate')]
+#[\PHPUnit\Framework\Attributes\Group('customer-account-write')]
+class AccountSessionInvalidationInProcessTest extends zcInProcessFeatureTestCaseStore
+{
+    use CustomerAccountConcerns;
+
+    protected $runTestInSeparateProcess = true;
+    protected $preserveGlobalState = false;
+
+    public function testCustomerSessionIsInvalidatedAfterOutOfBandPasswordChange(): void
+    {
+        $profile = ProfileManager::getProfileForLogin('florida-basic2');
+        $this->createCustomerAccountOrLogin('florida-basic2');
+
+        TestDb::update(
+            'customers',
+            ['customers_password' => password_hash('updated-password-789', PASSWORD_DEFAULT)],
+            'customers_email_address = :email_address',
+            [':email_address' => $profile['email_address']]
+        );
+
+        $response = $this->getSslMainPage('account');
+        $response->assertRedirect('main_page=login');
+
+        $this->followRedirect($response)
+            ->assertOk()
+            ->assertSee('Your session has expired because your password was changed. Please login again.');
+    }
+}

--- a/not_for_release/testFramework/FeatureStore/StoreEndpoints/AccountSessionInvalidationInProcessTest.php
+++ b/not_for_release/testFramework/FeatureStore/StoreEndpoints/AccountSessionInvalidationInProcessTest.php
@@ -24,6 +24,17 @@ class AccountSessionInvalidationInProcessTest extends zcInProcessFeatureTestCase
     {
         $profile = ProfileManager::getProfileForLogin('florida-basic2');
         $this->createCustomerAccountOrLogin('florida-basic2');
+        $customerId = (int) TestDb::selectValue(
+            'SELECT customers_id FROM customers WHERE customers_email_address = :email_address',
+            [':email_address' => $profile['email_address']]
+        );
+
+        TestDb::insert('customers_basket', [
+            'customers_id' => $customerId,
+            'products_id' => '3',
+            'customers_basket_quantity' => 2,
+            'customers_basket_date_added' => date('Ymd'),
+        ]);
 
         TestDb::update(
             'customers',
@@ -38,5 +49,12 @@ class AccountSessionInvalidationInProcessTest extends zcInProcessFeatureTestCase
         $this->followRedirect($response)
             ->assertOk()
             ->assertSee('Your session has expired because your password was changed. Please login again.');
+
+        $savedCartRows = (int) TestDb::selectValue(
+            'SELECT COUNT(*) FROM customers_basket WHERE customers_id = :customer_id',
+            [':customer_id' => $customerId]
+        );
+
+        $this->assertSame(1, $savedCartRows);
     }
 }

--- a/not_for_release/testFramework/FeatureStore/StoreEndpoints/AccountSessionInvalidationInProcessTest.php
+++ b/not_for_release/testFramework/FeatureStore/StoreEndpoints/AccountSessionInvalidationInProcessTest.php
@@ -57,4 +57,67 @@ class AccountSessionInvalidationInProcessTest extends zcInProcessFeatureTestCase
 
         $this->assertSame(1, $savedCartRows);
     }
+
+    public function testCustomerSessionWithoutBaselineHashRequiresReauthentication(): void
+    {
+        $profile = ProfileManager::getProfileForLogin('florida-basic1');
+        $this->createCustomerAccountOrLogin('florida-basic1');
+        $customerId = (int) TestDb::selectValue(
+            'SELECT customers_id FROM customers WHERE customers_email_address = :email_address',
+            [':email_address' => $profile['email_address']]
+        );
+
+        TestDb::insert('customers_basket', [
+            'customers_id' => $customerId,
+            'products_id' => '3',
+            'customers_basket_quantity' => 1,
+            'customers_basket_date_added' => date('Ymd'),
+        ]);
+
+        $this->removeSessionValue('zenid', 'customer_password_hash');
+
+        $response = $this->getSslMainPage('account');
+        $response->assertRedirect('main_page=login');
+
+        $this->followRedirect($response)
+            ->assertOk()
+            ->assertSee('Your session has expired because your password was changed. Please login again.');
+
+        $savedCartRows = (int) TestDb::selectValue(
+            'SELECT COUNT(*) FROM customers_basket WHERE customers_id = :customer_id',
+            [':customer_id' => $customerId]
+        );
+
+        $this->assertSame(1, $savedCartRows);
+    }
+
+    private function removeSessionValue(string $sessionCookieName, string $sessionKey): void
+    {
+        $sessionId = $this->cookies[$sessionCookieName] ?? '';
+        $this->assertNotSame('', $sessionId);
+        $encodedSession = (string) TestDb::selectValue(
+            'SELECT value FROM sessions WHERE sesskey = :session_id',
+            [':session_id' => $sessionId]
+        );
+        $this->assertNotSame('', $encodedSession);
+
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_write_close();
+        }
+
+        session_id(bin2hex(random_bytes(8)));
+        session_start();
+        session_decode(base64_decode($encodedSession));
+        unset($_SESSION[$sessionKey]);
+        $updatedSession = session_encode();
+        session_write_close();
+        session_id('');
+
+        TestDb::update(
+            'sessions',
+            ['value' => base64_encode($updatedSession)],
+            'sesskey = :session_id',
+            [':session_id' => $sessionId]
+        );
+    }
 }

--- a/not_for_release/testFramework/FeatureStore/StoreEndpoints/AccountSessionInvalidationInProcessTest.php
+++ b/not_for_release/testFramework/FeatureStore/StoreEndpoints/AccountSessionInvalidationInProcessTest.php
@@ -74,7 +74,7 @@ class AccountSessionInvalidationInProcessTest extends zcInProcessFeatureTestCase
             'customers_basket_date_added' => date('Ymd'),
         ]);
 
-        $this->removeSessionValue('zenid', 'customer_password_hash');
+        $this->updateSessionValue('zenid', 'customer_password_hash', null, true);
 
         $response = $this->getSslMainPage('account');
         $response->assertRedirect('main_page=login');
@@ -91,7 +91,36 @@ class AccountSessionInvalidationInProcessTest extends zcInProcessFeatureTestCase
         $this->assertSame(1, $savedCartRows);
     }
 
-    private function removeSessionValue(string $sessionCookieName, string $sessionKey): void
+    public function testCustomerSessionAllowsExplicitEmptyBaselineHash(): void
+    {
+        $profile = ProfileManager::getProfileForLogin('florida-basic2');
+        TestDb::update(
+            'customers',
+            ['customers_password' => password_hash((string) $profile['password'], PASSWORD_DEFAULT)],
+            'customers_email_address = :email_address',
+            [':email_address' => $profile['email_address']]
+        );
+        $this->createCustomerAccountOrLogin('florida-basic2');
+        $customerId = (int) TestDb::selectValue(
+            'SELECT customers_id FROM customers WHERE customers_email_address = :email_address',
+            [':email_address' => $profile['email_address']]
+        );
+
+        TestDb::update(
+            'customers',
+            ['customers_password' => ''],
+            'customers_id = :customer_id',
+            [':customer_id' => $customerId]
+        );
+
+        $this->updateSessionValue('zenid', 'customer_password_hash', '');
+
+        $this->getSslMainPage('account')
+            ->assertOk()
+            ->assertSee('My Account');
+    }
+
+    private function updateSessionValue(string $sessionCookieName, string $sessionKey, ?string $sessionValue, bool $remove = false): void
     {
         $sessionId = $this->cookies[$sessionCookieName] ?? '';
         $this->assertNotSame('', $sessionId);
@@ -108,7 +137,11 @@ class AccountSessionInvalidationInProcessTest extends zcInProcessFeatureTestCase
         session_id(bin2hex(random_bytes(8)));
         session_start();
         session_decode(base64_decode($encodedSession));
-        unset($_SESSION[$sessionKey]);
+        if ($remove) {
+            unset($_SESSION[$sessionKey]);
+        } else {
+            $_SESSION[$sessionKey] = $sessionValue;
+        }
         $updatedSession = session_encode();
         session_write_close();
         session_id('');

--- a/not_for_release/testFramework/Support/UnitTestBootstrap.php
+++ b/not_for_release/testFramework/Support/UnitTestBootstrap.php
@@ -61,6 +61,7 @@ class UnitTestBootstrap
         require_once DIR_FS_INCLUDES . 'defined_paths.php';
         require_once DIR_FS_INCLUDES . 'database_tables.php';
         require_once DIR_FS_INCLUDES . 'filenames.php';
+        self::registerCoreAutoloadMappings();
         require_once DIR_FS_CATALOG . DIR_WS_CLASSES . 'traits/Singleton.php';
         require_once DIR_FS_CATALOG . DIR_WS_CLASSES . 'EventDto.php';
         require_once DIR_FS_CATALOG . DIR_WS_CLASSES . 'traits/NotifierManager.php';
@@ -97,6 +98,22 @@ class UnitTestBootstrap
     private static function loadSessionStubs(): void
     {
         require_once TESTCWD . 'Support/helpers/unit_test_session_stubs.php';
+    }
+
+    private static function registerCoreAutoloadMappings(): void
+    {
+        static $registered = false;
+
+        if ($registered) {
+            return;
+        }
+
+        /** @var \Aura\Autoload\Loader $psr4Autoloader */
+        $psr4Autoloader = new \Aura\Autoload\Loader();
+        require DIR_FS_CATALOG . 'includes/psr4Autoload.php';
+        $psr4Autoloader->register();
+
+        $registered = true;
     }
 
     private static function defineIfMissing(string $name, mixed $value): void

--- a/not_for_release/testFramework/Unit/testsSundry/UnitTestBootstrapTest.php
+++ b/not_for_release/testFramework/Unit/testsSundry/UnitTestBootstrapTest.php
@@ -25,6 +25,7 @@ class UnitTestBootstrapTest extends TestCase
         $this->assertTrue(function_exists('zen_session_id'));
         $this->assertSame('zenid', \zen_session_name());
         $this->assertSame('1234567890', \zen_session_id());
+        $this->assertTrue(class_exists('Email'));
         $this->assertArrayHasKey('zco_notifier', $GLOBALS);
         $this->assertInstanceOf(\notifier::class, $GLOBALS['zco_notifier']);
     }


### PR DESCRIPTION
Invalidates external sessions on password change. So if you are logged in to a different browser or computer those sessions will be invalidated when changing the password on your "main" session