### PR TITLE
[2.2] Fix broken mobile-menu in responsive-classic

### DIFF
--- a/includes/templates/responsive_classic/templates/tpl_modules_mobile_menu.php
+++ b/includes/templates/responsive_classic/templates/tpl_modules_mobile_menu.php
@@ -42,15 +42,13 @@ if ($flag_show_about_us_sidebox_link === true) {
     <li><span><?php echo BOX_HEADING_CATEGORIES; ?></span>
 <?php
 // load the UL-generator class and produce the menu list dynamically from there
-require_once (DIR_WS_CLASSES . 'categories_ul_generator.php');
-$zen_CategoriesUL = new zen_categories_ul_generator;
+require_once DIR_WS_CLASSES . 'categories_ul_generator.php';
+$zen_CategoriesUL = new zen_categories_ul_generator(parent_group_end_string: "</ul>", child_end_string: "</li>\n");
 $menulist = $zen_CategoriesUL->buildTree(true);
-$menulist = str_replace('"level4"','"level5"',$menulist);
-$menulist = str_replace('"level3"','"level4"',$menulist);
-$menulist = str_replace('"level2"','"level3"',$menulist);
-$menulist = str_replace('"level1"','"level2"',$menulist);
-$menulist = str_replace('<li>','<li>',$menulist);
-$menulist = str_replace("</li>\n</ul>\n</li>\n</ul>\n","</li>\n</ul>\n",$menulist);
+$menulist = str_replace(
+    ['"level4"', '"level3"', '"level2"', '"level1"', '<li>', "</li>\n</ul>\n</li>\n</ul>\n"],
+    ['"level5"', '"level4"', '"level3"', '"level2"', '<li>', "</li>\n</ul>\n"],
+    $menulist);
 echo $menulist;
 ?>
     </li>
@@ -175,7 +173,6 @@ if ($flag_show_accessibility_sidebox_link === true) {
 </nav>
 
 <script src="<?php echo $template->get_template_dir('jquery.mmenu.min.all.js',DIR_WS_TEMPLATE, $current_page_base,'jscript') . '/jquery.mmenu.min.all.js' ?>"></script>
-<script src="<?php echo $template->get_template_dir('jquery.mmenu.fixedelements.min.js',DIR_WS_TEMPLATE, $current_page_base,'jscript') . '/jquery.mmenu.fixedelements.min.js' ?>"></script>
 <script>
   $(function() {
     $("#menu")
@@ -191,7 +188,6 @@ if ($flag_show_accessibility_sidebox_link === true) {
         },
         counters: true
       }).on('click', 'a[href^="#/"]', function() {
-        alert("Thank you for clicking, but that's a demo link.");
         return false;
       });
   });


### PR DESCRIPTION
Backport of #7834  for #7830

Broken:
<img width="439" height="506" alt="Screen Shot 2026-06-18 at 4 47 14 PM" src="https://github.com/user-attachments/assets/a4482620-2425-43a4-883e-cd028b389052" />
---
Fixed:
<img width="438" height="645" alt="Screen Shot 2026-06-18 at 4 39 45 PM" src="https://github.com/user-attachments/assets/13ba2bf6-47ae-4512-ba8f-28b0fbf701e7" />
