### PR TITLE
[2.2] In text-only emails, convert nonbreak-hyphen to dash

### DIFF
--- a/includes/functions/functions_email.php
+++ b/includes/functions/functions_email.php
@@ -176,6 +176,9 @@
             // clean up &amp; and && from email text
             $email_text = preg_replace('/((&amp;)|&)+/', '&', $email_text);
 
+            // Convert non-breaking hyphen to regular hyphen for text message
+            $email_text = str_replace('&#8209;', '-', $email_text);
+
             // clean up currencies for text emails
             if (defined('CURRENCIES_TRANSLATIONS') && !empty(CURRENCIES_TRANSLATIONS)) {
                 $zen_fix_currencies = preg_split("/[:,]/", str_replace(' ', '', CURRENCIES_TRANSLATIONS));


### PR DESCRIPTION
Backports #7836 for #7819