### PR TITLE
[2.2] Include auto-loaded observers in ipn_main_handler

### DIFF
--- a/includes/auto_loaders/paypal_ipn.core.php
+++ b/includes/auto_loaders/paypal_ipn.core.php
@@ -213,3 +213,13 @@ $autoLoadConfig[170][] = [
     'autoType' => 'init_script',
     'loadFile' => 'init_ipn_postcfg.php',
 ];
+/**
+ * Breakpoint 175.
+ *
+ * require 'includes/init_includes/init_observers.php';
+ *
+ */
+$autoLoadConfig[175][] = [
+    'autoType' => 'init_script',
+    'loadFile' => 'init_observers.php',
+];


### PR DESCRIPTION
Partially corrects #7767