### PR TITLE
Remove code that's redundant

### DIFF
--- a/admin/includes/modules/products_previous_next.php
+++ b/admin/includes/modules/products_previous_next.php
@@ -20,12 +20,6 @@ if (!isset($current_category_id)) {
 if (!isset($prev_next_list) || $prev_next_list == '') {
 // calculate the previous and next
 
-  $result = $db->Execute("SELECT products_type
-                          FROM " . TABLE_PRODUCTS . "
-                          WHERE products_id = " . (int)$products_filter);
-  $check_type = ($result->EOF) ? 0 : $result->fields['products_type'];
-  if (!defined('PRODUCT_INFO_PREVIOUS_NEXT_SORT')) define('PRODUCT_INFO_PREVIOUS_NEXT_SORT', zen_get_configuration_key_value_layout('PRODUCT_INFO_PREVIOUS_NEXT_SORT', $check_type));
-
   // sort order
     $prev_next_order = zen_products_sort_order();
 


### PR DESCRIPTION
The implementation of `zen_config()` exposed that this is dead code.

`zen_get_configuration_key_value_layout()` does a lookup from `product_type_layout` table for the specified key and prod-id. But this `PRODUCT_INFO_PREVIOUS_NEXT_SORT` key is not one that's part of the product-type-layout table at all. It's only in the `configuration` table, so the subsequent call to `zen_products_sort_order()` (which checks PRODUCT_INFO_PREVIOUS_NEXT_SORT) is sufficient on its own.
Further, PRODUCT_INFO_PREVIOUS_NEXT_SORT is part of a fresh install, so is always present, which means this whole lookup was pointless in the first place.

Hence removing the redundant query.