### PR TITLE
Check shipping-module existence prior to use

### DIFF
--- a/includes/classes/order_total.php
+++ b/includes/classes/order_total.php
@@ -56,6 +56,11 @@ class order_total
             $module_list = explode(';', zen_config('MODULE_ORDER_TOTAL_INSTALLED'));
 
             foreach ($module_list as $value) {
+                // If the module's not located (it might be from a disabled zc_plugin), nothing further to do
+                if (!isset($modules_found[$value])) {
+                    continue;
+                }
+
                 if (!$languageLoader->loadModuleLanguageFile($value, 'order_total')) {
                     $language_dir = (IS_ADMIN_FLAG === false) ? DIR_WS_LANGUAGES : (DIR_FS_CATALOG . DIR_WS_LANGUAGES);
                     $lang_file = zen_get_file_directory($language_dir . $_SESSION['language'] . '/modules/order_total/', $value, 'false');

--- a/includes/classes/shipping.php
+++ b/includes/classes/shipping.php
@@ -77,18 +77,21 @@ class shipping
         $modules_to_quote = [];
 
         $module_name = (empty($module)) ? '0' : substr($module['id'], 0, strpos($module['id'], '_'));
-        if (!empty($module) && in_array($module_name . '.php', $this->modules, true) && isset($modules_found[$module_name])) {
+        if (!empty($module) && in_array($module_name . '.php', $this->modules, true) && isset($modules_found[$module_name . '.php'])) {
             $modules_to_quote[] = [
                 'class' => $module_name,
                 'file' => $module_name . '.php',
             ];
         } else {
             foreach ($this->modules as $value) {
-                $class = pathinfo($value, \PATHINFO_FILENAME);
-                $modules_to_quote[] = [
-                    'class' => $class,
-                    'file' => $value,
-                ];
+                // double check that the module really exists before adding to the array
+                if (isset($modules_found[$value])) {
+                    $class = pathinfo($value, PATHINFO_FILENAME);
+                    $modules_to_quote[] = [
+                        'class' => $class,
+                        'file' => $value,
+                    ];
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #7850

The `shipping` class was missing the clause (present in the `payment.php` class) to verify that the module was "found".  A disabled zc_plugin isn't "found".

A similar issue is currently present in the `order_total` class, which is also corrected via this PR.