### PR TITLE
Correct return page from storefront product listing

### DIFF
--- a/includes/modules/product_listing.php
+++ b/includes/modules/product_listing.php
@@ -455,5 +455,5 @@ $zco_notifier->notify('NOTIFY_PRODUCT_LISTING_END', $current_page_base, $list_bo
 
 if ($how_many > 0 && (int)zen_config('PRODUCT_LISTING_MULTIPLE_ADD_TO_CART') !== 0 && $show_submit && $num_products_count > 0) {
     // bof: multiple products
-    echo zen_draw_form('multiple_products_cart_quantity', zen_href_link(FILENAME_DEFAULT, zen_get_all_get_params(['action']) . 'action=multiple_products_add_product'), 'post', 'enctype="multipart/form-data"');
+    echo zen_draw_form('multiple_products_cart_quantity', zen_href_link($current_page_base, zen_get_all_get_params(['action']) . 'action=multiple_products_add_product'), 'post', 'enctype="multipart/form-data"');
 }

--- a/includes/modules/responsive_classic/product_listing.php
+++ b/includes/modules/responsive_classic/product_listing.php
@@ -467,5 +467,5 @@ $zco_notifier->notify('NOTIFY_PRODUCT_LISTING_END', $current_page_base, $list_bo
 
 if ($how_many > 0 && (int)zen_config('PRODUCT_LISTING_MULTIPLE_ADD_TO_CART') !== 0 && $show_submit && $num_products_count > 0) {
     // bof: multiple products
-    echo zen_draw_form('multiple_products_cart_quantity', zen_href_link(FILENAME_DEFAULT, zen_get_all_get_params(['action']) . 'action=multiple_products_add_product'), 'post', 'enctype="multipart/form-data"');
+    echo zen_draw_form('multiple_products_cart_quantity', zen_href_link($current_page_base, zen_get_all_get_params(['action']) . 'action=multiple_products_add_product'), 'post', 'enctype="multipart/form-data"');
 }

--- a/zc_plugins/ResponsiveClassicPlugin/v1.0.0/catalog/includes/modules/responsive_classic_plugin/product_listing.php
+++ b/zc_plugins/ResponsiveClassicPlugin/v1.0.0/catalog/includes/modules/responsive_classic_plugin/product_listing.php
@@ -443,5 +443,5 @@ $zco_notifier->notify('NOTIFY_PRODUCT_LISTING_END', $current_page_base, $list_bo
 
 if ($how_many > 0 && zen_config('PRODUCT_LISTING_MULTIPLE_ADD_TO_CART') != 0 && $show_submit && $num_products_count > 0) {
     // bof: multiple products
-    echo zen_draw_form('multiple_products_cart_quantity', zen_href_link(FILENAME_DEFAULT, zen_get_all_get_params(['action']) . 'action=multiple_products_add_product'), 'post', 'enctype="multipart/form-data"');
+    echo zen_draw_form('multiple_products_cart_quantity', zen_href_link($current_page_base, zen_get_all_get_params(['action']) . 'action=multiple_products_add_product'), 'post', 'enctype="multipart/form-data"');
 }


### PR DESCRIPTION
If the site's got 'DISPLAY_CART' set to 'false' and 'PRODUCT_LISTING_MULTIPLE_ADD_TO_CART' set to a value other than '0', the product listing pages are enabled to allow the addition of multiple products at a time.  The "DISPLAY_CART'" setting at 'false' indicates that the customer should be returned to the page they were on when that add-to-cart action is completed.

That's not currently the case, since the product listing is used for **all** product listings, but the redirect is **always** made back to the index page.

If you're on the `all_products` page with the above configuration settings, adding an item to the cart results in a redirect to the home page.