### PR TITLE
Fix PHPUnit process-isolation gaps causing fatal redeclare in Unit suite

### DIFF
--- a/not_for_release/testFramework/Unit/fixtures/zen_href_link_stub.php
+++ b/not_for_release/testFramework/Unit/fixtures/zen_href_link_stub.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @copyright Copyright 2003-2026 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ */
+
+if (!function_exists('zen_href_link')) {
+    function zen_href_link(string $filename, string $parameters = ''): string
+    {
+        return $filename . ($parameters === '' ? '' : '?' . $parameters);
+    }
+}

--- a/not_for_release/testFramework/Unit/testsHtmlOutput/AdminCatalogUrlGenerationTest.php
+++ b/not_for_release/testFramework/Unit/testsHtmlOutput/AdminCatalogUrlGenerationTest.php
@@ -5,9 +5,11 @@
  */
 
 use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Tests\Support\zcUnitTestCase;
 use Tests\Support\zcURLTestObserver;
 
+#[RunTestsInSeparateProcesses]
 class AdminCatalogUrlGenerationTest extends zcUnitTestCase
 {
 

--- a/not_for_release/testFramework/Unit/testsHtmlOutput/AdminUrlGenerationTest.php
+++ b/not_for_release/testFramework/Unit/testsHtmlOutput/AdminUrlGenerationTest.php
@@ -5,11 +5,13 @@
  */
 
 use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Tests\Support\zcUnitTestCase;
 
 /**
  * Testing Library
  */
+#[RunTestsInSeparateProcesses]
 class AdminUrlGenerationTest extends zcUnitTestCase
 {
     public function setUp(): void

--- a/not_for_release/testFramework/Unit/testsHtmlOutput/CatalogUrlGenerationTest.php
+++ b/not_for_release/testFramework/Unit/testsHtmlOutput/CatalogUrlGenerationTest.php
@@ -5,12 +5,14 @@
  */
 
 use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Tests\Support\zcUnitTestCase;
 use Tests\Support\zcURLTestObserver;
 
 /**
  * Testing Library
  */
+#[RunTestsInSeparateProcesses]
 class CatalogUrlGenerationTest extends zcUnitTestCase
 {
 

--- a/not_for_release/testFramework/Unit/testsSundry/CliConfigurationLoaderTest.php
+++ b/not_for_release/testFramework/Unit/testsSundry/CliConfigurationLoaderTest.php
@@ -14,7 +14,6 @@ use Zencart\DbRepositories\ProductTypeLayoutRepository;
 
 class CliConfigurationLoaderTest extends TestCase
 {
-    protected $preserveGlobalState = false;
 
     public static function setUpBeforeClass(): void
     {

--- a/not_for_release/testFramework/Unit/testsSundry/ConfigGetCommandTest.php
+++ b/not_for_release/testFramework/Unit/testsSundry/ConfigGetCommandTest.php
@@ -14,7 +14,6 @@ use Zencart\Console\ConsoleOutput;
 
 class ConfigGetCommandTest extends TestCase
 {
-    protected $preserveGlobalState = false;
 
     public static function setUpBeforeClass(): void
     {

--- a/not_for_release/testFramework/Unit/testsSundry/ConsoleInputTest.php
+++ b/not_for_release/testFramework/Unit/testsSundry/ConsoleInputTest.php
@@ -12,7 +12,6 @@ use Zencart\Console\ConsoleInput;
 
 class ConsoleInputTest extends TestCase
 {
-    protected $preserveGlobalState = false;
 
     public static function setUpBeforeClass(): void
     {

--- a/not_for_release/testFramework/Unit/testsSundry/ConsoleKernelTest.php
+++ b/not_for_release/testFramework/Unit/testsSundry/ConsoleKernelTest.php
@@ -18,7 +18,6 @@ use Zencart\Console\PluginCommandDiscovery;
 
 class ConsoleKernelTest extends TestCase
 {
-    protected $preserveGlobalState = false;
     private string $basePath = '';
     private string $catalogPath = '';
     /**

--- a/not_for_release/testFramework/Unit/testsSundry/FileSystemPluginAdminPageTest.php
+++ b/not_for_release/testFramework/Unit/testsSundry/FileSystemPluginAdminPageTest.php
@@ -17,8 +17,6 @@ class FileSystemPluginAdminPageTest extends TestCase
     private const TEST_PLUGIN = 'UnitTestAdminPagePlugin';
     private const TEST_VERSION = 'v1.0.0';
 
-    protected $preserveGlobalState = false;
-
     private string $pluginRoot;
 
     public static function setUpBeforeClass(): void

--- a/not_for_release/testFramework/Unit/testsSundry/PluginCommandDiscoveryTest.php
+++ b/not_for_release/testFramework/Unit/testsSundry/PluginCommandDiscoveryTest.php
@@ -13,7 +13,6 @@ use Zencart\Console\PluginCommandDiscovery;
 
 class PluginCommandDiscoveryTest extends TestCase
 {
-    protected $preserveGlobalState = false;
 
     private string $basePath;
     private string $catalogPath;

--- a/not_for_release/testFramework/Unit/testsSundry/PluginListCommandTest.php
+++ b/not_for_release/testFramework/Unit/testsSundry/PluginListCommandTest.php
@@ -15,7 +15,6 @@ use Zencart\PluginSupport\PluginStatus;
 
 class PluginListCommandTest extends TestCase
 {
-    protected $preserveGlobalState = false;
 
     public static function setUpBeforeClass(): void
     {

--- a/not_for_release/testFramework/Unit/testsSundry/RenderedJscriptFrameworkTest.php
+++ b/not_for_release/testFramework/Unit/testsSundry/RenderedJscriptFrameworkTest.php
@@ -6,8 +6,10 @@
 
 namespace Tests\Unit\testsSundry;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Tests\Support\zcUnitTestCase;
 
+#[RunTestsInSeparateProcesses]
 class RenderedJscriptFrameworkTest extends zcUnitTestCase
 {
     public function testRenderedJscriptFrameworkUsesCsrfHeaderForObjectPayloads(): void

--- a/not_for_release/testFramework/Unit/testsSundry/ResponsiveClassicPluginRegressionTest.php
+++ b/not_for_release/testFramework/Unit/testsSundry/ResponsiveClassicPluginRegressionTest.php
@@ -4,15 +4,6 @@
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  */
 
-namespace {
-if (!function_exists('zen_href_link')) {
-    function zen_href_link(string $filename, string $parameters = ''): string
-    {
-        return $filename . ($parameters === '' ? '' : '?' . $parameters);
-    }
-}
-}
-
 namespace Tests\Unit\testsSundry {
 
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
@@ -21,6 +12,15 @@ use Tests\Support\zcUnitTestCase;
 #[RunTestsInSeparateProcesses]
 class ResponsiveClassicPluginRegressionTest extends zcUnitTestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        if (!function_exists('zen_href_link')) {
+            require dirname(__DIR__) . '/fixtures/zen_href_link_stub.php';
+        }
+    }
+
     public function testCategoriesSideboxShowsSpecialsLinkWhenSpecialsExist(): void
     {
         defined('SHOW_CATEGORIES_SEPARATOR_LINK') || define('SHOW_CATEGORIES_SEPARATOR_LINK', '0');

--- a/not_for_release/testFramework/Unit/testsSundry/TrustedPluginClassLoaderTest.php
+++ b/not_for_release/testFramework/Unit/testsSundry/TrustedPluginClassLoaderTest.php
@@ -13,7 +13,6 @@ use Zencart\Console\TrustedPluginClassLoader;
 
 class TrustedPluginClassLoaderTest extends TestCase
 {
-    protected $preserveGlobalState = false;
     /**
      * @var string[]
      */

--- a/not_for_release/testFramework/Unit/testsSundry/TrustedPluginVersionResolverTest.php
+++ b/not_for_release/testFramework/Unit/testsSundry/TrustedPluginVersionResolverTest.php
@@ -14,7 +14,6 @@ use Zencart\PluginSupport\PluginStatus;
 
 class TrustedPluginVersionResolverTest extends TestCase
 {
-    protected $preserveGlobalState = false;
 
     public static function setUpBeforeClass(): void
     {

--- a/not_for_release/testFramework/Unit/testsSundry/VersionShowCommandTest.php
+++ b/not_for_release/testFramework/Unit/testsSundry/VersionShowCommandTest.php
@@ -14,7 +14,6 @@ use Zencart\Console\ConsoleOutput;
 
 class VersionShowCommandTest extends TestCase
 {
-    protected $preserveGlobalState = false;
 
     public static function setUpBeforeClass(): void
     {


### PR DESCRIPTION
## Summary

- Running the full `Unit/` test directory in a single PHPUnit invocation hits a fatal `Cannot redeclare function zen_href_link()`. Several test classes bootstrap admin-side and catalog-side `includes/functions/html_output.php` in the same shared process, and both files unconditionally declare `zen_href_link()` with different signatures. Added `#[RunTestsInSeparateProcesses]` to `CatalogUrlGenerationTest`, `AdminCatalogUrlGenerationTest`, `AdminUrlGenerationTest`, and `RenderedJscriptFrameworkTest` so each runs in its own process.
- `ResponsiveClassicPluginRegressionTest` declared its `zen_href_link()` stub in a bare top-level `namespace { }` block, which PHPUnit's file-collection phase executes eagerly in the shared parent process regardless of per-class isolation attributes. Moved the stub into a lazily-`require`d, un-namespaced fixture file (`fixtures/zen_href_link_stub.php`) so it only loads inside the test's own isolated process.
- Removed the orphaned `protected $preserveGlobalState = false;` property from 10 test classes that never paired it with `runTestInSeparateProcess`, left over from an earlier pass that converted properly-paired classes to the `#[RunTestsInSeparateProcesses]` attribute.

## Test plan

- [x] `vendor/bin/phpunit not_for_release/testFramework/Unit/` (whole directory, single process) runs to completion with no fatal error
- [x] `composer tests-unit` passes for all affected files