### PR TITLE
Sideboxes from disabled zc_plugins still loaded

### DIFF
--- a/includes/modules/column_left.php
+++ b/includes/modules/column_left.php
@@ -8,24 +8,33 @@
  * @version $Id: DrByte 2026 Feb 26 Modified in v2.2.1 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
-  die('Illegal Access');
+    die('Illegal Access');
 }
+
 use Zencart\DbRepositories\LayoutBoxRepository;
 use Zencart\ResourceLoaders\SideboxFinder;
 use Zencart\FileSystem\FileSystem;
 
-$column_box_default='tpl_box_default_left.php';
+$column_box_default = 'tpl_box_default_left.php';
 // Check if there are boxes for the column
 global $db;
 $layoutBoxRepository = new LayoutBoxRepository($db);
 $sideboxes = $layoutBoxRepository->getActiveForLocation(0, $template_dir, 100);
 
+$sideboxFinder = new SideboxFinder(new FileSystem());
+$modules_found = $sideboxFinder->findFromFilesystem($installedPlugins, $template_dir);
+
 $column_width = (int)$tplSetting->BOX_WIDTH_LEFT;
 foreach ($sideboxes as $sidebox) {
-    $boxFile = (new SideboxFinder(new FileSystem))->sideboxPath($sidebox, $template_dir, true);
+    $box_name = $sidebox['layout_box_name'];
+    if (!empty($sidebox['plugin_details']) && !isset($modules_found[$box_name])) {
+        continue;
+    }
+
+    $boxFile = $sideboxFinder->sideboxPath($sidebox, $template_dir, true);
     if ($boxFile !== false) {
-        $box_id = zen_get_box_id($sidebox['layout_box_name']);
-        include($boxFile . $sidebox['layout_box_name']);
+        $box_id = zen_get_box_id($box_name);
+        require $boxFile . $box_name;
     }
 }
 $box_id = '';

--- a/includes/modules/column_right.php
+++ b/includes/modules/column_right.php
@@ -8,8 +8,9 @@
  * @version $Id: DrByte 2026 Feb 26 Modified in v2.2.1 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
-  die('Illegal Access');
+    die('Illegal Access');
 }
+
 use Zencart\DbRepositories\LayoutBoxRepository;
 use Zencart\ResourceLoaders\SideboxFinder;
 use Zencart\FileSystem\FileSystem;
@@ -20,12 +21,20 @@ global $db;
 $layoutBoxRepository = new LayoutBoxRepository($db);
 $sideboxes = $layoutBoxRepository->getActiveForLocation(1, $template_dir, 100);
 
+$sideboxFinder = new SideboxFinder(new FileSystem());
+$modules_found = $sideboxFinder->findFromFilesystem($installedPlugins, $template_dir);
+
 $column_width = (int)$tplSetting->BOX_WIDTH_RIGHT;
 foreach ($sideboxes as $sidebox) {
-    $boxFile = (new SideboxFinder(new FileSystem))->sideboxPath($sidebox, $template_dir, true);
+    $box_name = $sidebox['layout_box_name'];
+    if (!empty($sidebox['plugin_details']) && !isset($modules_found[$box_name])) {
+        continue;
+    }
+
+    $boxFile = $sideboxFinder->sideboxPath($sidebox, $template_dir, true);
     if ($boxFile !== false) {
-        $box_id = zen_get_box_id($sidebox['layout_box_name']);
-        include($boxFile . $sidebox['layout_box_name']);
+        $box_id = zen_get_box_id($box_name);
+        require $boxFile . $box_name;
     }
 }
 $box_id = '';


### PR DESCRIPTION
If a zc_plugin contains a sidebox, that sidebox is registered via the `Layout Box Controller` and then the zc_plugin is "Disabled", its sidebox is still loaded in the storefront (unless a transition to the `Layout Box Controller` is made and the sidebox removed).

This PR corrects that for zc300+ and will be backported for the zc223 release.