### PR TITLE
2.2: Don't load sideboxes from disabled zc_plugins

### DIFF
--- a/includes/classes/ResourceLoaders/SideboxFinder.php
+++ b/includes/classes/ResourceLoaders/SideboxFinder.php
@@ -31,8 +31,9 @@ class SideboxFinder
                 $sideboxes[$file] = $plugin['unique_key'] . '/' . $plugin['version'];
             }
         }
-        $mainDir = DIR_FS_CATALOG_MODULES . 'sideboxes/';
-        $mainDirTpl = DIR_FS_CATALOG_MODULES . 'sideboxes/' . $templateDir . '/';
+
+        $mainDir = DIR_FS_CATALOG . DIR_WS_MODULES . 'sideboxes/';
+        $mainDirTpl = $mainDir . $templateDir . '/';
         $files = $this->filesystem->listFilesFromDirectoryAlphaSorted($mainDir);
         foreach ($files as $file) {
             $sideboxes[$file] = '';

--- a/includes/modules/column_left.php
+++ b/includes/modules/column_left.php
@@ -8,24 +8,33 @@
  * @version $Id: DrByte 2026 Feb 26 Modified in v2.2.1 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
-  die('Illegal Access');
+    die('Illegal Access');
 }
+
 use Zencart\DbRepositories\LayoutBoxRepository;
 use Zencart\ResourceLoaders\SideboxFinder;
 use Zencart\FileSystem\FileSystem;
 
-$column_box_default='tpl_box_default_left.php';
+$column_box_default = 'tpl_box_default_left.php';
 // Check if there are boxes for the column
 global $db;
 $layoutBoxRepository = new LayoutBoxRepository($db);
 $sideboxes = $layoutBoxRepository->getActiveForLocation(0, $template_dir, 100);
 
+$sideboxFinder = new SideboxFinder(new FileSystem());
+$modules_found = $sideboxFinder->findFromFilesystem($installedPlugins, $template_dir);
+
 $column_width = (int)BOX_WIDTH_LEFT;
 foreach ($sideboxes as $sidebox) {
-    $boxFile = (new SideboxFinder(new FileSystem))->sideboxPath($sidebox, $template_dir, true);
+    $box_name = $sidebox['layout_box_name'];
+    if (!empty($sidebox['plugin_details']) && !isset($modules_found[$box_name])) {
+        continue;
+    }
+
+    $boxFile = $sideboxFinder->sideboxPath($sidebox, $template_dir, true);
     if ($boxFile !== false) {
-        $box_id = zen_get_box_id($sidebox['layout_box_name']);
-        include($boxFile . $sidebox['layout_box_name']);
+        $box_id = zen_get_box_id($box_name);
+        require $boxFile . $box_name;
     }
 }
 $box_id = '';

--- a/includes/modules/column_right.php
+++ b/includes/modules/column_right.php
@@ -8,8 +8,9 @@
  * @version $Id: DrByte 2026 Feb 26 Modified in v2.2.1 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
-  die('Illegal Access');
+    die('Illegal Access');
 }
+
 use Zencart\DbRepositories\LayoutBoxRepository;
 use Zencart\ResourceLoaders\SideboxFinder;
 use Zencart\FileSystem\FileSystem;
@@ -20,12 +21,20 @@ global $db;
 $layoutBoxRepository = new LayoutBoxRepository($db);
 $sideboxes = $layoutBoxRepository->getActiveForLocation(1, $template_dir, 100);
 
+$sideboxFinder = new SideboxFinder(new FileSystem());
+$modules_found = $sideboxFinder->findFromFilesystem($installedPlugins, $template_dir);
+
 $column_width = (int)BOX_WIDTH_RIGHT;
 foreach ($sideboxes as $sidebox) {
-    $boxFile = (new SideboxFinder(new FileSystem))->sideboxPath($sidebox, $template_dir, true);
+    $box_name = $sidebox['layout_box_name'];
+    if (!empty($sidebox['plugin_details']) && !isset($modules_found[$box_name])) {
+        continue;
+    }
+
+    $boxFile = $sideboxFinder->sideboxPath($sidebox, $template_dir, true);
     if ($boxFile !== false) {
-        $box_id = zen_get_box_id($sidebox['layout_box_name']);
-        include($boxFile . $sidebox['layout_box_name']);
+        $box_id = zen_get_box_id($box_name);
+        require $boxFile . $box_name;
     }
 }
 $box_id = '';


### PR DESCRIPTION
Ref #7859

This change ensures that sideboxes from disabled zc_plugins aren't loaded (as that can lead to various PHP warnings/errors)

The ZC 2.2.x change also requires an update to the `SideboxFinder.php` class' `findFromFilesystem` method, since there's no such constant as 'DIR_FS_CATALOG_MODULES' on the storefront.