### PR TITLE
Convert zen_get_configuration_key_value to zen_config

### DIFF
--- a/admin/configuration.php
+++ b/admin/configuration.php
@@ -79,7 +79,7 @@ if (!empty($action)) {
             }
 
             // set the WARN_BEFORE_DOWN_FOR_MAINTENANCE to false if DOWN_FOR_MAINTENANCE = true
-            if (zen_get_configuration_key_value('WARN_BEFORE_DOWN_FOR_MAINTENANCE') === 'true' && zen_get_configuration_key_value('DOWN_FOR_MAINTENANCE') === 'true') {
+            if (zen_config('WARN_BEFORE_DOWN_FOR_MAINTENANCE') === 'true' && zen_config('DOWN_FOR_MAINTENANCE') === 'true') {
                 $db->Execute(
                     "UPDATE " . TABLE_CONFIGURATION . "
                         SET configuration_value = 'false',
@@ -118,10 +118,10 @@ if ($cfg_group->EOF) {
 
 if ($gID === 7) {
     $shipping_errors = '';
-    if (zen_get_configuration_key_value('SHIPPING_ORIGIN_ZIP') === 'NONE' || zen_get_configuration_key_value('SHIPPING_ORIGIN_ZIP') === '') {
+    if (zen_config('SHIPPING_ORIGIN_ZIP') === 'NONE' || zen_config('SHIPPING_ORIGIN_ZIP') === '') {
         $shipping_errors .= '<br>' . ERROR_SHIPPING_ORIGIN_ZIP;
     }
-    if (zen_get_configuration_key_value('ORDER_WEIGHT_ZERO_STATUS') === '1' && (zen_config('MODULE_SHIPPING_FREESHIPPER_STATUS') !== 'True')) {
+    if (zen_config('ORDER_WEIGHT_ZERO_STATUS') === '1' && (zen_config('MODULE_SHIPPING_FREESHIPPER_STATUS') !== 'True')) {
         $shipping_errors .= '<br>' . ERROR_ORDER_WEIGHT_ZERO_STATUS;
     }
     if ($shipping_errors !== '') {
@@ -132,7 +132,7 @@ if ($gID === 7) {
         zen_redirect(zen_href_link(FILENAME_DENIED, '', 'SSL'));
     }
 } elseif ($gID === 5) {
-    if (zen_get_configuration_key_value('CUSTOMERS_ACTIVATION_REQUIRED') === 'true') {
+    if (zen_config('CUSTOMERS_ACTIVATION_REQUIRED') === 'true') {
         $db->Execute("UPDATE " . TABLE_CONFIGURATION . " SET configuration_value = '3' WHERE configuration_key = 'CUSTOMERS_APPROVAL_AUTHORIZATION'", 1);
         $db->Execute("UPDATE " . TABLE_CONFIGURATION . " SET configuration_value = 'customers_authorization' WHERE configuration_key = 'CUSTOMERS_AUTHORIZATION_FILENAME'", 1);
     }

--- a/admin/includes/init_includes/init_errors.php
+++ b/admin/includes/init_includes/init_errors.php
@@ -150,10 +150,10 @@ if (!$demo_check->EOF) {
 }
 
 // Check that shipping/payment modules have been defined
-if (zen_get_configuration_key_value('MODULE_PAYMENT_INSTALLED') === '') {
+if (empty(zen_config('MODULE_PAYMENT_INSTALLED'))) {
     $messageStack->add(ERROR_PAYMENT_MODULES_NOT_DEFINED, 'caution');
 }
-if (zen_get_configuration_key_value('MODULE_SHIPPING_INSTALLED') === '') {
+if (empty(zen_config('MODULE_SHIPPING_INSTALLED'))) {
     $messageStack->add(ERROR_SHIPPING_MODULES_NOT_DEFINED, 'caution');
 }
 

--- a/admin/modules.php
+++ b/admin/modules.php
@@ -25,10 +25,10 @@ switch ($set) {
         $module_key = 'MODULE_SHIPPING_INSTALLED';
         define('HEADING_TITLE', HEADING_TITLE_MODULES_SHIPPING);
         $shipping_errors = '';
-        if (zen_get_configuration_key_value('SHIPPING_ORIGIN_ZIP') === 'NONE' || zen_get_configuration_key_value('SHIPPING_ORIGIN_ZIP') === '') {
+        if (zen_config('SHIPPING_ORIGIN_ZIP') === 'NONE' || empty(zen_config('SHIPPING_ORIGIN_ZIP'))) {
             $shipping_errors .= '<br>' . ERROR_SHIPPING_ORIGIN_ZIP;
         }
-        if (zen_get_configuration_key_value('ORDER_WEIGHT_ZERO_STATUS') === '1' && (zen_config('MODULE_SHIPPING_FREESHIPPER_STATUS') !== 'True')) {
+        if (zen_config('ORDER_WEIGHT_ZERO_STATUS') === '1' && (zen_config('MODULE_SHIPPING_FREESHIPPER_STATUS') !== 'True')) {
             $shipping_errors .= '<br>' . ERROR_ORDER_WEIGHT_ZERO_STATUS;
         }
         if ($shipping_errors !== '') {


### PR DESCRIPTION
## Proposal

It seems `zen_get_configuration_key_value()` is almost the same as zen_config insomuch as it checks the configuration table for the key. zen_config (currently) first checks for a define though.

It's possible `zen_get_configuration_key_value()` might have been intended to "bypass cache" by doing a direct lookup. But I'm inclined to hold that this may be redundant nowadays.

Input welcome. 