### PR TITLE
v2.2: Correct (again) paypalwpp's email lang file

### DIFF
--- a/includes/classes/ResourceLoaders/LanguageLoader.php
+++ b/includes/classes/ResourceLoaders/LanguageLoader.php
@@ -127,6 +127,10 @@ class LanguageLoader
      */
     public function hasLanguageFile(string $rootPath, string $language, string $fileName, string $extraPath = ''): bool
     {
+        $extraPath = trim($extraPath, '/');
+        if ($extraPath !== '') {
+            $extraPath = '/' . $extraPath;
+        }
         if (is_file($rootPath . $language . $extraPath . '/' . $fileName)) {
             return true;
         }

--- a/includes/modules/payment/paypalwpp.php
+++ b/includes/modules/payment/paypalwpp.php
@@ -2459,7 +2459,7 @@ if (false) { // disabled until clarification is received about coupons in PayPal
         // send Welcome Email if appropriate
         if ($this->new_acct_notify == 'Yes') {
           // require the language file
-          zen_include_language_file('create_account_send_email.php', '/', 'inline');
+          zen_include_language_file('create_account_send_email.php', '/modules/', 'inline');
           // set the mail text
           $email_text = sprintf(EMAIL_GREET_NONE, $paypal_ec_payer_info['payer_firstname']) . EMAIL_WELCOME . "\n\n" . EMAIL_TEXT;
           $email_text .= "\n\n" . EMAIL_EC_ACCOUNT_INFORMATION . "\nUsername: " . $paypal_ec_payer_info['payer_email'] . "\nPassword: " . $password . "\n\n";


### PR DESCRIPTION
Ref #7872

Note that the 2.2 branch's change requires also an update to the `LanguageLoader`, making a similar change as done in zc300 to strip leading/trailing directory-separators and then adding only a leading one.

Needed there since the `zen_include_language_file` function requires both leading and trailing.