### PR TITLE
Include entered state in shipping-estimator's delivery address

### DIFF
--- a/includes/modules/shipping_estimator.php
+++ b/includes/modules/shipping_estimator.php
@@ -105,6 +105,7 @@ if ($_SESSION['cart']->count_contents() > 0) {
                 //add state zone_id
                 'zone_id' => $state_zone_id,
                 'format_id' => zen_get_address_format_id((int)$_POST['zone_country_id']),
+                'state' => $selectedState,
             ];
             $_SESSION['cart_country_id'] = $_POST['zone_country_id'];
             //add state zone_id
@@ -126,6 +127,7 @@ if ($_SESSION['cart']->count_contents() > 0) {
                 'country_id' => $_SESSION['cart_country_id'],
                 'zone_id' => $state_zone_id,
                 'format_id' => zen_get_address_format_id((int)$_SESSION['cart_country_id']),
+                'state' => $selectedState,
             ];
         } else {
             // first timer
@@ -143,6 +145,7 @@ if ($_SESSION['cart']->count_contents() > 0) {
                 'country_id' => zen_config('STORE_COUNTRY'),
                 'zone_id' => $state_zone_id,
                 'format_id' => zen_get_address_format_id((int)zen_config('STORE_COUNTRY')),
+                'state' => $selectedState,
             ];
         }
         // set the cost to be able to calculate free shipping


### PR DESCRIPTION
Some shipping modules (e.g. `upsoauth`) try to guide the customer to a delivery-address correction. For countries that don't have defined 'zones' (e.g. Aruba), the entered state "should be" included as part of the delivery-address created by the shipping estimator.