### PR TITLE
Fix: Additional images not copied when copying a product

### DIFF
--- a/admin/includes/languages/english/lang.category_product_listing.php
+++ b/admin/includes/languages/english/lang.category_product_listing.php
@@ -50,6 +50,7 @@ $define = [
     'TEXT_INFO_ATTRIBUTES_FEATURES_DELETE' => 'Delete <strong>ALL</strong> Product Attributes for:<br>',
     'TEXT_INFO_ATTRIBUTES_FEATURES_COPY_TO_PRODUCT' => 'Copy Attributes to another <strong>product</strong> from:<br>',
     'TEXT_INFO_ATTRIBUTES_FEATURES_COPY_TO_CATEGORY' => 'Copy Attributes to another <strong>category</strong> from:<br>',
+    'TEXT_COPY_ADDITIONAL_IMAGES' => 'Copy Product *additional* images?',
     'TEXT_COPY_ATTRIBUTES' => 'Copy Product Attributes to Duplicate?',
     'TEXT_COPY_SPECIALS' => 'Copy Product Specials Price to Duplicate?',
     'TEXT_COPY_DISCOUNTS_ONLY' => 'Only used for Duplicate Products with Quantity Discounts ...',

--- a/admin/includes/modules/copy_product.php
+++ b/admin/includes/modules/copy_product.php
@@ -56,6 +56,19 @@ if (zen_has_product_attributes($pInfo->products_id, false)) {
     ];
 }
 
+// offer to copy additional-images if any are associated in the database
+if (zen_config('ADDITIONAL_IMAGES_HANDLING') === 'Database') {
+    $additional_images = $db->Execute("SELECT count(additional_image) AS count FROM " . TABLE_PRODUCTS_ADDITIONAL_IMAGES . " WHERE products_id = " . (int)($pInfo->products_id ?? 0));
+    if (($additional_images->fields['count'] ?? 0) > 0) {
+        $contents[] = [
+            'text' => '<h6>' . TEXT_COPY_ADDITIONAL_IMAGES . '</h6>' .
+                '<div class="radio"><label>' . zen_draw_radio_field('copy_addl_images', 'copy_addl_images_yes', true) . TEXT_YES . '</label></div>' .
+                '<div class="radio"><label>' . zen_draw_radio_field('copy_addl_images', 'copy_addl_images_no') . TEXT_NO . '</label></div>',
+            'params' => 'infoBoxContent duplicate-only hiddenField',
+        ];
+    }
+}
+
 // only ask about specials if defined
 if (zen_has_product_specials($pInfo->products_id)) {
     $contents[] = [

--- a/admin/includes/modules/copy_product_confirm.php
+++ b/admin/includes/modules/copy_product_confirm.php
@@ -173,6 +173,14 @@ if ($_POST['copy_as'] === 'link') {
         }
     }
 
+    // copy product's *additional* images to the duplicate
+    if (($_POST['copy_addl_images'] ?? '') === 'copy_addl_images_yes' && zen_config('ADDITIONAL_IMAGES_HANDLING') === 'Database') {
+        $sql = "INSERT INTO " . TABLE_PRODUCTS_ADDITIONAL_IMAGES . " (products_id, additional_image, sort_order)
+                SELECT " . (int)$dup_products_id . ", additional_image, sort_order FROM " . TABLE_PRODUCTS_ADDITIONAL_IMAGES . "
+                WHERE products_id = " . (int)($products_id ?? 0) . " ORDER BY sort_order";
+        $result = $db->Execute($sql);
+    }
+
 // copy meta tags to Duplicate
     if (!empty($_POST['copy_metatags']) && $_POST['copy_metatags'] === 'copy_metatags_yes') {
         $metatags_status = $db->Execute(


### PR DESCRIPTION
When a store is using the (now default) database mode for tracking "additional image" associations with a product, the "Copy/Clone a product" wasn't copying those images. This update adds the option to also associate those images with the new product clone. The actual files are not copied, but database records are added to co-associate the same filenames with the new product ID.

Fixes #7877