### PR TITLE
ot_coupon revalidate during checkout

### DIFF
--- a/includes/modules/checkout_process.php
+++ b/includes/modules/checkout_process.php
@@ -107,6 +107,10 @@ $zco_notifier->notify('NOTIFY_CHECKOUT_PROCESS_BEFORE_ORDER_TOTALS_PROCESS');
 $order_totals = $order_total_modules->process();
 $zco_notifier->notify('NOTIFY_CHECKOUT_PROCESS_AFTER_ORDER_TOTALS_PROCESS');
 
+if (isset($ot_coupon) && method_exists($ot_coupon, 'shouldAbortCheckoutProcess') && $ot_coupon->shouldAbortCheckoutProcess()) {
+    zen_redirect(zen_href_link(FILENAME_CHECKOUT_CONFIRMATION, '', 'SSL'));
+}
+
 if (!isset($_SESSION['payment']) && $credit_covers === false) {
     zen_redirect(zen_href_link(FILENAME_DEFAULT));
 }

--- a/includes/modules/checkout_process.php
+++ b/includes/modules/checkout_process.php
@@ -108,6 +108,9 @@ $order_totals = $order_total_modules->process();
 $zco_notifier->notify('NOTIFY_CHECKOUT_PROCESS_AFTER_ORDER_TOTALS_PROCESS');
 
 if (isset($ot_coupon) && method_exists($ot_coupon, 'shouldAbortCheckoutProcess') && $ot_coupon->shouldAbortCheckoutProcess()) {
+    if (method_exists($ot_coupon, 'clearCheckoutProcessAbort')) {
+        $ot_coupon->clearCheckoutProcessAbort();
+    }
     zen_redirect(zen_href_link(FILENAME_CHECKOUT_CONFIRMATION, '', 'SSL'));
 }
 

--- a/includes/modules/order_total/ot_coupon.php
+++ b/includes/modules/order_total/ot_coupon.php
@@ -548,31 +548,37 @@ class ot_coupon extends base
 
         $coupon = $db->Execute("SELECT coupon_code, uses_per_coupon, uses_per_user FROM " . TABLE_COUPONS . " WHERE coupon_id = " . $cc_id, 1);
         $coupon_details = ['coupon_id' => $cc_id] + ($coupon->EOF ? ['uses_per_coupon' => 0, 'uses_per_user' => 0] : $coupon->fields);
-        $lockName = 'zc_coupon_redeem_' . $cc_id;
+        $lockName = $this->getCouponRedemptionLockName($coupon_details);
+        $redemptionCustomerId = $this->getCouponRedemptionTrackingCustomerId();
         $haveLock = false;
 
-        if ($this->couponHasUsageCaps($coupon_details)) {
+        if ($lockName !== null) {
             $haveLock = ($this->heldRedemptionLockName === $lockName);
             if (!$haveLock) {
                 $haveLock = $this->getNamedLock($lockName);
             }
         }
 
-        $withinLimits = $this->validateCouponMaximumUses($coupon_details) && $this->validateCouponUsesPerCustomer($coupon_details);
+        $withinLimits = false;
+        if ($lockName === null || $haveLock) {
+            $withinLimits = $this->validateCouponMaximumUses($coupon_details) && $this->validateCouponUsesPerCustomer($coupon_details);
+        } else {
+            $this->notify('NOTIFY_OT_COUPON_FINALIZATION_LOCK_UNAVAILABLE', ['coupon_id' => $cc_id, 'order_id' => (int)$insert_id, 'customer_id' => $redemptionCustomerId]);
+        }
 
         if ($withinLimits) {
             $db->Execute("INSERT INTO " . TABLE_COUPON_REDEEM_TRACK . "
                     (coupon_id, redeem_date, redeem_ip, customer_id, order_id)
-                    VALUES ('" . (int)$cc_id . "', now(), '" . zen_db_input($_SERVER['REMOTE_ADDR'] ?? '') . "', '" . (int)$_SESSION['customer_id'] . "', '" . (int)$insert_id . "')");
+                    VALUES ('" . (int)$cc_id . "', now(), '" . zen_db_input($_SERVER['REMOTE_ADDR'] ?? '') . "', '" . $redemptionCustomerId . "', '" . (int)$insert_id . "')");
         } else {
             /**
              * Race lost: a concurrent checkout claimed this coupon's final redemption slot after
              * the discount on this order had already been calculated. The redeem-track row is not
              * inserted, keeping the coupon's recorded use-count within its configured cap, and the
-             * event is surfaced (notifier + log) so the store owner can reconcile this order rather
+             * event is surfaced via notifier so the store owner can reconcile this order rather
              * than the coupon being silently double-redeemed.
              */
-            $this->notify('NOTIFY_OT_COUPON_REDEEM_LIMIT_RACE_LOST', ['coupon_id' => $cc_id, 'order_id' => (int)$insert_id, 'customer_id' => (int)$_SESSION['customer_id']]);
+            $this->notify('NOTIFY_OT_COUPON_REDEEM_LIMIT_RACE_LOST', ['coupon_id' => $cc_id, 'order_id' => (int)$insert_id, 'customer_id' => $redemptionCustomerId]);
         }
 
         if ($this->heldRedemptionLockName === $lockName) {
@@ -631,14 +637,18 @@ class ot_coupon extends base
             return $this->revalidateCouponAtFinalization($coupon_details);
         }
 
-        $lockName = 'zc_coupon_redeem_' . (int)$coupon_details['coupon_id'];
+        $lockName = $this->getCouponRedemptionLockName($coupon_details);
+
+        if ($lockName === null) {
+            return $this->revalidateCouponAtFinalization($coupon_details);
+        }
 
         if ($this->heldRedemptionLockName !== $lockName) {
             $this->releaseHeldRedemptionLockIfAny();
 
             if (!$this->getNamedLock($lockName)) {
                 $this->notify('NOTIFY_OT_COUPON_FINALIZATION_LOCK_UNAVAILABLE', ['coupon_id' => (int)$coupon_details['coupon_id']]);
-                $this->queueCheckoutProcessAbortMessage(sprintf(TEXT_INVALID_USES_COUPON, $coupon_details['coupon_code'], $coupon_details['uses_per_coupon']));
+                $this->queueCheckoutProcessAbortMessage($this->buildLockUnavailableMessage($coupon_details));
                 $this->remove_coupon_from_current_session();
                 $this->abortCheckoutProcess = true;
                 return false;
@@ -671,6 +681,76 @@ class ot_coupon extends base
     protected function couponHasUsageCaps(array $coupon_details): bool
     {
         return (!empty($coupon_details['uses_per_coupon']) || !empty($coupon_details['uses_per_user']));
+    }
+
+    /**
+     * Build the advisory-lock scope for this coupon.
+     *
+     * Global caps must serialize all users of the coupon. Per-user-only caps should serialize only
+     * requests for the same customer, so independent customers can still check out concurrently.
+     *
+     * @since ZC v2.2.3
+     */
+    protected function getCouponRedemptionLockName(array $coupon_details): ?string
+    {
+        if (!$this->couponHasUsageCaps($coupon_details)) {
+            return null;
+        }
+
+        $couponId = (int)$coupon_details['coupon_id'];
+
+        if (!empty($coupon_details['uses_per_coupon'])) {
+            return 'zc_coupon_redeem_' . $couponId;
+        }
+
+        return 'zc_coupon_redeem_' . $couponId . '_customer_' . $this->getCouponRedemptionLockCustomerId($coupon_details);
+    }
+
+    /**
+     * Resolve the customer identifier used for per-user redemption locking.
+     *
+     * @since ZC v2.2.3
+     */
+    protected function getCouponRedemptionLockCustomerId(array $coupon_details): int
+    {
+        if (!empty($_SESSION['customer_id'])) {
+            return (int)$_SESSION['customer_id'];
+        }
+
+        if (zen_in_guest_checkout()) {
+            return $this->resolveGuestCouponRedemptionLockCustomerId($coupon_details);
+        }
+
+        return 0;
+    }
+
+    /**
+     * Resolve the guest identifier used for per-user redemption locking.
+     *
+     * Guest-checkout integrations can supply a more specific lock identity than the default shared
+     * guest bucket by observing the notifier fired here.
+     *
+     * @since ZC v2.2.3
+     */
+    protected function resolveGuestCouponRedemptionLockCustomerId(array $coupon_details): int
+    {
+        $guestLockCustomerId = 0;
+        $this->notify('NOTIFY_OT_COUPON_GUEST_REDEMPTION_LOCK_CUSTOMER_ID', $coupon_details, $guestLockCustomerId);
+
+        return (int)$guestLockCustomerId;
+    }
+
+    /**
+     * Resolve the customer_id persisted into coupon_redeem_track.
+     *
+     * Guests remain tracked as customer_id 0 in core; guest-checkout integrations that maintain
+     * their own identity ledger can use notifiers around validation/finalization for stricter rules.
+     *
+     * @since ZC v2.2.3
+     */
+    protected function getCouponRedemptionTrackingCustomerId(): int
+    {
+        return (int)($_SESSION['customer_id'] ?? 0);
     }
 
     /**
@@ -732,6 +812,21 @@ class ot_coupon extends base
         if (is_object($messageStack)) {
             $messageStack->add_session($this->getCheckoutCouponMessageStack(), $message, 'caution');
         }
+    }
+
+    /**
+     * Build the customer-facing message used when checkout cannot obtain the finalization lock for
+     * this coupon.
+     *
+     * @since ZC v2.2.3
+     */
+    protected function buildLockUnavailableMessage(array $coupon_details): string
+    {
+        if (empty($coupon_details['uses_per_coupon']) && !empty($coupon_details['uses_per_user'])) {
+            return sprintf(TEXT_INVALID_USES_USER_COUPON, $coupon_details['coupon_code'], $coupon_details['uses_per_user']);
+        }
+
+        return sprintf(TEXT_INVALID_USES_COUPON, $coupon_details['coupon_code'], $coupon_details['uses_per_coupon']);
     }
 
     /**

--- a/includes/modules/order_total/ot_coupon.php
+++ b/includes/modules/order_total/ot_coupon.php
@@ -444,6 +444,55 @@ class ot_coupon extends base
     }
 
     /**
+     * Re-validate the time- and usage-based coupon restrictions at order-finalization time.
+     *
+     * Called from calculate_deductions() so the limits are re-checked immediately before the deduction is
+     * applied -- and before order::create() persists it.
+     *
+     * On failure the now-invalid coupon is dropped from the session (neither applied to the order 
+     * nor recorded as redeemed by apply_credit()); the order then proceeds at the correct, un-discounted total.
+     *
+     * @param array $coupon_details coupon row as fetched from TABLE_COUPONS
+     * @return bool true when the coupon is still valid; false when it was dropped
+     * @since ZC v2.2.3
+     */
+    protected function revalidateCouponAtFinalization(array $coupon_details): bool
+    {
+        global $messageStack;
+
+        $messages = [];
+
+        if (!empty($coupon_details['coupon_start_date']) && !$this->validateCouponStartDate($coupon_details)) {
+            $messages[] = sprintf(TEXT_INVALID_STARTDATE_COUPON, $coupon_details['coupon_code'], zen_date_short($coupon_details['coupon_start_date']));
+        }
+        if (!empty($coupon_details['coupon_expire_date']) && !$this->validateCouponEndDate($coupon_details)) {
+            $messages[] = sprintf(TEXT_INVALID_FINISHDATE_COUPON, $coupon_details['coupon_code'], zen_date_short($coupon_details['coupon_expire_date']));
+        }
+        if (!$this->validateCouponMaximumUses($coupon_details)) {
+            $messages[] = sprintf(TEXT_INVALID_USES_COUPON, $coupon_details['coupon_code'], $coupon_details['uses_per_coupon']);
+        }
+        if (!$this->validateCouponUsesPerCustomer($coupon_details)) {
+            $messages[] = sprintf(TEXT_INVALID_USES_USER_COUPON, $coupon_details['coupon_code'], $coupon_details['uses_per_user']);
+        }
+
+        if (empty($messages)) {
+            return true;
+        }
+
+        // coupon is no longer valid: drop it so it is neither applied to the order nor redeemed
+        $this->notify('NOTIFY_OT_COUPON_FINALIZATION_REVALIDATION_FAILED', ['coupon' => $coupon_details], $messages);
+        $this->remove_coupon_from_current_session();
+
+        if (is_object($messageStack)) {
+            foreach ($messages as $message) {
+                $messageStack->add_session('checkout', $message, 'caution');
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * This function is not used by this module
      *
      * @return bool
@@ -473,13 +522,85 @@ class ot_coupon extends base
     function apply_credit()
     {
         global $db, $insert_id;
+
         $cc_id = empty($_SESSION['cc_id']) ? 0 : (int)$_SESSION['cc_id'];
-        if (!empty($this->deduction)) {
+        if (empty($this->deduction) || $cc_id === 0) {
+            $_SESSION['cc_id'] = '';
+            return;
+        }
+
+        /**
+         * Atomically claim this coupon redemption.
+         *
+         * The coupons / coupon_redeem_track / orders tables are MyISAM, which supports neither
+         * transactions nor SELECT...FOR UPDATE row locking, so a DB transaction is not available here. 
+         * Instead a MySQL named advisory lock (GET_LOCK) -- engine-agnostic, serialized per connection
+         * makes the use-count check and the redeem-track INSERT a single atomic critical section: 
+         * the checks are re-run *inside* the lock immediately before the INSERT, so the second
+         * concurrent checkout to acquire the lock sees the first's freshly-inserted row.
+         */
+        $lockName = 'zc_coupon_redeem_' . $cc_id;
+        $haveLock = $this->getNamedLock($lockName);
+
+        $coupon = $db->Execute("SELECT coupon_code, uses_per_coupon, uses_per_user FROM " . TABLE_COUPONS . " WHERE coupon_id = " . $cc_id, 1);
+        $coupon_details = ['coupon_id' => $cc_id] + ($coupon->EOF ? ['uses_per_coupon' => 0, 'uses_per_user' => 0] : $coupon->fields);
+
+        $withinLimits = $this->validateCouponMaximumUses($coupon_details) && $this->validateCouponUsesPerCustomer($coupon_details);
+
+        if ($withinLimits) {
             $db->Execute("INSERT INTO " . TABLE_COUPON_REDEEM_TRACK . "
                     (coupon_id, redeem_date, redeem_ip, customer_id, order_id)
-                    VALUES ('" . (int)$cc_id . "', now(), '" . $_SERVER['REMOTE_ADDR'] . "', '" . (int)$_SESSION['customer_id'] . "', '" . (int)$insert_id . "')");
+                    VALUES ('" . (int)$cc_id . "', now(), '" . zen_db_input($_SERVER['REMOTE_ADDR'] ?? '') . "', '" . (int)$_SESSION['customer_id'] . "', '" . (int)$insert_id . "')");
+        } else {
+            /**
+             * Race lost: a concurrent checkout claimed this coupon's final redemption slot after
+             * the discount on this order had already been calculated. The redeem-track row is not
+             * inserted, keeping the coupon's recorded use-count within its configured cap, and the
+             * event is surfaced (notifier + log) so the store owner can reconcile this order rather
+             * than the coupon being silently double-redeemed.
+             */
+            $this->notify('NOTIFY_OT_COUPON_REDEEM_LIMIT_RACE_LOST', ['coupon_id' => $cc_id, 'order_id' => (int)$insert_id, 'customer_id' => (int)$_SESSION['customer_id']]);
+            error_log('ot_coupon: coupon redemption cap reached for coupon_id ' . $cc_id . ' during finalization of order ' . (int)$insert_id . '; redeem-track row not written.');
         }
+
+        if ($haveLock) {
+            $this->releaseNamedLock($lockName);
+        }
+
         $_SESSION['cc_id'] = '';
+    }
+
+    /**
+     * Acquire a MySQL named advisory lock (GET_LOCK).
+     *
+     * Used to serialize the coupon-redemption critical section in apply_credit() across concurrent
+     * requests on a MyISAM schema that has no transaction or row-locking support. Returns true when
+     * the lock was granted. A bounded timeout is used so a stuck peer cannot hang a checkout
+     * indefinitely; if the lock cannot be obtained the caller proceeds best-effort:
+     * the order has already been placed, so recording the redemption is preferable to dropping it.
+     *
+     * @return bool true when the lock was granted
+     * @since ZC v2.2.3
+     */
+    protected function getNamedLock(string $lockName, int $timeoutSeconds = 10): bool
+    {
+        global $db;
+
+        $result = $db->Execute("SELECT GET_LOCK('" . zen_db_input($lockName) . "', " . (int)$timeoutSeconds . ") AS got_lock");
+
+        return (!$result->EOF && (int)$result->fields['got_lock'] === 1);
+    }
+
+    /**
+     * Release a MySQL named advisory lock previously obtained via getNamedLock().
+     *
+     * @since ZC v2.2.3
+     */
+    protected function releaseNamedLock(string $lockName): void
+    {
+        global $db;
+
+        $db->Execute("SELECT RELEASE_LOCK('" . zen_db_input($lockName) . "')");
     }
 
     /**
@@ -509,6 +630,19 @@ class ot_coupon extends base
         $coupon_details = $result->fields;
 
         $this->coupon_code = $coupon_details['coupon_code'];
+
+        /**
+         * Re-validate the coupon's restrictions at finalization.
+         *
+         * Complimentary to performValidations() which only runs at apply-time
+         * This method is re-run by process() immediately before order::create() persists the discount, 
+         * re-checking here closes the gap. 
+         * If the coupon is no longer valid it is dropped (see revalidateCouponAtFinalization)
+         * and a zero deduction is returned so the now-invalid coupon is not honored.
+         */
+        if (!$this->revalidateCouponAtFinalization($coupon_details)) {
+            return $od_amount;
+        }
 
         $orderTotalDetails = $this->get_order_total($coupon_details['coupon_id']);
 

--- a/includes/modules/order_total/ot_coupon.php
+++ b/includes/modules/order_total/ot_coupon.php
@@ -146,8 +146,6 @@ class ot_coupon extends base
     {
         global $order, $currencies;
 
-        $this->abortCheckoutProcess = false;
-
         if (empty($_SESSION['cc_id'])) {
             $this->releaseHeldRedemptionLockIfAny();
             return;
@@ -686,6 +684,16 @@ class ot_coupon extends base
     public function shouldAbortCheckoutProcess(): bool
     {
         return $this->abortCheckoutProcess;
+    }
+
+    /**
+     * Clear the checkout-process abort flag after the caller has handled it.
+     *
+     * @since ZC v2.2.3
+     */
+    public function clearCheckoutProcessAbort(): void
+    {
+        $this->abortCheckoutProcess = false;
     }
 
     /**

--- a/includes/modules/order_total/ot_coupon.php
+++ b/includes/modules/order_total/ot_coupon.php
@@ -546,14 +546,17 @@ class ot_coupon extends base
             return;
         }
 
-        $lockName = 'zc_coupon_redeem_' . $cc_id;
-        $haveLock = ($this->heldRedemptionLockName === $lockName);
-        if (!$haveLock) {
-            $haveLock = $this->getNamedLock($lockName);
-        }
-
         $coupon = $db->Execute("SELECT coupon_code, uses_per_coupon, uses_per_user FROM " . TABLE_COUPONS . " WHERE coupon_id = " . $cc_id, 1);
         $coupon_details = ['coupon_id' => $cc_id] + ($coupon->EOF ? ['uses_per_coupon' => 0, 'uses_per_user' => 0] : $coupon->fields);
+        $lockName = 'zc_coupon_redeem_' . $cc_id;
+        $haveLock = false;
+
+        if ($this->couponHasUsageCaps($coupon_details)) {
+            $haveLock = ($this->heldRedemptionLockName === $lockName);
+            if (!$haveLock) {
+                $haveLock = $this->getNamedLock($lockName);
+            }
+        }
 
         $withinLimits = $this->validateCouponMaximumUses($coupon_details) && $this->validateCouponUsesPerCustomer($coupon_details);
 
@@ -624,7 +627,7 @@ class ot_coupon extends base
      */
     protected function prepareCouponForFinalization(array $coupon_details): bool
     {
-        if (!$this->shouldHoldRedemptionLockDuringCheckoutProcess()) {
+        if (!$this->shouldHoldRedemptionLockDuringCheckoutProcess() || !$this->couponHasUsageCaps($coupon_details)) {
             return $this->revalidateCouponAtFinalization($coupon_details);
         }
 
@@ -658,6 +661,16 @@ class ot_coupon extends base
         global $current_page_base;
 
         return (isset($current_page_base) && $current_page_base === FILENAME_CHECKOUT_PROCESS);
+    }
+
+    /**
+     * True when the coupon has a finite usage cap that needs concurrency control.
+     *
+     * @since ZC v2.2.3
+     */
+    protected function couponHasUsageCaps(array $coupon_details): bool
+    {
+        return (!empty($coupon_details['uses_per_coupon']) || !empty($coupon_details['uses_per_user']));
     }
 
     /**

--- a/includes/modules/order_total/ot_coupon.php
+++ b/includes/modules/order_total/ot_coupon.php
@@ -98,6 +98,11 @@ class ot_coupon extends base
      * @var array
      */
     protected $validation_errors = [];
+    /**
+     * Advisory lock currently held across checkout_process finalization, if any.
+     * @var string|null
+     */
+    protected ?string $heldRedemptionLockName = null;
 
     function __construct()
     {
@@ -137,6 +142,7 @@ class ot_coupon extends base
         global $order, $currencies;
 
         if (empty($_SESSION['cc_id'])) {
+            $this->releaseHeldRedemptionLockIfAny();
             return;
         }
 
@@ -188,6 +194,7 @@ class ot_coupon extends base
      */
     function clear_posts()
     {
+        $this->releaseHeldRedemptionLockIfAny();
         unset($_POST['dc_redeem_code']);
         unset($_SESSION['cc_id']);
     }
@@ -525,22 +532,16 @@ class ot_coupon extends base
 
         $cc_id = empty($_SESSION['cc_id']) ? 0 : (int)$_SESSION['cc_id'];
         if (empty($this->deduction) || $cc_id === 0) {
+            $this->releaseHeldRedemptionLockIfAny();
             $_SESSION['cc_id'] = '';
             return;
         }
 
-        /**
-         * Atomically claim this coupon redemption.
-         *
-         * The coupons / coupon_redeem_track / orders tables are MyISAM, which supports neither
-         * transactions nor SELECT...FOR UPDATE row locking, so a DB transaction is not available here. 
-         * Instead a MySQL named advisory lock (GET_LOCK) -- engine-agnostic, serialized per connection
-         * makes the use-count check and the redeem-track INSERT a single atomic critical section: 
-         * the checks are re-run *inside* the lock immediately before the INSERT, so the second
-         * concurrent checkout to acquire the lock sees the first's freshly-inserted row.
-         */
         $lockName = 'zc_coupon_redeem_' . $cc_id;
-        $haveLock = $this->getNamedLock($lockName);
+        $haveLock = ($this->heldRedemptionLockName === $lockName);
+        if (!$haveLock) {
+            $haveLock = $this->getNamedLock($lockName);
+        }
 
         $coupon = $db->Execute("SELECT coupon_code, uses_per_coupon, uses_per_user FROM " . TABLE_COUPONS . " WHERE coupon_id = " . $cc_id, 1);
         $coupon_details = ['coupon_id' => $cc_id] + ($coupon->EOF ? ['uses_per_coupon' => 0, 'uses_per_user' => 0] : $coupon->fields);
@@ -560,10 +561,11 @@ class ot_coupon extends base
              * than the coupon being silently double-redeemed.
              */
             $this->notify('NOTIFY_OT_COUPON_REDEEM_LIMIT_RACE_LOST', ['coupon_id' => $cc_id, 'order_id' => (int)$insert_id, 'customer_id' => (int)$_SESSION['customer_id']]);
-            error_log('ot_coupon: coupon redemption cap reached for coupon_id ' . $cc_id . ' during finalization of order ' . (int)$insert_id . '; redeem-track row not written.');
         }
 
-        if ($haveLock) {
+        if ($this->heldRedemptionLockName === $lockName) {
+            $this->releaseHeldRedemptionLockIfAny();
+        } elseif ($haveLock) {
             $this->releaseNamedLock($lockName);
         }
 
@@ -573,11 +575,9 @@ class ot_coupon extends base
     /**
      * Acquire a MySQL named advisory lock (GET_LOCK).
      *
-     * Used to serialize the coupon-redemption critical section in apply_credit() across concurrent
-     * requests on a MyISAM schema that has no transaction or row-locking support. Returns true when
-     * the lock was granted. A bounded timeout is used so a stuck peer cannot hang a checkout
-     * indefinitely; if the lock cannot be obtained the caller proceeds best-effort:
-     * the order has already been placed, so recording the redemption is preferable to dropping it.
+     * Used to serialize coupon finalization across concurrent requests on a MyISAM schema that has
+     * no transaction or row-locking support. Returns true when the lock was granted. A bounded
+     * timeout is used so a stuck peer cannot hang checkout indefinitely.
      *
      * @return bool true when the lock was granted
      * @since ZC v2.2.3
@@ -601,6 +601,67 @@ class ot_coupon extends base
         global $db;
 
         $db->Execute("SELECT RELEASE_LOCK('" . zen_db_input($lockName) . "')");
+    }
+
+    /**
+     * Re-validate the coupon's restrictions at finalization and, during checkout_process,
+     * hold the coupon's advisory lock until apply_credit() records the redemption.
+     *
+     * Holding the lock across order-total calculation and order persistence prevents a
+     * second concurrent checkout from receiving the same discount before the first request
+     * records its redeem-track row.
+     *
+     * @since ZC v2.2.3
+     */
+    protected function prepareCouponForFinalization(array $coupon_details): bool
+    {
+        if (!$this->shouldHoldRedemptionLockDuringCheckoutProcess()) {
+            return $this->revalidateCouponAtFinalization($coupon_details);
+        }
+
+        $lockName = 'zc_coupon_redeem_' . (int)$coupon_details['coupon_id'];
+
+        if ($this->heldRedemptionLockName !== $lockName) {
+            $this->releaseHeldRedemptionLockIfAny();
+
+            if (!$this->getNamedLock($lockName)) {
+                $this->notify('NOTIFY_OT_COUPON_FINALIZATION_LOCK_UNAVAILABLE', ['coupon_id' => (int)$coupon_details['coupon_id']]);
+                $this->remove_coupon_from_current_session();
+                return false;
+            }
+
+            $this->heldRedemptionLockName = $lockName;
+        }
+
+        return $this->revalidateCouponAtFinalization($coupon_details);
+    }
+
+    /**
+     * Hold coupon finalization locks only during checkout_process, where the discounted totals
+     * are about to be persisted.
+     *
+     * @since ZC v2.2.3
+     */
+    protected function shouldHoldRedemptionLockDuringCheckoutProcess(): bool
+    {
+        global $current_page_base;
+
+        return (isset($current_page_base) && $current_page_base === FILENAME_CHECKOUT_PROCESS);
+    }
+
+    /**
+     * Release any checkout_process coupon finalization lock currently held by this instance.
+     *
+     * @since ZC v2.2.3
+     */
+    protected function releaseHeldRedemptionLockIfAny(): void
+    {
+        if ($this->heldRedemptionLockName === null) {
+            return;
+        }
+
+        $this->releaseNamedLock($this->heldRedemptionLockName);
+        $this->heldRedemptionLockName = null;
     }
 
     /**
@@ -631,16 +692,7 @@ class ot_coupon extends base
 
         $this->coupon_code = $coupon_details['coupon_code'];
 
-        /**
-         * Re-validate the coupon's restrictions at finalization.
-         *
-         * Complimentary to performValidations() which only runs at apply-time
-         * This method is re-run by process() immediately before order::create() persists the discount, 
-         * re-checking here closes the gap. 
-         * If the coupon is no longer valid it is dropped (see revalidateCouponAtFinalization)
-         * and a zero deduction is returned so the now-invalid coupon is not honored.
-         */
-        if (!$this->revalidateCouponAtFinalization($coupon_details)) {
+        if (!$this->prepareCouponForFinalization($coupon_details)) {
             return $od_amount;
         }
 

--- a/includes/modules/order_total/ot_coupon.php
+++ b/includes/modules/order_total/ot_coupon.php
@@ -99,6 +99,11 @@ class ot_coupon extends base
      */
     protected $validation_errors = [];
     /**
+     * Indicates that checkout_process must not continue after this module dropped the coupon.
+     * @var bool
+     */
+    protected bool $abortCheckoutProcess = false;
+    /**
      * Advisory lock currently held across checkout_process finalization, if any.
      * @var string|null
      */
@@ -140,6 +145,8 @@ class ot_coupon extends base
     function process()
     {
         global $order, $currencies;
+
+        $this->abortCheckoutProcess = false;
 
         if (empty($_SESSION['cc_id'])) {
             $this->releaseHeldRedemptionLockIfAny();
@@ -492,8 +499,12 @@ class ot_coupon extends base
 
         if (is_object($messageStack)) {
             foreach ($messages as $message) {
-                $messageStack->add_session('checkout', $message, 'caution');
+                $messageStack->add_session($this->getCheckoutCouponMessageStack(), $message, 'caution');
             }
+        }
+
+        if ($this->shouldHoldRedemptionLockDuringCheckoutProcess()) {
+            $this->abortCheckoutProcess = true;
         }
 
         return false;
@@ -626,7 +637,9 @@ class ot_coupon extends base
 
             if (!$this->getNamedLock($lockName)) {
                 $this->notify('NOTIFY_OT_COUPON_FINALIZATION_LOCK_UNAVAILABLE', ['coupon_id' => (int)$coupon_details['coupon_id']]);
+                $this->queueCheckoutProcessAbortMessage(sprintf(TEXT_INVALID_USES_COUPON, $coupon_details['coupon_code'], $coupon_details['uses_per_coupon']));
                 $this->remove_coupon_from_current_session();
+                $this->abortCheckoutProcess = true;
                 return false;
             }
 
@@ -662,6 +675,42 @@ class ot_coupon extends base
 
         $this->releaseNamedLock($this->heldRedemptionLockName);
         $this->heldRedemptionLockName = null;
+    }
+
+    /**
+     * True when checkout_process must redirect the customer back instead of finalizing an order at
+     * a different total than the one they confirmed.
+     *
+     * @since ZC v2.2.3
+     */
+    public function shouldAbortCheckoutProcess(): bool
+    {
+        return $this->abortCheckoutProcess;
+    }
+
+    /**
+     * Message-stack target used when a coupon is dropped during checkout.
+     *
+     * @since ZC v2.2.3
+     */
+    protected function getCheckoutCouponMessageStack(): string
+    {
+        return $this->shouldHoldRedemptionLockDuringCheckoutProcess() ? 'checkout_confirmation' : 'checkout_payment';
+    }
+
+    /**
+     * Queue a caution message on the page the customer will be returned to when checkout cannot
+     * proceed with the coupon they previously confirmed.
+     *
+     * @since ZC v2.2.3
+     */
+    protected function queueCheckoutProcessAbortMessage(string $message): void
+    {
+        global $messageStack;
+
+        if (is_object($messageStack)) {
+            $messageStack->add_session($this->getCheckoutCouponMessageStack(), $message, 'caution');
+        }
     }
 
     /**

--- a/not_for_release/testFramework/Unit/testsDiscountCoupon/DiscountCouponRaceConditionTest.php
+++ b/not_for_release/testFramework/Unit/testsDiscountCoupon/DiscountCouponRaceConditionTest.php
@@ -1,0 +1,238 @@
+<?php
+/**
+ * @copyright Copyright 2003-2026 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ */
+
+use Tests\Support\zcDiscountCouponTest;
+
+class DiscountCouponRaceConditionTest extends zcDiscountCouponTest
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        require_once TESTCWD . 'Support/functionsDiscountCoupons.php';
+        require_once TESTCWD . 'Support/StubCouponValidation.php';
+        require_once DIR_FS_CATALOG . 'includes/modules/order_total/ot_coupon.php';
+        require_once DIR_FS_CATALOG . 'includes/classes/shopping_cart.php';
+        require_once DIR_FS_CATALOG . 'includes/classes/currencies.php';
+
+        if (!function_exists('zen_is_logged_in')) {
+            eval('function zen_is_logged_in(): bool { return !empty($_SESSION["customer_id"]); }');
+        }
+        if (!function_exists('zen_in_guest_checkout')) {
+            eval('function zen_in_guest_checkout(): bool { return false; }');
+        }
+        if (!function_exists('zen_db_input')) {
+            eval('function zen_db_input($string) { return addslashes((string)$string); }');
+        }
+
+        $_SESSION['currency'] = 'USD';
+        $GLOBALS['current_page_base'] = FILENAME_CHECKOUT_PROCESS;
+
+        defined('MODULE_ORDER_TOTAL_COUPON_HEADER') || define('MODULE_ORDER_TOTAL_COUPON_HEADER', '');
+        defined('MODULE_ORDER_TOTAL_COUPON_TITLE') || define('MODULE_ORDER_TOTAL_COUPON_TITLE', '');
+        defined('MODULE_ORDER_TOTAL_COUPON_DESCRIPTION') || define('MODULE_ORDER_TOTAL_COUPON_DESCRIPTION', '');
+        defined('MODULE_ORDER_TOTAL_COUPON_SORT_ORDER') || define('MODULE_ORDER_TOTAL_COUPON_SORT_ORDER', '');
+        defined('MODULE_ORDER_TOTAL_COUPON_INC_SHIPPING') || define('MODULE_ORDER_TOTAL_COUPON_INC_SHIPPING', '');
+        defined('MODULE_ORDER_TOTAL_COUPON_INC_TAX') || define('MODULE_ORDER_TOTAL_COUPON_INC_TAX', 'false');
+        defined('MODULE_ORDER_TOTAL_COUPON_CALC_TAX') || define('MODULE_ORDER_TOTAL_COUPON_CALC_TAX', 'Standard');
+        defined('MODULE_ORDER_TOTAL_COUPON_TAX_CLASS') || define('MODULE_ORDER_TOTAL_COUPON_TAX_CLASS', '');
+        defined('DISPLAY_PRICE_WITH_TAX') || define('DISPLAY_PRICE_WITH_TAX', 'false');
+
+        $GLOBALS['currencies'] = $this->getMockBuilder('currencies')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $GLOBALS['currencies']->method('get_decimal_places')->willReturn(2);
+
+        $_SESSION['cart'] = $this->getMockBuilder('shoppingCart')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $_SESSION['cart']->method('get_products')->willReturn([
+            [
+                'id' => 27,
+                'category' => 5,
+                'name' => 'Packard LaserJet 1100Xi Linked',
+                'model' => 'HPLJ1100XI',
+                'image' => 'hewlett_packard/lj1100xi.gif',
+                'price' => 499.99,
+                'quantity' => 1,
+                'weight' => 45,
+                'final_price' => 499.99,
+                'onetime_charges' => 0,
+                'tax_class_id' => 1,
+                'attributes' => '',
+                'attributes_values' => '',
+                'products_priced_by_attribute' => 0,
+                'product_is_free' => 0,
+                'products_discount_type' => 0,
+                'products_discount_type_from' => 0,
+                'products_virtual' => 0,
+                'product_is_always_free_shipping' => 0,
+                'products_quantity_order_min' => 1,
+                'products_quantity_order_units' => 1,
+                'products_quantity_order_max' => 0,
+                'products_quantity_mixed' => 0,
+                'products_mixed_discount_quantity' => 1,
+            ],
+        ]);
+    }
+
+    public function testConcurrentCheckoutCannotReceiveDiscountWhileCouponLockIsHeld(): void
+    {
+        $couponDetails = [
+            'coupon_id' => 1,
+            'coupon_code' => 'race-test',
+            'coupon_total' => 0,
+            'coupon_minimum_order' => 0,
+            'coupon_amount' => 10,
+            'coupon_type' => 'P',
+            'coupon_product_count' => 0,
+            'coupon_calc_base' => 0,
+            'uses_per_coupon' => 1,
+            'uses_per_user' => 0,
+            'coupon_start_date' => date('Y-m-d H:i:s', strtotime('-1 day')),
+            'coupon_expire_date' => date('Y-m-d H:i:s', strtotime('+1 day')),
+        ];
+        $GLOBALS['db'] = new DiscountCouponRaceDb($couponDetails);
+
+        $requestOneOrder = (object)['info' => $this->getBaseOrderInfo()];
+        $GLOBALS['order'] = $requestOneOrder;
+        $_SESSION['customer_id'] = 101;
+        $_SESSION['cc_id'] = '1';
+
+        $couponOne = new ot_coupon();
+        $couponOne->include_shipping = 'false';
+        $couponOne->process();
+
+        $this->assertEquals(452.49, $requestOneOrder->info['total']);
+
+        $requestTwoOrder = (object)['info' => $this->getBaseOrderInfo()];
+        $GLOBALS['order'] = $requestTwoOrder;
+        $_SESSION['customer_id'] = 202;
+        $_SESSION['cc_id'] = '1';
+
+        $couponTwo = new ot_coupon();
+        $couponTwo->include_shipping = 'false';
+        $couponTwo->process();
+
+        $this->assertEquals(
+            502.49,
+            $requestTwoOrder->info['total'],
+            'A concurrent checkout must not receive the coupon discount while another request holds the finalization lock.'
+        );
+
+        $GLOBALS['insert_id'] = 1001;
+        $_SESSION['customer_id'] = 101;
+        $_SESSION['cc_id'] = '1';
+        $couponOne->apply_credit();
+
+        $this->assertCount(1, $GLOBALS['db']->redemptions);
+
+        $GLOBALS['insert_id'] = 1002;
+        $_SESSION['customer_id'] = 202;
+        $_SESSION['cc_id'] = '1';
+        $couponTwo->apply_credit();
+
+        $this->assertCount(1, $GLOBALS['db']->redemptions);
+    }
+
+    protected function getBaseOrderInfo(): array
+    {
+        return [
+            'tax_groups' => [],
+            'tax' => 0,
+            'total' => 502.49,
+            'shipping_cost' => 2.50,
+            'shipping_tax' => 0,
+        ];
+    }
+}
+
+class DiscountCouponRaceDb
+{
+    public array $couponDetails;
+    public array $redemptions = [];
+    private ?string $heldLockName = null;
+
+    public function __construct(array $couponDetails)
+    {
+        $this->couponDetails = $couponDetails;
+    }
+
+    public function Execute(string $sql, $limit = null): DiscountCouponRaceResult
+    {
+        if (str_contains($sql, 'SELECT GET_LOCK(')) {
+            preg_match("/SELECT GET_LOCK\\('(.*)', \\d+\\)/", $sql, $matches);
+            $requestedLock = stripslashes($matches[1] ?? '');
+            if ($this->heldLockName !== null && $this->heldLockName === $requestedLock) {
+                return new DiscountCouponRaceResult(['got_lock' => 0], 1);
+            }
+
+            $this->heldLockName = $requestedLock;
+
+            return new DiscountCouponRaceResult(['got_lock' => 1], 1);
+        }
+
+        if (str_contains($sql, 'SELECT RELEASE_LOCK(')) {
+            $this->heldLockName = null;
+            return new DiscountCouponRaceResult(['released' => 1], 1);
+        }
+
+        if (str_contains($sql, 'FROM ' . TABLE_COUPONS . ' WHERE coupon_id = 1')) {
+            return new DiscountCouponRaceResult($this->couponDetails, 1);
+        }
+
+        if (str_contains($sql, 'SELECT count(coupon_id) as total_uses_of_coupon')) {
+            return new DiscountCouponRaceResult(['total_uses_of_coupon' => count($this->redemptions)], 1);
+        }
+
+        if (str_contains($sql, 'FROM ' . TABLE_COUPON_REDEEM_TRACK) && str_contains($sql, 'AND customer_id =')) {
+            preg_match('/AND customer_id = (\d+)/', $sql, $customerMatches);
+            $customerId = (int)($customerMatches[1] ?? 0);
+            $matching = array_values(array_filter(
+                $this->redemptions,
+                static fn(array $redemption): bool => $redemption['customer_id'] === $customerId
+            ));
+
+            return new DiscountCouponRaceResult(
+                empty($matching) ? [] : ['coupon_id' => $matching[0]['coupon_id']],
+                count($matching),
+                empty($matching)
+            );
+        }
+
+        if (str_contains($sql, 'INSERT INTO ' . TABLE_COUPON_REDEEM_TRACK)) {
+            preg_match("/VALUES \\('(\\d+)', now\\(\\), '.*', '(\\d+)', '(\\d+)'\\)/", $sql, $matches);
+            $this->redemptions[] = [
+                'coupon_id' => (int)($matches[1] ?? 0),
+                'customer_id' => (int)($matches[2] ?? 0),
+                'order_id' => (int)($matches[3] ?? 0),
+            ];
+
+            return new DiscountCouponRaceResult([], 1);
+        }
+
+        throw new RuntimeException('Unhandled SQL in test double: ' . $sql);
+    }
+}
+
+class DiscountCouponRaceResult
+{
+    public array $fields;
+    public bool $EOF;
+    private int $recordCount;
+
+    public function __construct(array $fields, int $recordCount, bool $eof = false)
+    {
+        $this->fields = $fields;
+        $this->recordCount = $recordCount;
+        $this->EOF = $eof;
+    }
+
+    public function RecordCount(): int
+    {
+        return $this->recordCount;
+    }
+}

--- a/not_for_release/testFramework/Unit/testsDiscountCoupon/DiscountCouponRaceConditionTest.php
+++ b/not_for_release/testFramework/Unit/testsDiscountCoupon/DiscountCouponRaceConditionTest.php
@@ -22,7 +22,7 @@ class DiscountCouponRaceConditionTest extends zcDiscountCouponTest
             eval('function zen_is_logged_in(): bool { return !empty($_SESSION["customer_id"]); }');
         }
         if (!function_exists('zen_in_guest_checkout')) {
-            eval('function zen_in_guest_checkout(): bool { return false; }');
+            eval('function zen_in_guest_checkout(): bool { return !empty($_SESSION["guest_checkout"]); }');
         }
         if (!function_exists('zen_db_input')) {
             eval('function zen_db_input($string) { return addslashes((string)$string); }');
@@ -42,6 +42,7 @@ class DiscountCouponRaceConditionTest extends zcDiscountCouponTest
         defined('MODULE_ORDER_TOTAL_COUPON_TAX_CLASS') || define('MODULE_ORDER_TOTAL_COUPON_TAX_CLASS', '');
         defined('DISPLAY_PRICE_WITH_TAX') || define('DISPLAY_PRICE_WITH_TAX', 'false');
         defined('TEXT_INVALID_USES_COUPON') || define('TEXT_INVALID_USES_COUPON', 'Coupon %1$s has reached its %2$s-use limit.');
+        defined('TEXT_INVALID_USES_USER_COUPON') || define('TEXT_INVALID_USES_USER_COUPON', 'Coupon %1$s has reached your %2$s-use limit.');
 
         $GLOBALS['currencies'] = $this->getMockBuilder('currencies')
             ->disableOriginalConstructor()
@@ -142,6 +143,57 @@ class DiscountCouponRaceConditionTest extends zcDiscountCouponTest
         $this->assertCount(1, $GLOBALS['db']->redemptions);
     }
 
+    public function testConcurrentCheckoutAbortSurvivesSecondProcessPass(): void
+    {
+        $couponDetails = [
+            'coupon_id' => 1,
+            'coupon_code' => 'two-pass-race-test',
+            'coupon_total' => 0,
+            'coupon_minimum_order' => 0,
+            'coupon_amount' => 10,
+            'coupon_type' => 'P',
+            'coupon_product_count' => 0,
+            'coupon_calc_base' => 0,
+            'uses_per_coupon' => 1,
+            'uses_per_user' => 0,
+            'coupon_start_date' => date('Y-m-d H:i:s', strtotime('-1 day')),
+            'coupon_expire_date' => date('Y-m-d H:i:s', strtotime('+1 day')),
+        ];
+        $GLOBALS['db'] = new DiscountCouponRaceDb($couponDetails);
+
+        $GLOBALS['order'] = (object)['info' => $this->getBaseOrderInfo()];
+        $_SESSION['customer_id'] = 101;
+        $_SESSION['cc_id'] = '1';
+
+        $couponOne = new ot_coupon();
+        $couponOne->include_shipping = 'false';
+        $couponOne->process();
+
+        $requestTwoOrder = (object)['info' => $this->getBaseOrderInfo()];
+        $GLOBALS['order'] = $requestTwoOrder;
+        $_SESSION['customer_id'] = 202;
+        $_SESSION['cc_id'] = '1';
+
+        $couponTwo = new ot_coupon();
+        $couponTwo->include_shipping = 'false';
+        $couponTwo->process();
+
+        $this->assertTrue($couponTwo->shouldAbortCheckoutProcess());
+        $this->assertArrayNotHasKey('cc_id', $_SESSION);
+        $this->assertEquals(502.49, $requestTwoOrder->info['total']);
+
+        $requestTwoSecondPassOrder = (object)['info' => $this->getBaseOrderInfo()];
+        $GLOBALS['order'] = $requestTwoSecondPassOrder;
+        $couponTwo->process();
+
+        $this->assertTrue($couponTwo->shouldAbortCheckoutProcess());
+        $this->assertEquals(
+            502.49,
+            $requestTwoSecondPassOrder->info['total'],
+            'The abort flag must survive the second checkout_process totals pass so checkout redirects before charging a different total.'
+        );
+    }
+
     public function testUnlimitedUseCouponDoesNotTakeAdvisoryLockDuringCheckoutProcess(): void
     {
         $couponDetails = [
@@ -177,6 +229,306 @@ class DiscountCouponRaceConditionTest extends zcDiscountCouponTest
         $this->assertSame(0, $GLOBALS['db']->getLockCalls);
     }
 
+    public function testPerUserOnlyCouponDoesNotSerializeDifferentCustomers(): void
+    {
+        $couponDetails = [
+            'coupon_id' => 1,
+            'coupon_code' => 'per-user-test',
+            'coupon_total' => 0,
+            'coupon_minimum_order' => 0,
+            'coupon_amount' => 10,
+            'coupon_type' => 'P',
+            'coupon_product_count' => 0,
+            'coupon_calc_base' => 0,
+            'uses_per_coupon' => 0,
+            'uses_per_user' => 1,
+            'coupon_start_date' => date('Y-m-d H:i:s', strtotime('-1 day')),
+            'coupon_expire_date' => date('Y-m-d H:i:s', strtotime('+1 day')),
+        ];
+        $GLOBALS['db'] = new DiscountCouponRaceDb($couponDetails);
+
+        $requestOneOrder = (object)['info' => $this->getBaseOrderInfo()];
+        $GLOBALS['order'] = $requestOneOrder;
+        $_SESSION['customer_id'] = 101;
+        $_SESSION['cc_id'] = '1';
+
+        $couponOne = new ot_coupon();
+        $couponOne->include_shipping = 'false';
+        $couponOne->process();
+
+        $requestTwoOrder = (object)['info' => $this->getBaseOrderInfo()];
+        $GLOBALS['order'] = $requestTwoOrder;
+        $_SESSION['customer_id'] = 202;
+        $_SESSION['cc_id'] = '1';
+
+        $couponTwo = new ot_coupon();
+        $couponTwo->include_shipping = 'false';
+        $couponTwo->process();
+
+        $this->assertEquals(452.49, $requestOneOrder->info['total']);
+        $this->assertEquals(452.49, $requestTwoOrder->info['total']);
+        $this->assertFalse($couponTwo->shouldAbortCheckoutProcess());
+        $this->assertContains('zc_coupon_redeem_1_customer_101', $GLOBALS['db']->getLockNames);
+        $this->assertContains('zc_coupon_redeem_1_customer_202', $GLOBALS['db']->getLockNames);
+
+        $GLOBALS['insert_id'] = 1001;
+        $_SESSION['customer_id'] = 101;
+        $_SESSION['cc_id'] = '1';
+        $couponOne->apply_credit();
+
+        $GLOBALS['insert_id'] = 1002;
+        $_SESSION['customer_id'] = 202;
+        $_SESSION['cc_id'] = '1';
+        $couponTwo->apply_credit();
+
+        $this->assertCount(2, $GLOBALS['db']->redemptions);
+    }
+
+    public function testGuestCheckoutWithUsesPerUserSetUsesSharedGuestIdentityLock(): void
+    {
+        $couponDetails = [
+            'coupon_id' => 1,
+            'coupon_code' => 'guest-user-test',
+            'coupon_total' => 0,
+            'coupon_minimum_order' => 0,
+            'coupon_amount' => 10,
+            'coupon_type' => 'P',
+            'coupon_product_count' => 0,
+            'coupon_calc_base' => 0,
+            'uses_per_coupon' => 0,
+            'uses_per_user' => 1,
+            'coupon_start_date' => date('Y-m-d H:i:s', strtotime('-1 day')),
+            'coupon_expire_date' => date('Y-m-d H:i:s', strtotime('+1 day')),
+        ];
+        $GLOBALS['db'] = new DiscountCouponRaceDb($couponDetails);
+
+        unset($_SESSION['customer_id']);
+        $_SESSION['guest_checkout'] = true;
+
+        $requestOneOrder = (object)['info' => $this->getBaseOrderInfo()];
+        $GLOBALS['order'] = $requestOneOrder;
+        $_SESSION['cc_id'] = '1';
+
+        $couponOne = new ot_coupon();
+        $couponOne->include_shipping = 'false';
+        $couponOne->process();
+
+        $requestTwoOrder = (object)['info' => $this->getBaseOrderInfo()];
+        $GLOBALS['order'] = $requestTwoOrder;
+        $_SESSION['cc_id'] = '1';
+
+        $couponTwo = new ot_coupon();
+        $couponTwo->include_shipping = 'false';
+        $couponTwo->process();
+
+        $this->assertEquals(452.49, $requestOneOrder->info['total']);
+        $this->assertEquals(502.49, $requestTwoOrder->info['total']);
+        $this->assertTrue($couponTwo->shouldAbortCheckoutProcess());
+        $this->assertContains('zc_coupon_redeem_1_customer_0', $GLOBALS['db']->getLockNames);
+    }
+
+    public function testGuestCheckoutCanOverridePerUserLockIdentity(): void
+    {
+        $couponDetails = [
+            'coupon_id' => 1,
+            'coupon_code' => 'guest-lock-override-test',
+            'coupon_total' => 0,
+            'coupon_minimum_order' => 0,
+            'coupon_amount' => 10,
+            'coupon_type' => 'P',
+            'coupon_product_count' => 0,
+            'coupon_calc_base' => 0,
+            'uses_per_coupon' => 0,
+            'uses_per_user' => 1,
+            'coupon_start_date' => date('Y-m-d H:i:s', strtotime('-1 day')),
+            'coupon_expire_date' => date('Y-m-d H:i:s', strtotime('+1 day')),
+        ];
+        $GLOBALS['db'] = new DiscountCouponRaceDb($couponDetails);
+
+        unset($_SESSION['customer_id']);
+        $_SESSION['guest_checkout'] = true;
+        $_SESSION['cc_id'] = '1';
+        $GLOBALS['order'] = (object)['info' => $this->getBaseOrderInfo()];
+
+        $coupon = new DiscountCouponRaceGuestAwareCoupon(98765);
+        $coupon->include_shipping = 'false';
+        $coupon->process();
+
+        $this->assertContains('zc_coupon_redeem_1_customer_98765', $GLOBALS['db']->getLockNames);
+    }
+
+    public function testPerUserOnlyLockTimeoutQueuesPerUserMessage(): void
+    {
+        $couponDetails = [
+            'coupon_id' => 1,
+            'coupon_code' => 'per-user-timeout',
+            'coupon_total' => 0,
+            'coupon_minimum_order' => 0,
+            'coupon_amount' => 10,
+            'coupon_type' => 'P',
+            'coupon_product_count' => 0,
+            'coupon_calc_base' => 0,
+            'uses_per_coupon' => 0,
+            'uses_per_user' => 1,
+            'coupon_start_date' => date('Y-m-d H:i:s', strtotime('-1 day')),
+            'coupon_expire_date' => date('Y-m-d H:i:s', strtotime('+1 day')),
+        ];
+        $GLOBALS['db'] = new DiscountCouponRaceDb($couponDetails);
+
+        $GLOBALS['order'] = (object)['info' => $this->getBaseOrderInfo()];
+        $_SESSION['customer_id'] = 101;
+        $_SESSION['cc_id'] = '1';
+
+        $couponOne = new ot_coupon();
+        $couponOne->include_shipping = 'false';
+        $couponOne->process();
+
+        $GLOBALS['order'] = (object)['info' => $this->getBaseOrderInfo()];
+        $_SESSION['customer_id'] = 101;
+        $_SESSION['cc_id'] = '1';
+
+        $couponTwo = new ot_coupon();
+        $couponTwo->include_shipping = 'false';
+        $couponTwo->process();
+
+        $this->assertTrue($couponTwo->shouldAbortCheckoutProcess());
+        $messages = array_column($GLOBALS['messageStack']->messages, 'message');
+        $this->assertContains('Coupon per-user-timeout has reached your 1-use limit.', $messages);
+    }
+
+    public function testApplyCreditDoesNotRedeemWhenFinalizationLockCannotBeReacquired(): void
+    {
+        $couponDetails = [
+            'coupon_id' => 1,
+            'coupon_code' => 'apply-credit-lock-test',
+            'coupon_total' => 0,
+            'coupon_minimum_order' => 0,
+            'coupon_amount' => 10,
+            'coupon_type' => 'P',
+            'coupon_product_count' => 0,
+            'coupon_calc_base' => 0,
+            'uses_per_coupon' => 1,
+            'uses_per_user' => 0,
+            'coupon_start_date' => date('Y-m-d H:i:s', strtotime('-1 day')),
+            'coupon_expire_date' => date('Y-m-d H:i:s', strtotime('+1 day')),
+        ];
+        $GLOBALS['db'] = new DiscountCouponRaceDb($couponDetails);
+        $GLOBALS['order'] = (object)['info' => $this->getBaseOrderInfo()];
+        $_SESSION['customer_id'] = 101;
+        $_SESSION['cc_id'] = '1';
+
+        $coupon = new ot_coupon();
+        $coupon->include_shipping = 'false';
+        $coupon->process();
+
+        $this->setProtectedProperty($coupon, 'heldRedemptionLockName', null);
+
+        $GLOBALS['insert_id'] = 1001;
+        $coupon->apply_credit();
+
+        $this->assertCount(0, $GLOBALS['db']->redemptions);
+        $this->assertSame('', $_SESSION['cc_id']);
+    }
+
+    public function testGuestCheckoutApplyCreditTracksRedemptionAsCustomerZero(): void
+    {
+        $couponDetails = [
+            'coupon_id' => 1,
+            'coupon_code' => 'guest-apply-credit-test',
+            'coupon_total' => 0,
+            'coupon_minimum_order' => 0,
+            'coupon_amount' => 10,
+            'coupon_type' => 'P',
+            'coupon_product_count' => 0,
+            'coupon_calc_base' => 0,
+            'uses_per_coupon' => 0,
+            'uses_per_user' => 1,
+            'coupon_start_date' => date('Y-m-d H:i:s', strtotime('-1 day')),
+            'coupon_expire_date' => date('Y-m-d H:i:s', strtotime('+1 day')),
+        ];
+        $GLOBALS['db'] = new DiscountCouponRaceDb($couponDetails);
+        unset($_SESSION['customer_id']);
+        $_SESSION['guest_checkout'] = true;
+        $_SESSION['cc_id'] = '1';
+        $GLOBALS['order'] = (object)['info' => $this->getBaseOrderInfo()];
+
+        $coupon = new ot_coupon();
+        $coupon->include_shipping = 'false';
+        $coupon->process();
+
+        $GLOBALS['insert_id'] = 1001;
+        $coupon->apply_credit();
+
+        $this->assertCount(1, $GLOBALS['db']->redemptions);
+        $this->assertSame(0, $GLOBALS['db']->redemptions[0]['customer_id']);
+    }
+
+    public function testCheckoutProcessRedirectsBackToConfirmationWhenCouponAbortFlagIsSet(): void
+    {
+        defined('IS_ADMIN_FLAG') || define('IS_ADMIN_FLAG', false);
+        defined('FILENAME_TIME_OUT') || define('FILENAME_TIME_OUT', 'timeout');
+        defined('FILENAME_DEFAULT') || define('FILENAME_DEFAULT', 'index');
+        defined('FILENAME_LOGIN') || define('FILENAME_LOGIN', 'login');
+        defined('FILENAME_CHECKOUT_SHIPPING') || define('FILENAME_CHECKOUT_SHIPPING', 'checkout_shipping');
+        defined('FILENAME_CHECKOUT_CONFIRMATION') || define('FILENAME_CHECKOUT_CONFIRMATION', 'checkout_confirmation');
+
+        if (!function_exists('zen_get_module_directory')) {
+            eval('function zen_get_module_directory($filename) { return $filename; }');
+        }
+        if (!function_exists('zen_get_customer_validate_session')) {
+            eval('function zen_get_customer_validate_session($customerId) { return true; }');
+        }
+        if (!function_exists('zen_request_has_valid_csrf_token')) {
+            eval('function zen_request_has_valid_csrf_token() { return true; }');
+        }
+        if (!function_exists('zen_session_destroy')) {
+            eval('function zen_session_destroy() { }');
+        }
+        if (!function_exists('zen_href_link')) {
+            eval('function zen_href_link($page, $params = "", $connection = "NONSSL") { return $page; }');
+        }
+        if (!function_exists('zen_redirect')) {
+            eval('function zen_redirect($url) { throw new DiscountCouponRaceRedirectException($url); }');
+        }
+
+        $stubRoot = $this->makeCheckoutProcessStubRoot();
+        $this->writeCheckoutProcessStubFiles($stubRoot);
+
+        $checkoutProcessScript = $this->writeCheckoutProcessHarness($stubRoot);
+
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_SESSION['customer_id'] = 202;
+        $_SESSION['payment'] = 'cod';
+        $_SESSION['shipping'] = 'flat_flat';
+        $_SESSION['cartID'] = 'cart-1';
+        $_SESSION['cart'] = new DiscountCouponRaceCheckoutCart();
+        $_SESSION['cart']->cartID = 'cart-1';
+
+        $GLOBALS['zco_notifier'] = new DiscountCouponRaceNotifier();
+        $GLOBALS['messageStack'] = new DiscountCouponRaceMessageStack();
+        $GLOBALS['order'] = null;
+        $GLOBALS['ot_coupon'] = new DiscountCouponRaceAbortCoupon();
+        $GLOBALS['cod'] = (object)['code' => 'cod'];
+        $zco_notifier = $GLOBALS['zco_notifier'];
+        $ot_coupon = $GLOBALS['ot_coupon'];
+        $credit_covers = false;
+
+        try {
+            require $checkoutProcessScript;
+            $this->fail('checkout_process.php should have redirected back to checkout confirmation.');
+        } catch (DiscountCouponRaceRedirectException $exception) {
+            $this->assertSame(FILENAME_CHECKOUT_CONFIRMATION, $exception->url);
+            $this->assertFalse($GLOBALS['ot_coupon']->shouldAbortCheckoutProcess());
+        } finally {
+            unset(
+                $GLOBALS['zco_notifier'],
+                $GLOBALS['order'],
+                $GLOBALS['ot_coupon'],
+                $GLOBALS['cod']
+            );
+        }
+    }
+
     protected function getBaseOrderInfo(): array
     {
         return [
@@ -187,6 +539,125 @@ class DiscountCouponRaceConditionTest extends zcDiscountCouponTest
             'shipping_tax' => 0,
         ];
     }
+
+    protected function setProtectedProperty(object $object, string $propertyName, mixed $value): void
+    {
+        $reflection = new ReflectionProperty($object, $propertyName);
+        $reflection->setAccessible(true);
+        $reflection->setValue($object, $value);
+    }
+
+    protected function makeCheckoutProcessStubRoot(): string
+    {
+        $root = sys_get_temp_dir() . '/zc-checkout-process-stubs-' . uniqid('', true);
+        mkdir($root, 0777, true);
+        mkdir($root . '/classes', 0777, true);
+        mkdir($root . '/modules', 0777, true);
+
+        return $root;
+    }
+
+    protected function writeCheckoutProcessStubFiles(string $root): void
+    {
+        file_put_contents($root . '/modules/require_languages.php', "<?php\n");
+        file_put_contents($root . '/classes/payment.php', <<<'PHP'
+<?php
+class payment
+{
+    public function __construct($code)
+    {
+    }
+
+    public function checkCreditCovered(): void
+    {
+    }
+
+    public function before_process(): void
+    {
+    }
+
+    public function clear_payment(): void
+    {
+    }
+}
+PHP);
+        file_put_contents($root . '/classes/order.php', <<<'PHP'
+<?php
+class order
+{
+    public array $billing = ['firstname' => 'Test'];
+    public array $products = [['id' => 1, 'model' => 'TEST']];
+    public array $info = [
+        'payment_method' => 'cod',
+        'payment_module_code' => 'cod',
+        'coupon_code' => '',
+        'currency' => 'USD',
+        'currency_value' => 1,
+        'shipping_method' => 'Flat Rate',
+        'order_status' => 1,
+    ];
+
+    public function create($orderTotals): int
+    {
+        return 1001;
+    }
+
+    public function create_add_products($insertId): void
+    {
+    }
+
+    public function send_order_email($insertId): void
+    {
+    }
+}
+PHP);
+        file_put_contents($root . '/classes/shipping.php', <<<'PHP'
+<?php
+class shipping
+{
+    public function __construct($shippingCode)
+    {
+    }
+}
+PHP);
+        file_put_contents($root . '/classes/order_total.php', <<<'PHP'
+<?php
+class order_total
+{
+    public function pre_confirmation_check(): array
+    {
+        return [];
+    }
+
+    public function process(): array
+    {
+        global $ot_coupon;
+        $ot_coupon->process();
+        return [];
+    }
+
+    public function clear_posts(): void
+    {
+    }
+}
+PHP);
+    }
+
+    protected function writeCheckoutProcessHarness(string $root): string
+    {
+        $source = file_get_contents(DIR_FS_CATALOG . 'includes/modules/checkout_process.php');
+        $moduleRequire = "require '" . addslashes($root . "/modules/") . "' . zen_get_module_directory('require_languages.php');";
+        $source = str_replace("require DIR_WS_MODULES . zen_get_module_directory('require_languages.php');", $moduleRequire, $source);
+        $source = str_replace("require DIR_WS_CLASSES . 'payment.php';", "require '" . addslashes($root . "/classes/payment.php") . "';", $source);
+        $source = str_replace("require DIR_WS_CLASSES . 'order.php';", "require '" . addslashes($root . "/classes/order.php") . "';", $source);
+        $source = str_replace("require DIR_WS_CLASSES . 'shipping.php';", "require '" . addslashes($root . "/classes/shipping.php") . "';", $source);
+        $source = str_replace("require DIR_WS_CLASSES . 'order_total.php';", "require '" . addslashes($root . "/classes/order_total.php") . "';", $source);
+
+        $harnessPath = $root . '/checkout_process_harness.php';
+        file_put_contents($harnessPath, $source);
+
+        return $harnessPath;
+    }
 }
 
 class DiscountCouponRaceDb
@@ -194,7 +665,8 @@ class DiscountCouponRaceDb
     public array $couponDetails;
     public array $redemptions = [];
     public int $getLockCalls = 0;
-    private ?string $heldLockName = null;
+    public array $getLockNames = [];
+    private array $heldLockNames = [];
 
     public function __construct(array $couponDetails)
     {
@@ -207,17 +679,20 @@ class DiscountCouponRaceDb
             $this->getLockCalls++;
             preg_match("/SELECT GET_LOCK\\('(.*)', \\d+\\)/", $sql, $matches);
             $requestedLock = stripslashes($matches[1] ?? '');
-            if ($this->heldLockName !== null && $this->heldLockName === $requestedLock) {
+            $this->getLockNames[] = $requestedLock;
+            if (isset($this->heldLockNames[$requestedLock])) {
                 return new DiscountCouponRaceResult(['got_lock' => 0], 1);
             }
 
-            $this->heldLockName = $requestedLock;
+            $this->heldLockNames[$requestedLock] = true;
 
             return new DiscountCouponRaceResult(['got_lock' => 1], 1);
         }
 
         if (str_contains($sql, 'SELECT RELEASE_LOCK(')) {
-            $this->heldLockName = null;
+            preg_match("/SELECT RELEASE_LOCK\\('(.*)'\\)/", $sql, $matches);
+            $releasedLock = stripslashes($matches[1] ?? '');
+            unset($this->heldLockNames[$releasedLock]);
             return new DiscountCouponRaceResult(['released' => 1], 1);
         }
 
@@ -287,5 +762,61 @@ class DiscountCouponRaceMessageStack
     {
         $this->stacks[] = $stack;
         $this->messages[] = compact('stack', 'message', 'type');
+    }
+}
+
+class DiscountCouponRaceGuestAwareCoupon extends ot_coupon
+{
+    public function __construct(private int $guestLockCustomerId)
+    {
+        parent::__construct();
+    }
+
+    protected function resolveGuestCouponRedemptionLockCustomerId(array $coupon_details): int
+    {
+        return $this->guestLockCustomerId;
+    }
+}
+
+class DiscountCouponRaceAbortCoupon
+{
+    private bool $abortCheckoutProcess = true;
+
+    public function process(): void
+    {
+    }
+
+    public function shouldAbortCheckoutProcess(): bool
+    {
+        return $this->abortCheckoutProcess;
+    }
+
+    public function clearCheckoutProcessAbort(): void
+    {
+        $this->abortCheckoutProcess = false;
+    }
+}
+
+class DiscountCouponRaceCheckoutCart
+{
+    public string $cartID = '';
+
+    public function reset(bool $resetDatabase): void
+    {
+    }
+}
+
+class DiscountCouponRaceNotifier
+{
+    public function notify(string $eventId, ...$params): void
+    {
+    }
+}
+
+class DiscountCouponRaceRedirectException extends RuntimeException
+{
+    public function __construct(public string $url)
+    {
+        parent::__construct($url);
     }
 }

--- a/not_for_release/testFramework/Unit/testsDiscountCoupon/DiscountCouponRaceConditionTest.php
+++ b/not_for_release/testFramework/Unit/testsDiscountCoupon/DiscountCouponRaceConditionTest.php
@@ -142,6 +142,41 @@ class DiscountCouponRaceConditionTest extends zcDiscountCouponTest
         $this->assertCount(1, $GLOBALS['db']->redemptions);
     }
 
+    public function testUnlimitedUseCouponDoesNotTakeAdvisoryLockDuringCheckoutProcess(): void
+    {
+        $couponDetails = [
+            'coupon_id' => 1,
+            'coupon_code' => 'unlimited-test',
+            'coupon_total' => 0,
+            'coupon_minimum_order' => 0,
+            'coupon_amount' => 10,
+            'coupon_type' => 'P',
+            'coupon_product_count' => 0,
+            'coupon_calc_base' => 0,
+            'uses_per_coupon' => 0,
+            'uses_per_user' => 0,
+            'coupon_start_date' => date('Y-m-d H:i:s', strtotime('-1 day')),
+            'coupon_expire_date' => date('Y-m-d H:i:s', strtotime('+1 day')),
+        ];
+        $GLOBALS['db'] = new DiscountCouponRaceDb($couponDetails);
+        $GLOBALS['order'] = (object)['info' => $this->getBaseOrderInfo()];
+        $_SESSION['customer_id'] = 101;
+        $_SESSION['cc_id'] = '1';
+
+        $coupon = new ot_coupon();
+        $coupon->include_shipping = 'false';
+        $coupon->process();
+
+        $this->assertEquals(452.49, $GLOBALS['order']->info['total']);
+        $this->assertSame(0, $GLOBALS['db']->getLockCalls);
+
+        $GLOBALS['insert_id'] = 1001;
+        $coupon->apply_credit();
+
+        $this->assertCount(1, $GLOBALS['db']->redemptions);
+        $this->assertSame(0, $GLOBALS['db']->getLockCalls);
+    }
+
     protected function getBaseOrderInfo(): array
     {
         return [
@@ -158,6 +193,7 @@ class DiscountCouponRaceDb
 {
     public array $couponDetails;
     public array $redemptions = [];
+    public int $getLockCalls = 0;
     private ?string $heldLockName = null;
 
     public function __construct(array $couponDetails)
@@ -168,6 +204,7 @@ class DiscountCouponRaceDb
     public function Execute(string $sql, $limit = null): DiscountCouponRaceResult
     {
         if (str_contains($sql, 'SELECT GET_LOCK(')) {
+            $this->getLockCalls++;
             preg_match("/SELECT GET_LOCK\\('(.*)', \\d+\\)/", $sql, $matches);
             $requestedLock = stripslashes($matches[1] ?? '');
             if ($this->heldLockName !== null && $this->heldLockName === $requestedLock) {

--- a/not_for_release/testFramework/Unit/testsDiscountCoupon/DiscountCouponRaceConditionTest.php
+++ b/not_for_release/testFramework/Unit/testsDiscountCoupon/DiscountCouponRaceConditionTest.php
@@ -30,6 +30,7 @@ class DiscountCouponRaceConditionTest extends zcDiscountCouponTest
 
         $_SESSION['currency'] = 'USD';
         $GLOBALS['current_page_base'] = FILENAME_CHECKOUT_PROCESS;
+        $GLOBALS['messageStack'] = new DiscountCouponRaceMessageStack();
 
         defined('MODULE_ORDER_TOTAL_COUPON_HEADER') || define('MODULE_ORDER_TOTAL_COUPON_HEADER', '');
         defined('MODULE_ORDER_TOTAL_COUPON_TITLE') || define('MODULE_ORDER_TOTAL_COUPON_TITLE', '');
@@ -40,6 +41,7 @@ class DiscountCouponRaceConditionTest extends zcDiscountCouponTest
         defined('MODULE_ORDER_TOTAL_COUPON_CALC_TAX') || define('MODULE_ORDER_TOTAL_COUPON_CALC_TAX', 'Standard');
         defined('MODULE_ORDER_TOTAL_COUPON_TAX_CLASS') || define('MODULE_ORDER_TOTAL_COUPON_TAX_CLASS', '');
         defined('DISPLAY_PRICE_WITH_TAX') || define('DISPLAY_PRICE_WITH_TAX', 'false');
+        defined('TEXT_INVALID_USES_COUPON') || define('TEXT_INVALID_USES_COUPON', 'Coupon %1$s has reached its %2$s-use limit.');
 
         $GLOBALS['currencies'] = $this->getMockBuilder('currencies')
             ->disableOriginalConstructor()
@@ -122,6 +124,8 @@ class DiscountCouponRaceConditionTest extends zcDiscountCouponTest
             $requestTwoOrder->info['total'],
             'A concurrent checkout must not receive the coupon discount while another request holds the finalization lock.'
         );
+        $this->assertTrue($couponTwo->shouldAbortCheckoutProcess());
+        $this->assertContains('checkout_confirmation', $GLOBALS['messageStack']->stacks);
 
         $GLOBALS['insert_id'] = 1001;
         $_SESSION['customer_id'] = 101;
@@ -234,5 +238,17 @@ class DiscountCouponRaceResult
     public function RecordCount(): int
     {
         return $this->recordCount;
+    }
+}
+
+class DiscountCouponRaceMessageStack
+{
+    public array $messages = [];
+    public array $stacks = [];
+
+    public function add_session(string $stack, string $message, string $type): void
+    {
+        $this->stacks[] = $stack;
+        $this->messages[] = compact('stack', 'message', 'type');
     }
 }

--- a/not_for_release/testFramework/Unit/testsDiscountCoupon/DiscountCouponsTest.php
+++ b/not_for_release/testFramework/Unit/testsDiscountCoupon/DiscountCouponsTest.php
@@ -5,10 +5,12 @@
  */
 
 use Tests\Support\zcDiscountCouponTest;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Unit Tests for discount coupons
  */
+#[RunTestsInSeparateProcesses]
 class DiscountCouponsTest extends zcDiscountCouponTest
 {
     public ot_coupon $coupon;
@@ -24,14 +26,14 @@ class DiscountCouponsTest extends zcDiscountCouponTest
         require_once DIR_FS_CATALOG . 'includes/classes/db/mysql/query_factory.php';
         $_SESSION['currency'] = 'USD';
         $_SESSION['cc_id'] = '1';
-        define('MODULE_ORDER_TOTAL_COUPON_HEADER', '');
-        define('MODULE_ORDER_TOTAL_COUPON_TITLE', '');
-        define('MODULE_ORDER_TOTAL_COUPON_DESCRIPTION', '');
-        define('MODULE_ORDER_TOTAL_COUPON_SORT_ORDER', '');
-        define('MODULE_ORDER_TOTAL_COUPON_INC_SHIPPING', '');
-        define('MODULE_ORDER_TOTAL_COUPON_INC_TAX', 'false');
-        define('MODULE_ORDER_TOTAL_COUPON_CALC_TAX', 'Standard');
-        define('MODULE_ORDER_TOTAL_COUPON_TAX_CLASS', '');
+        defined('MODULE_ORDER_TOTAL_COUPON_HEADER') || define('MODULE_ORDER_TOTAL_COUPON_HEADER', '');
+        defined('MODULE_ORDER_TOTAL_COUPON_TITLE') || define('MODULE_ORDER_TOTAL_COUPON_TITLE', '');
+        defined('MODULE_ORDER_TOTAL_COUPON_DESCRIPTION') || define('MODULE_ORDER_TOTAL_COUPON_DESCRIPTION', '');
+        defined('MODULE_ORDER_TOTAL_COUPON_SORT_ORDER') || define('MODULE_ORDER_TOTAL_COUPON_SORT_ORDER', '');
+        defined('MODULE_ORDER_TOTAL_COUPON_INC_SHIPPING') || define('MODULE_ORDER_TOTAL_COUPON_INC_SHIPPING', '');
+        defined('MODULE_ORDER_TOTAL_COUPON_INC_TAX') || define('MODULE_ORDER_TOTAL_COUPON_INC_TAX', 'false');
+        defined('MODULE_ORDER_TOTAL_COUPON_CALC_TAX') || define('MODULE_ORDER_TOTAL_COUPON_CALC_TAX', 'Standard');
+        defined('MODULE_ORDER_TOTAL_COUPON_TAX_CLASS') || define('MODULE_ORDER_TOTAL_COUPON_TAX_CLASS', '');
 
         $GLOBALS['currencies'] = $this->getMockBuilder('currencies')
             ->disableOriginalConstructor()
@@ -85,7 +87,7 @@ class DiscountCouponsTest extends zcDiscountCouponTest
             'shipping_cost' => 2.50,
             'shipping_tax' => 0,
         ];
-        define('DISPLAY_PRICE_WITH_TAX', 'false');
+        defined('DISPLAY_PRICE_WITH_TAX') || define('DISPLAY_PRICE_WITH_TAX', 'false');
         $this->instantiateQfr([
             'coupon_id' => '1',
             'coupon_code' => 'test',
@@ -117,7 +119,7 @@ class DiscountCouponsTest extends zcDiscountCouponTest
             'shipping_cost' => 2.50,
             'shipping_tax' => 0,
         ];
-        define('DISPLAY_PRICE_WITH_TAX', 'false');
+        defined('DISPLAY_PRICE_WITH_TAX') || define('DISPLAY_PRICE_WITH_TAX', 'false');
         $this->instantiateQfr([
             'coupon_id' => '1',
             'coupon_code' => 'test',
@@ -149,7 +151,7 @@ class DiscountCouponsTest extends zcDiscountCouponTest
             'shipping_cost' => 2.50,
             'shipping_tax' => 0,
         ];
-        define('DISPLAY_PRICE_WITH_TAX', 'false');
+        defined('DISPLAY_PRICE_WITH_TAX') || define('DISPLAY_PRICE_WITH_TAX', 'false');
         $this->instantiateQfr([
             'coupon_id' => '1',
             'coupon_code' => 'test',
@@ -181,7 +183,7 @@ class DiscountCouponsTest extends zcDiscountCouponTest
             'shipping_cost' => 2.50,
             'shipping_tax' => 0,
         ];
-        define('DISPLAY_PRICE_WITH_TAX', 'false');
+        defined('DISPLAY_PRICE_WITH_TAX') || define('DISPLAY_PRICE_WITH_TAX', 'false');
         $this->instantiateQfr([
             'coupon_id' => '1',
             'coupon_code' => 'test',
@@ -213,7 +215,7 @@ class DiscountCouponsTest extends zcDiscountCouponTest
             'shipping_cost' => 2.50,
             'shipping_tax' => 0,
         ];
-        define('DISPLAY_PRICE_WITH_TAX', 'false');
+        defined('DISPLAY_PRICE_WITH_TAX') || define('DISPLAY_PRICE_WITH_TAX', 'false');
         $this->instantiateQfr([
             'coupon_id' => '1',
             'coupon_code' => 'test',
@@ -245,7 +247,7 @@ class DiscountCouponsTest extends zcDiscountCouponTest
             'shipping_cost' => 2.50,
             'shipping_tax' => 0,
         ];
-        define('DISPLAY_PRICE_WITH_TAX', 'false');
+        defined('DISPLAY_PRICE_WITH_TAX') || define('DISPLAY_PRICE_WITH_TAX', 'false');
         $this->instantiateQfr([
             'coupon_id' => '1',
             'coupon_code' => 'test',
@@ -277,7 +279,7 @@ class DiscountCouponsTest extends zcDiscountCouponTest
             'shipping_cost' => 2.50,
             'shipping_tax' => 0,
         ];
-        define('DISPLAY_PRICE_WITH_TAX', 'false');
+        defined('DISPLAY_PRICE_WITH_TAX') || define('DISPLAY_PRICE_WITH_TAX', 'false');
         $this->instantiateQfr([
             'coupon_id' => '1',
             'coupon_code' => 'test',
@@ -309,7 +311,7 @@ class DiscountCouponsTest extends zcDiscountCouponTest
             'shipping_cost' => 2.50,
             'shipping_tax' => 0,
         ];
-        define('DISPLAY_PRICE_WITH_TAX', 'false');
+        defined('DISPLAY_PRICE_WITH_TAX') || define('DISPLAY_PRICE_WITH_TAX', 'false');
         $this->instantiateQfr([
             'coupon_id' => '1',
             'coupon_code' => 'test',
@@ -341,7 +343,7 @@ class DiscountCouponsTest extends zcDiscountCouponTest
             'shipping_cost' => 2.50,
             'shipping_tax' => 0,
         ];
-        define('DISPLAY_PRICE_WITH_TAX', 'false');
+        defined('DISPLAY_PRICE_WITH_TAX') || define('DISPLAY_PRICE_WITH_TAX', 'false');
         $this->instantiateQfr([
             'coupon_id' => '1',
             'coupon_code' => 'test',
@@ -373,7 +375,7 @@ class DiscountCouponsTest extends zcDiscountCouponTest
             'shipping_cost' => 5.75,
             'shipping_tax' => 0,
         ];
-        define('DISPLAY_PRICE_WITH_TAX', 'false');
+        defined('DISPLAY_PRICE_WITH_TAX') || define('DISPLAY_PRICE_WITH_TAX', 'false');
         $this->instantiateQfr([
             'coupon_id' => '1',
             'coupon_code' => 'test',


### PR DESCRIPTION
Coupon restrictions are first checked via performValidations(), but they can lapse between when the customer applies the coupon on the payment page and when the order is actually written at checkout. 
Such a lapse could be a delayed checkout, or multiple people doing checkout during a time-limited sale where the coupon also has use-limits. 
Or the coupon-use-window expires before the checkout occurs.