### PR TITLE
Standardize on DIR_FS_UPLOADS

### DIFF
--- a/admin/includes/defined_paths.php
+++ b/admin/includes/defined_paths.php
@@ -61,6 +61,7 @@ if (!defined('DIR_WS_LANGUAGES')) define('DIR_WS_LANGUAGES', DIR_WS_INCLUDES . '
 if (!defined('DIR_WS_CATALOG_LANGUAGES')) define('DIR_WS_CATALOG_LANGUAGES', HTTP_CATALOG_SERVER . DIR_WS_CATALOG . 'includes/languages/');
 if (!defined('DIR_FS_CATALOG_LANGUAGES')) define('DIR_FS_CATALOG_LANGUAGES', DIR_FS_CATALOG . 'includes/languages/');
 if (!defined('DIR_FS_CATALOG_IMAGES')) define('DIR_FS_CATALOG_IMAGES', DIR_FS_CATALOG . 'images/');
+if (!defined('DIR_FS_UPLOADS')) define('DIR_FS_UPLOADS', DIR_FS_CATALOG_IMAGES . 'uploads/');
 if (!defined('DIR_FS_CATALOG_MODULES')) define('DIR_FS_CATALOG_MODULES', DIR_FS_CATALOG . 'includes/modules/');
 if (!defined('DIR_FS_CATALOG_TEMPLATES')) define('DIR_FS_CATALOG_TEMPLATES', DIR_FS_CATALOG . 'includes/templates/');
 if (!defined('DIR_FS_BACKUP')) define('DIR_FS_BACKUP', DIR_FS_ADMIN . 'backups/');

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -182,7 +182,7 @@ if (!empty($action) && $order_exists === true) {
                                 zen_redirect(zen_href_link(FILENAME_ORDERS, zen_get_all_get_params(['download', 'action']) . 'action=edit', 'NONSSL'));
                 }
             // this define was added to admin in v3.0 for consistency with catalog; added here just as a safeguard: remove in v4 or later, since it's in defined_paths already.
-            defined('DIR_FS_UPLOADS') || define('DIR_FS_UPLOADS', DIR_FS_CATALOG_IMAGES . 'uploads/');
+            zen_define_default('DIR_FS_UPLOADS', DIR_FS_CATALOG_IMAGES . 'uploads/');
             $fs_path = DIR_FS_UPLOADS . $fileName;
             if (!file_exists($fs_path)) {
                 $messageStack->add_session(TEXT_FILE_NOT_FOUND, 'error');

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -181,7 +181,9 @@ if (!empty($action) && $order_exists === true) {
                                 $messageStack->add_session(sprintf(TEXT_EXTENSION_NOT_UNDERSTOOD, $file_extension), 'error');
                                 zen_redirect(zen_href_link(FILENAME_ORDERS, zen_get_all_get_params(['download', 'action']) . 'action=edit', 'NONSSL'));
                 }
-            $fs_path = DIR_FS_CATALOG_IMAGES . 'uploads/' . $fileName;
+            // this define was added to admin in v3.0 for consistency with catalog; added here just as a safeguard: remove in v4 or later, since it's in defined_paths already.
+            defined('DIR_FS_UPLOADS') || define('DIR_FS_UPLOADS', DIR_FS_CATALOG_IMAGES . 'uploads/');
+            $fs_path = DIR_FS_UPLOADS . $fileName;
             if (!file_exists($fs_path)) {
                 $messageStack->add_session(TEXT_FILE_NOT_FOUND, 'error');
                 zen_redirect(zen_href_link(FILENAME_ORDERS, zen_get_all_get_params(['download', 'action']) . 'action=edit'));


### PR DESCRIPTION
For consistency between catalog/admin.

Catalog already uses this constant. No reason to use a different one in admin when referencing it. 
Makes for easier future maintenance or relocation.