### PR TITLE
Faster garbage-collection

### DIFF
--- a/includes/functions/sessions.php
+++ b/includes/functions/sessions.php
@@ -125,7 +125,7 @@ function zen_session_recreate(): void
 {
     $saveSession = $_SESSION;
     $oldSessID = session_id();
-    session_regenerate_id();
+    session_regenerate_id(true);
     $newSessID = session_id();
     $_SESSION = $saveSession;
     if (IS_ADMIN_FLAG !== true) {


### PR DESCRIPTION
Deleting the old immediately should make things even more performant, even more secure.
- No SPA/long-poll/background-AJAX activity is in flight during these specific submit actions.
- Password reset's trigger is POST-only, so link-prefetching is a non-issue.
- Double-submit/double-click races exist either way (the duplicate request just gets its own fresh regeneration cycle), so true doesn't make that scenario meaningfully worse.
- Account creation / login don't have any reason to support another tab actively polling/transacting against the old session.
