### PR TITLE
Clamp coupon min/max limits

### DIFF
--- a/admin/coupon_admin.php
+++ b/admin/coupon_admin.php
@@ -284,6 +284,7 @@ switch ($_GET['action']) {
       $coupon_type = 'E'; // percentage off and free shipping
     }
     $_POST['coupon_amount'] = preg_replace('/[^0-9.]/', '', $_POST['coupon_amount']);
+    // Clamp percentages ('P' and 'E' types, see comments above) to under 100.
     if ($coupon_type === 'P' || $coupon_type === 'E') {
       $_POST['coupon_amount'] = (string)min(100, (float)$_POST['coupon_amount']);
     }

--- a/admin/coupon_admin.php
+++ b/admin/coupon_admin.php
@@ -285,6 +285,9 @@ switch ($_GET['action']) {
     }
     $_POST['coupon_amount'] = preg_replace('/[^0-9.]/', '', $_POST['coupon_amount']);
     // Clamp percentages ('P' and 'E' types, see comments above) to at most 100.
+    if ($coupon_type === 'P' || $coupon_type === 'E') {
+        $_POST['coupon_amount'] = (string)min(100, (float)$_POST['coupon_amount']);
+    }
     $sql_data_array = [
       'coupon_code' => zen_db_prepare_input($_POST['coupon_code']),
       'coupon_amount' => zen_db_prepare_input($_POST['coupon_amount']),

--- a/admin/coupon_admin.php
+++ b/admin/coupon_admin.php
@@ -284,10 +284,7 @@ switch ($_GET['action']) {
       $coupon_type = 'E'; // percentage off and free shipping
     }
     $_POST['coupon_amount'] = preg_replace('/[^0-9.]/', '', $_POST['coupon_amount']);
-    // Clamp percentages ('P' and 'E' types, see comments above) to under 100.
-    if ($coupon_type === 'P' || $coupon_type === 'E') {
-      $_POST['coupon_amount'] = (string)min(100, (float)$_POST['coupon_amount']);
-    }
+    // Clamp percentages ('P' and 'E' types, see comments above) to at most 100.
     $sql_data_array = [
       'coupon_code' => zen_db_prepare_input($_POST['coupon_code']),
       'coupon_amount' => zen_db_prepare_input($_POST['coupon_amount']),

--- a/admin/coupon_admin.php
+++ b/admin/coupon_admin.php
@@ -284,14 +284,17 @@ switch ($_GET['action']) {
       $coupon_type = 'E'; // percentage off and free shipping
     }
     $_POST['coupon_amount'] = preg_replace('/[^0-9.]/', '', $_POST['coupon_amount']);
+    if ($coupon_type === 'P' || $coupon_type === 'E') {
+      $_POST['coupon_amount'] = (string)min(100, (float)$_POST['coupon_amount']);
+    }
     $sql_data_array = [
       'coupon_code' => zen_db_prepare_input($_POST['coupon_code']),
       'coupon_amount' => zen_db_prepare_input($_POST['coupon_amount']),
       'coupon_product_count' => (int)$_POST['coupon_product_count'],
       'coupon_type' => zen_db_prepare_input($coupon_type),
-      'uses_per_coupon' => (int)$_POST['coupon_uses_coupon'],
+      'uses_per_coupon' => max(0, (int)$_POST['coupon_uses_coupon']),
       'uses_per_user' => (int)$_POST['coupon_uses_user'],
-      'coupon_minimum_order' => (float)$_POST['coupon_min_order'],
+      'coupon_minimum_order' => max(0, (float)$_POST['coupon_min_order']),
       'restrict_to_products' => zen_db_prepare_input($_POST['coupon_products']),
       'restrict_to_categories' => zen_db_prepare_input($_POST['coupon_categories']),
       'coupon_start_date' => $_POST['coupon_startdate'],

--- a/admin/coupon_admin.php
+++ b/admin/coupon_admin.php
@@ -294,7 +294,7 @@ switch ($_GET['action']) {
       'coupon_product_count' => (int)$_POST['coupon_product_count'],
       'coupon_type' => zen_db_prepare_input($coupon_type),
       'uses_per_coupon' => max(0, (int)$_POST['coupon_uses_coupon']),
-      'uses_per_user' => (int)$_POST['coupon_uses_user'],
+      'uses_per_user' => max(0, (int)$_POST['coupon_uses_user']),
       'coupon_minimum_order' => max(0, (float)$_POST['coupon_min_order']),
       'restrict_to_products' => zen_db_prepare_input($_POST['coupon_products']),
       'restrict_to_categories' => zen_db_prepare_input($_POST['coupon_categories']),

--- a/not_for_release/testFramework/FeatureAdmin/AdminEndpoints/CouponAdminBoundaryValidationTest.php
+++ b/not_for_release/testFramework/FeatureAdmin/AdminEndpoints/CouponAdminBoundaryValidationTest.php
@@ -62,7 +62,7 @@ class CouponAdminBoundaryValidationTest extends zcInProcessFeatureTestCaseAdmin
         $this->assertGreaterThan(0, $couponId);
 
         return TestDb::selectOne(
-            'SELECT coupon_type, coupon_amount, coupon_minimum_order, uses_per_coupon
+            'SELECT coupon_type, coupon_amount, coupon_minimum_order, uses_per_coupon, uses_per_user
                FROM coupons
               WHERE coupon_id = :coupon_id
               LIMIT 1',
@@ -131,6 +131,22 @@ class CouponAdminBoundaryValidationTest extends zcInProcessFeatureTestCaseAdmin
         $coupon = $this->fetchCoupon($couponCode);
 
         $this->assertSame('0', (string) $coupon['uses_per_coupon']);
+    }
+
+    // uses_per_user must be clamped to a minimum of 0; a negative value causes
+    // validateCouponUsesPerCustomer() to always fail (RecordCount() can't be < negative).
+    public function testNegativeUsesPerUserIsClampedToZero(): void
+    {
+        $this->completeInitialAdminSetup();
+
+        $couponCode = 'B2BFU-' . uniqid();
+        $this->postCouponUpdateConfirm($couponCode, [
+            'coupon_uses_user' => '-3',
+        ]);
+
+        $coupon = $this->fetchCoupon($couponCode);
+
+        $this->assertSame('0', (string) $coupon['uses_per_user']);
     }
 
     // 0 is the documented "unlimited uses" sentinel (see ot_coupon.php's

--- a/not_for_release/testFramework/FeatureAdmin/AdminEndpoints/CouponAdminBoundaryValidationTest.php
+++ b/not_for_release/testFramework/FeatureAdmin/AdminEndpoints/CouponAdminBoundaryValidationTest.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * @copyright Copyright 2003-2026 Zen Cart Development Team
+ * @license https://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ */
+
+namespace Tests\FeatureAdmin\AdminEndpoints;
+
+use Tests\Support\Database\TestDb;
+use Tests\Support\zcInProcessFeatureTestCaseAdmin;
+
+#[\PHPUnit\Framework\Attributes\Group('parallel-candidate')]
+class CouponAdminBoundaryValidationTest extends zcInProcessFeatureTestCaseAdmin
+{
+    protected $runTestInSeparateProcess = true;
+    protected $preserveGlobalState = false;
+
+    /**
+     * These tests POST directly to action=update_confirm (bypassing the
+     * action=update_preview step) because that handler builds and saves
+     * $sql_data_array with no validation gate of its own - it must not rely
+     * on the preview step having run first.
+     */
+    private function postCouponUpdateConfirm(string $couponCode, array $overrides = []): \Tests\Support\InProcess\FeatureResponse
+    {
+        $newPage = $this->getAdmin('/admin/index.php?cmd=coupon_admin&action=new')->assertOk();
+        $securityToken = $newPage->securityToken();
+        $this->assertNotNull($securityToken);
+
+        return $this->postAdmin(
+            '/admin/index.php?cmd=coupon_admin&action=update_confirm&oldaction=new',
+            array_merge([
+                'securityToken' => $securityToken,
+                'coupon_name' => [1 => 'Boundary Test Coupon'],
+                'coupon_desc' => [1 => 'Created by boundary validation test'],
+                'coupon_code' => $couponCode,
+                'coupon_amount' => '10',
+                'coupon_product_count' => '0',
+                'coupon_uses_coupon' => '5',
+                'coupon_uses_user' => '1',
+                'coupon_min_order' => '0',
+                'coupon_products' => '',
+                'coupon_categories' => '',
+                'coupon_referrer' => '',
+                'coupon_zone_restriction' => '0',
+                'coupon_calc_base' => '1',
+                'coupon_order_limit' => '',
+                'coupon_is_valid_for_sales' => '1',
+                'coupon_startdate' => '2026-01-01',
+                'coupon_finishdate' => '2027-01-01',
+            ], $overrides)
+        );
+    }
+
+    private function fetchCoupon(string $couponCode): ?array
+    {
+        $couponId = (int) TestDb::selectValue(
+            'SELECT coupon_id FROM coupons WHERE coupon_code = :coupon_code LIMIT 1',
+            [':coupon_code' => $couponCode]
+        );
+
+        $this->assertGreaterThan(0, $couponId);
+
+        return TestDb::selectOne(
+            'SELECT coupon_type, coupon_amount, coupon_minimum_order, uses_per_coupon
+               FROM coupons
+              WHERE coupon_id = :coupon_id
+              LIMIT 1',
+            [':coupon_id' => $couponId]
+        );
+    }
+
+    // A percentage-type coupon must be clamped to <= 100%.
+    public function testPercentageCouponAmountIsClampedTo100(): void
+    {
+        $this->completeInitialAdminSetup();
+
+        $couponCode = 'B2BF8-' . uniqid();
+        $this->postCouponUpdateConfirm($couponCode, [
+            'coupon_amount' => '9999%',
+        ]);
+
+        $coupon = $this->fetchCoupon($couponCode);
+
+        $this->assertSame('P', $coupon['coupon_type']);
+        $this->assertSame('100.0000', (string) $coupon['coupon_amount']);
+    }
+
+    // Non-percentage (flat-amount) coupons are a legitimate business decision
+    // and must NOT be clamped, even above 100.
+    public function testFlatAmountCouponAboveOneHundredIsNotClamped(): void
+    {
+        $this->completeInitialAdminSetup();
+
+        $couponCode = 'B2BF8-FLAT-' . uniqid();
+        $this->postCouponUpdateConfirm($couponCode, [
+            'coupon_amount' => '9999',
+        ]);
+
+        $coupon = $this->fetchCoupon($couponCode);
+
+        $this->assertSame('F', $coupon['coupon_type']);
+        $this->assertSame('9999.0000', (string) $coupon['coupon_amount']);
+    }
+
+    // coupon_minimum_order must be clamped to a minimum of 0.
+    public function testNegativeMinimumOrderIsClampedToZero(): void
+    {
+        $this->completeInitialAdminSetup();
+
+        $couponCode = 'B2BF9-' . uniqid();
+        $this->postCouponUpdateConfirm($couponCode, [
+            'coupon_min_order' => '-100',
+        ]);
+
+        $coupon = $this->fetchCoupon($couponCode);
+
+        $this->assertSame('0.0000', (string) $coupon['coupon_minimum_order']);
+    }
+
+    // uses_per_coupon must be clamped to a minimum of 0.
+    public function testNegativeUsesPerCouponIsClampedToZero(): void
+    {
+        $this->completeInitialAdminSetup();
+
+        $couponCode = 'B2BF10-' . uniqid();
+        $this->postCouponUpdateConfirm($couponCode, [
+            'coupon_uses_coupon' => '-5',
+        ]);
+
+        $coupon = $this->fetchCoupon($couponCode);
+
+        $this->assertSame('0', (string) $coupon['uses_per_coupon']);
+    }
+
+    // 0 is the documented "unlimited uses" sentinel (see ot_coupon.php's
+    // validateCouponMaximumUses()) and must be preserved, not bumped to 1.
+    public function testZeroUsesPerCouponIsPreservedAsUnlimitedSentinel(): void
+    {
+        $this->completeInitialAdminSetup();
+
+        $couponCode = 'B2BF10-ZERO-' . uniqid();
+        $this->postCouponUpdateConfirm($couponCode, [
+            'coupon_uses_coupon' => '0',
+        ]);
+
+        $coupon = $this->fetchCoupon($couponCode);
+
+        $this->assertSame('0', (string) $coupon['uses_per_coupon']);
+    }
+}


### PR DESCRIPTION
These min/max clamps help avoid accidental unintended side-effects.
- percentages must be less than or equal to 100
- uses must be 0 or greater
- min order must be 0 or greater