### PR TITLE
Don't treat arrays as repeated keys in sanitization.

### DIFF
--- a/includes/application_top.php
+++ b/includes/application_top.php
@@ -196,6 +196,13 @@ if (!empty($_SERVER['QUERY_STRING'])) {
         }
 
         $key = strtolower($parts[0]);
+
+        // If the key denotes an array append (ends with '[]'), it is
+        // expected to be repeated. Skip tracking it.
+        if (substr($key, -2) === '[]') {
+            continue;
+        }
+        
         $keys[] = $key;
     }
 


### PR DESCRIPTION
Don't treat arrays as repeated keys (fixes my search mod that allows multiple categories/manufacturers to be selected)