### PR TITLE
2.3: Correct over-sanitization of configuration title

### DIFF
--- a/admin/configuration.php
+++ b/admin/configuration.php
@@ -83,7 +83,7 @@ if (!empty($action)) {
                 );
                 $messageStack->add_session(
                     sprintf(TEXT_VALUE_SAVED,
-                        zen_output_string_protected($checks->fields['configuration_title']),
+                        $checks->fields['configuration_title'],
                         '<code>' . zen_output_string_protected($posted_original[$key]) . '</code>',
                         '<code>' . zen_output_string_protected($configuration_value) . '</code>'
                     ),

--- a/admin/configuration.php
+++ b/admin/configuration.php
@@ -238,7 +238,7 @@ foreach ($configuration as $item) {
     <div class="row row-hover align-items-center py-2">
         <div class="col-md-3">
             <?php
-            echo '<strong>' . zen_output_string_protected($item['configuration_title']) . '</strong>';
+            echo '<strong>' . $item['configuration_title'] . '</strong>';
             if (ADMIN_CONFIGURATION_KEY_ON == 1) {
                 echo '<br>Key: ' . $item['configuration_key'];
             }


### PR DESCRIPTION
Introduced in this PR #7793

Results in configuration titles with HTML tags getting over-sanitized; noting that there's no such sanitization on a configuration entry's description.

<img width="633" height="727" alt="image" src="https://github.com/user-attachments/assets/d4e2bca5-e145-4f82-90b5-f7378f62b426">
