### PR TITLE
Re-enable non-string language constants

### DIFF
--- a/includes/classes/ResourceLoaders/ArraysLanguageLoader.php
+++ b/includes/classes/ResourceLoaders/ArraysLanguageLoader.php
@@ -44,7 +44,7 @@ class ArraysLanguageLoader extends BaseLanguageLoader
                 $constants_made = true;
                 continue;
             }
-            preg_match_all('/%{2}([^%]+)%{2}/', $defineValue, $matches, \PREG_PATTERN_ORDER);
+            preg_match_all('/%{2}([^%]+)%{2}/', (string)$defineValue, $matches, \PREG_PATTERN_ORDER);
             if (count($matches[1])) {
                 foreach ($matches[1] as $index => $match) {
                     if (isset($defines[$match])) {

--- a/not_for_release/testFramework/Unit/testsTemplateResolver/ArraysLanguageLoaderNonStringConstantTest.php
+++ b/not_for_release/testFramework/Unit/testsTemplateResolver/ArraysLanguageLoaderNonStringConstantTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * @copyright Copyright 2003-2026 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ */
+
+namespace Tests\Unit\testsTemplateResolver;
+
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use Tests\Support\zcTemplateResolverTest;
+use Zencart\LanguageLoader\ArraysLanguageLoader;
+
+/**
+ * Regression coverage for a real-world crash reported against the DBIO plugin
+ * (lat9/dbio#269): ArraysLanguageLoader.php has `declare(strict_types=1)`, and
+ * makeConstants() passed a language-constant's value directly as the $subject
+ * argument to preg_match_all(), which is internally typed `string`. A plugin (or
+ * core) language file defining a non-string constant -- e.g. `'SOME_COUNT' => 167`
+ * -- triggered a fatal TypeError on every request that loaded it. Fixed by casting
+ * the value to (string) only for the regex call, leaving the value passed to the
+ * later define() call untouched so the constant's original type is preserved.
+ */
+#[RunTestsInSeparateProcesses]
+class ArraysLanguageLoaderNonStringConstantTest extends zcTemplateResolverTest
+{
+    public function testMakeConstantsAcceptsAnIntegerValuedLanguageConstantWithoutFatalError(): void
+    {
+        require_once DIR_FS_CATALOG . 'includes/classes/ResourceLoaders/BaseLanguageLoader.php';
+        require_once DIR_FS_CATALOG . 'includes/classes/ResourceLoaders/ArraysLanguageLoader.php';
+
+        $loader = new ArraysLanguageLoader([], 'unit_test_page', 'template_default');
+
+        $result = $loader->makeConstants(['DBIO_UNIT_TEST_INT_CONSTANT' => 167]);
+
+        $this->assertTrue($result, 'Expected makeConstants() to report that a constant was made.');
+        $this->assertTrue(defined('DBIO_UNIT_TEST_INT_CONSTANT'));
+        $this->assertSame(
+            167,
+            \DBIO_UNIT_TEST_INT_CONSTANT,
+            'Expected the constant to retain its original int type, not be stringified by the preg_match_all() fix.'
+        );
+    }
+
+    public function testMakeConstantsAcceptsABooleanValuedLanguageConstantWithoutFatalError(): void
+    {
+        require_once DIR_FS_CATALOG . 'includes/classes/ResourceLoaders/BaseLanguageLoader.php';
+        require_once DIR_FS_CATALOG . 'includes/classes/ResourceLoaders/ArraysLanguageLoader.php';
+
+        $loader = new ArraysLanguageLoader([], 'unit_test_page', 'template_default');
+
+        $loader->makeConstants(['DBIO_UNIT_TEST_BOOL_CONSTANT' => false]);
+
+        $this->assertTrue(defined('DBIO_UNIT_TEST_BOOL_CONSTANT'));
+        $this->assertFalse(\DBIO_UNIT_TEST_BOOL_CONSTANT);
+    }
+}


### PR DESCRIPTION
The addition of `strict_types` in PR #7801 now results in PHP fatal errors if a language-constant's value is non-string.

See this Database I/O Manager issue for additional details: https://github.com/lat9/dbio/issues/269