### PR TITLE
Remove unused checks of `$_GET['jscript']`

### DIFF
--- a/includes/languages/lang.english.php
+++ b/includes/languages/lang.english.php
@@ -303,7 +303,6 @@ $define = [
     'PAGE_REVIEWS' => 'Reviews',
     'PAGE_SHOPPING_CART' => 'Shopping Cart',
     'PAGE_SPECIALS' => 'Specials',
-    'PAYMENT_JAVASCRIPT_DISABLED' => 'We could not continue with checkout as Javascript is disabled. You must enable it to continue',
     'PAYMENT_METHOD_GV' => 'Gift Certificate/Coupon',
     'PAYMENT_MODULE_GV' => 'GV/DC',
     'PLEASE_SELECT' => 'Please select ...',

--- a/includes/modules/pages/checkout_payment/header_php.php
+++ b/includes/modules/pages/checkout_payment/header_php.php
@@ -10,10 +10,6 @@
 
 // This should be first line of the script:
 $zco_notifier->notify('NOTIFY_HEADER_START_CHECKOUT_PAYMENT');
-// if (!isset($_SESSION['jscript_enabled'])) {
-//     $messageStack->add_session ('shopping_cart', PAYMENT_JAVASCRIPT_DISABLED, 'error');
-//   zen_redirect(zen_href_link(FILENAME_SHOPPING_CART));
-// }
 
 // if there is nothing in the customers cart, redirect them to the shopping cart page
 if ($_SESSION['cart']->count_contents() <= 0) {

--- a/includes/modules/pages/shopping_cart/header_php.php
+++ b/includes/modules/pages/shopping_cart/header_php.php
@@ -13,9 +13,7 @@ $zco_notifier->notify('NOTIFY_HEADER_START_SHOPPING_CART');
 
 require(DIR_WS_MODULES . zen_get_module_directory('require_languages.php'));
 $breadcrumb->add(NAVBAR_TITLE);
-if (isset($_GET['jscript']) && $_GET['jscript'] == 'no') {
-    $messageStack->add('shopping_cart', PAYMENT_JAVASCRIPT_DISABLED, 'error');
-}
+
 // Validate Cart for checkout
 $_SESSION['valid_to_checkout'] = true;
 $_SESSION['cart_errors'] = '';


### PR DESCRIPTION
Removes the message on the `shopping_cart` page where `$_GET['jscript']` is checked. That value is never used in the core code.

That was introduced in this commit for zc154: https://github.com/zencart/zencart/commit/52b1ca0de67cedfec4cbd86ed4b4572bdd027639