### PR TITLE
2.3: Block accidental BOM

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -44,11 +44,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 
 const IS_AJAX_REQUEST = true;
 
-// -----
-// Buffer all output from this point forward. Nothing should be emitted ahead of the final
-// JSON response, but stray bytes (e.g. a UTF-8 BOM in a language file, an accidental notice)
-// can otherwise corrupt it; discard whatever accumulates before each response is sent.
-//
+/**
+ * Buffer all output from this point forward. Nothing should be emitted ahead of the final
+ * JSON response, but stray bytes (a UTF-8 BOM in a language file, error messages)
+ * can otherwise corrupt it; discard whatever accumulates before each response is sent.
+ *
+ * $ajaxObBaseLevel records the buffering level in effect before this script starts its own
+ * buffer, so cleanup only ever tears down levels *this script* introduced (including the gzip
+ * handler started by init_gzip.php during application_top.php) rather than any buffer that
+ * may already have been active due to the server's own output_buffering configuration.
+ */
+$ajaxObBaseLevel = ob_get_level();
 ob_start();
 require $zc_ajax_base_dir . 'includes/application_top.php';
 
@@ -75,9 +81,7 @@ function ajaxAbort($status = 400, $msg = null)
     global $zc_ajax_base_dir;
     http_response_code($status); // 400 = "Bad Request"
     require $zc_ajax_base_dir . 'includes/application_bottom.php';
-    while (ob_get_level() > 0) {
-        ob_end_clean();
-    }
+    ajaxDiscardBufferedOutput();
     if ($msg) {
         echo $msg;
     }
@@ -86,6 +90,25 @@ function ajaxAbort($status = 400, $msg = null)
 function inDeveloperMode(): bool
 {
     return (defined('DEVELOPER_MODE') && DEVELOPER_MODE === true);
+}
+
+/**
+ * Discards any output buffered since this script's own ob_start() (see $ajaxObBaseLevel
+ * above), without disturbing any buffer that was already active before this script ran
+ * (e.g. a server-level output_buffering setting). Buffers introduced during this request
+ * (such as the gzip handler from init_gzip.php) are fully torn down; this script's own
+ * buffer is emptied via ob_clean() rather than ended, so any pre-existing outer buffer
+ * beneath it is left intact.
+ */
+function ajaxDiscardBufferedOutput(): void
+{
+    global $ajaxObBaseLevel;
+    while (ob_get_level() > $ajaxObBaseLevel + 1) {
+        ob_end_clean();
+    }
+    if (ob_get_level() > $ajaxObBaseLevel) {
+        ob_clean();
+    }
 }
 // --- end support functions ------------------
 
@@ -120,7 +143,5 @@ if (defined($className . '::ALLOWED_METHODS') && !in_array($_GET['method'], $cla
 // Accepted request, so execute and return appropriate response:
 $result = $class->{$_GET['method']}();
 require $zc_ajax_base_dir . 'includes/application_bottom.php';
-while (ob_get_level() > 0) {
-    ob_end_clean();
-}
+ajaxDiscardBufferedOutput();
 echo json_encode($result);

--- a/ajax.php
+++ b/ajax.php
@@ -74,13 +74,13 @@ function ajaxAbort($status = 400, $msg = null)
 {
     global $zc_ajax_base_dir;
     http_response_code($status); // 400 = "Bad Request"
-    if (ob_get_level() > 0) {
+    require $zc_ajax_base_dir . 'includes/application_bottom.php';
+    while (ob_get_level() > 0) {
         ob_end_clean();
     }
     if ($msg) {
         echo $msg;
     }
-    require $zc_ajax_base_dir . 'includes/application_bottom.php';
     exit();
 }
 function inDeveloperMode(): bool
@@ -119,8 +119,8 @@ if (defined($className . '::ALLOWED_METHODS') && !in_array($_GET['method'], $cla
 
 // Accepted request, so execute and return appropriate response:
 $result = $class->{$_GET['method']}();
-if (ob_get_level() > 0) {
+require $zc_ajax_base_dir . 'includes/application_bottom.php';
+while (ob_get_level() > 0) {
     ob_end_clean();
 }
 echo json_encode($result);
-require $zc_ajax_base_dir . 'includes/application_bottom.php';

--- a/ajax.php
+++ b/ajax.php
@@ -43,6 +43,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 }
 
 const IS_AJAX_REQUEST = true;
+
+// -----
+// Buffer all output from this point forward. Nothing should be emitted ahead of the final
+// JSON response, but stray bytes (e.g. a UTF-8 BOM in a language file, an accidental notice)
+// can otherwise corrupt it; discard whatever accumulates before each response is sent.
+//
+ob_start();
 require $zc_ajax_base_dir . 'includes/application_top.php';
 
 // -----
@@ -67,6 +74,9 @@ function ajaxAbort($status = 400, $msg = null)
 {
     global $zc_ajax_base_dir;
     http_response_code($status); // 400 = "Bad Request"
+    if (ob_get_level() > 0) {
+        ob_end_clean();
+    }
     if ($msg) {
         echo $msg;
     }
@@ -109,5 +119,8 @@ if (defined($className . '::ALLOWED_METHODS') && !in_array($_GET['method'], $cla
 
 // Accepted request, so execute and return appropriate response:
 $result = $class->{$_GET['method']}();
+if (ob_get_level() > 0) {
+    ob_end_clean();
+}
 echo json_encode($result);
 require $zc_ajax_base_dir . 'includes/application_bottom.php';

--- a/includes/classes/ResourceLoaders/ArraysLanguageLoader.php
+++ b/includes/classes/ResourceLoaders/ArraysLanguageLoader.php
@@ -251,7 +251,8 @@ class ArraysLanguageLoader extends BaseLanguageLoader
         }
 
         $this->mainLoader->addLanguageFilesLoaded('arrays', $definesFile);
-        // file should return a variable 
+        self::warnIfFileHasBom($definesFile);
+        // file should return a variable
         $definesList = require $definesFile;
         return $definesList; 
     }

--- a/includes/classes/ResourceLoaders/BaseLanguageLoader.php
+++ b/includes/classes/ResourceLoaders/BaseLanguageLoader.php
@@ -48,4 +48,25 @@ class BaseLanguageLoader
     {
         return $this->fallback;
     }
+
+    /**
+     * A leading UTF-8 byte-order-mark (BOM) in a language define file is output as literal text
+     * the moment the file is require()'d/include()'d, since it precedes the opening '<?php' tag.
+     * That silently corrupts any output already in progress (e.g. an AJAX endpoint's JSON response).
+     * Logs a warning identifying the offending file so it can be re-saved without a BOM.
+     *
+     * @since ZC v2.3.0
+     */
+    protected static function warnIfFileHasBom(string $file): void
+    {
+        $handle = @fopen($file, 'rb');
+        if ($handle === false) {
+            return;
+        }
+        $firstBytes = fread($handle, 3);
+        fclose($handle);
+        if ($firstBytes === "\xEF\xBB\xBF") {
+            error_log('Language file has a UTF-8 byte-order-mark (BOM), which will corrupt output such as AJAX/JSON responses. Re-save it as UTF-8 without BOM: ' . $file);
+        }
+    }
 }

--- a/includes/classes/ResourceLoaders/FilesLanguageLoader.php
+++ b/includes/classes/ResourceLoaders/FilesLanguageLoader.php
@@ -62,6 +62,7 @@ class FilesLanguageLoader extends BaseLanguageLoader
             return false;
         }
         $this->mainLoader->addLanguageFilesLoaded('legacy', $defineFile);
+        self::warnIfFileHasBom($defineFile);
         include_once $defineFile;
         return true;
     }


### PR DESCRIPTION
Block accidental BOM

Traps unexpected ajax output.
Inspects language files for BOM before loading them

Ref #7886 