### PR TITLE
Don't truncate text in admin review preview

### DIFF
--- a/admin/includes/css/stylesheet.css
+++ b/admin/includes/css/stylesheet.css
@@ -1216,6 +1216,12 @@ tbody>tr>td.align-bottom {
 .object-fit-none {
     object-fit: none;
 }
+.border-0 {
+    border: 0 !important;
+}
+.shadow-none {
+    box-shadow: none !important;
+}
 /**/
 
 /* CKEditor */

--- a/admin/reviews.php
+++ b/admin/reviews.php
@@ -266,7 +266,7 @@ if ($action === 'edit') {
                 </div>
                 <div class="form-group mb-1">
                     <div class="col-sm-3">
-                        <p class="control-label border-0 shadow-none"><?= ENTRY_RATING ?></p>
+                        <p class="control-label"><?= ENTRY_RATING ?></p>
                     </div>
                     <div class="col-sm-9 col-md-6">
                         <span class="form-control border-0 shadow-none" title="<?= sprintf(TEXT_OF_5_STARS, $rInfo->reviews_rating) ?>">

--- a/admin/reviews.php
+++ b/admin/reviews.php
@@ -237,7 +237,7 @@ if ($action === 'edit') {
                         <p class="control-label"><?= ENTRY_FROM ?></p>
                     </div>
                     <div class="col-sm-9 col-md-6">
-                        <span class="form-control border-0 shadow-none"><?= $rInfo->customers_name ?></span>
+                        <span class="form-control border-0 shadow-none"><?= zen_output_string_protected($rInfo->customers_name) ?></span>
                     </div>
                 </div>
                 <div class="form-group mb-1">

--- a/admin/reviews.php
+++ b/admin/reviews.php
@@ -224,52 +224,52 @@ if ($action === 'edit') {
                 <div class="form-group">
                     <?= zen_info_image($rInfo->products_image, $rInfo->products_name, zen_config('SMALL_IMAGE_WIDTH'), zen_config('SMALL_IMAGE_HEIGHT')) ?>
                 </div>
-                <div class="form-group">
+                <div class="form-group mb-1">
                     <div class="col-sm-3">
                         <p class="control-label"><?= ENTRY_PRODUCT ?></p>
                     </div>
                     <div class="col-sm-9 col-md-6">
-                        <span class="form-control" style="border:none; -webkit-box-shadow: none"><?= $rInfo->products_name ?></span>
+                        <span class="form-control border-0 shadow-none"><?= $rInfo->products_name ?></span>
                     </div>
                 </div>
-                <div class="form-group">
+                <div class="form-group mb-1">
                     <div class="col-sm-3">
                         <p class="control-label"><?= ENTRY_FROM ?></p>
                     </div>
                     <div class="col-sm-9 col-md-6">
-                        <span class="form-control" style="border:none; -webkit-box-shadow: none"><?= $rInfo->customers_name ?></span>
+                        <span class="form-control border-0 shadow-none"><?= $rInfo->customers_name ?></span>
                     </div>
                 </div>
-                <div class="form-group">
+                <div class="form-group mb-1">
                     <div class="col-sm-3">
                         <p class="control-label"><?= ENTRY_DATE ?></p>
                     </div>
                     <div class="col-sm-9 col-md-6">
-                        <span class="form-control" style="border:none; -webkit-box-shadow: none"><?= zen_date_short($rInfo->date_added) ?></span>
+                        <span class="form-control border-0 shadow-none"><?= zen_date_short($rInfo->date_added) ?></span>
                     </div>
                 </div>
-                <div class="form-group">
+                <div class="form-group mb-1">
                     <div class="col-sm-3">
                         <p class="control-label"><?= ENTRY_REVIEW_TITLE ?></p>
                     </div>
                     <div class="col-sm-9 col-md-6">
-                        <span class="form-control" style="border:none; -webkit-box-shadow: none"><?= zen_output_string_protected($rInfo->reviews_title) ?></span>
+                        <span class="form-control border-0 shadow-none"><?= zen_output_string_protected($rInfo->reviews_title) ?></span>
                     </div>
                 </div>
-                <div class="form-group">
+                <div class="form-group mb-1">
                     <div class="col-sm-3">
                         <p class="control-label"><?= ENTRY_REVIEW ?></p>
                     </div>
                     <div class="col-sm-9 col-md-6">
-                        <span class="form-control" style="border:none; -webkit-box-shadow: none"><?= nl2br(zen_output_string_protected(zen_trunc_string($rInfo->reviews_text, 15)), false) ?></span>
+                        <span class="form-control"><?= nl2br(zen_output_string_protected($rInfo->reviews_text), false) ?></span>
                     </div>
                 </div>
-                <div class="form-group">
+                <div class="form-group mb-1">
                     <div class="col-sm-3">
-                        <p class="control-label"><?= ENTRY_RATING ?></p>
+                        <p class="control-label border-0 shadow-none"><?= ENTRY_RATING ?></p>
                     </div>
                     <div class="col-sm-9 col-md-6">
-                        <span class="form-control" style="border:none; -webkit-box-shadow: none" title="<?= sprintf(TEXT_OF_5_STARS, $rInfo->reviews_rating) ?>">
+                        <span class="form-control border-0 shadow-none" title="<?= sprintf(TEXT_OF_5_STARS, $rInfo->reviews_rating) ?>">
                             <?= str_repeat(zen_icon('star-shadow', size: 'lg'), (int)$rInfo->reviews_rating) ?>
                             &nbsp;<small>[<?= sprintf(TEXT_OF_5_STARS, $rInfo->reviews_rating) ?>]</small>
                         </span>
@@ -451,7 +451,7 @@ if ($action === 'edit') {
         } else {
 ?>
                             <a href="<?= zen_href_link(FILENAME_REVIEWS, zen_get_all_get_params(['rID']) . 'rID=' . $review['reviews_id']) ?>" title="<?= IMAGE_ICON_INFO ?>" role="button">
-                                <?= zen_icon('circle-info') ?>
+                                <?= zen_icon('circle-info', '', '2x', true, false) ?>
                             </a>
 <?php
         }


### PR DESCRIPTION
Fixes #7926

Update the admin's `Catalog :: Reviews` so that the review-text isn't truncated during the 'preview/binocular' view.

Pulls in Bootstrap 4/5 classes for no-border/no-box-shadow to do away with the unwanted inline `<style=` HTML attributes.

Also corrects the table's icon for non-selected lines so that it's not the teeny one that was there.