### PR TITLE
2.3: Backport Trusted Proxy support

### DIFF
--- a/admin/includes/application_top.php
+++ b/admin/includes/application_top.php
@@ -11,6 +11,20 @@ if (PHP_VERSION_ID < 80200) {
 }
 
 /**
+ * Capture the genuine TCP peer address before any other code runs.
+ *
+ * This must happen before application_bootstrap.php (which loads the init system) and before
+ * init_sessions.php later overwrites $_SERVER['REMOTE_ADDR'], so that trust decisions about
+ * forwarded headers always see the real proxy/peer address. Request is not autoloadable this early
+ * (the psr-4 autoloader is set up inside the bootstrap below), so the class and its trait are
+ * required explicitly here via __DIR__-relative paths into the storefront classes directory. Only
+ * the PHP-version guard above runs before this point, and it does not read $_SERVER['REMOTE_ADDR'].
+ */
+require_once __DIR__ . '/../../includes/classes/traits/Singleton.php';
+require_once __DIR__ . '/../../includes/classes/Request.php';
+\Zencart\Request\Request::captureOriginalRemoteAddr();
+
+/**
  * Bootstrap file contains former application_top code
  *
  * Initializes common classes & methods. Controlled by an array which describes

--- a/admin/includes/dist-configure.php
+++ b/admin/includes/dist-configure.php
@@ -78,6 +78,19 @@ define('DB_DATABASE', '');
 define('SQL_CACHE_METHOD', 'none');
 
 /**
+ * Optional: List of trusted proxy IP addresses.
+ * Leave it as an empty string/array if you are not using a proxy.
+ *
+ * But if you are hosting behind a proxy such as Cloudflare, you must add the official IP addresses of the proxy here.
+ * For example, for Cloudflare, you can find the list of IP addresses here: https://www.cloudflare.com/ips/
+ *
+ * Entries may be individual IPs or CIDR ranges (e.g. '173.245.48.0/20'),
+ * both IPv4 and IPv6 are supported.
+ * Supports listing entries as an array or a comma-delimited string.
+ */
+define('TRUSTED_PROXIES', []);
+
+/**
  * Reserved for future use
  */
 define('SESSION_STORAGE', 'temporary value added by zc_install');

--- a/includes/application_top.php
+++ b/includes/application_top.php
@@ -243,6 +243,19 @@ if (PHP_VERSION_ID < 80200) {
 }
 
 /**
+ * Capture the genuine TCP peer address before any other code runs.
+ *
+ * This must happen before init_sessions.php overwrites $_SERVER['REMOTE_ADDR'] with the resolved
+ * client IP, so that trust decisions about forwarded headers (zen_get_ip_address()) always see the
+ * real proxy/peer address. Request is not autoloadable this early (the psr-4 autoloader is
+ * registered further down), so the class and its trait are required explicitly here via
+ * __DIR__-relative paths. Nothing above this point reads $_SERVER['REMOTE_ADDR'].
+ */
+require_once __DIR__ . '/classes/traits/Singleton.php';
+require_once __DIR__ . '/classes/Request.php';
+\Zencart\Request\Request::captureOriginalRemoteAddr();
+
+/**
  * Set the local configuration parameters - mainly for developers
  */
 if (file_exists('includes/local/configure.php')) {

--- a/includes/classes/Request.php
+++ b/includes/classes/Request.php
@@ -19,6 +19,29 @@ class Request
     protected $paramBag;
 
     /**
+     * The genuine TCP peer address ($_SERVER['REMOTE_ADDR']) as it was at the very start of the
+     * request, captured once before any init code (notably init_sessions.php, which overwrites
+     * $_SERVER['REMOTE_ADDR'] with the result of zen_get_ip_address()) can mutate it.
+     *
+     * Trust decisions about client-suppliable forwarded headers (zen_get_ip_address())
+     * must be made against this immutable original peer address, never against the live
+     * $_SERVER['REMOTE_ADDR'] which may already have been resolved/overwritten earlier in the request.
+     * A static property (rather than a define() constant) is used deliberately so
+     * it can be reset between PHPUnit test cases running in the same process.
+     */
+    private static $originalRemoteAddr = null;
+
+    /**
+     * Per-request cache of the parsed TRUSTED_PROXIES list. TRUSTED_PROXIES is a define()'d
+     * constant and cannot change during a request, so re-parsing it (explode/array_map/array_filter)
+     * on every call — potentially once per zen_get_ip_address() call plus once per forwarded-header hop
+     * while resolving a chain — would be pure repeated work for an unchanging result.
+     * Nullable so ??= can distinguish "not yet computed" from "computed to an empty list"
+     * (an absent/empty TRUSTED_PROXIES is itself a valid, cacheable result).
+     */
+    private static $trustedProxiesCache = null;
+
+    /**
      * @return mixed|Request
      * @since ZC v1.5.8
      */
@@ -48,5 +71,236 @@ class Request
     public function has($key)
     {
         return (isset($this->paramBag[$key]));
+    }
+
+    /**
+     * Return the genuine TCP peer address captured at the start of the request.
+     *
+     * Lazily captures on first read as a safety net in case captureOriginalRemoteAddr() was not
+     * already called during bootstrap; the ??= semantics still guarantee a single, stable value.
+     *
+     * @since ZC v2.3.0
+     */
+    public static function getOriginalRemoteAddr(): string
+    {
+        self::captureOriginalRemoteAddr();
+        return self::$originalRemoteAddr ?? '';
+    }
+
+    /**
+     * Capture the genuine TCP peer address once, as early as possible in the request.
+     *
+     * Uses null-coalescing assignment so that the first capture sticks: calling this more than
+     * once during a single request is harmless and idempotent — the originally-captured value is
+     * never overwritten by a later (possibly already-mutated) $_SERVER['REMOTE_ADDR'].
+     *
+     * @since ZC v2.3.0
+     */
+    public static function captureOriginalRemoteAddr(): void
+    {
+        self::$originalRemoteAddr ??= ($_SERVER['REMOTE_ADDR'] ?? '');
+    }
+
+    /**
+     * Determine whether the genuine TCP peer is a configured trusted reverse proxy.
+     *
+     * The check is made against the captured original peer address, so it returns the same answer
+     * regardless of where in the request it is called and regardless of whether init_sessions.php
+     * has already overwritten $_SERVER['REMOTE_ADDR'].
+     *
+     * @since ZC v2.3.0
+     */
+    public static function isFromTrustedProxy(): bool
+    {
+        return self::isTrustedProxyAddress(self::getOriginalRemoteAddr());
+    }
+
+    /**
+     * Determine whether the given address matches a configured trusted reverse proxy.
+     *
+     * Each TRUSTED_PROXIES entry may be a single IP (exact match) or a CIDR range
+     * (e.g. 173.245.48.0/20) — providers such as Cloudflare publish their edge ranges as CIDR blocks
+     * (see the TRUSTED_PROXIES doc comment in includes/dist-configure.php), so an exact-match-only
+     * check could never match a real peer against the documented configuration.
+     *
+     * Unlike isFromTrustedProxy() (which always checks the captured original peer), this accepts
+     * an arbitrary address so callers can also test intermediate hops from a forwarded-header
+     * chain — see resolveClientFromForwardedChain().
+     *
+     * @since ZC v2.3.0
+     */
+    public static function isTrustedProxyAddress(string $address): bool
+    {
+        if ($address === '') {
+            return false;
+        }
+        $trustedProxies = self::getTrustedProxies();
+        if ($trustedProxies === []) {
+            return false;
+        }
+        /**
+         * inet_pton() on the candidate address is the same for every entry checked below (exact-IP or CIDR),
+         * so it's computed once here rather than once per entry (think CF's ~20 published ranges).
+         * If the address isn't a valid IP at all, no entry can match it (every match is now a binary comparison), so bail out early.
+         */
+        $addressBin = @inet_pton($address);
+        if ($addressBin === false) {
+            return false;
+        }
+        foreach ($trustedProxies as $proxyEntry) {
+            if (self::proxyEntryMatchesPeer($addressBin, $proxyEntry)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Return the parsed TRUSTED_PROXIES list, computed once per request and cached thereafter.
+     *
+     * Accepts either an array or a comma-separated string; trims and drops empty entries.
+     *
+     * @since ZC v2.3.0
+     */
+    public static function getTrustedProxies(): array
+    {
+        self::$trustedProxiesCache ??= self::parseTrustedProxiesConfig();
+        return self::$trustedProxiesCache;
+    }
+
+    /**
+     * Parse the raw TRUSTED_PROXIES configuration constant into a normalized list of proxy
+     * addresses. Split out from getTrustedProxies() so the parsing itself stays simple to read;
+     * only getTrustedProxies() knows about caching.
+     *
+     * @since ZC v2.3.0
+     */
+    private static function parseTrustedProxiesConfig(): array
+    {
+        $trustedProxiesConfig = defined('TRUSTED_PROXIES') ? constant('TRUSTED_PROXIES') : '';
+        if (is_array($trustedProxiesConfig)) {
+            return array_values(array_filter(array_map(static fn($proxy): string => trim((string) $proxy), $trustedProxiesConfig)));
+        }
+        return array_values(array_filter(array_map('trim', explode(',', (string) $trustedProxiesConfig))));
+    }
+
+    /**
+     * Resolve the real client address from a forwarded-header chain (e.g. X-Forwarded-For),
+     * which each hop conventionally APPENDS its observed source address to rather than
+     * overwriting — so the chain reads left-to-right as [client-claimed value, hop1, hop2, ...].
+     *
+     * A client can freely forge the leftmost entries before the request ever reaches a trusted
+     * proxy, so naively taking the first (leftmost) entry trusts attacker-controlled input even
+     * when the connection genuinely came through a trusted proxy. Instead, walk the chain from
+     * the right (the trusted-peer side): each trusted proxy's own append is authoritative for
+     * "who connected to me", so skip entries that are themselves trusted proxies and return the
+     * first (rightmost-to-leftmost) entry that isn't — that is the address the nearest trusted hop
+     * actually observed. If every entry in the chain is a trusted proxy (or the chain is empty
+     * after trimming), fall back to the captured original peer address.
+     *
+     * @since ZC v2.3.0
+     */
+    public static function resolveClientFromForwardedChain(string $forwardedChain): string
+    {
+        $hops = array_reverse(array_values(array_filter(array_map('trim', explode(',', $forwardedChain)), static fn(string $hop): bool => $hop !== '')));
+        foreach ($hops as $hop) {
+            if (!self::isTrustedProxyAddress($hop)) {
+                return $hop;
+            }
+        }
+        return self::getOriginalRemoteAddr();
+    }
+
+    /**
+     * Match a single TRUSTED_PROXIES entry (exact IP or CIDR range) against a given address.
+     *
+     * $peerBin is the caller's already-computed, known-valid inet_pton($peer), passed in so it
+     * isn't recomputed for every entry in a multi-entry proxy list.
+     *
+     * Exact-IP entries are compared as inet_pton() binary, not as raw text: IPv6 addresses have
+     * multiple valid textual representations for the same address (e.g. a fully- or partially-expanded form
+     * vs the "::" zero-run shorthand — "2001:db8:0:0::1" and "2001:db8::1" are the same address),
+     * so a plain string comparison could silently fail to trust a genuinely configured proxy
+     * whenever REMOTE_ADDR happens to be reported in a different (but equivalent)
+     * textual form than what an operator typed into TRUSTED_PROXIES.
+     *
+     * @since ZC v2.3.0
+     */
+    private static function proxyEntryMatchesPeer(string $peerBin, string $proxyEntry): bool
+    {
+        if (!str_contains($proxyEntry, '/')) {
+            $entryBin = @inet_pton($proxyEntry);
+            return $entryBin !== false && $entryBin === $peerBin;
+        }
+        return self::ipInCidrRange($peerBin, $proxyEntry);
+    }
+
+    /**
+     * Determine whether $ipBin (an already-inet_pton()'d address) falls within the given CIDR
+     * range. Supports both IPv4 and IPv6; returns false on any malformed input or family mismatch
+     * (e.g. an IPv4 peer against an IPv6 CIDR entry) rather than throwing,
+     * since TRUSTED_PROXIES is operator-supplied configuration.
+     *
+     * @since ZC v2.3.0
+     */
+    private static function ipInCidrRange(string $ipBin, string $cidr): bool
+    {
+        $parts = explode('/', $cidr, 2);
+        if (count($parts) !== 2 || !ctype_digit($parts[1])) {
+            return false;
+        }
+        [$subnet, $maskBits] = $parts;
+        $maskBits = (int) $maskBits;
+
+        $subnetBin = @inet_pton($subnet);
+        if ($subnetBin === false || strlen($ipBin) !== strlen($subnetBin)) {
+            return false;
+        }
+
+        $totalBits = strlen($ipBin) * 8;
+        if ($maskBits < 0 || $maskBits > $totalBits) {
+            return false;
+        }
+
+        $fullBytes = intdiv($maskBits, 8);
+        if ($fullBytes > 0 && substr($ipBin, 0, $fullBytes) !== substr($subnetBin, 0, $fullBytes)) {
+            return false;
+        }
+
+        $remainderBits = $maskBits % 8;
+        if ($remainderBits === 0) {
+            return true;
+        }
+
+        $mask = chr((0xFF << (8 - $remainderBits)) & 0xFF);
+        return (ord($ipBin[$fullBytes]) & ord($mask)) === (ord($subnetBin[$fullBytes]) & ord($mask));
+    }
+
+    /**
+     * Test-only: clear the captured peer address so each PHPUnit test case can start from a clean
+     * state and exercise both the trusted-proxy and not-trusted scenarios in the same process.
+     *
+     * Not for use in application code.
+     * @internal
+     *
+     * @since ZC v2.3.0
+     */
+    public static function resetOriginalRemoteAddrForTesting(): void
+    {
+        self::$originalRemoteAddr = null;
+    }
+
+    /**
+     * Test-only: clear the cached parsed TRUSTED_PROXIES list so each PHPUnit test case can
+     * exercise a different TRUSTED_PROXIES configuration without a stale cached parse leaking in
+     * from an earlier test in the same process. Not for use in application code.
+     *
+     * @internal
+     *
+     * @since ZC v2.3.0
+     */
+    public static function resetTrustedProxiesCacheForTesting(): void
+    {
+        self::$trustedProxiesCache = null;
     }
 }

--- a/includes/dist-configure.php
+++ b/includes/dist-configure.php
@@ -57,6 +57,19 @@ define('DB_DATABASE', '');
 define('SQL_CACHE_METHOD', 'none');
 
 /**
+ * Optional: List of trusted proxy IP addresses.
+ * Leave it as an empty string/array if you are not using a proxy.
+ *
+ * But if you are hosting behind a proxy such as Cloudflare, you must add the official IP addresses of the proxy here.
+ * For example, for Cloudflare, you can find the list of IP addresses here: https://www.cloudflare.com/ips/
+ *
+ * Entries may be individual IPs or CIDR ranges (e.g. '173.245.48.0/20'),
+ * both IPv4 and IPv6 are supported.
+ * Supports listing entries as an array or a comma-delimited string.
+ */
+define('TRUSTED_PROXIES', []);
+
+/**
  * Reserved for future use
  */
 define('SESSION_STORAGE', 'temporary value added by zc_install');

--- a/includes/functions/functions_traffic.php
+++ b/includes/functions/functions_traffic.php
@@ -14,16 +14,36 @@
 function zen_get_ip_address() {
     $ip = '';
     /**
-     * resolve any proxies
+     * Resolve any proxies, but only honor the client-suppliable forwarded headers when the genuine
+     * TCP peer is a configured trusted reverse proxy. The trust decision is made against the
+     * captured original peer address (Request::getOriginalRemoteAddr()), so it is correct and
+     * consistent no matter how many times this function is called in a request or whether
+     * init_sessions.php has already overwritten $_SERVER['REMOTE_ADDR'].
+     * When the peer is not a trusted proxy, the original peer address is returned directly.
+     *
+     * A trusted proxy conventionally APPENDS its own observed source address to an existing
+     * forwarded-header value rather than replacing it, so the header can read
+     * "client-claimed-value, hop1, hop2" — the leftmost entry is whatever the original,
+     * potentially untrusted, client supplied, and is not authoritative.
+     * Request::resolveClientFromForwardedChain() walks the chain from the right (the trusted side) and
+     * returns the first entry that isn't itself a trusted proxy, instead of naively trusting
+     * whichever value happens to be first.
      */
     if (isset($_SERVER)) {
-        $ip = $_SERVER['HTTP_X_FORWARDED_FOR'] ??
-            $_SERVER['HTTP_CLIENT_IP'] ??
-                $_SERVER['HTTP_X_FORWARDED'] ??
-                    $_SERVER['HTTP_X_CLUSTER_CLIENT_IP'] ??
-                        $_SERVER['HTTP_FORWARDED_FOR'] ??
-                            $_SERVER['HTTP_FORWARDED'] ??
-                                $_SERVER['REMOTE_ADDR'] ?? '';
+        if (\Zencart\Request\Request::isFromTrustedProxy()) {
+            $forwarded = $_SERVER['HTTP_X_FORWARDED_FOR'] ??
+                $_SERVER['HTTP_CLIENT_IP'] ??
+                    $_SERVER['HTTP_X_FORWARDED'] ??
+                        $_SERVER['HTTP_X_CLUSTER_CLIENT_IP'] ??
+                            $_SERVER['HTTP_FORWARDED_FOR'] ??
+                                $_SERVER['HTTP_FORWARDED'] ??
+                                    null;
+            $ip = ($forwarded !== null)
+                ? \Zencart\Request\Request::resolveClientFromForwardedChain((string) $forwarded)
+                : \Zencart\Request\Request::getOriginalRemoteAddr();
+        } else {
+            $ip = \Zencart\Request\Request::getOriginalRemoteAddr();
+        }
     }
     if (trim($ip) === '') {
         if (getenv('HTTP_X_FORWARDED_FOR')) {

--- a/not_for_release/testFramework/Unit/testsSundry/RequestSecurityTest.php
+++ b/not_for_release/testFramework/Unit/testsSundry/RequestSecurityTest.php
@@ -1,0 +1,451 @@
+<?php
+/**
+ * @copyright Copyright 2003-2026 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ *
+ * Trusted-proxy hardening coverage for zen_get_ip_address(): forwarded IP headers
+ * (X-Forwarded-For et al.) are only honored when the genuine TCP peer is a configured
+ * TRUSTED_PROXIES entry, and forwarded-header chains are resolved from the trusted (right) side
+ * rather than trusting the client-suppliable leftmost entry.
+ */
+
+namespace Tests\Unit\testsSundry;
+
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use Tests\Support\zcUnitTestCase;
+use Zencart\Request\Request;
+
+/**
+ * Several tests in this class call define() on the global TRUSTED_PROXIES constant, which PHP
+ * cannot undefine or redefine within a process. Per AGENTS.md's test-suite guidance, each such
+ * test carries the method-level #[RunInSeparateProcess] attribute rather than isolating the whole
+ * class with #[RunTestsInSeparateProcesses] — only those specific methods get their own process,
+ * so a TRUSTED_PROXIES value defined in one can never leak into another, while the majority of
+ * tests in this file keep running fast, in-process.
+ */
+class RequestSecurityTest extends zcUnitTestCase
+{
+    /**
+     * Shared combined TRUSTED_PROXIES value used by every test that needs a trusted-proxy
+     * configuration: an exact IP, an IPv4 and an IPv6 CIDR range (mirroring how a real deployment
+     * lists a provider's published ranges, e.g. Cloudflare's, alongside an exact address), plus
+     * three deliberately malformed entries (non-numeric mask, out-of-range mask, invalid subnet)
+     * used by testMalformedCidrEntriesInTrustedProxiesListAreIgnoredSafely() to confirm a typo in
+     * one entry neither matches everything nor breaks parsing of the rest of the list. Since each
+     * test that defines TRUSTED_PROXIES runs in its own process, this constant no longer needs to
+     * be identical across tests for correctness — it's kept as one shared value purely to avoid
+     * repeating the same six-entry string in every test method.
+     */
+    private const TEST_TRUSTED_PROXIES = '10.0.0.1,173.245.48.0/20,2400:cb00::/32,10.0.0.0/abc,10.0.0.0/40,not-an-ip/20';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        require_once DIR_FS_CATALOG . 'includes/classes/Request.php';
+        require_once DIR_FS_CATALOG . 'includes/functions/functions_traffic.php';
+
+        $_SERVER = [];
+
+        /**
+         * zen_get_ip_address() bases its trust decision on the peer address that Request captures
+         * once per request. Clear that captured value so each test starts clean and can
+         * independently exercise the trusted-proxy and not-trusted scenarios.
+         */
+        Request::resetOriginalRemoteAddrForTesting();
+
+        /**
+         * Request::getTrustedProxies() caches its parsed result per request. Clear it too, so a
+         * test that doesn't define TRUSTED_PROXIES isn't affected by a parse cached from an earlier
+         * test in the same (non-isolated) process, and so tests remain independent of execution
+         * order.
+         */
+        Request::resetTrustedProxiesCacheForTesting();
+    }
+
+    /**
+     * Regression test for the bootstrap chicken-and-egg problem this fix addresses.
+     *
+     * A request arrives from a trusted reverse proxy: the genuine TCP peer is the proxy
+     * (10.0.0.1) and the proxy reports the real client via X-Forwarded-For (203.0.113.5).
+     * During a real request, init_sessions.php overwrites $_SERVER['REMOTE_ADDR'] with the
+     * resolved client IP partway through bootstrap, and zen_get_ip_address() is called from
+     * roughly ten sites both before and after that overwrite.
+     *
+     * The trust decision must be identical on every call — not correct on the first call (when
+     * $_SERVER['REMOTE_ADDR'] still holds the proxy) and wrong on a later call (after it has been
+     * overwritten with the client IP, which is not a trusted proxy). Because the decision is based
+     * on the captured original peer address, it stays consistent across the overwrite.
+     */
+    #[RunInSeparateProcess]
+    public function testTrustDecisionIsConsistentAcrossRemoteAddrOverwrite(): void
+    {
+        if (!defined('TRUSTED_PROXIES')) {
+            define('TRUSTED_PROXIES', self::TEST_TRUSTED_PROXIES);
+        }
+
+        $_SERVER['REMOTE_ADDR'] = '10.0.0.1';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '203.0.113.5';
+
+        /**
+         * Capture the genuine peer address once, exactly as the bootstrap does before any init
+         * code can run.
+         */
+        Request::captureOriginalRemoteAddr();
+
+        /**
+         * First call — the equivalent of the very first zen_get_ip_address() use in the request,
+         * before init_sessions.php has overwritten $_SERVER['REMOTE_ADDR'].
+         */
+        $this->assertTrue(Request::isFromTrustedProxy());
+        $this->assertSame('203.0.113.5', zen_get_ip_address());
+
+        /**
+         * Simulate the init_sessions.php overwrite that happens partway through bootstrap.
+         */
+        $_SERVER['REMOTE_ADDR'] = zen_get_ip_address();
+        $this->assertSame('203.0.113.5', $_SERVER['REMOTE_ADDR']);
+
+        /**
+         * Second call — a later zen_get_ip_address() site, after the overwrite. A naive check
+         * against the now-overwritten $_SERVER['REMOTE_ADDR'] (203.0.113.5, not a trusted proxy)
+         * would flip the trust decision and stop honoring the forwarded header. The captured
+         * original peer address keeps it consistent.
+         */
+        $this->assertTrue(Request::isFromTrustedProxy());
+        $this->assertSame('203.0.113.5', zen_get_ip_address());
+    }
+
+    /**
+     * Conversely, when the genuine peer is NOT a trusted proxy, a spoofed X-Forwarded-For header
+     * must be ignored and the real peer address returned — and that must also remain consistent
+     * even after $_SERVER['REMOTE_ADDR'] is overwritten. This is the core defense against the
+     * visitor-count inflation / IP-block evasion reported by forged forwarded headers.
+     */
+    #[RunInSeparateProcess]
+    public function testForwardedForIgnoredWhenPeerNotTrusted(): void
+    {
+        if (!defined('TRUSTED_PROXIES')) {
+            define('TRUSTED_PROXIES', self::TEST_TRUSTED_PROXIES);
+        }
+
+        $_SERVER['REMOTE_ADDR'] = '198.51.100.9';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '203.0.113.5';
+
+        Request::captureOriginalRemoteAddr();
+
+        $this->assertFalse(Request::isFromTrustedProxy());
+        $this->assertSame('198.51.100.9', zen_get_ip_address());
+
+        $_SERVER['REMOTE_ADDR'] = zen_get_ip_address();
+
+        $this->assertFalse(Request::isFromTrustedProxy());
+        $this->assertSame('198.51.100.9', zen_get_ip_address());
+    }
+
+    /**
+     * With TRUSTED_PROXIES empty/undefined (the default for the overwhelming majority of stores,
+     * which sit behind no proxy), a forged X-Forwarded-For must be ignored outright and the real
+     * peer returned. This is the default-safe upgrade behavior: no configuration change is needed
+     * for forged-header spoofing to stop working. TRUSTED_PROXIES is left undefined here, so this
+     * runs in the shared, non-isolated process.
+     */
+    public function testForwardedForIgnoredByDefaultWhenNoTrustedProxiesConfigured(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = '198.51.100.20';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '203.0.113.5';
+
+        Request::captureOriginalRemoteAddr();
+
+        $this->assertFalse(Request::isFromTrustedProxy());
+        $this->assertSame('198.51.100.20', zen_get_ip_address());
+    }
+
+    /**
+     * TRUSTED_PROXIES entries are commonly published as CIDR ranges rather than individual IPs
+     * (e.g. Cloudflare's documented edge ranges — see includes/dist-configure.php).
+     * An exact-string-match-only check could never match a real peer against such a range,
+     * so the trusted-proxy check must support CIDR membership.
+     * 173.245.48.0/20 covers 173.245.48.0–173.245.63.255.
+     */
+    #[RunInSeparateProcess]
+    public function testCidrTrustedProxyMatchesPeerInsideIpv4Range(): void
+    {
+        if (!defined('TRUSTED_PROXIES')) {
+            define('TRUSTED_PROXIES', self::TEST_TRUSTED_PROXIES);
+        }
+
+        $_SERVER['REMOTE_ADDR'] = '173.245.50.10';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '203.0.113.5';
+        Request::captureOriginalRemoteAddr();
+
+        $this->assertTrue(Request::isFromTrustedProxy());
+        $this->assertSame('203.0.113.5', zen_get_ip_address());
+    }
+
+    /**
+     * A peer just outside the configured CIDR range (173.245.64.1 is one address past the
+     * 173.245.48.0/20 boundary at 173.245.63.255) must not be trusted.
+     */
+    #[RunInSeparateProcess]
+    public function testCidrTrustedProxyDoesNotMatchPeerOutsideIpv4Range(): void
+    {
+        if (!defined('TRUSTED_PROXIES')) {
+            define('TRUSTED_PROXIES', self::TEST_TRUSTED_PROXIES);
+        }
+
+        $_SERVER['REMOTE_ADDR'] = '173.245.64.1';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '203.0.113.5';
+        Request::captureOriginalRemoteAddr();
+
+        $this->assertFalse(Request::isFromTrustedProxy());
+        $this->assertSame('173.245.64.1', zen_get_ip_address());
+    }
+
+    /**
+     * IPv6 CIDR ranges must also be supported (e.g. Cloudflare also publishes IPv6 ranges).
+     * 2400:cb00::/32 covers any address whose first 32 bits are 2400:cb00.
+     */
+    #[RunInSeparateProcess]
+    public function testCidrTrustedProxyMatchesPeerInsideIpv6Range(): void
+    {
+        if (!defined('TRUSTED_PROXIES')) {
+            define('TRUSTED_PROXIES', self::TEST_TRUSTED_PROXIES);
+        }
+
+        $_SERVER['REMOTE_ADDR'] = '2400:cb00:1234:5678::1';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '203.0.113.5';
+        Request::captureOriginalRemoteAddr();
+
+        $this->assertTrue(Request::isFromTrustedProxy());
+        $this->assertSame('203.0.113.5', zen_get_ip_address());
+    }
+
+    /**
+     * The malformed entries baked into TEST_TRUSTED_PROXIES (non-numeric mask, out-of-range mask,
+     * invalid subnet) must be ignored safely: a peer that doesn't match any of the *valid* entries
+     * stays untrusted (a parsing bug that defaulted a bad mask to 0 would wrongly match everyone),
+     * and parsing them must not throw or otherwise prevent the valid entries later in the same
+     * list from still matching correctly.
+     */
+    #[RunInSeparateProcess]
+    public function testMalformedCidrEntriesInTrustedProxiesListAreIgnoredSafely(): void
+    {
+        if (!defined('TRUSTED_PROXIES')) {
+            define('TRUSTED_PROXIES', self::TEST_TRUSTED_PROXIES);
+        }
+
+        $_SERVER['REMOTE_ADDR'] = '198.51.100.50';
+        Request::captureOriginalRemoteAddr();
+        $this->assertFalse(Request::isFromTrustedProxy());
+
+        Request::resetOriginalRemoteAddrForTesting();
+        $_SERVER['REMOTE_ADDR'] = '10.0.0.1';
+        Request::captureOriginalRemoteAddr();
+        $this->assertTrue(Request::isFromTrustedProxy());
+    }
+
+    /**
+     * Request::getTrustedProxies() explicitly supports TRUSTED_PROXIES as a PHP array (not just a
+     * comma-delimited string) — every other test in this file uses the string form, so the array
+     * form has never actually been exercised. This intentionally defines TRUSTED_PROXIES with a
+     * different shape than TEST_TRUSTED_PROXIES, so it must run in its own process.
+     */
+    #[RunInSeparateProcess]
+    public function testTrustedProxiesConfiguredAsArrayIsHonored(): void
+    {
+        if (!defined('TRUSTED_PROXIES')) {
+            define('TRUSTED_PROXIES', ['10.0.0.1', '173.245.48.0/20']);
+        }
+
+        $_SERVER['REMOTE_ADDR'] = '173.245.50.5';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '203.0.113.9';
+        Request::captureOriginalRemoteAddr();
+
+        $this->assertTrue(Request::isFromTrustedProxy());
+        $this->assertSame('203.0.113.9', zen_get_ip_address());
+    }
+
+    /**
+     * A trusted proxy conventionally APPENDS its own observed source address to an existing
+     * X-Forwarded-For value rather than replacing it — a client talking directly to the proxy can
+     * freely set an arbitrary leftmost value before the proxy appends its own (authoritative)
+     * observation. Naively taking the first (leftmost) entry would trust that attacker-controlled
+     * value even though the connection genuinely came through a trusted proxy. This is the core
+     * regression test for that spoofing vector: the forged leftmost entry must be ignored, and the
+     * rightmost entry (what the trusted proxy actually appended) must be used instead.
+     */
+    #[RunInSeparateProcess]
+    public function testAttackerSpoofedLeadingForwardedForEntryIsIgnored(): void
+    {
+        if (!defined('TRUSTED_PROXIES')) {
+            define('TRUSTED_PROXIES', self::TEST_TRUSTED_PROXIES);
+        }
+
+        $_SERVER['REMOTE_ADDR'] = '10.0.0.1';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '6.6.6.6, 203.0.113.9';
+        Request::captureOriginalRemoteAddr();
+
+        $this->assertSame('203.0.113.9', zen_get_ip_address());
+    }
+
+    /**
+     * With no trusted proxies in the chain besides REMOTE_ADDR itself, a multi-entry
+     * X-Forwarded-For value should resolve to its rightmost entry — the one appended by the
+     * nearest (trusted) hop — not the leftmost, client-suppliable one.
+     */
+    #[RunInSeparateProcess]
+    public function testForwardedForChainTakesRightmostEntryWhenFromTrustedProxy(): void
+    {
+        if (!defined('TRUSTED_PROXIES')) {
+            define('TRUSTED_PROXIES', self::TEST_TRUSTED_PROXIES);
+        }
+
+        $_SERVER['REMOTE_ADDR'] = '10.0.0.1';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '203.0.113.7, 10.0.0.2, 10.0.0.3';
+        Request::captureOriginalRemoteAddr();
+
+        $this->assertSame('10.0.0.3', zen_get_ip_address());
+    }
+
+    /**
+     * A chain can pass through more than one trusted hop (e.g. a CDN edge behind a second internal
+     * proxy, both listed in TRUSTED_PROXIES). Each trusted hop's own append must be skipped in
+     * turn, walking right-to-left, until the first non-trusted entry — the real client — is found.
+     */
+    #[RunInSeparateProcess]
+    public function testForwardedForChainSkipsMultipleTrustedHopsToFindRealClient(): void
+    {
+        if (!defined('TRUSTED_PROXIES')) {
+            define('TRUSTED_PROXIES', self::TEST_TRUSTED_PROXIES);
+        }
+
+        $_SERVER['REMOTE_ADDR'] = '10.0.0.1';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '203.0.113.9, 173.245.50.5, 10.0.0.1';
+        Request::captureOriginalRemoteAddr();
+
+        $this->assertSame('203.0.113.9', zen_get_ip_address());
+    }
+
+    /**
+     * If every entry in the forwarded chain is itself a trusted proxy (a malformed or unusual
+     * chain with no genuine client entry), resolution must fall back to the captured original
+     * peer address rather than returning a trusted-proxy's own address as if it were the client,
+     * or an empty/invalid value.
+     */
+    #[RunInSeparateProcess]
+    public function testForwardedForChainFallsBackToPeerWhenEveryHopIsTrusted(): void
+    {
+        if (!defined('TRUSTED_PROXIES')) {
+            define('TRUSTED_PROXIES', self::TEST_TRUSTED_PROXIES);
+        }
+
+        $_SERVER['REMOTE_ADDR'] = '10.0.0.1';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '10.0.0.1, 173.245.50.5';
+        Request::captureOriginalRemoteAddr();
+
+        $this->assertSame('10.0.0.1', zen_get_ip_address());
+    }
+
+    /**
+     * A trusted proxy that simply doesn't send any forwarded header at all must still resolve
+     * cleanly to the genuine peer address — the null-coalescing fallback chain in
+     * zen_get_ip_address() must not be skipped or produce an empty/invalid result.
+     */
+    #[RunInSeparateProcess]
+    public function testTrustedProxyWithNoForwardedHeaderFallsBackToPeerAddress(): void
+    {
+        if (!defined('TRUSTED_PROXIES')) {
+            define('TRUSTED_PROXIES', self::TEST_TRUSTED_PROXIES);
+        }
+
+        $_SERVER['REMOTE_ADDR'] = '10.0.0.1';
+        Request::captureOriginalRemoteAddr();
+
+        $this->assertTrue(Request::isFromTrustedProxy());
+        $this->assertSame('10.0.0.1', zen_get_ip_address());
+    }
+
+    /**
+     * A CIDR entry for one address family must never match a peer from the other family.
+     * TEST_TRUSTED_PROXIES' IPv4 CIDR entry (173.245.48.0/20) must not match an IPv6 peer, and the
+     * IPv6 CIDR entry (2400:cb00::/32) is for a different range entirely, so this peer matches
+     * nothing in the list and the spoofed X-Forwarded-For must be ignored.
+     */
+    #[RunInSeparateProcess]
+    public function testCidrTrustedProxyDoesNotMatchAcrossAddressFamilies(): void
+    {
+        if (!defined('TRUSTED_PROXIES')) {
+            define('TRUSTED_PROXIES', self::TEST_TRUSTED_PROXIES);
+        }
+
+        $_SERVER['REMOTE_ADDR'] = 'fe80::1';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '203.0.113.5';
+        Request::captureOriginalRemoteAddr();
+
+        $this->assertFalse(Request::isFromTrustedProxy());
+        $this->assertSame('fe80::1', zen_get_ip_address());
+    }
+
+    /**
+     * When the resolved address fails IP validation (filter_var(..., FILTER_VALIDATE_IP)),
+     * zen_get_ip_address() must return the '.' sentinel rather than the raw invalid value or an
+     * empty string — callers throughout the codebase (last-login-IP storage, coupon-redemption
+     * logging, etc.) rely on always getting a non-empty, filterable result. This peer is untrusted
+     * (TRUSTED_PROXIES is undefined in this shared, non-isolated process), so it resolves straight
+     * to the captured original peer address, which here is deliberately not a valid IP. The
+     * invalid-IP branch also calls $GLOBALS['zco_notifier']->notify(), which the unit test
+     * bootstrap already wires up to a real (observerless, so side-effect-free) notifier instance.
+     */
+    public function testInvalidIpReturnsDotPlaceholder(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = 'not-a-valid-ip-address';
+        Request::captureOriginalRemoteAddr();
+
+        $this->assertSame('.', zen_get_ip_address());
+    }
+
+    /**
+     * An exact-IP TRUSTED_PROXIES entry must match on IP-address equivalence, not raw text.
+     * IPv6 has multiple valid textual representations of the same address — "2001:db8:0:0::1" and
+     * "2001:db8::1" both expand to the same 16-byte address (confirmed: inet_pton() on both
+     * produces identical binary). A naive string comparison would treat them as different entries
+     * and silently refuse to trust a genuinely configured proxy whenever REMOTE_ADDR happens to be
+     * reported in a different (but equivalent) form than what was typed into TRUSTED_PROXIES. This
+     * uses its own TRUSTED_PROXIES value (not the shared TEST_TRUSTED_PROXIES) since it needs a
+     * specific IPv6 exact-match entry not present in the shared config.
+     */
+    #[RunInSeparateProcess]
+    public function testExactMatchTrustedProxyEntryMatchesEquivalentIpv6Representation(): void
+    {
+        if (!defined('TRUSTED_PROXIES')) {
+            define('TRUSTED_PROXIES', '2001:db8:0:0::1');
+        }
+
+        $_SERVER['REMOTE_ADDR'] = '2001:db8::1';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '203.0.113.9';
+        Request::captureOriginalRemoteAddr();
+
+        $this->assertTrue(Request::isFromTrustedProxy());
+        $this->assertSame('203.0.113.9', zen_get_ip_address());
+    }
+
+    /**
+     * A malformed exact-match entry (not a valid IP at all) must be ignored safely rather than
+     * matching via a stray string comparison — TRUSTED_PROXIES is operator-supplied configuration
+     * that may contain a typo. The peer here is a genuinely valid IP (so the check reaches the
+     * per-entry comparison rather than short-circuiting on an invalid peer), it simply doesn't
+     * match the malformed entry.
+     */
+    #[RunInSeparateProcess]
+    public function testMalformedExactMatchEntryIsIgnoredSafely(): void
+    {
+        if (!defined('TRUSTED_PROXIES')) {
+            define('TRUSTED_PROXIES', 'not-an-ip-at-all');
+        }
+
+        $_SERVER['REMOTE_ADDR'] = '10.0.0.1';
+        Request::captureOriginalRemoteAddr();
+
+        $this->assertFalse(Request::isFromTrustedProxy());
+    }
+}

--- a/zc_install/includes/admin-configure-template.php
+++ b/zc_install/includes/admin-configure-template.php
@@ -76,6 +76,19 @@ define('DB_DATABASE', '%%_DB_DATABASE_%%');
 define('SQL_CACHE_METHOD', '%%_SQL_CACHE_METHOD_%%');
 
 /**
+ * Optional: List of trusted proxy IP addresses.
+ * Leave it as an empty string/array if you are not using a proxy.
+ *
+ * But if you are hosting behind a proxy such as Cloudflare, you must add the official IP addresses of the proxy here.
+ * For example, for Cloudflare, you can find the list of IP addresses here: https://www.cloudflare.com/ips/
+ *
+ * Entries may be individual IPs or CIDR ranges (e.g. '173.245.48.0/20'),
+ * both IPv4 and IPv6 are supported.
+ * Supports listing entries as an array or a comma-delimited string.
+ */
+define('TRUSTED_PROXIES', []);
+
+/**
  * Reserved for future use
  */
 define('SESSION_STORAGE', '%%_SESSION_STORAGE_%%');

--- a/zc_install/includes/catalog-configure-template.php
+++ b/zc_install/includes/catalog-configure-template.php
@@ -54,6 +54,19 @@ define('DB_DATABASE', '%%_DB_DATABASE_%%');
 define('SQL_CACHE_METHOD', '%%_SQL_CACHE_METHOD_%%');
 
 /**
+ * Optional: List of trusted proxy IP addresses.
+ * Leave it as an empty string/array if you are not using a proxy.
+ *
+ * But if you are hosting behind a proxy such as Cloudflare, you must add the official IP addresses of the proxy here.
+ * For example, for Cloudflare, you can find the list of IP addresses here: https://www.cloudflare.com/ips/
+ *
+ * Entries may be individual IPs or CIDR ranges (e.g. '173.245.48.0/20'),
+ * both IPv4 and IPv6 are supported.
+ * Supports listing entries as an array or a comma-delimited string.
+ */
+define('TRUSTED_PROXIES', []);
+
+/**
  * Reserved for future use
  */
 define('SESSION_STORAGE', '%%_SESSION_STORAGE_%%');


### PR DESCRIPTION
Backport's PR #7889 onto v2.3

Note: can be applied cleanly to v2.2.2 easily.
And can be manually applied (by hand) onto v2.1.x or v2.0.x

(To apply, you only need the `/admin/*` and `/includes/*` files. You don't need the `not_for_release` or `zc_install` files to patch a live site.)