### PR TITLE
Add routing map inoculation to dismiss rogue traffic quickly

### DIFF
--- a/includes/application_top.php
+++ b/includes/application_top.php
@@ -207,6 +207,16 @@ if (!$contaminated && isset($_GET['action']) && $_GET['action'] === 'buy_now') {
     }
 }
 
+/**
+ * reject catalog-filter params (cPath, manufacturers_id, etc.) when supplied
+ * for a page that never legitimately reads them, such as bots stuffing shopping_cart
+ * or other non-catalog pages with spoofed query strings. See includes/routing_map.php.
+ */
+if (!$contaminated) {
+    require_once __DIR__ . '/routing_map.php';
+    $contaminated = zen_request_has_disallowed_catalog_param($_GET);
+}
+
 if ($contaminated) {
     header('HTTP/1.1 406 Not Acceptable');
     exit(0);

--- a/includes/application_top.php
+++ b/includes/application_top.php
@@ -208,9 +208,10 @@ if (!$contaminated && isset($_GET['action']) && $_GET['action'] === 'buy_now') {
 }
 
 /**
- * reject catalog-filter params (cPath, manufacturers_id, etc.) when supplied
- * for a page that never legitimately reads them, such as bots stuffing shopping_cart
- * or other non-catalog pages with spoofed query strings. See includes/routing_map.php.
+ * reject catalog-filter params (manufacturers_id, sort, etc.) when supplied for
+ * a page confirmed to never legitimately read them, such as bots stuffing
+ * shopping_cart or checkout with spoofed query strings. cPath and products_id are
+ * deliberately NOT covered here -- see includes/routing_map.php.
  */
 if (!$contaminated) {
     require_once __DIR__ . '/routing_map.php';

--- a/includes/routing_map.php
+++ b/includes/routing_map.php
@@ -5,65 +5,67 @@
  * constants are available. Because of that, this file is deliberately
  * self-contained: no zen_* helper calls, no constants, just plain PHP.
  *
- * The idea: a small, fixed set of GET params only ever have meaning on a small,
- * fixed set of catalog "listing" pages (index, search results, specials, etc.).
- * A request supplying one of those params for any OTHER page
- * (ie: shopping_cart?manufacturers_id=8&products_id=1) is either a stale/spoofed link
- * or a bot probing arbitrary URL/param combinations, and can be rejected immediately (406)
- * before a session starts or any other bootstrapping occurs.
+ * The idea: a small, fixed set of GET params only ever have meaning on catalog
+ * "listing" pages (index, search results, specials, etc.). A request supplying
+ * one of those params for a page that's guaranteed to never legitimately use them
+ * (ie: shopping_cart?manufacturers_id=8&products_id=1) is either a stale/spoofed
+ * link or a bot probing arbitrary URL/param combinations, and can be rejected
+ * immediately (406) before a session starts or any other bootstrapping occurs.
+ *
+ * This is a deny-list of known-bad targets, not an allow-list of known-good pages.
+ * That's deliberate: this check runs before plugins are loaded, so it has no way
+ * to let a plugin register its own catalog-style page
+ * (e.g. a custom "Deals" page reading manufacturers_id/sort/keyword)
  *
  * Deliberately narrow, by design:
- *  - This is NOT an exhaustive per-page allow-list of every GET key,
- *    to avoid rejecting legitimate params this system doesn't control
+ *  - This is NOT an exhaustive deny-list of every non-catalog page in core,
+ *    let alone every plugin page. It only lists the pages actually confirmed as
+ *    real bot targets: the shopping cart and the checkout flow.
+ *    Extend it over time with other guaranteed-core, guaranteed-stable page names
+ *    as more patterns get reported, never with anything that could plausibly
+ *    be a plugin-defined page name.
+ *  - The restricted param list below is NOT an exhaustive allow-list of every GET
+ *    key either, to avoid rejecting legitimate params this system doesn't control
  *    (such as marketing/tracking params (utm_source, gclid, fbclid) or plugin-added keys).
- *  - cPath and products_id are deliberately NOT in the restricted list below,
- *    even though they're catalog-filter params too. Unlike the others, they're
- *    ALSO legitimate on product-detail "_info" pages (product_info, etc),
- *    and that page set varies by installed product type so it can't be safely enumerated
- *    here as a static list (no DB connection exists yet at this point in the
- *    request). cPath/products_id are instead gated downstream by
- *    zen_page_uses_catalog_breadcrumb_lookups() in functions_lookups.php,
- *    which can correctly enumerate that page set from TABLE_PRODUCT_TYPES.
- *  - Checkout/Account pages are NOT included either. They normally require an
- *    authenticated session (absent a guest-checkout plugin), and are also
- *    already covered by the same downstream function.
+ *  - cPath and products_id are deliberately NOT in the restricted list below, even
+ *    though they're catalog-filter params too. Unlike the others, they're ALSO
+ *    legitimate on product-detail "_info" pages (product_info, etc), and that page
+ *    set varies by installed product type so it can't be safely enumerated here as
+ *    a static list (no DB connection exists yet at this point in the request).
+ *    cPath/products_id are instead gated downstream by
+ *    zen_page_uses_catalog_breadcrumb_lookups() in functions_lookups.php, which can
+ *    correctly enumerate that page set from TABLE_PRODUCT_TYPES.
  *
  * Keys deliberately left OUT, documented so a future edit doesn't "helpfully" add them:
  *  - pID / pid: look like catalog candidates but are used by shopping_cart.php's
  *    own remove/update links, plus ask_a_question and the popup_image pages.
- *    Restricting them here would break the shopping cart's own UI.
+ *    Restricting them here would break the shopping cart's own UI -- notably,
+ *    shopping_cart is itself on the deny-list below, so this isn't hypothetical.
  *  - page: used broadly, not catalog-specific.
- *
- * Pages in $catalogPages beyond the obvious "listing" ones, and why:
- *  - redirect: legacy-URL/click-through redirects (action= params).
- *    Rejecting these would break real manufacturer-click tracking and legacy bookmarks.
- *  - advanced_search / advanced_search_result: these are pure 301-redirect stubs.
- *  - brands: reads $_GET['typefilter'] (but functionally inert). Included anyway: the page
- *    reads that key today, so a request carrying it currently renders 200.
- *    Excluding the page would turn that into a 406 for no functional gain.
- *  - featured_categories: $_GET['typefilter'] is dead code, but kept to avoid risk.
  */
 
 /**
  * @param array $get Typically $_GET.
- * @return bool true if a catalog-only filter param was supplied for a page that
- *              never legitimately reads it.
+ * @return bool true if a catalog-only filter param was supplied for a page
+ *              confirmed to never legitimately read it.
  *
  * @since ZC v2.3.0
  */
 function zen_request_has_disallowed_catalog_param(array $get): bool
 {
-    static $catalogPages = [
-        'index', 'search', 'search_result', 'advanced_search', 'advanced_search_result',
-        'specials', 'products_new', 'products_all', 'featured_products',
-        'product_reviews', 'product_reviews_info', 'product_reviews_write',
-        'redirect', 'brands', 'featured_categories',
+    static $knownNonCatalogPages = [
+        'shopping_cart',
+        'checkout_shipping', 'checkout_shipping_address',
+        'checkout_payment', 'checkout_payment_address',
+        'checkout_confirmation', 'checkout_process', 'checkout_success',
     ];
 
     // NOTE: cPath and products_id are intentionally excluded -- see the docblock above.
     static $catalogFilterKeys = [
-        'manufacturers_id', 'music_genre_id', 'record_company_id',
-        'disp_order', 'sort', 'typefilter', 'filter_id', 'alpha_filter_id',
+        'manufacturers_id',
+        'sort',
+        'music_genre_id', 'record_company_id',
+        'disp_order', 'typefilter', 'filter_id', 'alpha_filter_id',
         'keyword', 'dfrom', 'pfrom', 'dto', 'pto', 'search_in_description', 'inc_subcat',
         'categories_id', 'sale_category', 'reviews_id',
     ];
@@ -76,7 +78,7 @@ function zen_request_has_disallowed_catalog_param(array $get): bool
         $page = 'index';
     }
 
-    if (in_array($page, $catalogPages, true)) {
+    if (!in_array($page, $knownNonCatalogPages, true)) {
         return false;
     }
 

--- a/includes/routing_map.php
+++ b/includes/routing_map.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Routing-map check used by the very early request-inoculation block in
+ * application_top.php, before the framework, database, session, or FILENAME_*
+ * constants are available. Because of that, this file is deliberately
+ * self-contained: no zen_* helper calls, no constants, just plain PHP.
+ *
+ * The idea: a small, fixed set of GET params only ever have meaning on a small,
+ * fixed set of catalog "listing" pages (index, search results, specials, etc.).
+ * A request supplying one of those params for any OTHER page
+ * (ie: shopping_cart?manufacturers_id=8&products_id=1) is either a stale/spoofed link
+ * or a bot probing arbitrary URL/param combinations, and can be rejected immediately (406)
+ * before a session starts or any other bootstrapping occurs.
+ *
+ * Deliberately narrow, by design:
+ *  - This is NOT an exhaustive per-page allow-list of every GET key,
+ *    to avoid rejecting legitimate params this system doesn't control
+ *    (such as marketing/tracking params (utm_source, gclid, fbclid) or plugin-added keys).
+ *  - cPath and products_id are deliberately NOT in the restricted list below,
+ *    even though they're catalog-filter params too. Unlike the others, they're
+ *    ALSO legitimate on product-detail "_info" pages (product_info, etc),
+ *    and that page set varies by installed product type so it can't be safely enumerated
+ *    here as a static list (no DB connection exists yet at this point in the
+ *    request). cPath/products_id are instead gated downstream by
+ *    zen_page_uses_catalog_breadcrumb_lookups() in functions_lookups.php,
+ *    which can correctly enumerate that page set from TABLE_PRODUCT_TYPES.
+ *  - Checkout/Account pages are NOT included either. They normally require an
+ *    authenticated session (absent a guest-checkout plugin), and are also
+ *    already covered by the same downstream function.
+ *
+ * Keys deliberately left OUT, documented so a future edit doesn't "helpfully" add them:
+ *  - pID / pid: look like catalog candidates but are used by shopping_cart.php's
+ *    own remove/update links, plus ask_a_question and the popup_image pages.
+ *    Restricting them here would break the shopping cart's own UI.
+ *  - page: used broadly, not catalog-specific.
+ *
+ * Pages in $catalogPages beyond the obvious "listing" ones, and why:
+ *  - redirect: legacy-URL/click-through redirects (action= params).
+ *    Rejecting these would break real manufacturer-click tracking and legacy bookmarks.
+ *  - advanced_search / advanced_search_result: these are pure 301-redirect stubs.
+ *  - brands: reads $_GET['typefilter'] (but functionally inert). Included anyway: the page
+ *    reads that key today, so a request carrying it currently renders 200.
+ *    Excluding the page would turn that into a 406 for no functional gain.
+ *  - featured_categories: $_GET['typefilter'] is dead code, but kept to avoid risk.
+ */
+
+/**
+ * @param array $get Typically $_GET.
+ * @return bool true if a catalog-only filter param was supplied for a page that
+ *              never legitimately reads it.
+ *
+ * @since ZC v2.3.0
+ */
+function zen_request_has_disallowed_catalog_param(array $get): bool
+{
+    static $catalogPages = [
+        'index', 'search', 'search_result', 'advanced_search', 'advanced_search_result',
+        'specials', 'products_new', 'products_all', 'featured_products',
+        'product_reviews', 'product_reviews_info', 'product_reviews_write',
+        'redirect', 'brands', 'featured_categories',
+    ];
+
+    // NOTE: cPath and products_id are intentionally excluded -- see the docblock above.
+    static $catalogFilterKeys = [
+        'manufacturers_id', 'music_genre_id', 'record_company_id',
+        'disp_order', 'sort', 'typefilter', 'filter_id', 'alpha_filter_id',
+        'keyword', 'dfrom', 'pfrom', 'dto', 'pto', 'search_in_description', 'inc_subcat',
+        'categories_id', 'sale_category', 'reviews_id',
+    ];
+
+    if (in_array($get['main_page'] ?? '', $catalogPages, true)) {
+        return false;
+    }
+
+    foreach ($catalogFilterKeys as $key) {
+        if (isset($get[$key])) {
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/includes/routing_map.php
+++ b/includes/routing_map.php
@@ -17,18 +17,22 @@
  * to let a plugin register its own catalog-style page
  * (e.g. a custom "Deals" page reading manufacturers_id/sort/keyword).
  *
- * shopping_cart is matched explicitly. Every checkout-flow page including core
- * (checkout_shipping, checkout_payment, ...) and known third-party addons like
- * (checkout_one, checkout_one_confirmation, etc) is matched by the 'checkout_' prefix
- * instead of an enumerated list. Accepted trade-off: a plugin that names an unrelated
- * page starting with 'checkout_' would also be denied here, judged unlikely enough
- * in practice to be worth the reduced maintenance burden versus enumerating every
- * checkout-flow page by hand.
+ * Only checkout-flow pages are matched here. Core pages (checkout_shipping,
+ * checkout_payment, ...) and known third-party addons alike (checkout_one,
+ * checkout_one_confirmation, etc), all via the 'checkout_' prefix instead of an
+ * enumerated list.
+ *
+ * shopping_cart is deliberately NOT matched here because actionBuyNow() legitimately
+ * redirects to shopping_cart carrying the query string of whatever catalog listing
+ * the "Buy Now" button was clicked from. The actual protection against wasted
+ * breadcrumb/category queries lives downstream instead, in functions_lookups.php
+ * at zen_page_uses_catalog_breadcrumb_lookups().
  *
  * Deliberately narrow, by design:
  *  - This is NOT an exhaustive deny-list of every non-catalog page in core,
- *    let alone every plugin page. It only targets the pages actually confirmed as
- *    real bot targets: the shopping cart and the checkout flow.
+ *    let alone every plugin page. It only targets the checkout flow, the one place
+ *    confirmed safe from the redirect-leakage problem above (checkout is never the
+ *    target of a "Buy Now from a listing" redirect).
  *  - The restricted param list below is NOT an exhaustive allow-list of every GET
  *    key either, to avoid rejecting legitimate params this system doesn't control
  *    (such as marketing/tracking params (utm_source, gclid, fbclid) or plugin-added keys).
@@ -42,10 +46,7 @@
  *    correctly enumerate that page set from TABLE_PRODUCT_TYPES.
  *
  * Keys deliberately left OUT, documented so a future edit doesn't "helpfully" add them:
- *  - pID / pid: look like catalog candidates but are used by shopping_cart.php's
- *    own remove/update links, plus ask_a_question and the popup_image pages.
- *    Restricting them here would break the shopping cart's own UI ... notably,
- *    shopping_cart is itself denied below, so this isn't hypothetical.
+ *  - pID / pid: look like catalog candidates but are used legitimately on several pages.
  *  - page: used broadly, not catalog-specific.
  */
 
@@ -62,10 +63,12 @@ function zen_request_has_disallowed_catalog_param(array $get): bool
     static $catalogFilterKeys = [
         'manufacturers_id',
         'sort',
-        'music_genre_id', 'record_company_id',
         'disp_order', 'typefilter', 'filter_id', 'alpha_filter_id',
         'keyword', 'dfrom', 'pfrom', 'dto', 'pto', 'search_in_description', 'inc_subcat',
-        'categories_id', 'sale_category', 'reviews_id',
+        'categories_id',
+        'sale_category',
+        'reviews_id',
+        'music_genre_id', 'record_company_id',
     ];
 
     // Mirrors init_sanitize.php's own fallback:
@@ -76,7 +79,7 @@ function zen_request_has_disallowed_catalog_param(array $get): bool
         $page = 'index';
     }
 
-    if ($page !== 'shopping_cart' && !str_starts_with($page, 'checkout_')) {
+    if (!str_starts_with($page, 'checkout_')) {
         return false;
     }
 

--- a/includes/routing_map.php
+++ b/includes/routing_map.php
@@ -68,7 +68,15 @@ function zen_request_has_disallowed_catalog_param(array $get): bool
         'categories_id', 'sale_category', 'reviews_id',
     ];
 
-    if (in_array($get['main_page'] ?? '', $catalogPages, true)) {
+    // Mirrors init_sanitize.php's own fallback:
+    // an empty/missing main_page defaults to the index page (FILENAME_DEFAULT)
+    // e.g. index.php?manufacturers_id=8 is a legitimate URL shape that renders as the index/manufacturer listing
+    $page = $get['main_page'] ?? '';
+    if ($page === '') {
+        $page = 'index';
+    }
+
+    if (in_array($page, $catalogPages, true)) {
         return false;
     }
 

--- a/includes/routing_map.php
+++ b/includes/routing_map.php
@@ -15,15 +15,20 @@
  * This is a deny-list of known-bad targets, not an allow-list of known-good pages.
  * That's deliberate: this check runs before plugins are loaded, so it has no way
  * to let a plugin register its own catalog-style page
- * (e.g. a custom "Deals" page reading manufacturers_id/sort/keyword)
+ * (e.g. a custom "Deals" page reading manufacturers_id/sort/keyword).
+ *
+ * shopping_cart is matched explicitly. Every checkout-flow page including core
+ * (checkout_shipping, checkout_payment, ...) and known third-party addons like
+ * (checkout_one, checkout_one_confirmation, etc) is matched by the 'checkout_' prefix
+ * instead of an enumerated list. Accepted trade-off: a plugin that names an unrelated
+ * page starting with 'checkout_' would also be denied here, judged unlikely enough
+ * in practice to be worth the reduced maintenance burden versus enumerating every
+ * checkout-flow page by hand.
  *
  * Deliberately narrow, by design:
  *  - This is NOT an exhaustive deny-list of every non-catalog page in core,
- *    let alone every plugin page. It only lists the pages actually confirmed as
+ *    let alone every plugin page. It only targets the pages actually confirmed as
  *    real bot targets: the shopping cart and the checkout flow.
- *    Extend it over time with other guaranteed-core, guaranteed-stable page names
- *    as more patterns get reported, never with anything that could plausibly
- *    be a plugin-defined page name.
  *  - The restricted param list below is NOT an exhaustive allow-list of every GET
  *    key either, to avoid rejecting legitimate params this system doesn't control
  *    (such as marketing/tracking params (utm_source, gclid, fbclid) or plugin-added keys).
@@ -39,8 +44,8 @@
  * Keys deliberately left OUT, documented so a future edit doesn't "helpfully" add them:
  *  - pID / pid: look like catalog candidates but are used by shopping_cart.php's
  *    own remove/update links, plus ask_a_question and the popup_image pages.
- *    Restricting them here would break the shopping cart's own UI -- notably,
- *    shopping_cart is itself on the deny-list below, so this isn't hypothetical.
+ *    Restricting them here would break the shopping cart's own UI ... notably,
+ *    shopping_cart is itself denied below, so this isn't hypothetical.
  *  - page: used broadly, not catalog-specific.
  */
 
@@ -53,13 +58,6 @@
  */
 function zen_request_has_disallowed_catalog_param(array $get): bool
 {
-    static $knownNonCatalogPages = [
-        'shopping_cart',
-        'checkout_shipping', 'checkout_shipping_address',
-        'checkout_payment', 'checkout_payment_address',
-        'checkout_confirmation', 'checkout_process', 'checkout_success',
-    ];
-
     // NOTE: cPath and products_id are intentionally excluded -- see the docblock above.
     static $catalogFilterKeys = [
         'manufacturers_id',
@@ -78,7 +76,7 @@ function zen_request_has_disallowed_catalog_param(array $get): bool
         $page = 'index';
     }
 
-    if (!in_array($page, $knownNonCatalogPages, true)) {
+    if ($page !== 'shopping_cart' && !str_starts_with($page, 'checkout_')) {
         return false;
     }
 

--- a/not_for_release/testFramework/Unit/testsSundry/RoutingMapCatalogParamCheckTest.php
+++ b/not_for_release/testFramework/Unit/testsSundry/RoutingMapCatalogParamCheckTest.php
@@ -10,10 +10,12 @@
  * forum-reported bot pattern, shopping_cart?manufacturers_id=8&products_id=1.
  *
  * zen_request_has_disallowed_catalog_param() (includes/routing_map.php) is a deny-list
- * of known-bad targets (shopping_cart + checkout_*), not an allow-list of known-good
- * pages -- deliberately, since this runs before plugins load and has no way to let a
- * plugin register its own catalog-style page. A page NOT on the deny-list, including
- * any plugin page or any core page nobody's added yet, is always allowed through.
+ * of known-bad targets -- shopping_cart matched explicitly, every checkout-flow page
+ * (core and third-party one-page/guest-checkout addons alike) matched by the
+ * 'checkout_' prefix -- not an allow-list of known-good pages -- deliberately, since
+ * this runs before plugins load and has no way to let a plugin register its own
+ * catalog-style page. A page that doesn't match, including any plugin page or any
+ * core page nobody's added yet, is always allowed through.
  *
  * It's also deliberately self-contained (no framework, no constants, no DB) because it
  * runs before includes/configure.php is even loaded -- see application_top.php's
@@ -259,8 +261,9 @@ class RoutingMapCatalogParamCheckTest extends zcUnitTestCase
     }
 
     /**
-     * Every deny-listed page, with a representative filter key, must actually be
-     * rejected -- guards against a typo silently removing a page from the list.
+     * shopping_cart plus every core checkout-flow page, with a representative
+     * filter key, must actually be rejected -- guards against the prefix logic
+     * (or the explicit shopping_cart check) silently breaking.
      */
     public function testEachKnownNonCatalogPageIsRejected(): void
     {
@@ -278,5 +281,41 @@ class RoutingMapCatalogParamCheckTest extends zcUnitTestCase
                 "Expected '$page' to reject manufacturers_id."
             );
         }
+    }
+
+    /**
+     * Also match a 'checkout_' prefix match to accommodate both core and third-party
+     * one-page-checkout addon pages which follow the same naming convention:
+     * all get the same protection automatically, with no maintenance burden per addon.
+     */
+    public function testThirdPartyCheckoutAddonPagesAreAlsoRejected(): void
+    {
+        $knownAddonCheckoutPages = [
+            'checkout_one', 'checkout_one_confirmation', 'checkout_one_send_welcome_email',
+        ];
+
+        foreach ($knownAddonCheckoutPages as $page) {
+            $get = ['main_page' => $page, 'manufacturers_id' => '8'];
+            $this->assertTrue(
+                \zen_request_has_disallowed_catalog_param($get),
+                "Expected '$page' to reject manufacturers_id."
+            );
+        }
+    }
+
+    /**
+     * Documents the accepted trade-off of the prefix match, called out explicitly
+     * in routing_map.php's docblock: ANY page starting with 'checkout_' is denied here,
+     * even one from an unrelated plugin that has nothing to do with the checkout flow.
+     * Judged unlikely enough in practice to accept, in exchange for not having to enumerate
+     * every checkout-flow page (core and third-party) by hand.
+     * If this test starts failing a real plugin's build, that's the trade-off
+     * materializing, not a bug in this function.
+     */
+    public function testAnyCheckoutPrefixedPageIsRejectedEvenIfUnrelatedToCheckout(): void
+    {
+        $get = ['main_page' => 'checkout_totally_unrelated_plugin_page', 'manufacturers_id' => '8'];
+
+        $this->assertTrue(\zen_request_has_disallowed_catalog_param($get));
     }
 }

--- a/not_for_release/testFramework/Unit/testsSundry/RoutingMapCatalogParamCheckTest.php
+++ b/not_for_release/testFramework/Unit/testsSundry/RoutingMapCatalogParamCheckTest.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * @copyright Copyright 2003-2026 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ *
+ * Regression coverage for #7924 / #7921's follow-up discussion: application_top.php's
+ * very-early inoculation block now rejects (406, before any session/DB/file loads
+ * beyond this one) a request that supplies a catalog-only filter param (cPath,
+ * manufacturers_id, etc.) for a page that never legitimately reads it -- e.g. the
+ * original forum-reported bot pattern, shopping_cart?manufacturers_id=8&products_id=1.
+ *
+ * zen_request_has_disallowed_catalog_param() (includes/routing_map.php) is deliberately
+ * self-contained (no framework, no constants, no DB) because it runs before
+ * includes/configure.php is even loaded -- see application_top.php's inoculation block.
+ */
+
+namespace Tests\Unit\testsSundry;
+
+use Tests\Support\zcUnitTestCase;
+
+class RoutingMapCatalogParamCheckTest extends zcUnitTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        require_once DIR_FS_CATALOG . 'includes/routing_map.php';
+    }
+
+    /**
+     * Every catalog-filter key, fired at a page that never legitimately uses it.
+     * This is the actual bug: a bot supplying these params on, say, the shopping
+     * cart page to force wasted breadcrumb/category lookups downstream.
+     */
+    public function testEachCatalogFilterKeyIsRejectedOnANonCatalogPage(): void
+    {
+        // NOTE: cPath and products_id are NOT in this list -- see
+        // testCPathAndProductsIdAreDeliberatelyExcluded() for why.
+        $catalogFilterKeys = [
+            'manufacturers_id', 'music_genre_id', 'record_company_id',
+            'disp_order', 'sort', 'typefilter', 'filter_id', 'alpha_filter_id',
+            'keyword', 'dfrom', 'pfrom', 'dto', 'pto', 'search_in_description', 'inc_subcat',
+            'categories_id', 'sale_category', 'reviews_id',
+        ];
+
+        foreach ($catalogFilterKeys as $key) {
+            $get = ['main_page' => 'shopping_cart', $key => '1'];
+            $this->assertTrue(
+                \zen_request_has_disallowed_catalog_param($get),
+                "Expected '$key' on shopping_cart to be rejected."
+            );
+        }
+    }
+
+    /**
+     * The exact URL pattern reported in the forum thread behind #7921.
+     */
+    public function testTheOriginalForumReportedBotPatternIsRejected(): void
+    {
+        $get = [
+            'main_page' => 'shopping_cart',
+            'disp_order' => '8',
+            'manufacturers_id' => '8',
+            'page' => '6',
+            'products_id' => '1',
+        ];
+
+        $this->assertTrue(\zen_request_has_disallowed_catalog_param($get));
+    }
+
+    /**
+     * A real manufacturer-click-through / legacy-URL redirect must not be rejected --
+     * the redirect page's whole job is to accept manufacturers_id/record_company_id
+     * and 301 the visitor onward.
+     */
+    public function testALegitimateManufacturerClickThroughRedirectIsNotRejected(): void
+    {
+        $get = ['main_page' => 'redirect', 'action' => 'manufacturer', 'manufacturers_id' => '5'];
+
+        $this->assertFalse(\zen_request_has_disallowed_catalog_param($get));
+    }
+
+    /**
+     * An old bookmarked search URL, forwarded via the advanced_search_result redirect
+     * stub, must not be rejected -- its whole purpose is backward compatibility for
+     * exactly this kind of link.
+     */
+    public function testALegacyBookmarkedAdvancedSearchUrlIsNotRejected(): void
+    {
+        $get = ['main_page' => 'advanced_search_result', 'keyword' => 'widget', 'manufacturers_id' => '5'];
+
+        $this->assertFalse(\zen_request_has_disallowed_catalog_param($get));
+    }
+
+    /**
+     * brands/featured_categories both read $_GET['typefilter'] today (even though
+     * they then discard/never act on it), so a request carrying it currently renders
+     * 200. They must stay in the allow-list to avoid turning that into a 406 for no
+     * functional gain.
+     */
+    public function testBrandsAndFeaturedCategoriesAreNotRejectedForTypefilter(): void
+    {
+        $this->assertFalse(\zen_request_has_disallowed_catalog_param(['main_page' => 'brands', 'typefilter' => 'x']));
+        $this->assertFalse(\zen_request_has_disallowed_catalog_param(['main_page' => 'featured_categories', 'typefilter' => 'x']));
+    }
+
+    /**
+     * Every recognized catalog page, with a representative filter key, must NOT
+     * be rejected -- guards against a typo silently removing a page from the list.
+     */
+    public function testEachCatalogPageIsAllowedToUseFilterParams(): void
+    {
+        $catalogPages = [
+            'index', 'search', 'search_result', 'advanced_search', 'advanced_search_result',
+            'specials', 'products_new', 'products_all', 'featured_products',
+            'product_reviews', 'product_reviews_info', 'product_reviews_write',
+            'redirect', 'brands', 'featured_categories',
+        ];
+
+        foreach ($catalogPages as $page) {
+            $get = ['main_page' => $page, 'manufacturers_id' => '8', 'cPath' => '1_4'];
+            $this->assertFalse(
+                \zen_request_has_disallowed_catalog_param($get),
+                "Expected '$page' to be allowed to use catalog filter params."
+            );
+        }
+    }
+
+    public function testANonCatalogPageWithNoFilterParamsIsNotRejected(): void
+    {
+        $get = ['main_page' => 'shopping_cart', 'action' => 'add_product'];
+
+        $this->assertFalse(\zen_request_has_disallowed_catalog_param($get));
+    }
+
+    public function testMissingMainPageWithAFilterParamIsRejected(): void
+    {
+        $get = ['manufacturers_id' => '8'];
+
+        $this->assertTrue(\zen_request_has_disallowed_catalog_param($get));
+    }
+
+    /**
+     * pID/pid look like catalog candidates but are used by shopping_cart's own
+     * remove/update links, ask_a_question, and the popup_image pages -- they must
+     * stay out of the restricted list, or the cart's own UI breaks.
+     */
+    public function testDeliberatelyExcludedKeysAreNeverRejected(): void
+    {
+        $deliberatelyExcludedKeys = ['pID', 'pid', 'page', 'action', 'cID', 'id'];
+
+        foreach ($deliberatelyExcludedKeys as $key) {
+            $get = ['main_page' => 'shopping_cart', $key => '1'];
+            $this->assertFalse(
+                \zen_request_has_disallowed_catalog_param($get),
+                "Expected '$key' to remain unrestricted (see routing_map.php's excluded-keys notes)."
+            );
+        }
+    }
+
+    /**
+     * cPath and products_id ARE catalog-filter params, but unlike the others they're
+     * also legitimate on the open-ended, DB-driven set of product-detail "_info" pages
+     * (product_info, product_music_info, ... including plugin-added product types).
+     * This static, pre-DB check can't safely enumerate that set, so both keys are
+     * excluded here and left to the downstream DB-driven check instead. Getting this
+     * wrong would 406 every normal product-page view -- this is the regression this
+     * test guards against.
+     */
+    public function testCPathAndProductsIdAreDeliberatelyExcluded(): void
+    {
+        $get = ['main_page' => 'product_info', 'products_id' => '1', 'cPath' => '1_4'];
+
+        $this->assertFalse(\zen_request_has_disallowed_catalog_param($get));
+    }
+
+    /**
+     * Product-type "_info" pages and checkout pages are intentionally NOT covered
+     * by this early static check -- they're gated downstream (once the DB is
+     * available) by zen_page_uses_catalog_breadcrumb_lookups(). Confirms this
+     * function doesn't (incorrectly) reject them itself.
+     */
+    public function testProductInfoAndCheckoutPagesAreNotRejectedHere(): void
+    {
+        $pagesHandledDownstreamInstead = ['product_info', 'checkout_shipping', 'checkout_payment'];
+
+        foreach ($pagesHandledDownstreamInstead as $page) {
+            $get = ['main_page' => $page, 'products_id' => '1', 'cPath' => '1_4'];
+            $this->assertFalse(
+                \zen_request_has_disallowed_catalog_param($get),
+                "Expected '$page' to be left to the downstream DB-driven check, not rejected here."
+            );
+        }
+    }
+}

--- a/not_for_release/testFramework/Unit/testsSundry/RoutingMapCatalogParamCheckTest.php
+++ b/not_for_release/testFramework/Unit/testsSundry/RoutingMapCatalogParamCheckTest.php
@@ -4,18 +4,29 @@
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  *
  * Regression coverage for #7924 / #7921's follow-up discussion: application_top.php's
- * very-early inoculation block now rejects (406, before any session/DB/file loads
- * beyond this one) a request that supplies a catalog-only filter param (manufacturers_id,
- * etc.) for a page confirmed to never legitimately read it -- e.g. the original
- * forum-reported bot pattern, shopping_cart?manufacturers_id=8&products_id=1.
+ * very-early inoculation block rejects (406, before any session/DB/file loads beyond
+ * this one) a request that supplies a catalog-only filter param (manufacturers_id,
+ * etc.) for a checkout-flow page confirmed to never legitimately read it.
  *
  * zen_request_has_disallowed_catalog_param() (includes/routing_map.php) is a deny-list
- * of known-bad targets -- shopping_cart matched explicitly, every checkout-flow page
- * (core and third-party one-page/guest-checkout addons alike) matched by the
- * 'checkout_' prefix -- not an allow-list of known-good pages -- deliberately, since
- * this runs before plugins load and has no way to let a plugin register its own
- * catalog-style page. A page that doesn't match, including any plugin page or any
- * core page nobody's added yet, is always allowed through.
+ * of known-bad targets -- checkout-flow pages only (core and third-party
+ * one-page/guest-checkout addons alike), matched by the 'checkout_' prefix -- not an
+ * allow-list of known-good pages -- deliberately, since this runs before plugins load
+ * and has no way to let a plugin register its own catalog-style page. A page that
+ * doesn't match, including any plugin page or any core page nobody's added yet, is
+ * always allowed through.
+ *
+ * shopping_cart is deliberately NOT matched here (even though it's the page named in
+ * the original problem report): actionBuyNow()'s redirect-to-cart legitimately carries the
+ * entire query string of whatever catalog listing "Buy Now" was clicked from
+ * (a pre-existing dead-parameter bug in shopping_cart.php that this file can't safely
+ * work around), so shopping_cart?manufacturers_id=X is sometimes a real, just-completed
+ * purchase, not a bot -- confirmed via live production testing after an earlier version
+ * of this file DID match shopping_cart and broke the "Buy Now" button.
+ * shopping_cart's actual protection lives downstream instead, in
+ * zen_page_uses_catalog_breadcrumb_lookups() (functions_lookups.php), whose failure
+ * mode is skipping an already-unneeded breadcrumb lookup rather than rejecting the
+ * request outright.
  *
  * It's also deliberately self-contained (no framework, no constants, no DB) because it
  * runs before includes/configure.php is even loaded -- see application_top.php's
@@ -36,11 +47,11 @@ class RoutingMapCatalogParamCheckTest extends zcUnitTestCase
     }
 
     /**
-     * Every catalog-filter key, fired at a page that never legitimately uses it.
-     * This is the actual bug: a bot supplying these params on, say, the shopping
-     * cart page to force wasted breadcrumb/category lookups downstream.
+     * Every catalog-filter key, fired at a checkout page that never legitimately
+     * uses it. This is the actual problem: a bot supplying these params to force
+     * wasted breadcrumb/category lookups downstream.
      */
-    public function testEachCatalogFilterKeyIsRejectedOnANonCatalogPage(): void
+    public function testEachCatalogFilterKeyIsRejectedOnACheckoutPage(): void
     {
         // NOTE: cPath and products_id are NOT in this list -- see
         // testCPathAndProductsIdAreDeliberatelyExcluded() for why.
@@ -52,18 +63,22 @@ class RoutingMapCatalogParamCheckTest extends zcUnitTestCase
         ];
 
         foreach ($catalogFilterKeys as $key) {
-            $get = ['main_page' => 'shopping_cart', $key => '1'];
+            $get = ['main_page' => 'checkout_shipping', $key => '1'];
             $this->assertTrue(
                 \zen_request_has_disallowed_catalog_param($get),
-                "Expected '$key' on shopping_cart to be rejected."
+                "Expected '$key' on checkout_shipping to be rejected."
             );
         }
     }
 
     /**
-     * The exact URL pattern reported in the forum thread behind #7921.
+     * The exact URL pattern reported in the forum thread behind #7921 is NOT rejected
+     * by this function. See the class docblock: shopping_cart was removed from
+     * this early check because the "Buy Now" redirect legitimately produces indistinguishable URLs.
+     * shopping_cart's protection against the wasted-query problem this issue report was
+     * actually about lives downstream in zen_page_uses_catalog_breadcrumb_lookups().
      */
-    public function testTheOriginalForumReportedBotPatternIsRejected(): void
+    public function testTheOriginalForumReportedBotPatternIsNotRejectedHereAnymore(): void
     {
         $get = [
             'main_page' => 'shopping_cart',
@@ -73,7 +88,52 @@ class RoutingMapCatalogParamCheckTest extends zcUnitTestCase
             'products_id' => '1',
         ];
 
-        $this->assertTrue(\zen_request_has_disallowed_catalog_param($get));
+        $this->assertFalse(\zen_request_has_disallowed_catalog_param($get));
+    }
+
+    /**
+     * Regression test for the issue this file's shopping_cart exclusion exists to fix:
+     * actionBuyNow(), when DISPLAY_CART is enabled, redirects to shopping_cart carrying
+     * the *entire* query string of the catalog listing the "Buy Now" button was clicked from
+     * (a pre-existing dead-parameter bug in shopping_cart.php, not something this file can detect or work around).
+     * A customer buying from a manufacturer-filtered, sorted listing legitimately lands
+     * on exactly this URL shape and must not be 406'd for it.
+     */
+    public function testALegitimateBuyNowRedirectCarryingListingFiltersIsNotRejected(): void
+    {
+        $get = [
+            'main_page' => 'shopping_cart',
+            'manufacturers_id' => '5',
+            'sort' => '2a',
+            'disp_order' => '1',
+            'products_id' => '42',
+        ];
+
+        $this->assertFalse(\zen_request_has_disallowed_catalog_param($get));
+    }
+
+    /**
+     * shopping_cart must never be rejected by this early check, regardless of which
+     * catalog-filter key is present -- every one of them can legitimately leak
+     * through the Buy Now redirect described above, not just the ones in the
+     * specific regression case above.
+     */
+    public function testShoppingCartIsNeverRejectedForAnyCatalogFilterKey(): void
+    {
+        $catalogFilterKeys = [
+            'manufacturers_id', 'music_genre_id', 'record_company_id',
+            'disp_order', 'sort', 'typefilter', 'filter_id', 'alpha_filter_id',
+            'keyword', 'dfrom', 'pfrom', 'dto', 'pto', 'search_in_description', 'inc_subcat',
+            'categories_id', 'sale_category', 'reviews_id',
+        ];
+
+        foreach ($catalogFilterKeys as $key) {
+            $get = ['main_page' => 'shopping_cart', $key => '1'];
+            $this->assertFalse(
+                \zen_request_has_disallowed_catalog_param($get),
+                "Expected '$key' on shopping_cart to NOT be rejected."
+            );
+        }
     }
 
     /**
@@ -138,8 +198,8 @@ class RoutingMapCatalogParamCheckTest extends zcUnitTestCase
      * The whole point of the deny-list model: a page this check has never heard of
      * -- standing in for any plugin-added page -- must never be rejected, even
      * when it carries a restricted key. An allow-list would 406 this permanently,
-     * with no way for the page to ever opt in (plugins aren't loaded yet). See
-     * GitHub issue #7924's follow-up discussion.
+     * with no way for the page to ever opt in (plugins aren't loaded yet).
+     * See GitHub issue #7924's follow-up discussion.
      */
     public function testAnUnrecognizedPluginLikePageIsNeverRejected(): void
     {
@@ -166,14 +226,14 @@ class RoutingMapCatalogParamCheckTest extends zcUnitTestCase
 
     public function testANonCatalogPageWithNoFilterParamsIsNotRejected(): void
     {
-        $get = ['main_page' => 'shopping_cart', 'action' => 'add_product'];
+        $get = ['main_page' => 'checkout_shipping', 'action' => 'add_product'];
 
         $this->assertFalse(\zen_request_has_disallowed_catalog_param($get));
     }
 
     /**
      * A missing/empty main_page must be treated the same as init_sanitize.php treats
-     * it -- an empty main_page defaults to the index page (FILENAME_DEFAULT), so
+     * it: an empty main_page defaults to the index page (FILENAME_DEFAULT), so
      * index.php?manufacturers_id=8 (no main_page at all) is a real, legitimate URL
      * shape that renders as the index/manufacturer listing today. Must not be rejected.
      */
@@ -192,16 +252,18 @@ class RoutingMapCatalogParamCheckTest extends zcUnitTestCase
     }
 
     /**
-     * pID/pid look like catalog candidates but are used by shopping_cart's own
-     * remove/update links, ask_a_question, and the popup_image pages -- they must
-     * stay out of the restricted list, or the cart's own UI breaks.
+     * pID/pid look like catalog candidates but are used by shopping_cart.php's own
+     * remove/update links, ask_a_question, and the popup_image pages; they must
+     * stay out of the restricted list. Tested against checkout_shipping (a page this
+     * check actually inspects) rather than shopping_cart, which is never checked at
+     * all now regardless of key.
      */
     public function testDeliberatelyExcludedKeysAreNeverRejected(): void
     {
         $deliberatelyExcludedKeys = ['pID', 'pid', 'page', 'action', 'cID', 'id'];
 
         foreach ($deliberatelyExcludedKeys as $key) {
-            $get = ['main_page' => 'shopping_cart', $key => '1'];
+            $get = ['main_page' => 'checkout_shipping', $key => '1'];
             $this->assertFalse(
                 \zen_request_has_disallowed_catalog_param($get),
                 "Expected '$key' to remain unrestricted (see routing_map.php's excluded-keys notes)."
@@ -215,13 +277,12 @@ class RoutingMapCatalogParamCheckTest extends zcUnitTestCase
      * (product_info, product_music_info, ... including plugin-added product types).
      * This static, pre-DB check can't safely enumerate that set, so both keys are
      * excluded from $catalogFilterKeys entirely and left to the downstream DB-driven
-     * check instead. Tested against a page that IS on the deny-list (shopping_cart) --
-     * not product_info, which was never going to be checked anyway -- to actually
-     * exercise the exclusion rather than pass trivially.
+     * check instead. Tested against checkout_shipping (a page this check actually
+     * inspects), not shopping_cart, which is never checked at all now.
      */
     public function testCPathAndProductsIdAreDeliberatelyExcluded(): void
     {
-        $get = ['main_page' => 'shopping_cart', 'products_id' => '1', 'cPath' => '1_4'];
+        $get = ['main_page' => 'checkout_shipping', 'products_id' => '1', 'cPath' => '1_4'];
 
         $this->assertFalse(\zen_request_has_disallowed_catalog_param($get));
     }
@@ -240,11 +301,9 @@ class RoutingMapCatalogParamCheckTest extends zcUnitTestCase
     }
 
     /**
-     * Unlike product_info, checkout pages ARE on the deny-list -- so, since the
-     * earlier PR extended this same reasoning to checkout, a checkout page carrying
-     * a manufacturers_id-class key (never legitimately used there) IS rejected here,
-     * even though cPath/products_id specifically remain deferred downstream (see
-     * testCPathAndProductsIdAreDeliberatelyExcluded).
+     * Checkout pages carrying a manufacturers_id-class key (never legitimately used
+     * there) ARE rejected here, even though cPath/products_id specifically remain
+     * deferred downstream (see testCPathAndProductsIdAreDeliberatelyExcluded).
      */
     public function testCheckoutPagesAreRejectedForManufacturersIdClassKeysButNotCPathOrProductsId(): void
     {
@@ -261,20 +320,18 @@ class RoutingMapCatalogParamCheckTest extends zcUnitTestCase
     }
 
     /**
-     * shopping_cart plus every core checkout-flow page, with a representative
-     * filter key, must actually be rejected -- guards against the prefix logic
-     * (or the explicit shopping_cart check) silently breaking.
+     * Every core checkout-flow page, with a representative filter key, must actually
+     * be rejected -- guards against the 'checkout_' prefix logic silently breaking.
      */
-    public function testEachKnownNonCatalogPageIsRejected(): void
+    public function testEachCoreCheckoutPageIsRejected(): void
     {
-        $knownNonCatalogPages = [
-            'shopping_cart',
+        $coreCheckoutPages = [
             'checkout_shipping', 'checkout_shipping_address',
             'checkout_payment', 'checkout_payment_address',
             'checkout_confirmation', 'checkout_process', 'checkout_success',
         ];
 
-        foreach ($knownNonCatalogPages as $page) {
+        foreach ($coreCheckoutPages as $page) {
             $get = ['main_page' => $page, 'manufacturers_id' => '8'];
             $this->assertTrue(
                 \zen_request_has_disallowed_catalog_param($get),

--- a/not_for_release/testFramework/Unit/testsSundry/RoutingMapCatalogParamCheckTest.php
+++ b/not_for_release/testFramework/Unit/testsSundry/RoutingMapCatalogParamCheckTest.php
@@ -5,13 +5,19 @@
  *
  * Regression coverage for #7924 / #7921's follow-up discussion: application_top.php's
  * very-early inoculation block now rejects (406, before any session/DB/file loads
- * beyond this one) a request that supplies a catalog-only filter param (cPath,
- * manufacturers_id, etc.) for a page that never legitimately reads it -- e.g. the
- * original forum-reported bot pattern, shopping_cart?manufacturers_id=8&products_id=1.
+ * beyond this one) a request that supplies a catalog-only filter param (manufacturers_id,
+ * etc.) for a page confirmed to never legitimately read it -- e.g. the original
+ * forum-reported bot pattern, shopping_cart?manufacturers_id=8&products_id=1.
  *
- * zen_request_has_disallowed_catalog_param() (includes/routing_map.php) is deliberately
- * self-contained (no framework, no constants, no DB) because it runs before
- * includes/configure.php is even loaded -- see application_top.php's inoculation block.
+ * zen_request_has_disallowed_catalog_param() (includes/routing_map.php) is a deny-list
+ * of known-bad targets (shopping_cart + checkout_*), not an allow-list of known-good
+ * pages -- deliberately, since this runs before plugins load and has no way to let a
+ * plugin register its own catalog-style page. A page NOT on the deny-list, including
+ * any plugin page or any core page nobody's added yet, is always allowed through.
+ *
+ * It's also deliberately self-contained (no framework, no constants, no DB) because it
+ * runs before includes/configure.php is even loaded -- see application_top.php's
+ * inoculation block.
  */
 
 namespace Tests\Unit\testsSundry;
@@ -95,8 +101,8 @@ class RoutingMapCatalogParamCheckTest extends zcUnitTestCase
     /**
      * brands/featured_categories both read $_GET['typefilter'] today (even though
      * they then discard/never act on it), so a request carrying it currently renders
-     * 200. They must stay in the allow-list to avoid turning that into a 406 for no
-     * functional gain.
+     * 200. Under the deny-list model they're simply never listed, so they're allowed
+     * by default -- no special-casing needed, unlike the old allow-list.
      */
     public function testBrandsAndFeaturedCategoriesAreNotRejectedForTypefilter(): void
     {
@@ -105,10 +111,10 @@ class RoutingMapCatalogParamCheckTest extends zcUnitTestCase
     }
 
     /**
-     * Every recognized catalog page, with a representative filter key, must NOT
-     * be rejected -- guards against a typo silently removing a page from the list.
+     * Every catalog "listing" page must NOT be rejected -- guards against a typo
+     * accidentally adding one of these to the deny-list.
      */
-    public function testEachCatalogPageIsAllowedToUseFilterParams(): void
+    public function testCatalogListingPagesAreNotRejected(): void
     {
         $catalogPages = [
             'index', 'search', 'search_result', 'advanced_search', 'advanced_search_result',
@@ -123,6 +129,36 @@ class RoutingMapCatalogParamCheckTest extends zcUnitTestCase
                 \zen_request_has_disallowed_catalog_param($get),
                 "Expected '$page' to be allowed to use catalog filter params."
             );
+        }
+    }
+
+    /**
+     * The whole point of the deny-list model: a page this check has never heard of
+     * -- standing in for any plugin-added page -- must never be rejected, even
+     * when it carries a restricted key. An allow-list would 406 this permanently,
+     * with no way for the page to ever opt in (plugins aren't loaded yet). See
+     * GitHub issue #7924's follow-up discussion.
+     */
+    public function testAnUnrecognizedPluginLikePageIsNeverRejected(): void
+    {
+        $get = ['main_page' => 'some_plugins_custom_catalog_page', 'manufacturers_id' => '8', 'sort' => '2a'];
+
+        $this->assertFalse(\zen_request_has_disallowed_catalog_param($get));
+    }
+
+    /**
+     * Documents the accepted trade-off: core utility pages not on the deny-list
+     * (login, contact_us, account, ...) no longer get this specific early-reject
+     * optimization. That's intentional -- growing the deny-list to cover every
+     * non-catalog core page would reintroduce the same false-positive risk the
+     * deny-list model exists to avoid. These pages simply fall through to normal
+     * processing, exactly as if this file didn't exist.
+     */
+    public function testCoreUtilityPagesNotOnTheDenyListAreNotRejectedEither(): void
+    {
+        foreach (['login', 'contact_us', 'account'] as $page) {
+            $get = ['main_page' => $page, 'manufacturers_id' => '8'];
+            $this->assertFalse(\zen_request_has_disallowed_catalog_param($get));
         }
     }
 
@@ -176,32 +212,70 @@ class RoutingMapCatalogParamCheckTest extends zcUnitTestCase
      * also legitimate on the open-ended, DB-driven set of product-detail "_info" pages
      * (product_info, product_music_info, ... including plugin-added product types).
      * This static, pre-DB check can't safely enumerate that set, so both keys are
-     * excluded here and left to the downstream DB-driven check instead. Getting this
-     * wrong would 406 every normal product-page view -- this is the regression this
-     * test guards against.
+     * excluded from $catalogFilterKeys entirely and left to the downstream DB-driven
+     * check instead. Tested against a page that IS on the deny-list (shopping_cart) --
+     * not product_info, which was never going to be checked anyway -- to actually
+     * exercise the exclusion rather than pass trivially.
      */
     public function testCPathAndProductsIdAreDeliberatelyExcluded(): void
     {
-        $get = ['main_page' => 'product_info', 'products_id' => '1', 'cPath' => '1_4'];
+        $get = ['main_page' => 'shopping_cart', 'products_id' => '1', 'cPath' => '1_4'];
 
         $this->assertFalse(\zen_request_has_disallowed_catalog_param($get));
     }
 
     /**
-     * Product-type "_info" pages and checkout pages are intentionally NOT covered
-     * by this early static check -- they're gated downstream (once the DB is
-     * available) by zen_page_uses_catalog_breadcrumb_lookups(). Confirms this
-     * function doesn't (incorrectly) reject them itself.
+     * Product-detail "_info" pages are never on the deny-list (open-ended, DB-driven
+     * set -- see class docblock), so they're never rejected by this early check
+     * regardless of which key is supplied. They're gated downstream instead, once
+     * the DB is available, by zen_page_uses_catalog_breadcrumb_lookups().
      */
-    public function testProductInfoAndCheckoutPagesAreNotRejectedHere(): void
+    public function testProductInfoPagesAreNeverRejectedHere(): void
     {
-        $pagesHandledDownstreamInstead = ['product_info', 'checkout_shipping', 'checkout_payment'];
+        $get = ['main_page' => 'product_info', 'products_id' => '1', 'cPath' => '1_4', 'manufacturers_id' => '8'];
 
-        foreach ($pagesHandledDownstreamInstead as $page) {
-            $get = ['main_page' => $page, 'products_id' => '1', 'cPath' => '1_4'];
+        $this->assertFalse(\zen_request_has_disallowed_catalog_param($get));
+    }
+
+    /**
+     * Unlike product_info, checkout pages ARE on the deny-list -- so, since the
+     * earlier PR extended this same reasoning to checkout, a checkout page carrying
+     * a manufacturers_id-class key (never legitimately used there) IS rejected here,
+     * even though cPath/products_id specifically remain deferred downstream (see
+     * testCPathAndProductsIdAreDeliberatelyExcluded).
+     */
+    public function testCheckoutPagesAreRejectedForManufacturersIdClassKeysButNotCPathOrProductsId(): void
+    {
+        foreach (['checkout_shipping', 'checkout_payment'] as $page) {
+            $this->assertTrue(
+                \zen_request_has_disallowed_catalog_param(['main_page' => $page, 'manufacturers_id' => '8']),
+                "Expected '$page' to reject manufacturers_id."
+            );
             $this->assertFalse(
+                \zen_request_has_disallowed_catalog_param(['main_page' => $page, 'products_id' => '1', 'cPath' => '1_4']),
+                "Expected '$page' to still allow products_id/cPath (deferred downstream)."
+            );
+        }
+    }
+
+    /**
+     * Every deny-listed page, with a representative filter key, must actually be
+     * rejected -- guards against a typo silently removing a page from the list.
+     */
+    public function testEachKnownNonCatalogPageIsRejected(): void
+    {
+        $knownNonCatalogPages = [
+            'shopping_cart',
+            'checkout_shipping', 'checkout_shipping_address',
+            'checkout_payment', 'checkout_payment_address',
+            'checkout_confirmation', 'checkout_process', 'checkout_success',
+        ];
+
+        foreach ($knownNonCatalogPages as $page) {
+            $get = ['main_page' => $page, 'manufacturers_id' => '8'];
+            $this->assertTrue(
                 \zen_request_has_disallowed_catalog_param($get),
-                "Expected '$page' to be left to the downstream DB-driven check, not rejected here."
+                "Expected '$page' to reject manufacturers_id."
             );
         }
     }

--- a/not_for_release/testFramework/Unit/testsSundry/RoutingMapCatalogParamCheckTest.php
+++ b/not_for_release/testFramework/Unit/testsSundry/RoutingMapCatalogParamCheckTest.php
@@ -133,11 +133,24 @@ class RoutingMapCatalogParamCheckTest extends zcUnitTestCase
         $this->assertFalse(\zen_request_has_disallowed_catalog_param($get));
     }
 
-    public function testMissingMainPageWithAFilterParamIsRejected(): void
+    /**
+     * A missing/empty main_page must be treated the same as init_sanitize.php treats
+     * it -- an empty main_page defaults to the index page (FILENAME_DEFAULT), so
+     * index.php?manufacturers_id=8 (no main_page at all) is a real, legitimate URL
+     * shape that renders as the index/manufacturer listing today. Must not be rejected.
+     */
+    public function testMissingMainPageWithAFilterParamIsNotRejected(): void
     {
         $get = ['manufacturers_id' => '8'];
 
-        $this->assertTrue(\zen_request_has_disallowed_catalog_param($get));
+        $this->assertFalse(\zen_request_has_disallowed_catalog_param($get));
+    }
+
+    public function testEmptyMainPageWithAFilterParamIsNotRejected(): void
+    {
+        $get = ['main_page' => '', 'manufacturers_id' => '8'];
+
+        $this->assertFalse(\zen_request_has_disallowed_catalog_param($get));
     }
 
     /**


### PR DESCRIPTION
Rejects visits containing malformed URLs mixing GET params with pages that don't use them. 

Applies cleanly to older Zen Cart versions, if done by hand. (the application_top change just needs to be before the current 406 header loop, like shown in this commit's diff)

Should also apply https://github.com/zencart/zencart/pull/7924 for more thorough protection. 
Both this and that PR are compatible back to PHP 7.1+