### PR TITLE
Change row-hover background color in configuration.php

### DIFF
--- a/admin/configuration.php
+++ b/admin/configuration.php
@@ -168,7 +168,7 @@ if ($gID === 7) {
     <?php require DIR_WS_INCLUDES . 'admin_html_head.php'; ?>
     <style>
         .row-hover:hover {
-            background-color: #f8f9fa; /* Bootstrap's .table-hover color */
+            background-color: #E7E7E7; /* Matches .navbar-adm1-collapse color */
         }
         .save-button {
             position: fixed;


### PR DESCRIPTION
Using the Bootstrap .table-hover color results in a color so light that it is hard to tell which row you are on.

Changing to match the current .navbar-adm1-collapse background color better highlights the row and aligns with the color layout on the admin home page.

I would recommend backporting this as well.