### PR TITLE
Missing language definitions for non-fallback language

### DIFF
--- a/includes/classes/ResourceLoaders/CatalogArraysLanguageLoader.php
+++ b/includes/classes/ResourceLoaders/CatalogArraysLanguageLoader.php
@@ -217,7 +217,8 @@ class CatalogArraysLanguageLoader extends ArraysLanguageLoader
         $defineList = array_merge($defineList, $defineListPlugin);
 
         // -----
-        // Finally, load any extra definitions in the current template's override directory, **for the current session language*.
+        // Finally, load any extra definitions in the current template's override directory, first the 'fallback' language
+        // (i.e. 'english') and then the current session language, if different.
         //
         // Any definitions found here overwrite **all** previous-found definitions.
         //
@@ -230,8 +231,14 @@ class CatalogArraysLanguageLoader extends ArraysLanguageLoader
             $languageMainDir = $this->templateResolver->getTemplateBasePath($templateKey) . DIR_WS_LANGUAGES;
             $defineListTemplate = array_merge(
                 $defineListTemplate,
-                $this->loadArraysFromDirectory($languageMainDir, $_SESSION['language'], '/extra_definitions/' . $templateKey)
+                $this->loadArraysFromDirectory($languageMainDir, $this->fallback, '/extra_definitions/' . $templateKey)
             );
+            if ($this->fallback !== $_SESSION['language']) {
+                $defineListTemplate = array_merge(
+                    $defineListTemplate,
+                    $this->loadArraysFromDirectory($languageMainDir, $_SESSION['language'], '/extra_definitions/' . $templateKey)
+                );
+            }
         }
 
         // -----


### PR DESCRIPTION
For a multi-language site, if a child template doesn't override its parents' `extra_definitions` for the non-fallback language, a PHP fatal error for missing language definitions occurs.

This PR corrects that issue.