### PR TITLE
Normalize malformed category and product cPaths

### DIFF
--- a/includes/functions/functions_categories.php
+++ b/includes/functions/functions_categories.php
@@ -265,6 +265,39 @@ function zen_get_product_path($product_id): string
 }
 
 /**
+ * Return the authoritative category path for a product, preserving a requested category
+ * only when the product is directly linked to that category.
+ *
+ * Unlike zen_get_product_path(), this uses the already-loaded Product data, so the
+ * master-category and unrelated-category cases add no queries; only a legitimate alternate
+ * linked category needs its path generated.
+ *
+ * @param Product $product_info the loaded product
+ * @param int $requested_category_id the category asked for (0 when the request had no usable cPath)
+ * @return string authoritative cPath, or '' when the product has no master category
+ * @since ZC v2.3.0
+ */
+function zen_get_valid_cpath_for_product(Product $product_info, int $requested_category_id): string
+{
+    $master_category_id = (int)$product_info->get('master_categories_id');
+    $master_cPath = $master_category_id > 0 ? (string)$product_info->get('cPath') : '';
+
+    if ($requested_category_id === $master_category_id) {
+        return $master_cPath;
+    }
+
+    $linked_categories = $product_info->get('linked_categories');
+    if ($requested_category_id > 0 && is_array($linked_categories)) {
+        $linked_categories = array_map('intval', $linked_categories);
+        if (in_array($requested_category_id, $linked_categories, true)) {
+            return zen_get_generated_category_path_rev($requested_category_id);
+        }
+    }
+
+    return $master_cPath;
+}
+
+/**
  * Parse and sanitize the cPath parameter values
  * @param string $cPath
  * @return array
@@ -289,23 +322,46 @@ function zen_parse_category_path(string $cPath): array
 /**
  * Redirect to an authoritative category path while retaining other applicable GET parameters.
  *
+ * The retained parameters are the ones init_canonical already decided are keepable for this
+ * request ($excludeParams), so a permanent redirect only carries over what the store already
+ * treats as part of a URL's identity.  That list also has every unrecognized parameter of this
+ * request appended to it, so bot-supplied junk is not reflected back into a permanently-cacheable
+ * Location header.  Plugins adjust it via NOTIFY_INIT_CANONICAL_PARAM_WHITELIST.
+ *
+ * Only GET requests are redirected: a 301 causes browsers to re-issue as GET, which would
+ * silently discard the body of any other request method.
+ *
+ * @param string $valid_cPath authoritative category path
+ * @param int $products_id 0 for a category listing
  * @since ZC v2.3.0
  */
 function zen_redirect_to_valid_cpath(string $valid_cPath, int $products_id = 0): void
 {
+    global $current_page_base, $excludeParams;
+
+    if (($_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'GET') {
+        return;
+    }
+
     $parameters = 'cPath=' . $valid_cPath;
 
     if ($products_id > 0) {
         $parameters .= '&products_id=' . $products_id;
     }
 
-    $other_parameters = zen_get_all_get_params(['cPath', 'products_id', 'action', 'notify']);
-
-    $page = FILENAME_DEFAULT;
-    if (isset($_GET['main_page']) && is_string($_GET['main_page'])) {
-        $page = $_GET['main_page'];
+    // if init_canonical didn't run (or was overridden away), fail closed and retain nothing
+    if (!empty($excludeParams)) {
+        $other_parameters = zen_get_all_get_params(array_merge($excludeParams, ['cPath', 'products_id', 'action', 'notify']));
+        if ($other_parameters !== '') {
+            $parameters .= '&' . rtrim($other_parameters, '&');
+        }
     }
-    zen_redirect(zen_href_link($page, $parameters), 301);
+
+    // use the sanitized current page rather than the raw request value
+    $page = !empty($current_page_base) ? $current_page_base : FILENAME_DEFAULT;
+
+    // no session id: this response is permanently cacheable, and by search engines too
+    zen_redirect(zen_href_link($page, $parameters, 'NONSSL', false), 301);
 }
 
 /**
@@ -729,13 +785,26 @@ function zen_get_generated_category_path_ids($id, string $from = 'category')
  */
 function zen_get_generated_category_path_rev($this_categories_id): string
 {
+    // Memoize/cache lookups already done.
+    // the ancestor walk is one uncached query per level, and the storefront asks for the
+    // same path more than once per request (canonical, cPath validation, sideboxes).
+    // Not memoized in admin, where the tree can change mid-request.
+    static $paths = [];
+    $cacheable = !defined('IS_ADMIN_FLAG') || IS_ADMIN_FLAG !== true;
+    $cache_key = (string)$this_categories_id;
+    if ($cacheable && isset($paths[$cache_key])) {
+        return $paths[$cache_key];
+    }
+
     $categories = [];
     zen_get_parent_categories($categories, $this_categories_id);
 
     $categories = array_reverse($categories);
     $categories[] = $this_categories_id;
 
-    return implode('_', $categories);
+    $paths[$cache_key] = implode('_', $categories);
+
+    return $paths[$cache_key];
 }
 
 /**

--- a/includes/functions/functions_categories.php
+++ b/includes/functions/functions_categories.php
@@ -287,6 +287,31 @@ function zen_parse_category_path(string $cPath): array
 }
 
 /**
+ * Redirect to an authoritative category path while retaining other applicable GET parameters.
+ *
+ * @since ZC v2.3.0
+ */
+function zen_redirect_to_valid_cpath(string $valid_cPath, int $products_id = 0): void
+{
+    $parameters = 'cPath=' . $valid_cPath;
+
+    if ($products_id > 0) {
+        $parameters .= '&products_id=' . $products_id;
+    }
+
+    $other_parameters = zen_get_all_get_params(['cPath', 'products_id']);
+    if ($other_parameters !== '') {
+        $parameters .= '&' . rtrim($other_parameters, '&');
+    }
+
+    $page = FILENAME_DEFAULT;
+    if (isset($_GET['main_page']) && is_string($_GET['main_page'])) {
+        $page = $_GET['main_page'];
+    }
+    zen_redirect(zen_href_link($page, $parameters), 301);
+}
+
+/**
  * Determine whether the product_id is associated with the category
  * @param int $product_id
  * @param int $cat_id

--- a/includes/functions/functions_categories.php
+++ b/includes/functions/functions_categories.php
@@ -299,10 +299,7 @@ function zen_redirect_to_valid_cpath(string $valid_cPath, int $products_id = 0):
         $parameters .= '&products_id=' . $products_id;
     }
 
-    $other_parameters = zen_get_all_get_params(['cPath', 'products_id']);
-    if ($other_parameters !== '') {
-        $parameters .= '&' . rtrim($other_parameters, '&');
-    }
+    $other_parameters = zen_get_all_get_params(['cPath', 'products_id', 'action', 'notify']);
 
     $page = FILENAME_DEFAULT;
     if (isset($_GET['main_page']) && is_string($_GET['main_page'])) {

--- a/includes/functions/functions_categories.php
+++ b/includes/functions/functions_categories.php
@@ -802,9 +802,13 @@ function zen_get_generated_category_path_rev($this_categories_id): string
     $categories = array_reverse($categories);
     $categories[] = $this_categories_id;
 
-    $paths[$cache_key] = implode('_', $categories);
+    $path = implode('_', $categories);
 
-    return $paths[$cache_key];
+    if ($cacheable) {
+        $paths[$cache_key] = $path;
+    }
+
+    return $path;
 }
 
 /**

--- a/includes/functions/functions_products.php
+++ b/includes/functions/functions_products.php
@@ -22,32 +22,6 @@ function zen_get_product_details($product_id, $language_id = null): Product
 }
 
 /**
- * Return the canonical category path for a product, preserving a requested category
- * only when the product is directly linked to that category.
- *
- * @since ZC v2.3.0
- */
-function zen_get_product_path_for_category(Product $product_info, int $category_id): string
-{
-    $master_category_id = (int)$product_info->get('master_categories_id');
-    $master_cPath = $master_category_id > 0 ? (string)$product_info->get('cPath') : '';
-
-    if ($category_id === $master_category_id) {
-        return $master_cPath;
-    }
-
-    $linked_categories = $product_info->get('linked_categories');
-    if ($category_id > 0 && is_array($linked_categories)) {
-        $linked_categories = array_map('intval', $linked_categories);
-        if (in_array($category_id, $linked_categories, true)) {
-            return zen_get_generated_category_path_rev($category_id);
-        }
-    }
-
-    return $master_cPath;
-}
-
-/**
  * @since ZC v1.5.7
  */
 function zen_product_set_header_response(int|string $product_id, ?Product $product_info = null): void
@@ -110,8 +84,9 @@ function zen_product_set_header_response(int|string $product_id, ?Product $produ
         return;
     }
 
-    if (isset($_GET['cPath'], $current_category_id) && is_string($_GET['cPath'])) {
-        $valid_cPath = zen_get_product_path_for_category($product_info, (int)$current_category_id);
+    // normalize a malformed/fabricated category path so that one URL serves the product
+    if (isset($_GET['cPath']) && is_string($_GET['cPath'])) {
+        $valid_cPath = zen_get_valid_cpath_for_product($product_info, (int)($current_category_id ?? 0));
         if ($valid_cPath !== '' && $_GET['cPath'] !== $valid_cPath) {
             zen_redirect_to_valid_cpath($valid_cPath, (int)$product_id);
         }

--- a/includes/functions/functions_products.php
+++ b/includes/functions/functions_products.php
@@ -22,11 +22,37 @@ function zen_get_product_details($product_id, $language_id = null): Product
 }
 
 /**
+ * Return the canonical category path for a product, preserving a requested category
+ * only when the product is directly linked to that category.
+ *
+ * @since ZC v2.3.0
+ */
+function zen_get_product_path_for_category(Product $product_info, int $category_id): string
+{
+    $master_category_id = (int)$product_info->get('master_categories_id');
+    $master_cPath = $master_category_id > 0 ? (string)$product_info->get('cPath') : '';
+
+    if ($category_id === $master_category_id) {
+        return $master_cPath;
+    }
+
+    $linked_categories = $product_info->get('linked_categories');
+    if ($category_id > 0 && is_array($linked_categories)) {
+        $linked_categories = array_map('intval', $linked_categories);
+        if (in_array($category_id, $linked_categories, true)) {
+            return zen_get_generated_category_path_rev($category_id);
+        }
+    }
+
+    return $master_cPath;
+}
+
+/**
  * @since ZC v1.5.7
  */
 function zen_product_set_header_response(int|string $product_id, ?Product $product_info = null): void
 {
-    global $zco_notifier, $breadcrumb, $robotsNoIndex;
+    global $zco_notifier, $breadcrumb, $robotsNoIndex, $current_category_id;
 
     // make sure we got a Product-class instance and it's for the current product
     if ($product_info === null || get_class($product_info) !== 'Product' || $product_info->getID() !== (int)$product_id) {
@@ -82,6 +108,13 @@ function zen_product_set_header_response(int|string $product_id, ?Product $produ
         $robotsNoIndex = true;
         header('HTTP/1.1 410 Gone');
         return;
+    }
+
+    if (isset($_GET['cPath'], $current_category_id) && is_string($_GET['cPath'])) {
+        $valid_cPath = zen_get_product_path_for_category($product_info, (int)$current_category_id);
+        if ($valid_cPath !== '' && $_GET['cPath'] !== $valid_cPath) {
+            zen_redirect_to_valid_cpath($valid_cPath, (int)$product_id);
+        }
     }
 }
 

--- a/includes/modules/pages/index/header_php.php
+++ b/includes/modules/pages/index/header_php.php
@@ -35,11 +35,6 @@ if (isset($cPath) && zen_not_null($cPath)) {
             $current_category_not_found = true;
         } elseif ($category_status->fields['categories_status'] == '0') {
             $current_category_is_disabled = true;
-        } elseif (isset($_GET['cPath']) && is_string($_GET['cPath'])) {
-            $valid_cPath = zen_get_generated_category_path_rev($current_category_id);
-            if ($_GET['cPath'] !== $valid_cPath) {
-                zen_redirect_to_valid_cpath($valid_cPath);
-            }
         }
     }
     $category_products_query =
@@ -103,6 +98,11 @@ if (isset($cPath) && zen_not_null($cPath)) {
     //      of display for stores that have an 'invalid' mix of products and categories within a
     //      category.
     //
+    // 4. Finally, if the category is present and enabled but the requested 'cPath' doesn't match the
+    //    category's authoritative path (e.g. a malformed or fabricated hierarchy), redirect (301) to
+    //    the generated path so that one URL serves the category.  Determining the category-depth first
+    //    keeps the page displayable for observers of NOTIFY_ZEN_REDIRECT that cancel the redirect.
+    //
     if (!$category_redirect_handled) {
         if ($current_category_not_found) {
             unset($_GET['cPath']);
@@ -119,6 +119,14 @@ if (isset($cPath) && zen_not_null($cPath)) {
             $category_depth = 'products';
         } else {
             $category_depth = ($current_category_has_subcats) ? 'nested' : 'products';
+        }
+
+        if (!$current_category_not_found && !$current_category_is_disabled
+            && $current_category_id > 0 && isset($_GET['cPath']) && is_string($_GET['cPath'])) {
+            $valid_cPath = zen_get_generated_category_path_rev($current_category_id);
+            if ($_GET['cPath'] !== $valid_cPath) {
+                zen_redirect_to_valid_cpath($valid_cPath);
+            }
         }
     }
 }

--- a/includes/modules/pages/index/header_php.php
+++ b/includes/modules/pages/index/header_php.php
@@ -35,6 +35,11 @@ if (isset($cPath) && zen_not_null($cPath)) {
             $current_category_not_found = true;
         } elseif ($category_status->fields['categories_status'] == '0') {
             $current_category_is_disabled = true;
+        } elseif (isset($_GET['cPath']) && is_string($_GET['cPath'])) {
+            $valid_cPath = zen_get_generated_category_path_rev($current_category_id);
+            if ($_GET['cPath'] !== $valid_cPath) {
+                zen_redirect_to_valid_cpath($valid_cPath);
+            }
         }
     }
     $category_products_query =

--- a/not_for_release/testFramework/Unit/testsCategories/CpathRedirectTest.php
+++ b/not_for_release/testFramework/Unit/testsCategories/CpathRedirectTest.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * @copyright Copyright 2003-2026 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ */
+
+namespace Tests\Unit\testsCategories;
+
+use Tests\Support\zcUnitTestCase;
+
+class CpathRedirectTest extends zcUnitTestCase
+{
+    protected $preserveGlobalState = false;
+    protected $runTestInSeparateProcess = true;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        defined('SEARCH_ENGINE_FRIENDLY_URLS') || define('SEARCH_ENGINE_FRIENDLY_URLS', 'false');
+        defined('ENABLE_SSL') || define('ENABLE_SSL', 'false');
+
+        require_once DIR_FS_CATALOG . 'includes/functions/functions_categories.php';
+        require_once DIR_FS_CATALOG . 'includes/functions/functions_general_shared.php';
+        require_once DIR_FS_CATALOG . 'includes/functions/functions_strings.php';
+        require_once DIR_FS_CATALOG . 'includes/functions/functions_urls.php';
+        require_once DIR_FS_CATALOG . 'includes/functions/html_output.php';
+
+        $_GET = [];
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $GLOBALS['current_page_base'] = 'index';
+    }
+
+    public function testRedirectRetainsTheParametersCanonicalDeemedKeepable(): void
+    {
+        $_GET = [
+            'main_page' => 'index',
+            'cPath' => '23_22_21_3',
+            'page' => '2',
+            'manufacturers_id' => '5',
+        ];
+        $this->setCanonicalParamFilter();
+
+        $redirect = $this->captureRedirect('1_3');
+
+        $this->assertStringContainsString('cPath=1_3', $redirect['url']);
+        $this->assertStringContainsString('page=2', $redirect['url']);
+        $this->assertStringContainsString('manufacturers_id=5', $redirect['url']);
+    }
+
+    public function testRedirectDropsParametersCanonicalExcludes(): void
+    {
+        $_GET = [
+            'main_page' => 'index',
+            'cPath' => '23_3',
+            'sort' => '20a',
+            'filter_id' => '7',
+            'utm_source' => 'somebot',
+            'my_rogue_param' => 'junk',
+        ];
+        $this->setCanonicalParamFilter();
+
+        $redirect = $this->captureRedirect('1_3');
+
+        $this->assertStringNotContainsString('sort=', $redirect['url']);
+        $this->assertStringNotContainsString('filter_id=', $redirect['url']);
+        $this->assertStringNotContainsString('utm_source', $redirect['url']);
+        $this->assertStringNotContainsString('my_rogue_param', $redirect['url']);
+    }
+
+    public function testProductRedirectIncludesProductIdAndDropsCartActions(): void
+    {
+        $_GET = [
+            'main_page' => 'product_info',
+            'cPath' => '99_5',
+            'products_id' => '17',
+            'action' => 'add_product',
+            'notify' => '17',
+        ];
+        $this->setCanonicalParamFilter();
+        $GLOBALS['current_page_base'] = 'product_info';
+
+        $redirect = $this->captureRedirect('1_9', 17);
+
+        $this->assertStringContainsString('main_page=product_info', $redirect['url']);
+        $this->assertStringContainsString('cPath=1_9', $redirect['url']);
+        $this->assertStringContainsString('products_id=17', $redirect['url']);
+        $this->assertStringNotContainsString('action=', $redirect['url']);
+        $this->assertStringNotContainsString('notify=', $redirect['url']);
+    }
+
+    /**
+     * Without init_canonical's parameter filter there is no allow-list to consult, so nothing
+     * beyond the path itself may be reflected into a permanently-cacheable redirect.
+     */
+    public function testRedirectFailsClosedWhenTheCanonicalParamFilterIsUnavailable(): void
+    {
+        $_GET = ['main_page' => 'index', 'cPath' => '23_3', 'page' => '2', 'my_rogue_param' => 'junk'];
+        unset($GLOBALS['excludeParams']);
+
+        $redirect = $this->captureRedirect('1_3');
+
+        $this->assertStringContainsString('cPath=1_3', $redirect['url']);
+        $this->assertStringNotContainsString('page=2', $redirect['url']);
+        $this->assertStringNotContainsString('my_rogue_param', $redirect['url']);
+    }
+
+    public function testRedirectIssuesA301WithoutASessionIdAndUsesTheSanitizedPage(): void
+    {
+        // conditions under which zen_href_link() would append the session id to the link
+        $GLOBALS['session_started'] = true;
+        $GLOBALS['request_type'] = 'SSL';
+        $GLOBALS['http_domain'] = 'zencart-git.local';
+        $GLOBALS['https_domain'] = 'secure.zencart-git.local';
+        defined('SID') || define('SID', 'zenid=1234567890');
+
+        $_GET = ['main_page' => '../../evil', 'cPath' => '23_3'];
+        $this->setCanonicalParamFilter();
+
+        $redirect = $this->captureRedirect('1_3');
+
+        $this->assertSame(301, $redirect['httpResponseCode']);
+        $this->assertStringNotContainsString('zenid', $redirect['url']);
+        $this->assertStringContainsString('main_page=index', $redirect['url']);
+        $this->assertStringNotContainsString('evil', $redirect['url']);
+    }
+
+    public function testNonGetRequestsAreNotRedirected(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_GET = ['cPath' => '23_3'];
+        $this->setCanonicalParamFilter();
+
+        $this->assertNull($this->captureRedirect('1_3'));
+    }
+
+    /**
+     * Stand in for init_canonical, which leaves its parameter filter in the global scope with
+     * every unrecognized parameter of the request appended to it.
+     */
+    private function setCanonicalParamFilter(): void
+    {
+        $excludeParams = ['action', 'disp_order', 'filter_id', 'notify', 'sort', 'utm_source', 'zenid'];
+        $keepableParams = ['cPath', 'manufacturers_id', 'page', 'products_id'];
+
+        foreach (array_keys($_GET) as $key) {
+            if (!in_array($key, $excludeParams, true) && !in_array($key, $keepableParams, true)) {
+                $excludeParams[] = $key;
+            }
+        }
+
+        $GLOBALS['excludeParams'] = $excludeParams;
+    }
+
+    /**
+     * Capture what zen_redirect() was asked to do, by cancelling the redirect via
+     * NOTIFY_ZEN_REDIRECT so that the test process isn't exited.
+     */
+    private function captureRedirect(string $valid_cPath, int $products_id = 0): ?array
+    {
+        $capture = new class {
+            public ?array $redirect = null;
+
+            public function update(&$class, $eventID, $params, &$request_handled)
+            {
+                $this->redirect = $params;
+                $request_handled = true;
+            }
+        };
+        $GLOBALS['zco_notifier']->attach($capture, ['NOTIFY_ZEN_REDIRECT']);
+
+        \zen_redirect_to_valid_cpath($valid_cPath, $products_id);
+
+        return $capture->redirect;
+    }
+}

--- a/not_for_release/testFramework/Unit/testsCategories/ProductPathForCategoryTest.php
+++ b/not_for_release/testFramework/Unit/testsCategories/ProductPathForCategoryTest.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * @copyright Copyright 2003-2026 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ */
+
+namespace Tests\Unit\testsCategories;
+
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use Tests\Support\zcUnitTestCase;
+
+#[RunTestsInSeparateProcesses]
+class ProductPathForCategoryTest extends zcUnitTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        defined('TABLE_CATEGORIES') || define('TABLE_CATEGORIES', 'categories');
+        defined('TOPMOST_CATEGORY_PARENT_ID') || define('TOPMOST_CATEGORY_PARENT_ID', 0);
+
+        require_once DIR_FS_CATALOG . 'includes/classes/db/mysql/query_factory.php';
+        require_once DIR_FS_CATALOG . 'includes/functions/functions_categories.php';
+        require_once DIR_FS_CATALOG . 'includes/functions/functions_products.php';
+
+        $GLOBALS['db'] = $this->getMockBuilder(\queryFactory::class)->getMock();
+    }
+
+    public function testMasterCategoryUsesPathAlreadyLoadedByProduct(): void
+    {
+        $product = $this->createProduct([
+            'master_categories_id' => '9',
+            'linked_categories' => ['14'],
+            'cPath' => '1_9',
+        ]);
+
+        $GLOBALS['db']->expects($this->never())->method('Execute');
+
+        $this->assertSame('1_9', \zen_get_product_path_for_category($product, 9));
+    }
+
+    public function testDirectlyLinkedCategoryUsesItsGeneratedPath(): void
+    {
+        $product = $this->createProduct([
+            'master_categories_id' => '9',
+            'linked_categories' => ['14'],
+            'cPath' => '1_9',
+        ]);
+
+        $GLOBALS['db']->expects($this->exactly(2))
+            ->method('Execute')
+            ->willReturnCallback([$this, 'parentCategoryQuery']);
+
+        $this->assertSame('3_14', \zen_get_product_path_for_category($product, 14));
+    }
+
+    public function testUnrelatedCategoryFallsBackToMasterPathWithoutAQuery(): void
+    {
+        $product = $this->createProduct([
+            'master_categories_id' => '9',
+            'linked_categories' => ['14'],
+            'cPath' => '1_9',
+        ]);
+
+        $GLOBALS['db']->expects($this->never())->method('Execute');
+
+        $this->assertSame('1_9', \zen_get_product_path_for_category($product, 22));
+    }
+
+    public function testInvalidTerminalCategoryFallsBackToMasterPathWithoutAQuery(): void
+    {
+        $product = $this->createProduct([
+            'master_categories_id' => '9',
+            'linked_categories' => ['14'],
+            'cPath' => '1_9',
+        ]);
+
+        $GLOBALS['db']->expects($this->never())->method('Execute');
+
+        $this->assertSame('1_9', \zen_get_product_path_for_category($product, 0));
+    }
+
+    public function testProductWithoutAMasterCategoryDoesNotProduceAPath(): void
+    {
+        $product = $this->createProduct([
+            'master_categories_id' => '0',
+            'linked_categories' => [],
+            'cPath' => '0',
+        ]);
+
+        $GLOBALS['db']->expects($this->never())->method('Execute');
+
+        $this->assertSame('', \zen_get_product_path_for_category($product, 0));
+    }
+
+    private function createProduct(array $data): \Product
+    {
+        $product = $this->createStub(\Product::class);
+        $product->method('get')
+            ->willReturnCallback(static fn (string $name) => $data[$name] ?? null);
+
+        return $product;
+    }
+
+    public function parentCategoryQuery(string $sql): \queryFactoryResult
+    {
+        preg_match('/categories_id = (\d+)/', $sql, $matches);
+        $parent_ids = [14 => 3, 3 => TOPMOST_CATEGORY_PARENT_ID];
+
+        $result = new \queryFactoryResult(null);
+        $result->is_cached = true;
+        $result->result = isset($matches[1], $parent_ids[(int)$matches[1]])
+            ? [['parent_id' => $parent_ids[(int)$matches[1]]]]
+            : [];
+
+        return $result;
+    }
+}

--- a/not_for_release/testFramework/Unit/testsCategories/ValidCpathForProductTest.php
+++ b/not_for_release/testFramework/Unit/testsCategories/ValidCpathForProductTest.php
@@ -6,12 +6,13 @@
 
 namespace Tests\Unit\testsCategories;
 
-use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Tests\Support\zcUnitTestCase;
 
-#[RunTestsInSeparateProcesses]
-class ProductPathForCategoryTest extends zcUnitTestCase
+class ValidCpathForProductTest extends zcUnitTestCase
 {
+    protected $preserveGlobalState = false;
+    protected $runTestInSeparateProcess = true;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -36,7 +37,7 @@ class ProductPathForCategoryTest extends zcUnitTestCase
 
         $GLOBALS['db']->expects($this->never())->method('Execute');
 
-        $this->assertSame('1_9', \zen_get_product_path_for_category($product, 9));
+        $this->assertSame('1_9', \zen_get_valid_cpath_for_product($product, 9));
     }
 
     public function testDirectlyLinkedCategoryUsesItsGeneratedPath(): void
@@ -51,7 +52,7 @@ class ProductPathForCategoryTest extends zcUnitTestCase
             ->method('Execute')
             ->willReturnCallback([$this, 'parentCategoryQuery']);
 
-        $this->assertSame('3_14', \zen_get_product_path_for_category($product, 14));
+        $this->assertSame('3_14', \zen_get_valid_cpath_for_product($product, 14));
     }
 
     public function testUnrelatedCategoryFallsBackToMasterPathWithoutAQuery(): void
@@ -64,7 +65,7 @@ class ProductPathForCategoryTest extends zcUnitTestCase
 
         $GLOBALS['db']->expects($this->never())->method('Execute');
 
-        $this->assertSame('1_9', \zen_get_product_path_for_category($product, 22));
+        $this->assertSame('1_9', \zen_get_valid_cpath_for_product($product, 22));
     }
 
     public function testInvalidTerminalCategoryFallsBackToMasterPathWithoutAQuery(): void
@@ -77,7 +78,7 @@ class ProductPathForCategoryTest extends zcUnitTestCase
 
         $GLOBALS['db']->expects($this->never())->method('Execute');
 
-        $this->assertSame('1_9', \zen_get_product_path_for_category($product, 0));
+        $this->assertSame('1_9', \zen_get_valid_cpath_for_product($product, 0));
     }
 
     public function testProductWithoutAMasterCategoryDoesNotProduceAPath(): void
@@ -90,7 +91,7 @@ class ProductPathForCategoryTest extends zcUnitTestCase
 
         $GLOBALS['db']->expects($this->never())->method('Execute');
 
-        $this->assertSame('', \zen_get_product_path_for_category($product, 0));
+        $this->assertSame('', \zen_get_valid_cpath_for_product($product, 0));
     }
 
     private function createProduct(array $data): \Product


### PR DESCRIPTION
Redirect active category requests to the authoritative generated category path.

For product pages, reuse the loaded Product data to preserve a requested category only when the product is directly linked to it. Otherwise, redirect to the product's master-category path.

Retain applicable request parameters on the permanent redirect, sourced from the parameter policy init_canonical already applied to this request, and drop the invalid cPath, cart actions, and any session value.

Add regression coverage for the path resolution (master, linked, unrelated, invalid, and missing category paths) and for the redirect itself.

Fixes #7903 and replaces/closes #7934

## Why this resolves #7903

- A malformed category URL such as `cPath=23_22_21_3` is compared with the authoritative path   generated for category 3. It receives a 301 redirect instead of serving category 3 under the   false hierarchy.
- Product URLs are resolved against the product's actual direct category links. A legitimate   linked-category path is preserved; an unrelated or malformed path falls back to the master   category.
- After the redirect the URL, breadcrumbs, and active sidebox categories all describe the same   hierarchy, and for category listings the canonical link — which echoes the requested cPath,   the "canonical tag that doesn't help" from the report — now describes it too.
- Crawlers are directed to one stable URL rather than being allowed to discover unlimited cPath   permutations containing identical content.
- `zen_get_valid_cpath_for_product()` reuses `Product::$data`, so master and invalid-category cases add no database queries. Only a legitimate alternate linked category requires its parent path to be generated.
- Centralizing product validation in `zen_product_set_header_response()` avoids five copied header blocks and covers product types using the standard response flow.

## Redirect behavior

- Retained parameters come from init_canonical's `$excludeParams`, so the 301 carries over only  what the store already treats as part of a URL's identity, and unrecognized parameters — which init_canonical has already appended to that list — are never reflected into a cacheable `Location` header. Plugins adjust this through the existing  `NOTIFY_INIT_CANONICAL_PARAM_WHITELIST`. If init_canonical was overridden away, the redirect fails closed and retains nothing.
- No session id is appended, which would otherwise be baked into a permanently-cached and indexable response when cookies are disabled.
- Non-GET requests are not redirected, since a 301 causes browsers to re-issue as GET and silently discard the request body.
- The target is built from the sanitized `$current_page_base`, not the raw `main_page` value.
- On the index page the check runs inside the block guarded by `$category_redirect_handled`, so observers of `NOTIFY_INDEX_CATEGORY_STATUS_CHECK` keep their override, and the category depth is resolved first so the page stays displayable if an observer of `NOTIFY_ZEN_REDIRECT` cancels  the redirect.
- `zen_get_generated_category_path_rev()` is memoized per request on the storefront: the ancestor walk is one uncached query per level, and the storefront now asks for the same path from the canonical link, the cPath validation, and the sideboxes. Not memoized in admin, where the tree can change mid-request.

## Not addressed here

Product canonical links exclude cPath by default (`$includeCPath = false`), and when included are generated from the master category. A product URL 301'd to a preserved linked-category path therefore still lands on a page whose canonical describes a different path. That predates this change and is out of scope for #7903, which reported the category-listing case.