### PR TITLE
Defer customer order statistics in admin listing

### DIFF
--- a/admin/customers.php
+++ b/admin/customers.php
@@ -1345,11 +1345,14 @@ if ($action === 'edit' || $action === 'update') {
         $customers_query_numrows
     );
     $customers = $db->Execute($customers_query_raw);
+    $selected_customer = null;
     foreach ($customers as $result) {
-        $cust = new Customer($result['customers_id']);
+        $load_order_statistics = !isset($cInfo) && (!isset($_GET['cID']) || (int)$_GET['cID'] === (int)$result['customers_id']);
+        $cust = new Customer($result['customers_id'], load_order_statistics: $load_order_statistics);
         $customer = $cust->getData();
-        if ((!isset($_GET['cID']) || (int)$_GET['cID'] === $customer['customers_id']) && !isset($cInfo)) {
+        if ($load_order_statistics) {
             $cInfo = new objectInfo($customer);
+            $selected_customer = $cust;
         }
 
         if (isset($cInfo) && is_object($cInfo) && ($customer['customers_id'] === (int)$cInfo->customers_id)) {
@@ -1640,7 +1643,7 @@ if ($action === 'edit' || $action === 'update') {
                 $_GET['search'] = zen_output_string_protected($_GET['search']);
             }
             if (isset($cInfo) && is_object($cInfo)) {
-                $customer = new Customer($cInfo->customers_id);
+                $customer = $selected_customer ?? new Customer($cInfo->customers_id);
 
                 $heading[] = [
                     'text' =>

--- a/includes/classes/Customer.php
+++ b/includes/classes/Customer.php
@@ -22,7 +22,13 @@ class Customer extends base
     protected bool $is_in_guest_checkout = false;
     protected array $data = [];
 
-    public function __construct($customer_id = null)
+    /**
+     * @param int|string|null $customer_id
+     * @param bool $load_order_statistics Admin-only: set false to skip the order-count/lifetime-value
+     *                                    queries when only the base customer record is needed,
+     *                                    such as when building a customer listing.
+     */
+    public function __construct($customer_id = null, protected bool $load_order_statistics = true)
     {
         $this->is_logged_in = $this->someoneIsLoggedIn();
         $this->is_in_guest_checkout = $this->isInGuestCheckout();
@@ -635,10 +641,19 @@ class Customer extends base
         $this->data['number_of_reviews'] = (int)$result->fields['number_of_reviews'];
 
         if (IS_ADMIN_FLAG) {
-            $this->data['number_of_orders'] = $this->countCustomersPreviousOrders();
-            // only calculating this on the Admin side, for performance reasons
-            if ($this->data['number_of_orders']) {
-                $this->data['lifetime_value'] = $this->getLifetimeValue();
+            /**
+             * The order-history queries are the expensive part of loading a customer, and a listing
+             * page such as admin/customers.php only needs them for the one customer it has selected.
+             * When they're deferred, the related keys are left unset rather than zeroed, so callers
+             * can tell "not loaded" apart from "no orders". ('lifetime_value' already behaves that
+             * way for a customer with no orders.)
+             */
+            if ($this->load_order_statistics) {
+                $this->data['number_of_orders'] = $this->countCustomersPreviousOrders();
+                // only calculating this on the Admin side, for performance reasons
+                if ($this->data['number_of_orders']) {
+                    $this->data['lifetime_value'] = $this->getLifetimeValue();
+                }
             }
         } else {
             $this->data['lifetime_value'] = null;

--- a/includes/classes/Customer.php
+++ b/includes/classes/Customer.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 /**
  * @copyright Copyright 2003-2025 Zen Cart Development Team
- * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @license https://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: DrByte 2025 Oct 25 Modified in v2.2.0 $
  * @since ZC v1.5.8
  */
@@ -793,18 +793,22 @@ class Customer extends base
     protected function getPricingGroupAssociation(): void
     {
         global $db;
-        $sql =
-            "SELECT group_name, group_percentage
-               FROM " . TABLE_GROUP_PRICING . "
-              WHERE group_id = " . (int)$this->data['customers_group_pricing'];
-        $result = $db->Execute($sql);
 
-        if ($result->RecordCount()) {
-            $this->data['pricing_group_name'] = $result->fields['group_name'];
-            $this->data['pricing_group_discount_percentage'] = $result->fields['group_percentage'];
-        } else {
-            $this->data['pricing_group_name'] = defined('TEXT_NONE') ? TEXT_NONE : '';
-            $this->data['pricing_group_discount_percentage'] = 0;
+        $this->data['pricing_group_name'] = defined('TEXT_NONE') ? TEXT_NONE : '';
+        $this->data['pricing_group_discount_percentage'] = 0;
+
+        // group_pricing.group_id is auto_increment, so it is never zero. Skip unnecessary lookups.
+        if (!empty($this->data['customers_group_pricing'])) {
+            $sql =
+                "SELECT group_name, group_percentage
+                   FROM " . TABLE_GROUP_PRICING . "
+                  WHERE group_id = " . (int)$this->data['customers_group_pricing'];
+            $result = $db->Execute($sql);
+
+            if ($result->RecordCount()) {
+                $this->data['pricing_group_name'] = $result->fields['group_name'];
+                $this->data['pricing_group_discount_percentage'] = $result->fields['group_percentage'];
+            }
         }
 
         $this->notify('NOTIFY_CUSTOMER_PRICING_GROUP_LOADED', $this->data);
@@ -1017,7 +1021,8 @@ class Customer extends base
                     entry_country_id AS country_id,
                     countries_name AS country_name,
                     countries_iso_code_3 AS country_iso,
-                    countries_iso_code_2 AS country_iso_2
+                    countries_iso_code_2 AS country_iso_2,
+                    c.address_format_id
                FROM " . TABLE_ADDRESS_BOOK . " ab
                     INNER JOIN " . TABLE_COUNTRIES . " c ON (ab.entry_country_id = c.countries_id)
                     LEFT JOIN " . TABLE_ZONES . " z ON (ab.entry_zone_id = z.zone_id AND z.zone_country_id = c.countries_id)
@@ -1030,7 +1035,11 @@ class Customer extends base
         $addressArray = [];
 
         foreach ($results as $result) {
-            $format_id = zen_get_address_format_id((int)$result['country_id']);
+            // The countries table is already joined above, so the address format comes back with the row
+            // so we use that instead of calling zen_get_address_format_id() here for extra queries.
+            // It's removed from the row afterwards to keep the returned 'address' element unchanged.
+            $format_id = (int)$result['address_format_id'];
+            unset($result['address_format_id']);
 
             if (empty($result['state']) && !empty($result['zone_name'])) {
                 $result['state'] = $result['zone_name'];

--- a/not_for_release/testFramework/FeatureAdmin/AdminEndpoints/AdminCustomerManagementTest.php
+++ b/not_for_release/testFramework/FeatureAdmin/AdminEndpoints/AdminCustomerManagementTest.php
@@ -26,6 +26,35 @@ class AdminCustomerManagementTest extends zcInProcessFeatureTestCaseAdmin
         $this->resetStorefrontSession();
     }
 
+    /**
+     * The customers listing only loads order statistics for the selected customer; this confirms
+     * the info panel is still fully populated for that customer, whether it was selected by cID or
+     * defaulted to the first row.
+     *
+     * @see \Customer::__construct() $load_order_statistics
+     */
+    public function testAdminCustomerListingShowsOrderStatisticsForSelectedCustomer(): void
+    {
+        $profile = $this->createCustomerAccountOrLogin('florida-basic2');
+        $customerId = $this->getCustomerIdFromEmail($profile['email_address']);
+
+        $this->assertNotNull($customerId);
+
+        $this->completeInitialAdminSetup();
+
+        $this->getAdmin('/admin/index.php?cmd=customers&cID=' . $customerId)
+            ->assertOk()
+            ->assertHeader('X-ZC-InProcess-Runner', 'admin')
+            ->assertSee($profile['email_address'])
+            ->assertSee('Number of Orders:')
+            ->assertSee('Number of Reviews:');
+
+        $this->visitAdminCommand('customers')
+            ->assertOk()
+            ->assertSee('Number of Orders:')
+            ->assertSee('Number of Reviews:');
+    }
+
     public function testAdminCanEditCustomerAndAssignGroups(): void
     {
         $profile = $this->createCustomerAccountOrLogin('florida-basic2');

--- a/not_for_release/testFramework/Support/Traits/CustomerDbStubConcerns.php
+++ b/not_for_release/testFramework/Support/Traits/CustomerDbStubConcerns.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * @copyright Copyright 2003-2026 Zen Cart Development Team
+ * @license https://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ */
+
+namespace Tests\Support\Traits;
+
+/**
+ * A recording $db stub for exercising Customer::load() without a database.
+ *
+ * All of load()'s lookups go through the same stub, so they are told apart by the table (or a
+ * distinctive column) named in the SQL. Every statement is recorded, which is what lets these
+ * tests assert on the queries that no longer run.
+ */
+trait CustomerDbStubConcerns
+{
+    protected const STUB_CUSTOMER_ID = 42;
+    protected const STUB_ADDRESS_BOOK_ID = 7;
+
+    /**
+     * Every SQL statement handed to the $db stub, in order.
+     *
+     * @var string[]
+     */
+    protected array $queries = [];
+
+    /**
+     * Rows the address-book lookup should return. Defaults to none.
+     *
+     * @var array<int, array<string, string>>
+     */
+    protected array $addressBookRows = [];
+
+    /**
+     * Values overriding the canned customers-table row.
+     *
+     * @var array<string, string>
+     */
+    protected array $customerRowOverrides = [];
+
+    protected function installCustomerDbStub(): void
+    {
+        require_once DIR_FS_CATALOG . DIR_WS_CLASSES . 'class.base.php';
+        require_once DIR_FS_CATALOG . DIR_WS_CLASSES . 'class.notifier.php';
+        require_once DIR_FS_CATALOG . 'includes/classes/db/mysql/query_factory.php';
+
+        $_SESSION = [];
+        $this->queries = [];
+
+        $GLOBALS['zco_notifier'] = new \notifier();
+        $GLOBALS['currencies'] = new class {
+            public function format($number, $calculate_currency_value = true, $currency_type = '', $currency_value = ''): string
+            {
+                return '$' . number_format((float)$number, 2);
+            }
+        };
+
+        $db = $this->createStub(\queryFactory::class);
+        $db->method('Execute')->willReturnCallback([$this, 'routeCustomerQuery']);
+        $db->method('ExecuteNoCache')->willReturnCallback([$this, 'routeCustomerQuery']);
+        $db->method('bindVars')->willReturnCallback(
+            static fn (string $sql, string $bindVarString, $sqlValue, $type): string => $sql
+        );
+
+        $GLOBALS['db'] = $db;
+    }
+
+    protected function removeCustomerDbStub(): void
+    {
+        unset($GLOBALS['db'], $GLOBALS['currencies']);
+    }
+
+    public function routeCustomerQuery(string $sql, ...$ignored): \queryFactoryResult
+    {
+        $this->queries[] = $sql;
+
+        return $this->makeResult(match (true) {
+            str_contains($sql, TABLE_ADDRESS_BOOK) => $this->addressBookRows,
+            str_contains($sql, 'number_of_reviews') => [['number_of_reviews' => '3']],
+            str_contains($sql, 'COUNT(*) AS count') => [['count' => '2']],
+            str_contains($sql, 'o.orders_id') => $this->orderRows(),
+            str_contains($sql, TABLE_GROUP_PRICING) => [['group_name' => 'Wholesale', 'group_percentage' => '12.50']],
+            str_contains($sql, TABLE_CUSTOMERS . ' c') => [$this->customerRow()],
+            default => [],
+        });
+    }
+
+    /**
+     * @return array<int, array<string, string>>
+     */
+    protected function orderRows(): array
+    {
+        return [
+            [
+                'orders_id' => '1002',
+                'date_purchased' => '2026-07-30 09:15:00',
+                'order_total_raw' => '50.0000',
+                'currency' => 'USD',
+                'currency_value' => '1.000000',
+                'language_code' => 'en',
+            ],
+            [
+                'orders_id' => '1001',
+                'date_purchased' => '2026-06-01 11:00:00',
+                'order_total_raw' => '25.0000',
+                'currency' => 'USD',
+                'currency_value' => '1.000000',
+                'language_code' => 'en',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function customerRow(): array
+    {
+        return array_merge([
+            'customers_id' => (string)self::STUB_CUSTOMER_ID,
+            'customers_firstname' => 'Testy',
+            'customers_lastname' => 'McTest',
+            'customers_email_address' => 'mctest@zencart.test',
+            'customers_password' => 'not-loaded-into-data',
+            'customers_default_address_id' => (string)self::STUB_ADDRESS_BOOK_ID,
+            'customers_group_pricing' => '0',
+            'customers_authorization' => '0',
+            'customers_newsletter' => '0',
+            'number_of_logins' => '5',
+        ], $this->customerRowOverrides);
+    }
+
+    /**
+     * A single address-book row as the joined lookup in getFormattedAddressBookList() returns it.
+     *
+     * @return array<string, string>
+     */
+    protected function addressBookRow(): array
+    {
+        return [
+            'address_book_id' => (string)self::STUB_ADDRESS_BOOK_ID,
+            'customers_id' => (string)self::STUB_CUSTOMER_ID,
+            'firstname' => 'Testy',
+            'lastname' => 'McTest',
+            'company' => '',
+            'street_address' => '1 Test Way',
+            'suburb' => '',
+            'city' => 'Testville',
+            'postcode' => '33101',
+            'state' => '',
+            'zone_id' => '18',
+            'zone_name' => 'Florida',
+            'zone_iso' => 'FL',
+            'country_id' => '223',
+            'country_name' => 'United States',
+            'country_iso' => 'USA',
+            'country_iso_2' => 'US',
+            'address_format_id' => '2',
+        ];
+    }
+
+    /**
+     * @param array<int, array<string, string>> $rows
+     */
+    protected function makeResult(array $rows): \queryFactoryResult
+    {
+        $result = new \queryFactoryResult(null);
+        $result->is_cached = true;
+        $result->result = $rows;
+        $result->fields = $rows[0] ?? [];
+        $result->EOF = ($rows === []);
+
+        return $result;
+    }
+
+    /**
+     * Recorded queries reading from the named table.
+     *
+     * @return string[]
+     */
+    protected function queriesReadingFrom(string $table): array
+    {
+        return array_values(array_filter(
+            $this->queries,
+            static fn (string $sql): bool => (bool)preg_match('/\bFROM\s+' . preg_quote($table, '/') . '\b/i', $sql)
+        ));
+    }
+}

--- a/not_for_release/testFramework/Unit/testsSundry/CustomerOrderStatisticsDeferralTest.php
+++ b/not_for_release/testFramework/Unit/testsSundry/CustomerOrderStatisticsDeferralTest.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * @copyright Copyright 2003-2026 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ *
+ * Admin-side, the Customer class loads order statistics (order count, lifetime value and the
+ * "last order" details) for every customer it is constructed for. A listing page such as
+ * admin/customers.php builds one Customer per row but only displays those statistics for the
+ * single selected customer, so every other row paid for two orders-table queries it never used.
+ *
+ * Customer::__construct() now takes $load_order_statistics; these tests assert on the actual
+ * queries issued, since the point of the flag is the queries that no longer run.
+ */
+
+namespace Tests\Unit\testsSundry;
+
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use Tests\Support\zcUnitTestCase;
+
+#[RunTestsInSeparateProcesses]
+class CustomerOrderStatisticsDeferralTest extends zcUnitTestCase
+{
+    private const CUSTOMER_ID = 42;
+
+    /**
+     * Every SQL statement handed to the $db stub, in order.
+     *
+     * @var string[]
+     */
+    private array $queries = [];
+
+    public function setUp(): void
+    {
+        // Customer only loads order statistics admin-side, so this must be set before the
+        // bootstrap defines it as false.
+        defined('IS_ADMIN_FLAG') || define('IS_ADMIN_FLAG', true);
+
+        parent::setUp();
+
+        require_once DIR_FS_CATALOG . DIR_WS_CLASSES . 'class.base.php';
+        require_once DIR_FS_CATALOG . DIR_WS_CLASSES . 'class.notifier.php';
+        require_once DIR_FS_CATALOG . 'includes/classes/db/mysql/query_factory.php';
+
+        $_SESSION = [];
+        $this->queries = [];
+
+        $GLOBALS['zco_notifier'] = new \notifier();
+        $GLOBALS['currencies'] = new class {
+            public function format($number, $calculate_currency_value = true, $currency_type = '', $currency_value = ''): string
+            {
+                return '$' . number_format((float)$number, 2);
+            }
+        };
+
+        $db = $this->createStub(\queryFactory::class);
+        $db->method('Execute')->willReturnCallback([$this, 'routeQuery']);
+        $db->method('ExecuteNoCache')->willReturnCallback([$this, 'routeQuery']);
+        $db->method('bindVars')->willReturnCallback(
+            static fn (string $sql, string $bindVarString, $sqlValue, $type): string => $sql
+        );
+
+        $GLOBALS['db'] = $db;
+    }
+
+    public function tearDown(): void
+    {
+        unset($GLOBALS['db'], $GLOBALS['currencies']);
+        parent::tearDown();
+    }
+
+    public function testOrderStatisticsAreLoadedByDefault(): void
+    {
+        $data = (new \Customer(self::CUSTOMER_ID))->getData();
+
+        $this->assertSame(self::CUSTOMER_ID, $data['customers_id']);
+        $this->assertSame(2, $data['number_of_orders']);
+        $this->assertEqualsWithDelta(75.0, $data['lifetime_value'], 0.001);
+        $this->assertSame('2026-07-30 09:15:00', $data['last_order']['date_purchased']);
+
+        $this->assertCount(2, $this->ordersTableQueries(), 'The order count and lifetime-value queries should both run.');
+    }
+
+    public function testOrderStatisticsAreSkippedWhenDeferred(): void
+    {
+        $data = (new \Customer(self::CUSTOMER_ID, load_order_statistics: false))->getData();
+
+        $this->assertSame([], $this->ordersTableQueries(), 'No orders-table query should be issued when order statistics are deferred.');
+
+        $this->assertArrayNotHasKey('number_of_orders', $data);
+        $this->assertArrayNotHasKey('lifetime_value', $data);
+        $this->assertArrayNotHasKey('last_order', $data);
+    }
+
+    /**
+     * Deferring the statistics must not cost the caller any of the ordinary customer data --
+     * that is what keeps admin/customers.php on the Customer class instead of a hand-rolled query.
+     */
+    public function testTheRestOfTheCustomerRecordIsStillLoadedWhenDeferred(): void
+    {
+        $data = (new \Customer(self::CUSTOMER_ID, load_order_statistics: false))->getData();
+
+        $this->assertSame(self::CUSTOMER_ID, $data['customers_id']);
+        $this->assertSame('Testy', $data['customers_firstname']);
+        $this->assertSame('mctest@zencart.test', $data['customers_email_address']);
+        $this->assertSame(3, $data['number_of_reviews']);
+        $this->assertSame([], $data['addresses']);
+        $this->assertArrayNotHasKey('customers_password', $data);
+    }
+
+    /**
+     * Routes a stubbed query to its canned result. All of Customer::load()'s lookups go through
+     * the same $db stub, so they are told apart by the table (or distinctive column) named.
+     */
+    public function routeQuery(string $sql, ...$ignored): \queryFactoryResult
+    {
+        $this->queries[] = $sql;
+
+        return $this->makeResult(match (true) {
+            str_contains($sql, TABLE_ADDRESS_BOOK) => [],
+            str_contains($sql, 'number_of_reviews') => [['number_of_reviews' => '3']],
+            str_contains($sql, 'COUNT(*) AS count') => [['count' => '2']],
+            str_contains($sql, 'o.orders_id') => [
+                [
+                    'orders_id' => '1002',
+                    'date_purchased' => '2026-07-30 09:15:00',
+                    'order_total_raw' => '50.0000',
+                    'currency' => 'USD',
+                    'currency_value' => '1.000000',
+                    'language_code' => 'en',
+                ],
+                [
+                    'orders_id' => '1001',
+                    'date_purchased' => '2026-06-01 11:00:00',
+                    'order_total_raw' => '25.0000',
+                    'currency' => 'USD',
+                    'currency_value' => '1.000000',
+                    'language_code' => 'en',
+                ],
+            ],
+            str_contains($sql, TABLE_CUSTOMERS . ' c') => [$this->customerRow()],
+            default => [],
+        });
+    }
+
+    private function customerRow(): array
+    {
+        return [
+            'customers_id' => (string)self::CUSTOMER_ID,
+            'customers_firstname' => 'Testy',
+            'customers_lastname' => 'McTest',
+            'customers_email_address' => 'mctest@zencart.test',
+            'customers_password' => 'not-loaded-into-data',
+            'customers_default_address_id' => '0',
+            'customers_group_pricing' => '0',
+            'customers_authorization' => '0',
+            'customers_newsletter' => '0',
+            'number_of_logins' => '5',
+        ];
+    }
+
+    /**
+     * @param array<int, array<string, string>> $rows
+     */
+    private function makeResult(array $rows): \queryFactoryResult
+    {
+        $result = new \queryFactoryResult(null);
+        $result->is_cached = true;
+        $result->result = $rows;
+        $result->fields = $rows[0] ?? [];
+        $result->EOF = ($rows === []);
+
+        return $result;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function ordersTableQueries(): array
+    {
+        return array_values(array_filter(
+            $this->queries,
+            static fn (string $sql): bool => (bool)preg_match('/\bFROM\s+' . preg_quote(TABLE_ORDERS, '/') . '\b/i', $sql)
+        ));
+    }
+}

--- a/not_for_release/testFramework/Unit/testsSundry/CustomerOrderStatisticsDeferralTest.php
+++ b/not_for_release/testFramework/Unit/testsSundry/CustomerOrderStatisticsDeferralTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @copyright Copyright 2003-2026 Zen Cart Development Team
- * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @license https://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  *
  * Admin-side, the Customer class loads order statistics (order count, lifetime value and the
  * "last order" details) for every customer it is constructed for. A listing page such as
@@ -15,19 +15,13 @@
 namespace Tests\Unit\testsSundry;
 
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use Tests\Support\Traits\CustomerDbStubConcerns;
 use Tests\Support\zcUnitTestCase;
 
 #[RunTestsInSeparateProcesses]
 class CustomerOrderStatisticsDeferralTest extends zcUnitTestCase
 {
-    private const CUSTOMER_ID = 42;
-
-    /**
-     * Every SQL statement handed to the $db stub, in order.
-     *
-     * @var string[]
-     */
-    private array $queries = [];
+    use CustomerDbStubConcerns;
 
     public function setUp(): void
     {
@@ -37,54 +31,32 @@ class CustomerOrderStatisticsDeferralTest extends zcUnitTestCase
 
         parent::setUp();
 
-        require_once DIR_FS_CATALOG . DIR_WS_CLASSES . 'class.base.php';
-        require_once DIR_FS_CATALOG . DIR_WS_CLASSES . 'class.notifier.php';
-        require_once DIR_FS_CATALOG . 'includes/classes/db/mysql/query_factory.php';
-
-        $_SESSION = [];
-        $this->queries = [];
-
-        $GLOBALS['zco_notifier'] = new \notifier();
-        $GLOBALS['currencies'] = new class {
-            public function format($number, $calculate_currency_value = true, $currency_type = '', $currency_value = ''): string
-            {
-                return '$' . number_format((float)$number, 2);
-            }
-        };
-
-        $db = $this->createStub(\queryFactory::class);
-        $db->method('Execute')->willReturnCallback([$this, 'routeQuery']);
-        $db->method('ExecuteNoCache')->willReturnCallback([$this, 'routeQuery']);
-        $db->method('bindVars')->willReturnCallback(
-            static fn (string $sql, string $bindVarString, $sqlValue, $type): string => $sql
-        );
-
-        $GLOBALS['db'] = $db;
+        $this->installCustomerDbStub();
     }
 
     public function tearDown(): void
     {
-        unset($GLOBALS['db'], $GLOBALS['currencies']);
+        $this->removeCustomerDbStub();
         parent::tearDown();
     }
 
     public function testOrderStatisticsAreLoadedByDefault(): void
     {
-        $data = (new \Customer(self::CUSTOMER_ID))->getData();
+        $data = (new \Customer(self::STUB_CUSTOMER_ID))->getData();
 
-        $this->assertSame(self::CUSTOMER_ID, $data['customers_id']);
+        $this->assertSame(self::STUB_CUSTOMER_ID, $data['customers_id']);
         $this->assertSame(2, $data['number_of_orders']);
         $this->assertEqualsWithDelta(75.0, $data['lifetime_value'], 0.001);
         $this->assertSame('2026-07-30 09:15:00', $data['last_order']['date_purchased']);
 
-        $this->assertCount(2, $this->ordersTableQueries(), 'The order count and lifetime-value queries should both run.');
+        $this->assertCount(2, $this->queriesReadingFrom(TABLE_ORDERS), 'The order count and lifetime-value queries should both run.');
     }
 
     public function testOrderStatisticsAreSkippedWhenDeferred(): void
     {
-        $data = (new \Customer(self::CUSTOMER_ID, load_order_statistics: false))->getData();
+        $data = (new \Customer(self::STUB_CUSTOMER_ID, load_order_statistics: false))->getData();
 
-        $this->assertSame([], $this->ordersTableQueries(), 'No orders-table query should be issued when order statistics are deferred.');
+        $this->assertSame([], $this->queriesReadingFrom(TABLE_ORDERS), 'No orders-table query should be issued when order statistics are deferred.');
 
         $this->assertArrayNotHasKey('number_of_orders', $data);
         $this->assertArrayNotHasKey('lifetime_value', $data);
@@ -97,89 +69,13 @@ class CustomerOrderStatisticsDeferralTest extends zcUnitTestCase
      */
     public function testTheRestOfTheCustomerRecordIsStillLoadedWhenDeferred(): void
     {
-        $data = (new \Customer(self::CUSTOMER_ID, load_order_statistics: false))->getData();
+        $data = (new \Customer(self::STUB_CUSTOMER_ID, load_order_statistics: false))->getData();
 
-        $this->assertSame(self::CUSTOMER_ID, $data['customers_id']);
+        $this->assertSame(self::STUB_CUSTOMER_ID, $data['customers_id']);
         $this->assertSame('Testy', $data['customers_firstname']);
         $this->assertSame('mctest@zencart.test', $data['customers_email_address']);
         $this->assertSame(3, $data['number_of_reviews']);
         $this->assertSame([], $data['addresses']);
         $this->assertArrayNotHasKey('customers_password', $data);
-    }
-
-    /**
-     * Routes a stubbed query to its canned result. All of Customer::load()'s lookups go through
-     * the same $db stub, so they are told apart by the table (or distinctive column) named.
-     */
-    public function routeQuery(string $sql, ...$ignored): \queryFactoryResult
-    {
-        $this->queries[] = $sql;
-
-        return $this->makeResult(match (true) {
-            str_contains($sql, TABLE_ADDRESS_BOOK) => [],
-            str_contains($sql, 'number_of_reviews') => [['number_of_reviews' => '3']],
-            str_contains($sql, 'COUNT(*) AS count') => [['count' => '2']],
-            str_contains($sql, 'o.orders_id') => [
-                [
-                    'orders_id' => '1002',
-                    'date_purchased' => '2026-07-30 09:15:00',
-                    'order_total_raw' => '50.0000',
-                    'currency' => 'USD',
-                    'currency_value' => '1.000000',
-                    'language_code' => 'en',
-                ],
-                [
-                    'orders_id' => '1001',
-                    'date_purchased' => '2026-06-01 11:00:00',
-                    'order_total_raw' => '25.0000',
-                    'currency' => 'USD',
-                    'currency_value' => '1.000000',
-                    'language_code' => 'en',
-                ],
-            ],
-            str_contains($sql, TABLE_CUSTOMERS . ' c') => [$this->customerRow()],
-            default => [],
-        });
-    }
-
-    private function customerRow(): array
-    {
-        return [
-            'customers_id' => (string)self::CUSTOMER_ID,
-            'customers_firstname' => 'Testy',
-            'customers_lastname' => 'McTest',
-            'customers_email_address' => 'mctest@zencart.test',
-            'customers_password' => 'not-loaded-into-data',
-            'customers_default_address_id' => '0',
-            'customers_group_pricing' => '0',
-            'customers_authorization' => '0',
-            'customers_newsletter' => '0',
-            'number_of_logins' => '5',
-        ];
-    }
-
-    /**
-     * @param array<int, array<string, string>> $rows
-     */
-    private function makeResult(array $rows): \queryFactoryResult
-    {
-        $result = new \queryFactoryResult(null);
-        $result->is_cached = true;
-        $result->result = $rows;
-        $result->fields = $rows[0] ?? [];
-        $result->EOF = ($rows === []);
-
-        return $result;
-    }
-
-    /**
-     * @return string[]
-     */
-    private function ordersTableQueries(): array
-    {
-        return array_values(array_filter(
-            $this->queries,
-            static fn (string $sql): bool => (bool)preg_match('/\bFROM\s+' . preg_quote(TABLE_ORDERS, '/') . '\b/i', $sql)
-        ));
     }
 }

--- a/not_for_release/testFramework/Unit/testsSundry/CustomerRedundantLookupTest.php
+++ b/not_for_release/testFramework/Unit/testsSundry/CustomerRedundantLookupTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * @copyright Copyright 2003-2026 Zen Cart Development Team
+ * @license https://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ *
+ * Two lookups in Customer::load() were issued more often than they needed to be, which the admin
+ * customer listing pays for once per row:
+ *
+ * - getFormattedAddressBookList() already INNER JOINs the countries table, but then called
+ *   zen_get_address_format_id() per address, re-querying countries for a column the join could
+ *   have carried.
+ * - getPricingGroupAssociation() queried group_pricing even when the customer has no pricing
+ *   group, which -- since group_id is auto_increment and therefore never zero -- can only ever
+ *   come back empty.
+ */
+
+namespace Tests\Unit\testsSundry;
+
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use Tests\Support\Traits\CustomerDbStubConcerns;
+use Tests\Support\zcUnitTestCase;
+
+#[RunTestsInSeparateProcesses]
+class CustomerRedundantLookupTest extends zcUnitTestCase
+{
+    use CustomerDbStubConcerns;
+
+    public function setUp(): void
+    {
+        defined('IS_ADMIN_FLAG') || define('IS_ADMIN_FLAG', true);
+
+        parent::setUp();
+
+        $this->installCustomerDbStub();
+        $this->addressBookRows = [$this->addressBookRow()];
+    }
+
+    public function tearDown(): void
+    {
+        $this->removeCustomerDbStub();
+        parent::tearDown();
+    }
+
+    public function testTheAddressFormatComesFromTheJoinRatherThanAPerAddressQuery(): void
+    {
+        $addresses = (new \Customer(self::STUB_CUSTOMER_ID))->getData('addresses');
+
+        $this->assertCount(1, $addresses);
+        $this->assertSame(2, $addresses[0]['format_id']);
+
+        // The address-book query reads countries via a JOIN; zen_get_address_format_id() is the
+        // only thing that would SELECT ... FROM countries directly.
+        $this->assertSame(
+            [],
+            $this->queriesReadingFrom(TABLE_COUNTRIES),
+            'The address format should come from the existing join, not a standalone countries lookup.'
+        );
+        $this->assertCount(1, $this->queriesReadingFrom(TABLE_ADDRESS_BOOK));
+    }
+
+    /**
+     * The format id is used internally but was never part of the returned address row, and the
+     * default address row is merged into the customer's own data -- so it must not leak in.
+     */
+    public function testTheReturnedAddressRowIsUnchanged(): void
+    {
+        $customer = new \Customer(self::STUB_CUSTOMER_ID);
+        $addresses = $customer->getData('addresses');
+
+        $this->assertArrayNotHasKey('address_format_id', $addresses[0]['address']);
+        $this->assertArrayNotHasKey('address_format_id', $customer->getData());
+        $this->assertSame('Florida', $addresses[0]['address']['state'], 'An empty state should still fall back to the zone name.');
+    }
+
+    public function testNoPricingGroupLookupWhenTheCustomerHasNoPricingGroup(): void
+    {
+        $data = (new \Customer(self::STUB_CUSTOMER_ID))->getData();
+
+        $this->assertSame([], $this->queriesReadingFrom(TABLE_GROUP_PRICING));
+
+        $this->assertSame('', $data['pricing_group_name']);
+        $this->assertSame(0, $data['pricing_group_discount_percentage']);
+    }
+
+    public function testThePricingGroupIsStillLookedUpWhenTheCustomerHasOne(): void
+    {
+        $this->customerRowOverrides = ['customers_group_pricing' => '4'];
+
+        $data = (new \Customer(self::STUB_CUSTOMER_ID))->getData();
+
+        $this->assertCount(1, $this->queriesReadingFrom(TABLE_GROUP_PRICING));
+
+        $this->assertSame('Wholesale', $data['pricing_group_name']);
+        $this->assertSame('12.50', $data['pricing_group_discount_percentage']);
+    }
+}


### PR DESCRIPTION
The admin Customers listing can be slow because of lifetime-value calculations which run on every row, despite only being displayed for the selected customer.

This PR makes the following changes which defer the more expensive queries to run only where they're needed.
- Customer::__construct() takes an optional second parameter, $load_order_statistics, defaulting to true, so existing callers are unaffected.
- The admin customer listing now loads order count/lifetime statistics only for the selected customer, and reuses that instance for the detail sidebar.
- Admin-side, when statistics are skipped, number_of_orders, lifetime_value and last_order are left unset rather than zeroed, so callers can distinguish "not loaded" from "no orders".