### PR TITLE
[2.x] Correct customer lifetime value and last-order currency conversion

### DIFF
--- a/includes/classes/Customer.php
+++ b/includes/classes/Customer.php
@@ -735,14 +735,17 @@ class Customer extends base
             if (null === $last_order) {
                 $last_order = [
                     'date_purchased' => $result['date_purchased'],
-                    'order_total' => $currencies->format($result['order_total_raw'], false, $result['currency'], $result['currency_value']),
+                    'order_total' => $currencies->format($result['order_total_raw'], true, $result['currency'], $result['currency_value']),
                     'order_total_raw' => $result['order_total_raw'],
                     'currency' => $result['currency'],
                     'currency_value' => $result['currency_value'],
                     'language_code' => $result['language_code'],
                 ];
             }
-            $lifetime_value += $result['order_total_raw'] * $result['currency_value'];
+            // orders.order_total is stored in the store's default currency, so the orders are
+            // already in a common unit; multiplying by the order's currency_value here would
+            // convert each one *out* of that unit and sum unlike currencies.
+            $lifetime_value += $result['order_total_raw'];
         }
         $this->data['last_order'] = $last_order;
         $this->data['lifetime_value'] = $lifetime_value;


### PR DESCRIPTION
orders.order_total is stored in the store's default currency, so summing it needs no per-order currency_value multiplier, and the last order's total must be converted for display like every other order total in core.

Only affects stores using more than one currency.

Note: 0b0a5e398 ("Customer::getOrderHistory doesn't convert from default currency", [#6067](https://github.com/zencart/zencart/issues/6067), Dec 2023) fixed the identical `false` → `true` in `getOrderHistory()` and established the premise. `getLifetimeValue()` was simply missed in that PR.