### PR TITLE
Optimization: Count order line-items for a page of orders in one query

### DIFF
--- a/includes/classes/Customer.php
+++ b/includes/classes/Customer.php
@@ -1065,8 +1065,16 @@ class Customer extends base
             $results = $db->Execute($sql, $max_number_to_return);
         }
 
-        $ordersArray = [];
+        $orders = [];
         foreach ($results as $result) {
+            $orders[] = $result;
+        }
+
+        // Counted for the whole page in one statement, rather than a query per order.
+        $product_counts = $this->getProductCountsForOrders(array_column($orders, 'orders_id'));
+
+        $ordersArray = [];
+        foreach ($orders as $result) {
             if (!empty($result['delivery_name'])) {
                 $order_type = defined('TEXT_ORDER_SHIPPED_TO') ? TEXT_ORDER_SHIPPED_TO : 'Shipped To:';
                 $order_name = $result['delivery_name'];
@@ -1076,13 +1084,6 @@ class Customer extends base
                 $order_name = $result['billing_name'];
                 $order_country = $result['billing_country'];
             }
-
-            $sql =
-                "SELECT COUNT(*) AS count
-                   FROM " . TABLE_ORDERS_PRODUCTS . "
-                  WHERE orders_id = " . (int)$result['orders_id'];
-            $queryResult = $db->Execute($sql);
-            $products_count = $queryResult->EOF ? 0 : $queryResult->fields['count'];
 
             $ordersArray[] = [
                 'orders_id' => (int)$result['orders_id'],
@@ -1096,10 +1097,45 @@ class Customer extends base
                 'currency' => $result['currency'],
                 'currency_value' => $result['currency_value'],
                 'language_code' => $result['language_code'],
-                'product_count' => $products_count,
+                'product_count' => $product_counts[(int)$result['orders_id']] ?? 0,
             ];
         }
         return $ordersArray;
+    }
+
+    /**
+     * Return the number of line-items in each of the supplied orders, keyed by orders_id.
+     *
+     * Counting a page's orders in one statement keeps getOrderHistory() from issuing a query per
+     * order. Only the grouped column and the aggregate are selected, so this stays valid under
+     * ONLY_FULL_GROUP_BY, and (orders_id, products_id) covers it.
+     *
+     * @param array $orders_ids
+     * @return array<int, int> orders_id => line-item count; orders with no line-items are absent
+     * @since ZC v3.0.0
+     */
+    protected function getProductCountsForOrders(array $orders_ids): array
+    {
+        global $db;
+
+        $orders_ids = array_filter(array_map('intval', $orders_ids));
+        if (empty($orders_ids)) {
+            return [];
+        }
+
+        $sql =
+            "SELECT orders_id, COUNT(*) AS count
+               FROM " . TABLE_ORDERS_PRODUCTS . "
+              WHERE orders_id IN (" . implode(',', $orders_ids) . ")
+              GROUP BY orders_id";
+        $results = $db->Execute($sql);
+
+        $counts = [];
+        foreach ($results as $result) {
+            $counts[(int)$result['orders_id']] = (int)$result['count'];
+        }
+
+        return $counts;
     }
 
     /**

--- a/not_for_release/testFramework/Unit/testsSundry/CustomerOrderHistoryProductCountTest.php
+++ b/not_for_release/testFramework/Unit/testsSundry/CustomerOrderHistoryProductCountTest.php
@@ -1,0 +1,238 @@
+<?php
+/**
+ * @copyright Copyright 2003-2026 Zen Cart Development Team
+ * @license https://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ *
+ * Customer::getOrderHistory() used to run a COUNT(*) against orders_products once per order in
+ * its result loop. That is paid on admin/customers.php (which asks for 5 orders for the selected
+ * customer) and on the storefront account and account_history pages.
+ *
+ * The counts are now gathered for the whole page in a single grouped query. These tests assert on
+ * the number of statements issued as well as the values, since the point of the change is the
+ * queries that no longer run.
+ */
+
+namespace Tests\Unit\testsSundry;
+
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use Tests\Support\zcUnitTestCase;
+
+#[RunTestsInSeparateProcesses]
+class CustomerOrderHistoryProductCountTest extends zcUnitTestCase
+{
+    private const CUSTOMER_ID = 42;
+
+    /**
+     * Line-item counts the orders_products lookup should report, keyed by orders_id. Order 1001
+     * is deliberately absent: an order with no line-items returns no row from a grouped count.
+     *
+     * @var array<int, int>
+     */
+    private array $lineItemCounts = [1003 => 4, 1002 => 1];
+
+    /**
+     * @var string[]
+     */
+    private array $queries = [];
+
+    /**
+     * Rows the order-history lookup should return. Overridden by one test below.
+     *
+     * @var array<int, array<string, string>>|null
+     */
+    private ?array $orderHistoryRows = null;
+
+    public function setUp(): void
+    {
+        defined('IS_ADMIN_FLAG') || define('IS_ADMIN_FLAG', true);
+
+        parent::setUp();
+
+        require_once DIR_FS_CATALOG . DIR_WS_CLASSES . 'class.base.php';
+        require_once DIR_FS_CATALOG . DIR_WS_CLASSES . 'class.notifier.php';
+        require_once DIR_FS_CATALOG . 'includes/classes/db/mysql/query_factory.php';
+
+        $_SESSION = ['languages_id' => 1];
+        $this->queries = [];
+
+        $GLOBALS['zco_notifier'] = new \notifier();
+        $GLOBALS['currencies'] = new class {
+            public function format($number, $calculate_using_exchange_rate = true, $currency_code = '', $currency_value = ''): string
+            {
+                return '$' . number_format((float)$number, 2);
+            }
+        };
+
+        $db = $this->createStub(\queryFactory::class);
+        $db->method('Execute')->willReturnCallback([$this, 'routeQuery']);
+        $db->method('ExecuteNoCache')->willReturnCallback([$this, 'routeQuery']);
+        $db->method('bindVars')->willReturnCallback(
+            static fn (string $sql, string $bindVarString, $sqlValue, $type): string => $sql
+        );
+
+        $GLOBALS['db'] = $db;
+    }
+
+    public function tearDown(): void
+    {
+        unset($GLOBALS['db'], $GLOBALS['currencies']);
+        parent::tearDown();
+    }
+
+    public function testTheLineItemCountsAreGatheredInASingleQuery(): void
+    {
+        $customer = new \Customer(self::CUSTOMER_ID);
+        $this->queries = [];
+
+        $customer->getOrderHistory();
+
+        $this->assertCount(
+            1,
+            $this->queriesReadingFrom(TABLE_ORDERS_PRODUCTS),
+            'Three orders should still cost exactly one orders_products query.'
+        );
+    }
+
+    public function testEachOrderReportsItsOwnLineItemCount(): void
+    {
+        $history = (new \Customer(self::CUSTOMER_ID))->getOrderHistory();
+
+        $this->assertCount(3, $history);
+        $this->assertSame([1003, 1002, 1001], array_column($history, 'orders_id'));
+        $this->assertSame([4, 1, 0], array_column($history, 'product_count'));
+    }
+
+    /**
+     * An order with no matching orders_products rows is absent from a grouped count, so the
+     * lookup result has to be treated as sparse rather than positional.
+     */
+    public function testAnOrderWithNoLineItemsReportsZero(): void
+    {
+        $history = (new \Customer(self::CUSTOMER_ID))->getOrderHistory();
+
+        $emptyOrder = array_values(array_filter($history, static fn (array $o): bool => $o['orders_id'] === 1001));
+
+        $this->assertCount(1, $emptyOrder);
+        $this->assertSame(0, $emptyOrder[0]['product_count']);
+    }
+
+    /**
+     * A customer with no orders must not issue a lookup with an empty IN() list.
+     */
+    public function testNoLookupIsIssuedForACustomerWithNoOrders(): void
+    {
+        $customer = new \Customer(self::CUSTOMER_ID);
+        $this->orderHistoryRows = [];
+        $this->queries = [];
+
+        $history = $customer->getOrderHistory();
+
+        $this->assertSame([], $history);
+        $this->assertSame([], $this->queriesReadingFrom(TABLE_ORDERS_PRODUCTS));
+    }
+
+    public function routeQuery(string $sql, ...$ignored): \queryFactoryResult
+    {
+        $this->queries[] = $sql;
+
+        return $this->makeResult(match (true) {
+            str_contains($sql, TABLE_ORDERS_PRODUCTS) => $this->lineItemCountRows($sql),
+            str_contains($sql, TABLE_ADDRESS_BOOK) => [],
+            str_contains($sql, 'number_of_reviews') => [['number_of_reviews' => '0']],
+            str_contains($sql, 'COUNT(*) AS count') => [['count' => '0']],
+            str_contains($sql, 'o.delivery_name') => $this->orderHistoryRows(),
+            str_contains($sql, TABLE_CUSTOMERS . ' c') => [$this->customerRow()],
+            default => [],
+        });
+    }
+
+    /**
+     * Mimics a grouped count: only orders named in the IN() list and having line-items come back.
+     *
+     * @return array<int, array<string, string>>
+     */
+    private function lineItemCountRows(string $sql): array
+    {
+        $rows = [];
+        foreach ($this->lineItemCounts as $orders_id => $count) {
+            if (preg_match('/\b' . $orders_id . '\b/', $sql)) {
+                $rows[] = ['orders_id' => (string)$orders_id, 'count' => (string)$count];
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @return array<int, array<string, string>>
+     */
+    private function orderHistoryRows(): array
+    {
+        if ($this->orderHistoryRows !== null) {
+            return $this->orderHistoryRows;
+        }
+
+        $rows = [];
+        foreach ([1003, 1002, 1001] as $orders_id) {
+            $rows[] = [
+                'orders_id' => (string)$orders_id,
+                'date_purchased' => '2026-07-30 09:15:00',
+                'delivery_name' => 'Testy McTest',
+                'delivery_country' => 'United States',
+                'billing_name' => 'Testy McTest',
+                'billing_country' => 'United States',
+                'order_total' => '50.0000',
+                'currency' => 'USD',
+                'currency_value' => '1.000000',
+                'orders_status' => '2',
+                'orders_status_name' => 'Processing',
+                'language_code' => 'en',
+            ];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function customerRow(): array
+    {
+        return [
+            'customers_id' => (string)self::CUSTOMER_ID,
+            'customers_firstname' => 'Testy',
+            'customers_lastname' => 'McTest',
+            'customers_email_address' => 'mctest@zencart.test',
+            'customers_default_address_id' => '0',
+            'customers_group_pricing' => '0',
+            'customers_authorization' => '0',
+            'customers_newsletter' => '0',
+            'number_of_logins' => '5',
+        ];
+    }
+
+    /**
+     * @return string[]
+     */
+    private function queriesReadingFrom(string $table): array
+    {
+        return array_values(array_filter(
+            $this->queries,
+            static fn (string $sql): bool => (bool)preg_match('/\bFROM\s+' . preg_quote($table, '/') . '\b/i', $sql)
+        ));
+    }
+
+    /**
+     * @param array<int, array<string, string>> $rows
+     */
+    private function makeResult(array $rows): \queryFactoryResult
+    {
+        $result = new \queryFactoryResult(null);
+        $result->is_cached = true;
+        $result->result = $rows;
+        $result->fields = $rows[0] ?? [];
+        $result->EOF = ($rows === []);
+
+        return $result;
+    }
+}

--- a/not_for_release/testFramework/Unit/testsSundry/CustomerOrderHistoryProductCountTest.php
+++ b/not_for_release/testFramework/Unit/testsSundry/CustomerOrderHistoryProductCountTest.php
@@ -12,8 +12,9 @@
  * queries that no longer run.
  */
 
-namespace Tests\Unit\testsSundry;
+declare(strict_types=1);
 
+namespace Tests\Unit\testsSundry;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Tests\Support\zcUnitTestCase;
 


### PR DESCRIPTION
Fixes N+1 problem

`getOrderHistory()` ran a `COUNT` against `orders_products` per order in its result loop, paid on `admin/customers.php` and on the storefront `account` and `account_history` pages.

The grouped lookup selects only the grouped column and the aggregate, so it is valid under `ONLY_FULL_GROUP_BY`.
