### PR TITLE
Remove Possibility of Infinite loop

### DIFF
--- a/includes/classes/Email.php
+++ b/includes/classes/Email.php
@@ -313,28 +313,32 @@ class Email
         // CLEAN UP CHARACTERS
         $email_text = preg_replace('/((&amp;)|&)+/', '&', $email_text);
 
+        $zen_fix_current = [];
+        $zen_fix_replace = [];
+
         if (!empty(zen_config('CURRENCIES_TRANSLATIONS'))) {
+            // Add curency conversions if any
             $zen_fix_currencies = preg_split("/[:,]/", str_replace(' ', '', zen_config('CURRENCIES_TRANSLATIONS')));
             $size = count($zen_fix_currencies);
+            
+            // Convert in to array
             for ($i = 0, $n = $size; $i < $n; $i += 2) {
                 if (empty($zen_fix_currencies[$i + 1])) {
                     break;
                 }
-                $zen_fix_current = $zen_fix_currencies[$i];
-                $zen_fix_replace = $zen_fix_currencies[$i + 1];
-                if ($zen_fix_current !== '') {
-                    while (str_contains($email_text, $zen_fix_current)) {
-                        $email_text = str_replace($zen_fix_current, $zen_fix_replace, $email_text);
-                    }
+                $current = $zen_fix_currencies[$i];
+
+                if ($current !== '') {
+                    $zen_fix_current[]  = $current;
+                    $zen_fix_replace[] = $zen_fix_currencies[$i + 1];
                 }
             }
         }
-
-        $email_text = str_replace(
-            ['&quot;', '&lt;', '&gt;', "\x00", '&nbsp;', '&#8209;'],
-            ['"', '<', '>', ' ', ' ', '-'],
-            $email_text
-        );
+        //Add special characters
+        $zen_fix_current  = array_merge($zen_fix_current,  ['&quot;', '&lt;', '&gt;', "\x00", '&nbsp;', '&#8209;']);
+        $zen_fix_replace = array_merge($zen_fix_replace, ['"', '<', '>', ' ', ' ', '-']);
+        // Replace in string
+        $email_text = str_replace($zen_fix_current, $zen_fix_replace, $email_text);
 
         return $email_text;
     }


### PR DESCRIPTION
This fixes the issue raised by @bumba000 [https://www.zen-cart.com/showthread.php/231165-Frequent-Duplicate-Orders-Cart-Not-Emptying?p=1412070#post1412070](https://www.zen-cart.com/showthread.php/231165-Frequent-Duplicate-Orders-Cart-Not-Emptying?p=1412070#post1412070). Additionally, I have tidied the function to make it a bit more efficient.

Remove while loop calling str_replace as this could be infinite loop if the user specifies same value for search and replace.

Tidy function

- Change $zen_fix_current and $zen_fix_replace to arrays so only one call to str_replace required
- Added special character into above array to remove second call to str_replace.