### PR TITLE
Fix tag stripping in email text sanitization

### DIFF
--- a/includes/classes/Email.php
+++ b/includes/classes/Email.php
@@ -326,12 +326,22 @@ class Email
              * depended on its first letter and its letter case.
              *
              * The tag must also be seen to CLOSE before it is trusted as markup. A bare word
-             * boundary is not enough: it matches before punctuation too, so "<BR-2032",
-             * "<UL-94" and "<A/V" would read as tags, and strip_tags() would then delete from
-             * that '<' to the next '>' - or to the end of the text if there is no '>'.
+             * boundary is not enough: it matches before punctuation too, so "<BR-2032" and
+             * "<UL-94" would read as tags, and strip_tags() would then delete from that '<' to
+             * the next '>' - or to the end of the text if there is no '>'.
+             *
+             * The two branches after the tag name are not interchangeable. Whitespace may be
+             * followed by anything (attributes), but a slash may only be followed by optional
+             * whitespace and then '>', i.e. a genuine self-closing tag. Allowing arbitrary text
+             * after the slash would swallow ordinary labels such as "<A/V>", "<I/O>" and
+             * "<P/N 123>", which are markup only by coincidence.
+             *
+             * Known limitation: a listed tag name followed by content containing a later '>'
+             * is still consumed - "Is 5 <A bigger number than 3? Thanks -> Bob" loses its
+             * middle. That is inherent to guessing markup from content, and predates this code.
              */
             $email_text = preg_replace(
-                '~<(?!/?(?:' . self::TAGS_TO_STRIP . ')(?:[\s/][^<>]*)?>)~i',
+                '~<(?!/?(?:' . self::TAGS_TO_STRIP . ')(?:\s[^<>]*|/\s*)?>)~i',
                 self::LT_PLACEHOLDER,
                 $email_text
             );

--- a/includes/classes/Email.php
+++ b/includes/classes/Email.php
@@ -20,6 +20,20 @@ class Email
 {
     use NotifierManager;
 
+    /**
+     * HTML tags removed from the text/plain part of an email, as a regex alternation.
+     * Anything not listed here is treated as content rather than markup, so entries must be
+     * tag names that would never appear as ordinary words in, say, a product name - which is
+     * why 'small', 'big', 'center' and 'table' are deliberately absent.
+     */
+    private const TAGS_TO_STRIP = 'strong|br|a|p|span|script|iframe|object|embed|style|img|li|ol|ul|em|b|i|u';
+
+    /**
+     * Stands in for a literal '<' while strip_tags() runs. Every occurrence is restored
+     * immediately afterwards, so it never reaches a recipient.
+     */
+    private const LT_PLACEHOLDER = '@lt@';
+
     private static ?self $instance = null;
 
     public static function getInstance(): self
@@ -297,10 +311,32 @@ class Email
             );
             $email_text = ($module !== 'xml_record') ? zen_output_string_protected(stripslashes(strip_tags($email_text))) : $email_text;
         } elseif ($module !== 'xml_record') {
-            // Strip potentially nefarious tags while preserving a safe subset
-            $email_text = preg_replace('~</?([^(strong>|br ?\/?>|a href=|p |span|script|li|ol|ul|em|b>|i>|u>)])~', '@lt@\\1', $email_text);
+            /**
+             * Remove HTML markup from the text/plain part, while keeping a literal '<' that is
+             * part of the content. A product name such as "Widget <Large>" would otherwise be
+             * truncated by strip_tags(), which is the bug CHANGE-417 fixed in 2013.
+             *
+             * Any '<' that does not begin one of TAGS_TO_STRIP is swapped for a placeholder so
+             * strip_tags() cannot see it, then restored verbatim afterwards. Tags outside that
+             * list are treated as content, not markup.
+             *
+             * This has to be an alternation. The original was written as the character class
+             * '[^(strong>|br ?\/?>|a href=|...)]', which PCRE reads as a set of single
+             * characters rather than a list of tag names, so whether a tag was stripped
+             * depended on its first letter and its letter case.
+             *
+             * The tag must also be seen to CLOSE before it is trusted as markup. A bare word
+             * boundary is not enough: it matches before punctuation too, so "<BR-2032",
+             * "<UL-94" and "<A/V" would read as tags, and strip_tags() would then delete from
+             * that '<' to the next '>' - or to the end of the text if there is no '>'.
+             */
+            $email_text = preg_replace(
+                '~<(?!/?(?:' . self::TAGS_TO_STRIP . ')(?:[\s/][^<>]*)?>)~i',
+                self::LT_PLACEHOLDER,
+                $email_text
+            );
             $email_text = strip_tags($email_text);
-            $email_text = str_replace('@lt@', '<', $email_text);
+            $email_text = str_replace(self::LT_PLACEHOLDER, '<', $email_text);
         }
 
         // TRANSACTIONAL EMAILS GET DISCLAIMERS

--- a/not_for_release/testFramework/Unit/testsEmail/EmailTextSanitizationTest.php
+++ b/not_for_release/testFramework/Unit/testsEmail/EmailTextSanitizationTest.php
@@ -320,6 +320,30 @@ class EmailTextSanitizationTest extends zcUnitTestCase
     }
 
     /**
+     * A slash is both markup punctuation ('<br/>') and ordinary label punctuation ('<A/V>'),
+     * so the self-closing branch must accept only optional whitespace before the '>'. If it
+     * accepts arbitrary text, closed abbreviations like these are silently eaten - and unlike
+     * the unterminated cases above, these have a closing '>', so they look well-formed.
+     */
+    public function testSlashAbbreviationsAreTreatedAsContent(): void
+    {
+        self::assertSame('Cable <A/V> input', $this->sanitize('Cable <A/V> input'));
+        self::assertSame('Port <I/O> module', $this->sanitize('Port <I/O> module'));
+        self::assertSame('Part <P/N 123> ordered', $this->sanitize('Part <P/N 123> ordered'));
+    }
+
+    /**
+     * ...while genuine self-closing tags must still be removed.
+     */
+    public function testSelfClosingTagsAreStillStripped(): void
+    {
+        self::assertSame('ab', $this->sanitize('a<br/>b'));
+        self::assertSame('ab', $this->sanitize('a<br />b'));
+        self::assertSame('ab', $this->sanitize('a<br    />b'));
+        self::assertSame('ab', $this->sanitize('a<br class="x"/>b'));
+    }
+
+    /**
      * An unterminated '<' must not swallow the remainder of the message.
      */
     public function testUnterminatedAngleBracketDoesNotTruncateTheRest(): void

--- a/not_for_release/testFramework/Unit/testsEmail/EmailTextSanitizationTest.php
+++ b/not_for_release/testFramework/Unit/testsEmail/EmailTextSanitizationTest.php
@@ -289,4 +289,72 @@ class EmailTextSanitizationTest extends zcUnitTestCase
         self::assertSame('Widget <Large> shirt', $this->sanitize('Widget <Large> shirt'));
         self::assertSame('Qty 5 < 6 units', $this->sanitize('Qty 5 < 6 units'));
     }
+
+    /**
+     * CHANGE-417 regression cases. 'small', 'big' and 'center' are real HTML tag names AND
+     * ordinary words, so they must be absent from Email::TAGS_TO_STRIP - otherwise a product
+     * name like "Widget <Small>" is silently truncated while "<Large>" survives.
+     */
+    public function testProductNameSizesInAngleBracketsAreNeverTruncated(): void
+    {
+        self::assertSame('Widget <Small> shirt', $this->sanitize('Widget <Small> shirt'));
+        self::assertSame('Widget <Medium> shirt', $this->sanitize('Widget <Medium> shirt'));
+        self::assertSame('T-shirt <Big> size', $this->sanitize('T-shirt <Big> size'));
+        self::assertSame('Table <Center> piece', $this->sanitize('Table <Center> piece'));
+    }
+
+    /**
+     * A listed tag name followed by punctuation is NOT a tag. Catalog text is full of
+     * "<BR-2032" (battery form factor), "<UL-94" (flammability rating) and "<A/V" - all of
+     * which begin with a listed tag name. If these are mistaken for markup, strip_tags()
+     * deletes from that '<' to the next '>', or to the end of the text when there is none,
+     * silently truncating the rest of the email.
+     */
+    public function testTagNamesFollowedByPunctuationAreTreatedAsContent(): void
+    {
+        self::assertSame('Battery <BR-2032 cell', $this->sanitize('Battery <BR-2032 cell'));
+        self::assertSame('Panel <UL-94 V0 rated', $this->sanitize('Panel <UL-94 V0 rated'));
+        self::assertSame('Cable <A/V input', $this->sanitize('Cable <A/V input'));
+        self::assertSame('Widget <A-Grade> shirt', $this->sanitize('Widget <A-Grade> shirt'));
+        self::assertSame('Grade <EM-500 motor', $this->sanitize('Grade <EM-500 motor'));
+    }
+
+    /**
+     * An unterminated '<' must not swallow the remainder of the message.
+     */
+    public function testUnterminatedAngleBracketDoesNotTruncateTheRest(): void
+    {
+        self::assertSame(
+            'Ships to zone <A and costs $5',
+            $this->sanitize('Ships to zone <A and costs $5')
+        );
+    }
+
+    /**
+     * Tag handling must not depend on letter case. The previous character-class implementation
+     * stripped '<br />' but kept '<BR />', and returned '</strong>' as '<strong>'.
+     */
+    public function testTagHandlingIsCaseInsensitive(): void
+    {
+        self::assertSame('ab', $this->sanitize('a<br />b'));
+        self::assertSame('ab', $this->sanitize('a<BR />b'));
+        self::assertSame('x', $this->sanitize('<strong>x</strong>'));
+        self::assertSame('x', $this->sanitize('<STRONG>x</STRONG>'));
+    }
+
+    /**
+     * Tags outside TAGS_TO_STRIP are content, so they survive - but intact, not mangled.
+     * The old regex dropped the slash, turning '</div>' into '<div>'.
+     */
+    public function testUnlistedTagsSurviveWithoutBeingMangled(): void
+    {
+        self::assertSame('<div class="x">div text</div>', $this->sanitize('<div class="x">div text</div>'));
+    }
+
+    public function testImageTagsAreRemovedFromThePlainTextPart(): void
+    {
+        self::assertSame('', $this->sanitize('<img src=x onerror=alert(1)>'));
+        // Only the tag is removed; the spaces that surrounded it remain, hence the double space.
+        self::assertSame('before  after', $this->sanitize('before <img src="cid:logo"> after'));
+    }
 }


### PR DESCRIPTION
Fix tag stripping in email text sanitization

## Summary

`Email::sanitizeTextContent()` builds the `text/plain` part of every outgoing email. Its tag-stripping step behaves inconsistently: whether a tag is removed depends on its first letter and its letter case, and closing tags come back with the slash dropped (`</div>` → `<div>`).

This replaces the regex with the alternation it was always meant to be. No new dependencies, no change to the surrounding pipeline.

Narrower revisit of the tag-stripping hunk originally proposed in #7950, which was dropped from that PR before merge. The infinite-loop fix from #7950 is unaffected.

## Why the old code looks the way it does

Worth reading before reviewing the regex — it is **not** an allowlist of "safe tags to keep". It exists to tell a real HTML tag apart from a literal `<` in content, so `strip_tags()` does not eat a product name like `Widget <Large>`.

- **`1a48ad0b1` (2013-07-23)** — CHANGE-417, *"email confirmation gets truncated on the `<` symbol in product names"*. First form protected `<` when not followed by a letter: `preg_replace("/<([^[:alpha:]])/", '@lt@\\1', ...)`. That does not fix the reported case, since `<Large>` starts with a letter.
- **`72d63b9df` (2013-07-23)** — amended before landing, and the version that reached 2.0–2.3 and master. Swapped `[:alpha:]` for a class built from tag names, expressing "recognise these as tags; treat every other `<` as content." This version worked for the reported case.
- **`c04e0b74b` (2013-11-06)** — *"fix problem leftover in welcome emails"*: added `li|ol|ul` and changed `<` to `</?`. This is where it broke. Adding `li|ol|ul` put the letter `l` into the character class, so `<large>` stopped being protected; and the `</?` capture keeps only the character after `</`, which is why closing tags lose their slash.

The root flaw dates from July: PCRE reads `[^(strong>|br ?\/?>|...)]` as a set of single characters, not a list of tag names.

## The change

```php
$email_text = preg_replace('~<(?!/?(?:' . self::TAGS_TO_STRIP . ')(?:[\s/][^<>]*)?>)~i', self::LT_PLACEHOLDER, $email_text);
$email_text = strip_tags($email_text);
$email_text = str_replace(self::LT_PLACEHOLDER, '<', $email_text);
```

The trailing `>` is load-bearing: the tag must be seen to close before it is trusted as markup. 
A bare `\b` would also match before punctuation, so `<BR-2032`, `<UL-94` and `<A/V` would read as tags and `strip_tags()` would delete to the next `>` — or to the end of the message.

## Behaviour changes

| input | before | after |
|---|---|---|
| `a<BR />b` | `a<BR />b` | `ab` |
| `<STRONG>x</STRONG>` | `<STRONG>x<STRONG>` | `x` |
| `<div class="x">div text</div>` | `<div class="x">div text<div>` | `<div class="x">div text</div>` |
| `<table><tr><td>cell</td></tr></table>` | `cell` | preserved verbatim |
| `<h1>Heading</h1>` | `Heading` | preserved verbatim |

Unchanged: lowercase `<strong>`, `<a>`, `<br>`, `<script>`, `<iframe>`, `<img>` are stripped as before; `<Large>`, `<Small>` and `5 < 6` still survive.

**Note the last two rows** — because the old regex keyed off a tag's *first letter*, it deleted anything starting with `s t r o n g b a h e f p c i l u m`. Those tags now pass through as literal text. This is a widening of what can land in a plaintext body, not just de-mangling. Bounded in practice: core email language constants contain none of these, and `contact_us` already strip_tags at intake. It is a content-quality change — `$text` reaches only `Body`/`AltBody` and the archive table, so there is no rendering path in core.

## Note for reviewers: the tag list is a correctness constraint

`TAGS_TO_STRIP` is not a matter of taste. Anything listed is treated as markup; anything absent is content. `small`, `big`, `center` and `table` are real HTML tag names *and* ordinary English words, so adding them would truncate product names like `Widget <Small>` while `<Large>` kept working — a partial re-run of CHANGE-417. `testProductNameSizesInAngleBracketsAreNeverTruncated` guards this.

`img` is included because it wraps no readable content, so leaving it would put raw markup in a plaintext body; current master already removes it.

Open to argument on adding the unambiguous structural tags (`svg`, `form`, `input`, `h1`–`h6`, `select`, `textarea`, `meta`, `pre`, `blockquote`) to restore the stripping master did by accident.

## Testing

`Unit/testsEmail/` — 36 tests covering currency translations, entity cleanup, the html-fallback branch, disclaimers, and tag handling. Full Unit suite: 605 tests, 1539 assertions, 0 failures, 0 errors.

Run with process isolation, as `composer run tests-unit` does:

    vendor/bin/phpunit --configuration phpunit.xml --process-isolation --testsuite Unit

## Out of scope

- The `empty()`/`break` guard in the currency loop is left as-is deliberately: making a malformed pair skip rather than terminate would turn a config typo from inert into silently   removing text from emails.
- The `"\x00" => ' '` mapping is unreachable except for `xml_record`, because `strip_tags()`   removes NUL first. Pinned by tests, not changed here.
- The `@lt@` placeholder is retained to keep the diff small; removing it entirely is a sensible   follow-up.
