### PR TITLE
Correct admin/catalog directory detection in `FileSystem`

### DIFF
--- a/includes/autoload_func.php
+++ b/includes/autoload_func.php
@@ -44,12 +44,36 @@ foreach ($initSystemList as $entry) {
             if ($debugAutoload) echo 'case "class": ' . $entry['class'] . "<br>\n";
             $objectName = $entry['object'];
             $className = $entry['class'];
+            /**
+             * A classInstantiate entry is queued whether or not the matching class
+             * entry found its file, and the two carry no reference to each other,
+             * so the only place the mismatch can be caught is here.
+             * Instantiating a class that was never loaded is a fatal, which we
+             * want to avoid during bootstrapping.
+             */
+            if (!class_exists($className) && ($entry['loaderType'] ?? 'core') === 'plugin') {
+                trigger_error('Autoloader: class "' . $className . '" was not loaded; skipping instantiation as "' . $objectName . '".', E_USER_WARNING);
+                break;
+            }
+            // A missing core class still fails fast on the line below.
             $$objectName = new $className();
             break;
         case 'sessionClass':
             if ($debugAutoload) echo 'case "sessionClass": ' . $entry['class'] . "<br>\n";
             $objectName = $entry['object'];
             $className = $entry['class'];
+            /**
+             * Discard any incomplete decoded session and let the normal path below build a usable one.
+             */
+            if (isset($_SESSION[$objectName]) && $_SESSION[$objectName] instanceof __PHP_Incomplete_Class) {
+                unset($_SESSION[$objectName]);
+            }
+            if (!class_exists($className) && ($entry['loaderType'] ?? 'core') === 'plugin') {
+                trigger_error('Autoloader: class "' . $className . '" was not loaded; skipping session instantiation as "' . $objectName . '".', E_USER_WARNING);
+                // Discard whatever was unserialized, whether succesful or not.
+                unset($_SESSION[$objectName]);
+                break;
+            }
             if (!$entry['checkInstantiated'] || !isset($_SESSION[$objectName])) {
                 $_SESSION[$objectName] = new $className();
             }
@@ -60,6 +84,12 @@ foreach ($initSystemList as $entry) {
             $methodName = $entry['method'];
               if (isset($_SESSION[$objectName]) && is_object($_SESSION[$objectName])) {
                   $_SESSION[$objectName]->$methodName();
+              /**
+               * A plugin object skipped above leaves nothing to call, so skip.
+               * A core object still fails fast on the final branch.
+               */
+              } elseif ((!isset(${$objectName}) || !is_object(${$objectName})) && ($entry['loaderType'] ?? 'core') === 'plugin') {
+                  trigger_error('Autoloader: object "' . $objectName . '" is not available; skipping method "' . $methodName . '".', E_USER_WARNING);
               } else {
                   ${$objectName}->$methodName();
               }

--- a/includes/classes/FileSystem.php
+++ b/includes/classes/FileSystem.php
@@ -109,52 +109,6 @@ class FileSystem
     /**
      * @since ZC v1.5.7
      */
-    public function isAdminDir(string $filePath): bool
-    {
-        if (!defined('DIR_FS_ADMIN')) {
-            return false;
-        }
-        $test = str_replace(DIR_FS_ADMIN, '', $filePath);
-
-        return $test === $filePath;
-    }
-
-    /**
-     * @since ZC v1.5.7
-     */
-    public function isCatalogDir(string $filePath): bool
-    {
-        if ($this->isAdminDir($filePath)) {
-            return false;
-        }
-        if (!defined('DIR_FS_CATALOG')) {
-            return false;
-        }
-        $test = str_replace(DIR_FS_CATALOG, '', $filePath);
-        if ($test !== $filePath) {
-            return false;
-        }
-        return true;
-
-    }
-
-    /**
-     * @since ZC v1.5.7
-     */
-    public function getRelativeDir(string $filePath): string
-    {
-        if ($this->isAdminDir($filePath)) {
-            return str_replace(DIR_FS_ADMIN, '', $filePath);
-        }
-        if ($this->isCatalogDir($filePath)) {
-            return str_replace(DIR_FS_CATALOG, '', $filePath);
-        }
-        return $filePath;
-    }
-
-    /**
-     * @since ZC v1.5.7
-     */
     public function getDirectorySize(string $path, $decimals = 2, bool $addSuffix = true): string
     {
         $bytes = 0;

--- a/includes/classes/InitSystem.php
+++ b/includes/classes/InitSystem.php
@@ -99,11 +99,19 @@ class InitSystem
             $filePath = $entry['classPath'];
         }
         if ($entry['loaderType'] === 'plugin') {
-            $filePath = $this->findPluginDirectory($entry['classPath'] ?? DIR_WS_CLASSES, $entry['pluginInfo']['unique_key']);
+            $classPath = $entry['classPath'] ?? DIR_WS_CLASSES;
+            $pluginPath = $this->findPluginDirectory($classPath, $entry['pluginInfo']['unique_key']);
+            // We check the joined fragment, to avoid misfires from concatenation.
+            if ($pluginPath === null || !$this->isPluginRelativePath($classPath . $entry['loadFile'])) {
+                $this->debugList[] = 'loading class - ' . $entry['loadFile'] . ' - REFUSED';
+                return;
+            }
+            $filePath = $pluginPath;
         }
         $this->debugList[] = 'processing class - ' . $filePath . $entry['loadFile'];
         $result = 'FAILED';
-        if (file_exists($filePath . $entry['loadFile'])) {
+        // is_file() rather than file_exists(), which also accepts a directory
+        if (is_file($filePath . $entry['loadFile'])) {
             $result = 'SUCCESS';
             $this->actionList[] = ['type' => 'include', 'filePath' => $filePath . $entry['loadFile'], 'forceLoad' => $entry['forceLoad']];
         }
@@ -122,13 +130,18 @@ class InitSystem
         $this->debugList[] = 'processing class instantiate - class = ' . $className . ' object name = ' . $objectName;
         $classSession = (isset($entry['classSession']) && $entry['classSession'] === true);
         $checkInstantiated = (isset($entry['checkInstantiated']) && $entry['checkInstantiated'] === true);
+        /**
+         * loaderType travels with the action so that the autoloader loop can tell a
+         * broken plugin from a broken core install. Only the former is recoverable:
+         * continuing without a core class leaves the request half-initialised.
+         */
         if (!$classSession) {
             $this->debugList[] = 'instantiating normal class - ' . $className . ' as ' . $objectName;
-            $this->actionList[] = ['type' => 'class', 'object' => $objectName, 'class' => $className];
+            $this->actionList[] = ['type' => 'class', 'object' => $objectName, 'class' => $className, 'loaderType' => $entry['loaderType']];
             return;
         }
         $this->debugList[] = 'instantiating session bound class - ' . $className . ' as ' . $objectName;
-        $this->actionList[] = ['type' => 'sessionClass', 'object' => $objectName, 'class' => $className, 'checkInstantiated' => $checkInstantiated];
+        $this->actionList[] = ['type' => 'sessionClass', 'object' => $objectName, 'class' => $className, 'checkInstantiated' => $checkInstantiated, 'loaderType' => $entry['loaderType']];
         return;
     }
 
@@ -140,7 +153,7 @@ class InitSystem
         $objectName = $entry['objectName'];
         $methodName = $entry['methodName'];
         $this->debugList[] = 'processing object method - ' . $objectName . ' => ' . $methodName;
-        $this->actionList[] = ['type' => 'objectMethod', 'object' => $objectName, 'method' => $methodName];
+        $this->actionList[] = ['type' => 'objectMethod', 'object' => $objectName, 'method' => $methodName, 'loaderType' => $entry['loaderType']];
     }
 
     /**
@@ -184,16 +197,39 @@ class InitSystem
      */
     protected function processAutoTypeInit_script(array $entry): void
     {
-        $actualDir = DIR_WS_INCLUDES . 'init_includes/';
-        if ($entry['loaderType'] === 'plugin') {
-            $actualDir = $this->findPluginDirectory($actualDir, $entry['pluginInfo']['unique_key']);
+        $isPluginEntry = ($entry['loaderType'] === 'plugin');
+        $relativeDir = DIR_WS_INCLUDES . 'init_includes/';
+        $actualDir = $relativeDir;
+        if ($isPluginEntry) {
+            $pluginDir = $this->findPluginDirectory($relativeDir, $entry['pluginInfo']['unique_key']);
+            /**
+             * The joined fragment is checked, not the directory and loadFile
+             * separately, to avoid traversal on concatenation.
+             */
+            if ($pluginDir === null || !$this->isPluginRelativePath($relativeDir . $entry['loadFile'])) {
+                $this->debugList[] = 'loading init_script - ' . $entry['loadFile'] . ' - REFUSED';
+                return;
+            }
+            $actualDir = $pluginDir;
         }
-        if (file_exists($actualDir . 'overrides/' . $entry['loadFile'])) {
+        if (is_file($actualDir . 'overrides/' . $entry['loadFile'])) {
             $actualDir .= 'overrides/';
         }
-        $this->actionList[] = ['type' => 'require', 'filePath' => $actualDir . $entry['loadFile'], 'forceLoad' => $entry['forceLoad']];
-        $this->debugList[] = 'loading init_script - ' . $actualDir . $entry['loadFile'];
 
+        /**
+         * Missing core files fail fast here.
+         * But for plugins missing classes are only warned about here, to avoid crashing during bootstrapping.
+         *
+         * Uses is_file() because file_exists() accepts a directory which would fail on require.
+         */
+        $filePath = $actualDir . $entry['loadFile'];
+        if ($isPluginEntry && !is_file($filePath)) {
+            trigger_error('Autoloader: init_script "' . $filePath . '" was not found; skipping.', E_USER_WARNING);
+            $this->debugList[] = 'loading init_script - ' . $filePath . ' - FAILED';
+            return;
+        }
+        $this->actionList[] = ['type' => 'require', 'filePath' => $filePath, 'forceLoad' => $entry['forceLoad']];
+        $this->debugList[] = 'loading init_script - ' . $filePath . ' - SUCCESS';
     }
 
     /**
@@ -331,11 +367,59 @@ class InitSystem
     /**
      * @since ZC v1.5.7
      */
-    protected function findPluginDirectory(string $filePath, string $pluginName): string
+    /**
+     * The plugin directory $filePath names, or null if it does not name one.
+     *
+     * Null rather than a fallback directory: substituting the plugin's context root
+     * would leave the caller free to find some other file of the same name sitting
+     * there and load that instead, which is the silent-wrong-file behaviour this is
+     * meant to prevent. A refused entry loads nothing.
+     *
+     * @since ZC v1.5.7
+     */
+    protected function findPluginDirectory(string $filePath, string $pluginName): ?string
     {
-        $relDir = $this->fileSystem->getRelativeDir($filePath);
         $pluginDir = $this->pluginManager->getPluginVersionDirectory($pluginName, $this->installedPlugins);
-        $actualDir = $pluginDir . $this->context . '/' . $relDir;
-        return $actualDir;
+        if ($pluginDir === null) {
+            $this->debugList[] = 'rejected plugin path - no installed directory for plugin - ' . $pluginName;
+            return null;
+        }
+        if (!$this->isPluginRelativePath($filePath)) {
+            $this->debugList[] = 'rejected plugin path - not relative to the plugin - ' . $filePath;
+            return null;
+        }
+        return $pluginDir . $this->context . '/' . $filePath;
+    }
+
+    /**
+     * Whether $path may be appended to a plugin's own directory.
+     *
+     * An auto_loader addresses files inside its own plugin, in whichever context is
+     * loading it, so its classPath is a plain relative fragment.
+     * An absolute path cannot be honoured. The plugin's tree is the only thing it may name.
+     *
+     * Both path-separator conventions are rejected regardless of platform.
+     * A validator can afford to be conservative where a path comparison cannot:
+     * there is no legitimate auto_loader path that this turns away,
+     * and being wrong about which convention applies would be the only way to let one through.
+     *
+     * To reach files outside its own tree a plugin should use the PSR-4 namespaces
+     * registered for it at bootstrap: Zencart\Plugins\Admin\<Key> and
+     * Zencart\Plugins\Catalog\<Key> are both available from either context.
+     *
+     * @since ZC v3.0.0
+     */
+    protected function isPluginRelativePath(string $path): bool
+    {
+        if ($path === '') {
+            return true;
+        }
+        if (str_starts_with($path, '/') || str_starts_with($path, '\\')) {
+            return false;
+        }
+        if (preg_match('#^[A-Za-z]:[/\\\\]#', $path) === 1) {
+            return false; // Windows drive-rooted, e.g. C:\store or C:/store
+        }
+        return preg_match('#(^|[/\\\\])\.\.([/\\\\]|$)#', $path) !== 1;
     }
 }

--- a/not_for_release/testFramework/Unit/testsSundry/AutoloadFuncGuardsTest.php
+++ b/not_for_release/testFramework/Unit/testsSundry/AutoloadFuncGuardsTest.php
@@ -1,0 +1,250 @@
+<?php
+/**
+ * @copyright Copyright 2003-2026 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\testsSundry;
+
+use PHPUnit\Framework\TestCase;
+use Tests\Support\UnitTestBootstrap;
+
+/**
+ * Covers the autoloader loop's handling of an action list that refers to a class
+ * which was never loaded.
+ *
+ * A classInstantiate entry is queued whether or not the matching class entry found
+ * its file, and the two carry no reference to each other, so this loop is the only
+ * place the mismatch can be caught. Before v3.0.0 it ran `new $className()` blindly,
+ * turning a missing plugin file into a fatal during bootstrap, which took out the
+ * storefront and the admin page needed to disable the plugin responsible.
+ */
+class AutoloadFuncGuardsTest extends TestCase
+{
+    /**
+     * @var string[]
+     */
+    private array $warnings = [];
+
+    public static function setUpBeforeClass(): void
+    {
+        UnitTestBootstrap::initialize();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->warnings = [];
+    }
+
+    /**
+     * Runs the real autoloader loop over a hand-built action list, capturing any
+     * warnings it raises. Returns the variables the loop left behind.
+     *
+     * @param array<int, array<string, mixed>> $initSystemList
+     * @return array<string, mixed>
+     */
+    private function runAutoloadLoop(array $initSystemList): array
+    {
+        set_error_handler(function (int $errno, string $errstr): bool {
+            $this->warnings[] = $errstr;
+            return true;
+        });
+
+        try {
+            require DIR_FS_CATALOG . 'includes/autoload_func.php';
+        } finally {
+            restore_error_handler();
+        }
+
+        $created = get_defined_vars();
+        unset($created['initSystemList'], $created['debugAutoload'], $created['entry']);
+        return $created;
+    }
+
+    public function testMissingClassIsSkippedInsteadOfFatal(): void
+    {
+        $created = $this->runAutoloadLoop([
+            ['type' => 'class', 'object' => 'missingObj', 'class' => 'ZcClassThatWasNeverLoaded', 'loaderType' => 'plugin'],
+        ]);
+
+        $this->assertArrayNotHasKey('missingObj', $created);
+        $this->assertCount(1, $this->warnings);
+        $this->assertStringContainsString('ZcClassThatWasNeverLoaded', $this->warnings[0]);
+        $this->assertStringContainsString('was not loaded', $this->warnings[0]);
+    }
+
+    public function testMissingSessionClassIsSkippedInsteadOfFatal(): void
+    {
+        $sessionBefore = $GLOBALS['_SESSION'] ?? [];
+        $GLOBALS['_SESSION'] = [];
+
+        try {
+            $this->runAutoloadLoop([
+                [
+                    'type' => 'sessionClass',
+                    'object' => 'missingSessionObj',
+                    'class' => 'ZcSessionClassThatWasNeverLoaded',
+                    'checkInstantiated' => false,
+                    'loaderType' => 'plugin',
+                ],
+            ]);
+            $sessionAfter = $GLOBALS['_SESSION'];
+        } finally {
+            $GLOBALS['_SESSION'] = $sessionBefore;
+        }
+
+        $this->assertArrayNotHasKey('missingSessionObj', $sessionAfter);
+        $this->assertCount(1, $this->warnings);
+        $this->assertStringContainsString('was not loaded', $this->warnings[0]);
+    }
+
+    /**
+     * A session serialized while the class still existed leaves an
+     * __PHP_Incomplete_Class in the slot, which is_object() accepts. Leaving it there
+     * would carry the failure forward to any objectMethod entry using that object, so
+     * the unusable value has to be discarded.
+     */
+    public function testIncompleteSessionObjectIsDiscardedRatherThanCarriedForward(): void
+    {
+        $sessionBefore = $GLOBALS['_SESSION'] ?? [];
+        $GLOBALS['_SESSION'] = [
+            'staleObj' => unserialize('O:22:"ZcSessionClassLongGone":1:{s:1:"a";i:1;}'),
+        ];
+        self::assertTrue(is_object($GLOBALS['_SESSION']['staleObj']), 'fixture should be an incomplete object');
+
+        try {
+            $this->runAutoloadLoop([
+                [
+                    'type' => 'sessionClass',
+                    'object' => 'staleObj',
+                    'class' => 'ZcSessionClassLongGone',
+                    'checkInstantiated' => false,
+                    'loaderType' => 'plugin',
+                ],
+                ['type' => 'objectMethod', 'object' => 'staleObj', 'method' => 'someMethod', 'loaderType' => 'plugin'],
+            ]);
+            $sessionAfter = $GLOBALS['_SESSION'];
+        } finally {
+            $GLOBALS['_SESSION'] = $sessionBefore;
+        }
+
+        $this->assertArrayNotHasKey('staleObj', $sessionAfter);
+        $this->assertCount(2, $this->warnings);
+        $this->assertStringContainsString('is not available', $this->warnings[1]);
+    }
+
+    /**
+     * The class being available again does not make the stale value usable. The
+     * session is decoded before this loop runs, so the slot can hold an
+     * __PHP_Incomplete_Class even on a request where the class loads fine, and
+     * checkInstantiated would keep it because the slot is set.
+     */
+    public function testIncompleteSessionObjectIsReplacedWhenTheClassIsAvailable(): void
+    {
+        $sessionBefore = $GLOBALS['_SESSION'] ?? [];
+        $GLOBALS['_SESSION'] = [
+            'probeObj' => unserialize('O:24:"AutoloadFuncGuardsProbeX":1:{s:1:"a";i:1;}'),
+        ];
+        self::assertInstanceOf(\__PHP_Incomplete_Class::class, $GLOBALS['_SESSION']['probeObj']);
+
+        try {
+            $this->runAutoloadLoop([
+                [
+                    'type' => 'sessionClass',
+                    'object' => 'probeObj',
+                    'class' => AutoloadFuncGuardsProbe::class,
+                    'checkInstantiated' => true,
+                ],
+                ['type' => 'objectMethod', 'object' => 'probeObj', 'method' => 'markCalled'],
+            ]);
+            $sessionAfter = $GLOBALS['_SESSION'];
+        } finally {
+            $GLOBALS['_SESSION'] = $sessionBefore;
+        }
+
+        $this->assertSame([], $this->warnings);
+        $this->assertInstanceOf(AutoloadFuncGuardsProbe::class, $sessionAfter['probeObj']);
+        $this->assertTrue($sessionAfter['probeObj']->called);
+    }
+
+    /**
+     * Skipping an instantiation must not simply move the fatal to the objectMethod
+     * entry that expects the object to exist.
+     */
+    public function testObjectMethodOnAMissingObjectIsSkippedInsteadOfFatal(): void
+    {
+        $this->runAutoloadLoop([
+            ['type' => 'class', 'object' => 'missingObj', 'class' => 'ZcClassThatWasNeverLoaded', 'loaderType' => 'plugin'],
+            ['type' => 'objectMethod', 'object' => 'missingObj', 'method' => 'someMethod', 'loaderType' => 'plugin'],
+        ]);
+
+        $this->assertCount(2, $this->warnings);
+        $this->assertStringContainsString('is not available', $this->warnings[1]);
+        $this->assertStringContainsString('someMethod', $this->warnings[1]);
+    }
+
+    /**
+     * Recovery is for plugins only. A core class is part of the store itself, and
+     * continuing without notifier, shoppingCart or the like would serve a
+     * half-initialised request, so those keep failing fast exactly as before.
+     */
+    public function testMissingCoreClassStillFailsFast(): void
+    {
+        $this->expectException(\Error::class);
+
+        $this->runAutoloadLoop([
+            ['type' => 'class', 'object' => 'coreObj', 'class' => 'ZcCoreClassThatWasNeverLoaded', 'loaderType' => 'core'],
+        ]);
+    }
+
+    /**
+     * An entry with no loaderType at all is treated as core, so an action list built
+     * before this field existed keeps its fail-fast behaviour.
+     */
+    public function testEntryWithoutLoaderTypeIsTreatedAsCore(): void
+    {
+        $this->expectException(\Error::class);
+
+        $this->runAutoloadLoop([
+            ['type' => 'class', 'object' => 'legacyObj', 'class' => 'ZcCoreClassThatWasNeverLoaded'],
+        ]);
+    }
+
+    public function testMissingCoreObjectMethodStillFailsFast(): void
+    {
+        $this->expectException(\Error::class);
+
+        $this->runAutoloadLoop([
+            ['type' => 'objectMethod', 'object' => 'absentCoreObj', 'method' => 'someMethod', 'loaderType' => 'core'],
+        ]);
+    }
+
+    /**
+     * The guard must not disturb the normal path.
+     */
+    public function testExistingClassIsStillInstantiatedAndItsMethodCalled(): void
+    {
+        $created = $this->runAutoloadLoop([
+            ['type' => 'class', 'object' => 'realObj', 'class' => AutoloadFuncGuardsProbe::class],
+            ['type' => 'objectMethod', 'object' => 'realObj', 'method' => 'markCalled'],
+        ]);
+
+        $this->assertSame([], $this->warnings);
+        $this->assertArrayHasKey('realObj', $created);
+        $this->assertInstanceOf(AutoloadFuncGuardsProbe::class, $created['realObj']);
+        $this->assertTrue($created['realObj']->called);
+    }
+}
+
+class AutoloadFuncGuardsProbe
+{
+    public bool $called = false;
+
+    public function markCalled(): void
+    {
+        $this->called = true;
+    }
+}

--- a/not_for_release/testFramework/Unit/testsSundry/InitSystemPluginDirectoryTest.php
+++ b/not_for_release/testFramework/Unit/testsSundry/InitSystemPluginDirectoryTest.php
@@ -1,0 +1,440 @@
+<?php
+/**
+ * @copyright Copyright 2003-2026 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\testsSundry;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\UnitTestBootstrap;
+use Zencart\DbRepositories\PluginControlRepository;
+use Zencart\DbRepositories\PluginControlVersionRepository;
+use Zencart\FileSystem\FileSystem;
+use Zencart\InitSystem\InitSystem;
+use Zencart\PluginManager\PluginManager;
+
+/**
+ * Covers the directory an auto_loader entry resolves to for a zc_plugin.
+ *
+ * A plugin's classPath addresses files inside its own tree, in whichever context is
+ * loading it, so it is a relative fragment. Anything absolute or containing '..' is
+ * refused rather than concatenated, because the result would name a location outside
+ * the plugin that a caller would then include from.
+ */
+class InitSystemPluginDirectoryTest extends TestCase
+{
+    private const TEST_PLUGIN = 'UnitTestDirectoryPlugin';
+    private const TEST_VERSION = 'v1.0.0';
+
+    public static function setUpBeforeClass(): void
+    {
+        UnitTestBootstrap::initialize();
+    }
+
+    protected function tearDown(): void
+    {
+        $root = DIR_FS_CATALOG . 'zc_plugins/' . self::TEST_PLUGIN;
+        if (is_dir($root)) {
+            (new FileSystem())->deleteDirectory($root);
+        }
+        parent::tearDown();
+    }
+
+    private function pluginRoot(): string
+    {
+        return DIR_FS_CATALOG . 'zc_plugins/' . self::TEST_PLUGIN . '/' . self::TEST_VERSION . '/';
+    }
+
+    private function initSystem(string $context): InitSystem
+    {
+        $pluginManager = new PluginManager(
+            $this->createStub(PluginControlRepository::class),
+            $this->createStub(PluginControlVersionRepository::class)
+        );
+
+        $installedPlugins = [
+            self::TEST_PLUGIN => [
+                'unique_key' => self::TEST_PLUGIN,
+                'version' => self::TEST_VERSION,
+            ],
+        ];
+
+        return new class ($context, 'config', new FileSystem(), $pluginManager, $installedPlugins) extends InitSystem {
+            public function pluginDirectoryFor(string $filePath, string $pluginName): ?string
+            {
+                return $this->findPluginDirectory($filePath, $pluginName);
+            }
+        };
+    }
+
+    // ------------------------------------------------------ relative resolution
+
+    public function testRelativeClassPathResolvesInsideTheAdminTree(): void
+    {
+        $this->assertSame(
+            $this->pluginRoot() . 'admin/' . DIR_WS_CLASSES,
+            $this->initSystem('admin')->pluginDirectoryFor(DIR_WS_CLASSES, self::TEST_PLUGIN)
+        );
+    }
+
+    public function testRelativeClassPathResolvesInsideTheCatalogTree(): void
+    {
+        $this->assertSame(
+            $this->pluginRoot() . 'catalog/' . DIR_WS_CLASSES,
+            $this->initSystem('catalog')->pluginDirectoryFor(DIR_WS_CLASSES, self::TEST_PLUGIN)
+        );
+    }
+
+    public function testInitScriptDirectoryResolvesInsideThePlugin(): void
+    {
+        $this->assertSame(
+            $this->pluginRoot() . 'admin/' . DIR_WS_INCLUDES . 'init_includes/',
+            $this->initSystem('admin')->pluginDirectoryFor(DIR_WS_INCLUDES . 'init_includes/', self::TEST_PLUGIN)
+        );
+    }
+
+    public function testEmptyPathResolvesToThePluginContextRoot(): void
+    {
+        $this->assertSame(
+            $this->pluginRoot() . 'admin/',
+            $this->initSystem('admin')->pluginDirectoryFor('', self::TEST_PLUGIN)
+        );
+    }
+
+    // ------------------------------------------------------------- refused paths
+
+    /**
+     * A refused path yields no directory at all. Returning the plugin's context root
+     * instead would let the caller load whatever file of the same name happened to sit
+     * there, which is the silent-wrong-file outcome this is meant to prevent.
+     *
+     * @param string $marker '@catalog@' / '@admin@' are substituted here rather than
+     *                       in the provider, which runs before setUpBeforeClass().
+     */
+    #[DataProvider('refusedPathProvider')]
+    public function testPathsOutsideThePluginAreRefused(string $marker): void
+    {
+        $path = str_replace(
+            ['@catalog@', '@admin@'],
+            [DIR_FS_CATALOG, DIR_FS_ADMIN],
+            $marker
+        );
+
+        $this->assertNull(
+            $this->initSystem('admin')->pluginDirectoryFor($path, self::TEST_PLUGIN),
+            $path . ' should have been refused'
+        );
+    }
+
+    /**
+     * The specific outcome the null return exists to prevent: a refused classPath must
+     * not fall through to a same-named file sitting in the plugin's context root.
+     */
+    public function testRefusedClassPathDoesNotLoadASameNamedFileFromThePluginRoot(): void
+    {
+        $decoy = $this->pluginRoot() . 'admin/observers';
+        mkdir($decoy, 0777, true);
+        file_put_contents($decoy . '/UnitTestDirectoryObserver.php', "<?php\n// decoy\n");
+
+        $this->assertNull(
+            $this->resolveClassEntry('admin', ['classPath' => '/etc/'])
+        );
+    }
+
+    public function testUnknownPluginKeyIsRefused(): void
+    {
+        $this->assertNull(
+            $this->initSystem('admin')->pluginDirectoryFor(DIR_WS_CLASSES, 'NoSuchPlugin')
+        );
+    }
+
+    public static function refusedPathProvider(): array
+    {
+        return [
+            'absolute catalog classPath' => ['@catalog@' . 'includes/classes/'],
+            'absolute admin classPath' => ['@admin@' . 'includes/classes/'],
+            'absolute path outside the store' => ['/etc/'],
+            'relative traversal' => ['../../../etc/'],
+            'traversal below a real directory' => ['includes/../../../../etc/'],
+            'traversal at the end' => ['includes/classes/..'],
+            'backslash traversal' => ['..\\..\\etc\\'],
+            'backslash-rooted path' => ['\\etc\\'],
+            'windows drive-rooted, backslash' => ['C:\\xampp\\htdocs\\'],
+            'windows drive-rooted, forward slash' => ['C:/xampp/htdocs/'],
+        ];
+    }
+
+    /**
+     * A directory whose name merely begins with dots is not traversal and must
+     * still resolve.
+     */
+    public function testDotPrefixedDirectoryNameIsNotMistakenForTraversal(): void
+    {
+        $this->assertSame(
+            $this->pluginRoot() . 'admin/includes/..hidden/',
+            $this->initSystem('admin')->pluginDirectoryFor('includes/..hidden/', self::TEST_PLUGIN)
+        );
+    }
+
+    // ------------------------------------------- end-to-end through the loader
+
+    /**
+     * The cases above call findPluginDirectory() directly. These drive the real
+     * loader, so they also cover what processAutoTypeClass() hands it -- notably the
+     * value used when classPath is omitted entirely.
+     *
+     * @param array<string, mixed> $entryExtras
+     */
+    private function resolveClassEntry(string $context, array $entryExtras = []): ?string
+    {
+        $loaderList = [
+            200 => [
+                array_merge([
+                    'autoType' => 'class',
+                    'loaderType' => 'plugin',
+                    'loadFile' => 'observers/UnitTestDirectoryObserver.php',
+                    'forceLoad' => false,
+                    'pluginInfo' => ['unique_key' => self::TEST_PLUGIN],
+                ], $entryExtras),
+            ],
+        ];
+
+        foreach ($this->initSystem($context)->processLoaderList($loaderList) as $action) {
+            if (($action['type'] ?? null) === 'include') {
+                return $action['filePath'];
+            }
+        }
+        return null;
+    }
+
+    private function createPluginClassFile(string $side): void
+    {
+        $dir = $this->pluginRoot() . $side . '/' . DIR_WS_CLASSES . 'observers';
+        if (!is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+        file_put_contents($dir . '/UnitTestDirectoryObserver.php', "<?php\n// unit test fixture\n");
+    }
+
+    /**
+     * Omitting classPath means "my own tree, current context". Sending the absolute
+     * non-plugin default instead would resolve admin-side plugin classes elsewhere.
+     */
+    public function testOmittedClassPathLoadsFromThePluginAdminTree(): void
+    {
+        $this->createPluginClassFile('admin');
+
+        $this->assertSame(
+            $this->pluginRoot() . 'admin/' . DIR_WS_CLASSES . 'observers/UnitTestDirectoryObserver.php',
+            $this->resolveClassEntry('admin')
+        );
+    }
+
+    public function testOmittedClassPathLoadsFromThePluginCatalogTree(): void
+    {
+        $this->createPluginClassFile('catalog');
+
+        $this->assertSame(
+            $this->pluginRoot() . 'catalog/' . DIR_WS_CLASSES . 'observers/UnitTestDirectoryObserver.php',
+            $this->resolveClassEntry('catalog')
+        );
+    }
+
+    public function testExplicitRelativeClassPathMatchesOmission(): void
+    {
+        $this->createPluginClassFile('admin');
+
+        $this->assertSame(
+            $this->resolveClassEntry('admin'),
+            $this->resolveClassEntry('admin', ['classPath' => DIR_WS_CLASSES])
+        );
+    }
+
+    /**
+     * An absolute classPath is refused, so no include is queued at all. Previously it
+     * produced a path with the store root embedded twice, which could never be found
+     * and which left the following classInstantiate to fatal on a missing class.
+     */
+    public function testAbsoluteClassPathQueuesNoInclude(): void
+    {
+        $this->createPluginClassFile('admin');
+
+        $this->assertNull(
+            $this->resolveClassEntry('admin', ['classPath' => DIR_FS_CATALOG . DIR_WS_CLASSES])
+        );
+    }
+
+    // ------------------------------------------------------------- init_script
+
+    /**
+     * @return array{0: ?string, 1: string[]} the queued require path, and any warnings
+     */
+    private function resolveInitScript(string $loadFile): array
+    {
+        $warnings = [];
+        set_error_handler(static function (int $errno, string $errstr) use (&$warnings): bool {
+            $warnings[] = $errstr;
+            return true;
+        });
+
+        try {
+            $actions = $this->initSystem('admin')->processLoaderList([
+                200 => [[
+                    'autoType' => 'init_script',
+                    'loaderType' => 'plugin',
+                    'loadFile' => $loadFile,
+                    'forceLoad' => false,
+                    'pluginInfo' => ['unique_key' => self::TEST_PLUGIN],
+                ]],
+            ]);
+        } finally {
+            restore_error_handler();
+        }
+
+        foreach ($actions as $action) {
+            if (($action['type'] ?? null) === 'require') {
+                return [$action['filePath'], $warnings];
+            }
+        }
+        return [null, $warnings];
+    }
+
+    private function createPluginInitScript(string $name): string
+    {
+        $dir = $this->pluginRoot() . 'admin/' . DIR_WS_INCLUDES . 'init_includes';
+        if (!is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+        file_put_contents($dir . '/' . $name, "<?php\n// unit test fixture\n");
+        return $dir . '/' . $name;
+    }
+
+    /**
+     * loadFile is appended after the directory is validated, so a traversal there
+     * escapes the plugin just as effectively as one in classPath.
+     */
+    #[DataProvider('escapingLoadFileProvider')]
+    public function testTraversalInClassLoadFileIsRefused(string $loadFile): void
+    {
+        $this->createPluginClassFile('admin');
+
+        $this->assertNull($this->resolveClassEntry('admin', ['loadFile' => $loadFile]));
+    }
+
+    /**
+     * The fixture directory has to exist: file_exists() will not resolve a '..'
+     * through a directory that is absent, so without it the traversal would fail to
+     * resolve and the test would pass without exercising the check.
+     */
+    #[DataProvider('escapingLoadFileProvider')]
+    public function testTraversalInInitScriptLoadFileIsRefused(string $loadFile): void
+    {
+        $this->createPluginInitScript('init_unit_test.php');
+
+        [$queued, ] = $this->resolveInitScript($loadFile);
+
+        $this->assertNull($queued);
+    }
+
+    /**
+     * The first two cases resolve to a file that genuinely exists outside the plugin
+     * -- six levels up from either base directory is the store root -- so without the
+     * check the entry would be found and queued. The rest would fail to resolve
+     * anyway; they are here so the validator is pinned rather than the filesystem.
+     */
+    public static function escapingLoadFileProvider(): array
+    {
+        $toStoreRoot = str_repeat('../', 6);
+
+        return [
+            'climbs out to a real file' => [$toStoreRoot . 'includes/defined_paths.php'],
+            'climbs out below a real directory' => ['observers/../' . $toStoreRoot . 'includes/defined_paths.php'],
+            'backslash traversal' => ['..\\..\\..\\..\\includes\\defined_paths.php'],
+            'absolute' => ['/etc/passwd'],
+        ];
+    }
+
+    /**
+     * classPath and loadFile are validated together, not separately. Each half here is
+     * harmless on its own, but concatenating '.' with './manifest.php' gives
+     * '../manifest.php', which climbs out of the context directory into the plugin
+     * version root -- and from there into the other context's tree.
+     */
+    public function testIndividuallyValidFragmentsThatComposeIntoTraversalAreRefused(): void
+    {
+        $this->createPluginClassFile('admin');
+        file_put_contents($this->pluginRoot() . 'manifest.php', "<?php\n// decoy\n");
+
+        $this->assertNull(
+            $this->resolveClassEntry('admin', ['classPath' => '.', 'loadFile' => './manifest.php'])
+        );
+    }
+
+    /**
+     * file_exists() is true for a directory, so an empty or directory-valued loadFile
+     * would be queued and then fatal on the require/include.
+     */
+    public function testDirectoryValuedLoadFileIsNotQueued(): void
+    {
+        $this->createPluginClassFile('admin');
+
+        $this->assertNull($this->resolveClassEntry('admin', ['loadFile' => 'observers']));
+        $this->assertNull($this->resolveClassEntry('admin', ['loadFile' => '']));
+    }
+
+    public function testDirectoryValuedInitScriptLoadFileIsNotQueued(): void
+    {
+        $this->createPluginInitScript('init_unit_test.php');
+
+        [$queued, ] = $this->resolveInitScript('');
+
+        $this->assertNull($queued);
+    }
+
+    /**
+     * A core init_script keeps failing fast: continuing without one would leave the
+     * request half-initialised, which is worse than stopping.
+     */
+    public function testMissingCoreInitScriptIsStillQueued(): void
+    {
+        $actions = $this->initSystem('admin')->processLoaderList([
+            200 => [[
+                'autoType' => 'init_script',
+                'loaderType' => 'core',
+                'loadFile' => 'init_does_not_exist.php',
+                'forceLoad' => false,
+            ]],
+        ]);
+
+        $this->assertCount(1, $actions);
+        $this->assertSame('require', $actions[0]['type']);
+    }
+
+    public function testInitScriptThatExistsIsQueued(): void
+    {
+        $expected = $this->createPluginInitScript('init_unit_test.php');
+
+        [$queued, $warnings] = $this->resolveInitScript('init_unit_test.php');
+
+        $this->assertSame($expected, $queued);
+        $this->assertSame([], $warnings);
+    }
+
+    /**
+     * A missing init_script previously queued a require regardless, which the
+     * autoloader loop turned into a fatal during bootstrap.
+     */
+    public function testMissingInitScriptIsNotQueuedAndWarns(): void
+    {
+        [$queued, $warnings] = $this->resolveInitScript('init_does_not_exist.php');
+
+        $this->assertNull($queued);
+        $this->assertCount(1, $warnings);
+        $this->assertStringContainsString('init_does_not_exist.php', $warnings[0]);
+        $this->assertStringContainsString('was not found', $warnings[0]);
+    }
+}


### PR DESCRIPTION
Resolve plugin auto_loader paths without comparing directories

A plugin auto_loader addresses files inside its own plugin, in whichever context is loading it. `findPluginDirectory()` did not treat it that way: it handed the declared `classPath` to `FileSystem::getRelativeDir()` to work out whether the
path named the admin tree, the catalog tree, or neither, and stripped a prefix accordingly. That indirection is the source of some very rare but long-standing problems, and it is not needed. This makes the relative contract explicit
and drops the comparison entirely.

## What was wrong

`isAdminDir()` and `isCatalogDir()` have returned the opposite of what their names claim since v1.5.7 (see #4432). `isAdminDir()` reported true for any path that is *not* under `DIR_FS_ADMIN`, including relative paths and paths outside the store.

Nothing broke, because the fault cancels itself. `getRelativeDir()` guards each `str_replace()` with the matching predicate, and each predicate returns true exactly when its search string is absent -- which is exactly when the `str_replace()` does nothing. Every branch is a no-op on the inputs it actually receives, so the method has never once removed a prefix. For the relative paths that `processAutoTypeClass()` and `processAutoTypeInit_script()` pass, returning the input unchanged is the right answer, so the wrong branch produced the right result unexpectedly. That made it unusable.

It stops cancelling if a plugin declares an absolute `classPath`. The path is returned unchanged and then appended to the plugin directory, embedding the store root twice, so the file is never found. `processAutoTypeClass()` records FAILED and queues nothing, but the matching `classInstantiate` entry is queued regardless, and the autoloader loop then runs `new $className()` on a class that was never loaded, resulting in a fatal error.

## What changed here now in v3.0.0

`FileSystem::isAdminDir()`, `isCatalogDir()` and `getRelativeDir()` are removed.

`InitSystem::findPluginDirectory()` now appends the declared path to the plugin's context directory, after checking it is something that may be appended. `isPluginRelativePath()` refuses absolute paths -- rooted, backslash-rooted or drive-rooted -- and any path that would resolve outside the plugin directory. A refused path yields no directory at all, and the entry is skipped. Substituting the plugin's context root would be wrong too. Refusals are recorded in the debug list.

processAutoTypeInit_script() likewise queued its require unconditionally, checking only whether an overrides variant existed, so a plugin declaring a missing init_script produced a bootstrap fatal. It now checks the script itself and warns when skipping.

The validator rejects both separator conventions on every platform. A validator can be conservative where a path comparison cannot: no legitimate auto_loader path is turned away by this, whereas a comparison would first have to decide which convention applied to a given path. That decision is what previously required separator normalisation, drive-letter detection and case handling, and none of it is needed to answer whether a fragment is clean.

`includes/autoload_func.php` no longer instantiates a class it cannot see.
The `class` and `sessionClass` cases check `class_exists()` first, and `objectMethod` checks the object was created, so a skipped instantiation does not simply move the fatal one entry further down the list. Each raises an `E_USER_WARNING` naming what was skipped, and the loop continues. The session case also discards an __PHP_Incomplete_Class left by decoding that ran before the class was available. That happens whether or not the class is loadable now, and checkInstantiated would otherwise preserve the stale value because the slot is set.

## Cross-tree access

Removing the admin/catalog distinction from the loader costs nothing, because plugins already have a better mechanism for it. Both bootstraps register `Zencart\Plugins\Admin\<Key>` and `Zencart\Plugins\Catalog\<Key>` for every installed plugin, and both prefixes are registered from either context, so a plugin class in one tree can be autoloaded from the other by namespace with no auto_loader entry at all. Plugins may also ship a `psr4Autoload.php` in their root to register their own prefixes.

## Compatibility

The three removed methods were public but have no callers in core, and their return values have only ever selected between two no-ops, so no caller can have depended on their behaviour without noticing.
Thus: Removed rather than deprecated on that basis.

An absolute `classPath` in a plugin auto_loader now resolves nothing instead of fataling. Core auto_loaders are unaffected -- they carry full paths by design and never reach `findPluginDirectory()`, which only runs for `loaderType` `plugin`.

## Tests

44 tests, 66 assertions, in two new files.

`InitSystemPluginDirectoryTest` covers relative resolution in both contexts, a ten-case provider of paths that must be refused, a directory name beginning with dots that must *not* be mistaken for one, and end-to-end runs through `processLoaderList()` for omitted, relative and absolute `classPath`.

`AutoloadFuncGuardsTest` drives the real autoloader loop over a hand-built action list. Against the previous code its cases fail with `Class "..." not found` at `includes/autoload_func.php:47` -- the same file and line as the report on #7032.

`composer tests-unit`: 0 failing files, 476 tests. PHPStan clean under both the catalog and admin configurations.

## Background

Supersedes and closes #7032, which could not be merged: it is marked by the author as not modifiable by maintainers and has since conflicted.
The `IS_ADMIN_FLAG` context change from that PR landed separately in 57182715b. Fixes #4432.

Both #4432 and #7032 asked for the predicates to be corrected rather than removed, and #4435 before them. The question repeatedly put to those PRs ("which plugin fails without the change") had no answer, and this explains why: with the relative form that every plugin uses, nothing fails. The inversion is real, and it is unobservable, and the right response is to delete the methods rather than fix answers nobody can consume.
