### PR TITLE
Keep the configuration form's `original` field byte-identical to its input

### DIFF
--- a/admin/configuration.php
+++ b/admin/configuration.php
@@ -266,7 +266,16 @@ foreach ($configuration as $item) {
                 echo $inputField;
             }
             ?>
-            <?= zen_draw_hidden_field("original[$fieldName]", $cfgValue) ?>
+            <?php
+            /**
+             * Rendered directly, rather than via zen_draw_hidden_field, so that this field carries
+             * exactly the same escaping as the visible input above it, bypassing the zen_not_null
+             * check that could make an untouched setting look edited on every save.
+             *
+             * $cfgValue is already htmlspecialchars()'d for use in a double-quoted attribute.
+             */
+            ?>
+            <input type="hidden" name="original[<?= $fieldName ?>]" value="<?= $cfgValue ?>">
         </div>
         <div class="col-md-6 bg-info p-3"><?= $item['configuration_description'] ?></div>
     </div>


### PR DESCRIPTION
Backport of a one-line fix from #7935 (v3.0.0). **Only the fix ports** — the "child templates" configuration feature that PR introduced (`is_template_setting`, per-template saves, inherited values) is new on master and does not apply to 2.3 or older.

### The bug

`admin/configuration.php` decides what to write by comparing each posted `configuration[cfg_N]` value against the `original[cfg_N]` hidden field rendered beside it. That hidden field goes through `zen_draw_hidden_field()`, which drops the `value=` attribute entirely for anything `zen_not_null()` considers absent — a whitespace-only string, or the literal string `NULL`.

Those two kinds of value therefore post back an empty `original`, so an untouched form looks edited. On every save of that group:

- a redundant `UPDATE`, which passes the value through `zen_db_prepare_input()` and **trims a whitespace-only setting away to `''`**;
- a "value saved" confirmation naming a change the admin never made;
- a matching `admin_activity` entry.

### The fix

Render the field directly, reusing the value that was already `htmlspecialchars()`'d for the visible input two lines above, so both fields carry identical escaping and neither depends on `zen_not_null()`.

### Verification

Every other awkward value already round-trips correctly — `&`, `<`, quotes and pre-encoded entities are all fine, because `zen_output_string()` in its default mode only maps `"` to `&quot;` rather than re-encoding. Checked against 2.3's own `zen_output_string()` / `zen_not_null()` / `zen_draw_hidden_field()`, simulating the browser's attribute decoding:

| value | before | after |
|---|---|---|
| `abc`, `0`, `''`, `Tom & Jerry`, `A &amp; B`, `say "hi"`, `it's`, `<b>b</b>`, `' :: '` | round-trips | round-trips |
| `'   '` (whitespace only) | input posts `'   '`, original posts `''` | round-trips |
| `NULL` (literal) | input posts `'NULL'`, original posts `''` | round-trips |

On master this is covered by `ConfigurationFormRoundTripTest`, which submits a configuration group's form completely untouched and asserts nothing is written; it fails on exactly these two values without the fix. That test does not port — it is built on the in-process admin runner (`zcInProcessFeatureTestCaseAdmin`), which 2.3 predates. Happy to write a BrowserKit equivalent for this branch if wanted.