### PR TITLE
Disregard `products_image` from additional images

### DIFF
--- a/admin/includes/modules/collect_info.php
+++ b/admin/includes/modules/collect_info.php
@@ -78,6 +78,9 @@ if (isset($_GET['pID']) && empty($_POST)) {
 $additional_images_query = $db->Execute("SELECT id, additional_image FROM " . TABLE_PRODUCTS_ADDITIONAL_IMAGES . " WHERE products_id = " . (int)($_GET['pID'] ?? 0) . " ORDER BY sort_order");
 $additional_images = [];
 foreach ($additional_images_query as $additional_image) {
+    if (isset($pInfo->products_image) && $pInfo->products_image === $additional_image['additional_image']) {
+        continue;
+    }
     $additional_images[] = [
         'id' => $additional_image['id'],
         'additional_image' => $additional_image['additional_image']

--- a/admin/includes/modules/document_general/collect_info.php
+++ b/admin/includes/modules/document_general/collect_info.php
@@ -78,6 +78,9 @@ if (isset($_GET['pID']) && empty($_POST)) {
 $additional_images_query = $db->Execute("SELECT id, additional_image FROM " . TABLE_PRODUCTS_ADDITIONAL_IMAGES . " WHERE products_id = " . (int)($_GET['pID'] ?? 0) . " ORDER BY sort_order");
 $additional_images = [];
 foreach ($additional_images_query as $additional_image) {
+    if (isset($pInfo->products_image) && $pInfo->products_image === $additional_image['additional_image']) {
+        continue;
+    }
     $additional_images[] = [
         'id' => $additional_image['id'],
         'additional_image' => $additional_image['additional_image']

--- a/admin/includes/modules/document_product/collect_info.php
+++ b/admin/includes/modules/document_product/collect_info.php
@@ -78,6 +78,9 @@ if (isset($_GET['pID']) && empty($_POST)) {
 $additional_images_query = $db->Execute("SELECT id, additional_image FROM " . TABLE_PRODUCTS_ADDITIONAL_IMAGES . " WHERE products_id = " . (int)($_GET['pID'] ?? 0) . " ORDER BY sort_order");
 $additional_images = [];
 foreach ($additional_images_query as $additional_image) {
+    if (isset($pInfo->products_image) && $pInfo->products_image === $additional_image['additional_image']) {
+        continue;
+    }
     $additional_images[] = [
         'id' => $additional_image['id'],
         'additional_image' => $additional_image['additional_image']

--- a/admin/includes/modules/product_free_shipping/collect_info.php
+++ b/admin/includes/modules/product_free_shipping/collect_info.php
@@ -78,6 +78,9 @@ if (isset($_GET['pID']) && empty($_POST)) {
 $additional_images_query = $db->Execute("SELECT id, additional_image FROM " . TABLE_PRODUCTS_ADDITIONAL_IMAGES . " WHERE products_id = " . (int)($_GET['pID'] ?? 0) . " ORDER BY sort_order");
 $additional_images = [];
 foreach ($additional_images_query as $additional_image) {
+    if (isset($pInfo->products_image) && $pInfo->products_image === $additional_image['additional_image']) {
+        continue;
+    }
     $additional_images[] = [
         'id' => $additional_image['id'],
         'additional_image' => $additional_image['additional_image']

--- a/admin/includes/modules/product_music/collect_info.php
+++ b/admin/includes/modules/product_music/collect_info.php
@@ -80,6 +80,9 @@ if (isset($_GET['pID']) && empty($_POST)) {
 $additional_images_query = $db->Execute("SELECT id, additional_image FROM " . TABLE_PRODUCTS_ADDITIONAL_IMAGES . " WHERE products_id = " . (int)($_GET['pID'] ?? 0) . " ORDER BY sort_order");
 $additional_images = [];
 foreach ($additional_images_query as $additional_image) {
+    if (isset($pInfo->products_image) && $pInfo->products_image === $additional_image['additional_image']) {
+        continue;
+    }
     $additional_images[] = [
         'id' => $additional_image['id'],
         'additional_image' => $additional_image['additional_image']

--- a/includes/classes/Product.php
+++ b/includes/classes/Product.php
@@ -343,6 +343,9 @@ class Product
         $sql = "SELECT id, sort_order, additional_image FROM " . TABLE_PRODUCTS_ADDITIONAL_IMAGES . " WHERE products_id = $product_id ORDER BY sort_order";
         $results = $db->Execute($sql);
         foreach ($results as $additional_image) {
+            if ($data['products_image'] === $additional_image['additional_image']) {
+                continue;
+            }
             $data['additional_images'][] = [
                 'id' => (int)$additional_image['id'],
                 'image_filename' => $additional_image['additional_image'],


### PR DESCRIPTION
The "Scan for additional images" tool includes a product's base image when updating the `products_additional_images` table, resulting in that base image being incorrectly reported as an additional one.

This PR does not correct that processing, it just filters the product's base image from the list of additional images for the storefront and admin displays.