### PR TITLE
ZC 3.0.0/POSM 1.6.2: Including `zen_config`

### DIFF
--- a/zc_plugins/POSM/v6.1.2/admin/includes/functions/extra_functions/zen_config.php
+++ b/zc_plugins/POSM/v6.1.2/admin/includes/functions/extra_functions/zen_config.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * zen_config.php: Provides a zc300 function for use by earlier ZC versions,
+ *
+ */
+if (!function_exists('zen_config')) {
+    /**
+     * Function to retrieve a database constant, presumed to be in either
+     * the configuration or product_type_layout tables.
+     */
+    function zen_config(string $key, mixed $default = null): mixed
+    {
+        return defined($key) ? constant($key) : $default;
+    }
+}

--- a/zc_plugins/POSM/v6.1.2/catalog/includes/functions/extra_functions/zen_config.php
+++ b/zc_plugins/POSM/v6.1.2/catalog/includes/functions/extra_functions/zen_config.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * zen_config.php: Provides a zc300 function for use by earlier ZC versions,
+ *
+ */
+if (!function_exists('zen_config')) {
+    /**
+     * Function to retrieve a database constant, presumed to be in either
+     * the configuration or product_type_layout tables.
+     */
+    function zen_config(string $key, mixed $default = null): mixed
+    {
+        return defined($key) ? constant($key) : $default;
+    }
+}


### PR DESCRIPTION
Fixes #7962

Including the `zen_config` polyfill, since the plugin can be used for Zen Cart versions prior to 3.0.0.