### PR TITLE
Conditionally use nl2br in orders comments display

### DIFF
--- a/admin/orders.php
+++ b/admin/orders.php
@@ -1147,10 +1147,10 @@ if ($show_orders_weights === true) {
                                         <td>
 <?php
                                                 if ($first) {
-                                                     echo nl2br(zen_output_string_protected($item['comments'] ?? ''), false);
+                                                     echo !preg_match('/(<br|<p|<div|<dd|<li|<span)/i', $item['comments']) ? nl2br(zen_output_string_protected($item['comments'] ?? ''), false) : zen_output_string_protected($item['comments'] ?? '');
                                                      $first = false;
                                                 } else {
-                                                     echo nl2br($item['comments'] ?? '', false);
+                                                     echo !preg_match('/(<br|<p|<div|<dd|<li|<span)/i', $item['comments']) ? nl2br($item['comments'] ?? '', false) : ($item['comments'] ?? '');
                                                 }
 ?>
                                         </td>


### PR DESCRIPTION
This is complementary to PR #7335 .
In admin order detail, in the display of order's comments, unnecessary `<br>` tags are added to HTML code. This results in more blank lines, making comments challenging to read and wasting page space.
This PR adds these tags conditionally, like it is done in other parts of ZC code.