### PR TITLE
Admin email convertion from HTML to text message

### DIFF
--- a/admin/mail.php
+++ b/admin/mail.php
@@ -208,10 +208,10 @@ if ($action == 'preview') {
           <div class="col-sm-3 text-right"><b><?php echo TEXT_SUBJECT; ?></b></div>
           <div class="col-sm-9"><?php echo htmlspecialchars(stripslashes($_POST['subject']), ENT_COMPAT, CHARSET, TRUE); ?></div>
           <div class="col-sm-12"><hr></div>
-          <div class="col-sm-3 text-right"><b><?php echo strip_tags(TEXT_MESSAGE_HTML); ?></b></div>
+          <div class="col-sm-3 text-right"><b><?php echo TEXT_MESSAGE_HTML; ?></b></div>
           <div class="col-sm-9">
-              <?php if (zen_config('EMAIL_USE_HTML') !== 'true') echo TEXT_WARNING_HTML_DISABLED . '<br>'; ?>
               <?php
+              if (zen_config('EMAIL_USE_HTML') !== 'true') echo TEXT_WARNING_HTML_DISABLED . '<br>';
               $html_preview = zen_output_string(isset($_POST['message_html']) ? $_POST['message_html'] : '');
               echo (false !== stripos($html_preview, '<br') ? $html_preview : nl2br($html_preview, false));
               ?>
@@ -221,10 +221,10 @@ if ($action == 'preview') {
           <div class="col-sm-9 tt">
               <?php
               $message_preview = empty($_POST['message']) ? $_POST['message_html'] : $_POST['message'];
-              $message_preview = (false !== stripos($message_preview, '<br') ? $message_preview : nl2br($message_preview, false));
-              $message_preview = str_replace(array('<br>', '<br />'), "<br />\n", $message_preview);
+              $message_preview = str_replace('&nbsp;', " ", $message_preview);
+              $message_preview = str_replace(['<br>', '<br />'], "<br>\n", $message_preview);
               $message_preview = str_replace('</p>', "</p>\n", $message_preview);
-              echo  nl2br(htmlspecialchars(stripslashes(strip_tags($message_preview)), ENT_COMPAT, CHARSET, true), false);
+              echo  nl2br(stripslashes(strip_tags($message_preview)), false);
               ?>
           </div>
           <div class="col-sm-12"><hr></div>


### PR DESCRIPTION
Fixes #7970 
This PR removes unwanted `<br>` tags and `&nbsp;` characters from admin emails.