### PR TITLE
State_field_flicker in address forms

### DIFF
--- a/includes/templates/template_default/jscript/zen_addr_pulldowns.php
+++ b/includes/templates/template_default/jscript/zen_addr_pulldowns.php
@@ -52,44 +52,6 @@ if (zen_config('ACCOUNT_STATE_DRAW_INITIAL_DROPDOWN') === 'true') {
 jQuery(document).ready(function() {
     const country_zones = '<?php echo addslashes(json_encode($c2z)); ?>';
 <?php
-// -----
-// Notes:
-//
-// 1. The '#stBreak' <br> is also never needed/wanted since it will 'throw' the state-field input underneath
-// the state/zone label.
-//
-// 2. If the '#stateLabel' label is empty, hide it!  It will be when the site uses dropdown states and on
-// the 'shipping_estimator' page.
-//
-// 3. Initialize the display for the dropdown vs. hand-entry of the state fields.  If the initially-selected
-// country doesn't have zones, the dropdown will contain only 1 element ('Type a choice below ...').  In that
-// case, the dropdown and associated elements will be hidden and the hand-input 'state' field will be shown.
-//
-// 4. There can be unwanted whitespace, e.g. an &nbsp; prior to the (optional) <span class="alert"> following
-// the 'stateZone' dropdown.  In that case, when the <span> is hidden for unzoned countries, the state input
-// field is slightly offset from the other input fields.
-//
-?>
-    if (jQuery('#stateZone > option').length > 1) {
-        jQuery('#stateLabel').hide();
-        jQuery('#state').hide();
-        jQuery('#stateZone').show();
-        if (jQuery('#stateZone option:selected').val() == 0) {
-            jQuery('#zoneLabel').nextAll('span.alert').first().show();
-        } else {
-            jQuery('#zoneLabel').nextAll('span.alert').first().hide();
-        }
-    } else {
-        if (jQuery('#stateLabel').text().length === 0) {
-            jQuery('#stateLabel').text(jQuery('#zoneLabel').text());
-        }
-        jQuery('#state').show();
-        jQuery('#zoneLabel').hide();
-        jQuery('#stateZone').hide();
-        jQuery('#zoneLabel').nextAll('span.alert').first().hide();
-        jQuery('#stBreak').hide();
-    }
-<?php
     // -----
     // This function provides the processing needed when a country has been changed.  It makes
     // use of the country_zones (countries-to-zones) array, built above.  Normally invoked
@@ -120,7 +82,6 @@ jQuery(document).ready(function() {
             jQuery('#zoneLabel').show();
             jQuery('#stateZone').show();
             jQuery('#zoneLabel').nextAll('span.alert').first().show();
-            jQuery('#stBreak').show();
         } else {
             if (jQuery('#stateLabel').text().length === 0) {
                 jQuery('#stateLabel').text(jQuery('#zoneLabel').text());
@@ -130,7 +91,6 @@ jQuery(document).ready(function() {
             jQuery('#zoneLabel').hide();
             jQuery('#stateZone').hide();
             jQuery('#zoneLabel').nextAll('span.alert').first().hide();
-            jQuery('#stBreak').hide();
         }
     }
     $('#stateZone').on('change', function() {

--- a/includes/templates/template_default/templates/tpl_modules_address_book_details.php
+++ b/includes/templates/template_default/templates/tpl_modules_address_book_details.php
@@ -69,23 +69,36 @@
 <?php
   if (zen_config('ACCOUNT_STATE') === 'true') {
     if ($flag_show_pulldown_states == true) {
+        if (!empty(zen_get_country_zones($selected_country))) {
 ?>
 <label class="inputLabel" for="stateZone" id="zoneLabel"><?php echo ENTRY_STATE; ?></label>
 <?php
-      echo zen_draw_pull_down_menu('zone_id', zen_prepare_country_zones_pull_down($selected_country), $zone_id, 'id="stateZone"');
-      echo '<span class="alert">' . ((!empty(ENTRY_STATE_TEXT) && (int)zen_config('ENTRY_STATE_MIN_LENGTH') > 0) ? ENTRY_STATE_TEXT : '') . '</span>';
-    }
+            echo zen_draw_pull_down_menu('zone_id', zen_prepare_country_zones_pull_down($selected_country), $zone_id, 'id="stateZone"');
+            echo '<span class="alert" style="display: none;">' . ((!empty(ENTRY_STATE_TEXT) && (int)zen_config('ENTRY_STATE_MIN_LENGTH') > 0) ? ENTRY_STATE_TEXT : '') . '</span>';
 ?>
-
-<?php if ($flag_show_pulldown_states == true) { ?>
-<br class="clearBoth" id="stBreak">
-<?php } ?>
+<div class="clearfix"></div>
+<label class="inputLabel" for="state" id="stateLabel" style="display: none;"><?php echo ENTRY_STATE; ?></label>
+<?php
+            echo zen_draw_input_field('state', zen_get_zone_name((int)$entry->fields['entry_country_id'], (int)$entry->fields['entry_zone_id'], $entry->fields['entry_state']), zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_state', '40') . ' id="state" style="display: none;"' . ((int)zen_config('ENTRY_STATE_MIN_LENGTH') > 0 ? ' placeholder="' . ENTRY_STATE_TEXT . '"' : ''));
+        } else {
+?>
+<label class="inputLabel" for="stateZone" id="zoneLabel" style="display: none;"><?php echo ENTRY_STATE; ?></label>
+<?php
+            echo zen_draw_pull_down_menu('zone_id', zen_prepare_country_zones_pull_down($selected_country), $zone_id, 'id="stateZone" style="display: none;"');
+            echo '<span class="alert" style="display: none;">' . ((!empty(ENTRY_STATE_TEXT) && (int)zen_config('ENTRY_STATE_MIN_LENGTH') > 0) ? ENTRY_STATE_TEXT : '') . '</span>';
+?>
+<div class="clearfix"></div>
+<label class="inputLabel" for="state" id="stateLabel"><?php echo ENTRY_STATE; ?></label>
+<?php
+            echo zen_draw_input_field('state', zen_get_zone_name((int)$entry->fields['entry_country_id'], (int)$entry->fields['entry_zone_id'], $entry->fields['entry_state']), zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_state', '40') . ' id="state"' . ((int)zen_config('ENTRY_STATE_MIN_LENGTH') > 0 ? ' placeholder="' . ENTRY_STATE_TEXT . '"' : ''));
+        }
+    } else {
+?>
 <label class="inputLabel" for="state" id="stateLabel"><?php echo $state_field_label; ?></label>
 <?php
-    echo zen_draw_input_field('state', zen_get_zone_name((int)$entry->fields['entry_country_id'], (int)$entry->fields['entry_zone_id'], $entry->fields['entry_state']), zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_state', '40') . ' id="state"' . ((int)zen_config('ENTRY_STATE_MIN_LENGTH') > 0 ? ' placeholder="' . ENTRY_STATE_TEXT . '"' : ''));
+        echo zen_draw_input_field('state', zen_get_zone_name((int)$entry->fields['entry_country_id'], (int)$entry->fields['entry_zone_id'], $entry->fields['entry_state']), zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_state', '40') . ' id="state"' . ((int)zen_config('ENTRY_STATE_MIN_LENGTH') > 0 ? ' placeholder="' . ENTRY_STATE_TEXT . '"' : ''));
 
-    if ($flag_show_pulldown_states == false) {
-      echo zen_draw_hidden_field('zone_id', $zone_name, ' ');
+        echo zen_draw_hidden_field('zone_id', $zone_name, ' ');
     }
 ?>
 <br class="clearBoth">

--- a/includes/templates/template_default/templates/tpl_modules_checkout_new_address.php
+++ b/includes/templates/template_default/templates/tpl_modules_checkout_new_address.php
@@ -65,23 +65,35 @@
 <?php
   if (zen_config('ACCOUNT_STATE') === 'true') {
     if ($flag_show_pulldown_states == true) {
+        if (!empty(zen_get_country_zones($selected_country))) {
 ?>
 <label class="inputLabel" for="stateZone" id="zoneLabel"><?php echo ENTRY_STATE; ?></label>
 <?php
-      echo zen_draw_pull_down_menu('zone_id', zen_prepare_country_zones_pull_down($selected_country), $zone_id, 'id="stateZone"');
-      echo '<span class="alert">' . ((!empty(ENTRY_STATE_TEXT) && (int)zen_config('ENTRY_STATE_MIN_LENGTH') > 0) ? ENTRY_STATE_TEXT : '') . '</span>';
-    }
+            echo zen_draw_pull_down_menu('zone_id', zen_prepare_country_zones_pull_down($selected_country), $zone_id, 'id="stateZone"');
+            echo '<span class="alert">' . ((!empty(ENTRY_STATE_TEXT) && (int)zen_config('ENTRY_STATE_MIN_LENGTH') > 0) ? ENTRY_STATE_TEXT : '') . '</span>';
 ?>
-
-<?php if ($flag_show_pulldown_states == true) { ?>
-<br class="clearBoth" id="stBreak">
-<?php } ?>
+<div class="clearfix"></div>
+<label class="inputLabel" for="state" id="stateLabel" style="display: none;"><?php echo ENTRY_STATE; ?></label>
+<?php
+            echo zen_draw_input_field('state', '', zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_state', '40') . ' id="state" style="display: none;"' . ((int)zen_config('ENTRY_STATE_MIN_LENGTH') > 0 ? ' placeholder="' . ENTRY_STATE_TEXT . '"' : ''));
+        } else {
+?>
+<label class="inputLabel" for="stateZone" id="zoneLabel" style="display: none;"><?php echo ENTRY_STATE; ?></label>
+<?php
+            echo zen_draw_pull_down_menu('zone_id', zen_prepare_country_zones_pull_down($selected_country), $zone_id, 'id="stateZone" style="display: none;"');
+            echo '<span class="alert" style="display: none;">' . ((!empty(ENTRY_STATE_TEXT) && (int)zen_config('ENTRY_STATE_MIN_LENGTH') > 0) ? ENTRY_STATE_TEXT : '') . '</span>';
+?>
+<div class="clearfix"></div>
+<label class="inputLabel" for="state" id="stateLabel"><?php echo ENTRY_STATE; ?></label>
+<?php
+            echo zen_draw_input_field('state', '', zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_state', '40') . ' id="state"' . ((int)zen_config('ENTRY_STATE_MIN_LENGTH') > 0 ? ' placeholder="' . ENTRY_STATE_TEXT . '"' : ''));
+        }
+    } else {
+?>
 <label class="inputLabel" for="state" id="stateLabel"><?php echo $state_field_label; ?></label>
 <?php
-    echo zen_draw_input_field('state', '', zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_state', '40') . ' id="state"' . ((int)zen_config('ENTRY_STATE_MIN_LENGTH') > 0 ? ' placeholder="' . ENTRY_STATE_TEXT . '"' : ''));
-
-    if ($flag_show_pulldown_states == false) {
-      echo zen_draw_hidden_field('zone_id', $zone_name, ' ');
+        echo zen_draw_input_field('state', '', zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_state', '40') . ' id="state"' . ((int)zen_config('ENTRY_STATE_MIN_LENGTH') > 0 ? ' placeholder="' . ENTRY_STATE_TEXT . '"' : ''));
+        echo zen_draw_hidden_field('zone_id', $zone_name, ' ');
     }
 ?>
 <br class="clearBoth">

--- a/includes/templates/template_default/templates/tpl_modules_create_account.php
+++ b/includes/templates/template_default/templates/tpl_modules_create_account.php
@@ -87,22 +87,35 @@
 <?php
   if (zen_config('ACCOUNT_STATE') === 'true') {
     if ($flag_show_pulldown_states == true) {
+        if (!empty(zen_get_country_zones($selected_country))) {
 ?>
 <label class="inputLabel" for="stateZone" id="zoneLabel"><?php echo ENTRY_STATE; ?></label>
 <?php
-      echo zen_draw_pull_down_menu('zone_id', zen_prepare_country_zones_pull_down($selected_country), $zone_id, 'id="stateZone"');
-      echo '<span class="alert">' . ((!empty(ENTRY_STATE_TEXT) && (int)zen_config('ENTRY_STATE_MIN_LENGTH') > 0) ? ENTRY_STATE_TEXT : '') . '</span>';
-    }
+            echo zen_draw_pull_down_menu('zone_id', zen_prepare_country_zones_pull_down($selected_country), $zone_id, 'id="stateZone"');
+            echo '<span class="alert">' . ((!empty(ENTRY_STATE_TEXT) && (int)zen_config('ENTRY_STATE_MIN_LENGTH') > 0) ? ENTRY_STATE_TEXT : '') . '</span>';
 ?>
-
-<?php if ($flag_show_pulldown_states == true) { ?>
-<br class="clearBoth" id="stBreak">
-<?php } ?>
+<div class="clearfix"></div>
+<label class="inputLabel" for="state" id="stateLabel" style="display: none;"><?php echo ENTRY_STATE; ?></label>
+<?php
+            echo zen_draw_input_field('state', '', zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_state', '40') . ' id="state" style="display: none;"' . ((int)zen_config('ENTRY_STATE_MIN_LENGTH') > 0 ? ' placeholder="' . ENTRY_STATE_TEXT . '"' : ''));
+        } else {
+?>
+<label class="inputLabel" for="stateZone" id="zoneLabel" style="display: none;"><?php echo ENTRY_STATE; ?></label>
+<?php
+            echo zen_draw_pull_down_menu('zone_id', zen_prepare_country_zones_pull_down($selected_country), $zone_id, 'id="stateZone" style="display: none;"');
+            echo '<span class="alert" style="display: none;">' . ((!empty(ENTRY_STATE_TEXT) && (int)zen_config('ENTRY_STATE_MIN_LENGTH') > 0) ? ENTRY_STATE_TEXT : '') . '</span>';
+?>
+<div class="clearfix"></div>
+<label class="inputLabel" for="state" id="stateLabel"><?php echo ENTRY_STATE; ?></label>
+<?php
+            echo zen_draw_input_field('state', '', zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_state', '40') . ' id="state"' . ((int)zen_config('ENTRY_STATE_MIN_LENGTH') > 0 ? ' placeholder="' . ENTRY_STATE_TEXT . '"' : ''));
+        }
+    } else {
+?>
 <label class="inputLabel" for="state" id="stateLabel"><?php echo $state_field_label; ?></label>
 <?php
-    echo zen_draw_input_field('state', '', zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_state', '40') . ' id="state"' . ((int)zen_config('ENTRY_STATE_MIN_LENGTH') > 0 ? ' placeholder="' . ENTRY_STATE_TEXT . '"' : ''));
-    if ($flag_show_pulldown_states == false) {
-      echo zen_draw_hidden_field('zone_id', $zone_name, ' ');
+        echo zen_draw_input_field('state', '', zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_state', '40') . ' id="state"' . ((int)zen_config('ENTRY_STATE_MIN_LENGTH') > 0 ? ' placeholder="' . ENTRY_STATE_TEXT . '"' : ''));
+        echo zen_draw_hidden_field('zone_id', $zone_name, ' ');
     }
 ?>
 <br class="clearBoth">

--- a/includes/templates/template_default/templates/tpl_modules_shipping_estimator.php
+++ b/includes/templates/template_default/templates/tpl_modules_shipping_estimator.php
@@ -59,17 +59,29 @@ if (zen_is_logged_in() && !zen_in_guest_checkout()) {
     <br class="clearBoth">
 
     <a id="seView"></a>
-    <label class="inputLabel" for="stateZone" id="zoneLabel"><?= ENTRY_STATE ?></label>
 <?php
     if ($flag_show_pulldown_states) {
+        if (!empty(zen_get_country_zones($selected_country))) {
 ?>
-    <?= zen_draw_pull_down_menu('zone_id', zen_prepare_country_zones_pull_down($selected_country), $state_zone_id, 'id="stateZone"') ?>
-    <br class="clearBoth" id="stBreak">
-<?php
+            <label class="inputLabel" for="stateZone" id="zoneLabel"><?= ENTRY_STATE ?></label>
+            <?= zen_draw_pull_down_menu('zone_id', zen_prepare_country_zones_pull_down($selected_country), $state_zone_id, 'id="stateZone"') ?>
+            <div class="clearfix"></div>
+            <label class="inputLabel" for="state" id="stateLabel" style="display: none;"><?= ENTRY_STATE ?></label>
+            <?php echo zen_draw_input_field('state', $selectedState, zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_state', '40') . ' id="state" style="display: none;"');
+        } else {
+?>
+            <label class="inputLabel" for="stateZone" id="zoneLabel" style="display: none;"><?= ENTRY_STATE ?></label>
+            <?= zen_draw_pull_down_menu('zone_id', zen_prepare_country_zones_pull_down($selected_country), $state_zone_id, 'id="stateZone" style="display: none;"') ?>
+            <div class="clearfix"></div>
+            <label class="inputLabel" for="state" id="stateLabel"><?= ENTRY_STATE ?></label>
+            <?php echo zen_draw_input_field('state', $selectedState, zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_state', '40') . ' id="state"');
+        }
+    } else {
+?>
+        <label class="inputLabel" for="state" id="stateLabel"><?= $state_field_label ?? '' ?></label>
+        <?php echo zen_draw_input_field('state', $selectedState, zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_state', '40') . ' id="state"');
     }
 ?>
-    <label class="inputLabel" for="state" id="stateLabel"><?= ($state_field_label ?? '') ?></label>
-    <?= zen_draw_input_field('state', $selectedState, zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_state', '40') . ' id="state"') .'&nbsp;<span class="alert" id="stText">&nbsp;</span>' ?>
     <br class="clearBoth">
 <?php
     if (CART_SHIPPING_METHOD_ZIP_REQUIRED === 'true') {


### PR DESCRIPTION
Fixes #7966 #4800 and #4810 (although this one was already partially fixed)
The only way to avoid flicker of some page elements on loading is to set everything as it should be from the beginning. CSS/JS toggle is only used when a user interacts.
This PR uses PHP/CSS to display fields as they should be from the beginning. This avoids any flickering due to JS reloading some elements, and it simplifies the JS script, although.

The simplified JS script is included in this PR, but the file can be left as it was for backward compatibility. Although I don't see any backward compatibility issue, as the only optional templates available for `ZC v2` or `v3` are the _Responsive Classic Redesign_ for which this PR files can be used as is, and the _ZCA Bootstrap Template_ for which I already have updated files.