### PR TITLE
Drop the unreachable second case for processor code 1380

### DIFF
--- a/zc_plugins/PayPalRestful/v2.1.1/catalog/includes/modules/payment/paypalr.php
+++ b/zc_plugins/PayPalRestful/v2.1.1/catalog/includes/modules/payment/paypalr.php
@@ -1818,7 +1818,6 @@ class paypalr extends \base
 
                     case '0500':    //- Card refused
                     case '1330':    //- Card not valid
-                    case '1380':    //- Invalid expiration
                     case '5100':    //- Generic decline
                     case '5140':    //- Card closed
                     case '5180':    //- Luhn check failed; don't use card


### PR DESCRIPTION
`checkCardPaymentResponse` lists processor code `1380` in two groups, first under CVV check failed with the comment "Invalid card verification value", then again seven lines down under card declined with the comment "Invalid expiration". PHP takes the first matching case, so the second has never been reached and `1380` always produces the CVV message.

That first one is the right home for it: PayPal documents 1380 as an invalid card verification value, and expired cards already have their own case at `5400`. So I removed the later label rather than the earlier one, which leaves the buyer facing message exactly as it is today.

The part I cannot answer is whether a different decline code was meant on that line. The comment next to it describes something the group around it handles nowhere else, so if a code got mistyped there it is still missing from the list.
