### PR TITLE
Separate `PluginManifest` class; addl. plugin msgs

### DIFF
--- a/admin/includes/languages/english/lang.plugin_manager.php
+++ b/admin/includes/languages/english/lang.plugin_manager.php
@@ -63,7 +63,8 @@ $define = [
     'TEXT_VERSION_INSTALLED' => '<strong>Version Installed:</strong> %s',
 
     'WARNING_NONENCAPSULATED_REMOVAL' => '<b>Note:</b> Installing this plugin will result in files provided by a non-encapsulated version (if present) being <b>permanently</b> removed!',
-    'WARNING_TEMPLATE_IS_ACTIVE' => 'This plugin contains the template currently selected by the <a href="%1$s">%2$s</a> tool. Uninstalling the plugin prior to selecting a different template will have unwanted consequences!',
+    'WARNING_TEMPLATE_IS_ACTIVE' => 'This plugin contains a template that is currently selected by the <a href="%1$s">%2$s</a> tool. Uninstalling the plugin prior to selecting a different template will have unwanted consequences!',
+    'WARNING_TEMPLATE_IS_ACTIVE_PARENT' => 'This plugin contains a template that is the <em>parent</em> of one or more templates that are currently selected by the <a href="%1$s">%2$s</a> tool. Uninstalling the plugin prior to selecting a different template will have unwanted consequences!',
 ];
 
 return $define;

--- a/includes/classes/PluginSupport/InstallerFactory.php
+++ b/includes/classes/PluginSupport/InstallerFactory.php
@@ -11,6 +11,7 @@ namespace Zencart\PluginSupport;
 
 use queryFactory;
 use Zencart\Exceptions\PluginInstallerException;
+use Zencart\PluginSupport\PluginManifest;
 
 /**
  * @since ZC v1.5.7
@@ -36,7 +37,8 @@ class InstallerFactory
         if (!is_dir($versionDir)) {
             throw new PluginInstallerException('NO PLUGIN VERSION DIRECTORY');
         }
-        if (!file_exists($versionDir . 'manifest.php')) {
+
+        if (new PluginManifest()->exists($plugin, $version) === null) {
             throw new PluginInstallerException('NO VERSION MANIFEST');
         }
 

--- a/includes/classes/PluginSupport/InstallerFactory.php
+++ b/includes/classes/PluginSupport/InstallerFactory.php
@@ -38,7 +38,7 @@ class InstallerFactory
             throw new PluginInstallerException('NO PLUGIN VERSION DIRECTORY');
         }
 
-        if (new PluginManifest()->exists($plugin, $version) === null) {
+        if ((new PluginManifest())->exists($plugin, $version) === null) {
             throw new PluginInstallerException('NO VERSION MANIFEST');
         }
 

--- a/includes/classes/PluginSupport/PluginManifest.php
+++ b/includes/classes/PluginSupport/PluginManifest.php
@@ -17,6 +17,19 @@ if (!defined('IS_ADMIN_FLAG')) {
 class PluginManifest
 {
     protected array $manifest_info;
+    protected string $pluginsRoot;  //- Note: No ending DIRECTORY_SEPARATOR!
+
+    /**
+     * @since ZC v3.0.0
+     */
+    public function __construct(?string $pluginsRoot = null)
+    {
+        if ($pluginsRoot === null) {
+            $pluginsRoot = DIR_FS_CATALOG . 'zc_plugins';
+        }
+
+        $this->pluginsRoot = rtrim($pluginsRoot, '/\\');
+    }
 
     /**
      * Returns the array of information returned by the requested plugin
@@ -55,7 +68,7 @@ class PluginManifest
      */
     public function exists(string $plugin_key, string $version): ?string
     {
-        $manifest_filename = DIR_FS_CATALOG . "zc_plugins/$plugin_key/$version/manifest.php";
+        $manifest_filename = $this->pluginsRoot . "/$plugin_key/$version/manifest.php";
         if (isset($this->manifest_info[$plugin_key][$version]) || is_file($manifest_filename)) {
             return $manifest_filename;
         }

--- a/includes/classes/PluginSupport/PluginManifest.php
+++ b/includes/classes/PluginSupport/PluginManifest.php
@@ -1,0 +1,97 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright 2003-2025 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: lat9 2025 Sep 27 New in v3.0.0 $
+ *
+ * @since ZC v3.0.0
+ */
+namespace Zencart\PluginSupport;
+
+if (!defined('IS_ADMIN_FLAG')) {
+    die('Illegal access');
+}
+
+class PluginManifest
+{
+    protected array $manifest_info;
+
+    /**
+     * Returns the array of information returned by the requested plugin
+     * key/version's manifest.php. Returns `null` if no such file is found for
+     * the plugin or the returned value isn't an array.
+     *
+     * @since ZC v3.0.0
+     */
+    public function get(string $plugin_key, string $version): ?array
+    {
+        if (isset($this->manifest_info[$plugin_key][$version])) {
+            return $this->manifest_info[$plugin_key][$version]['contents'];
+        }
+
+        $manifest_filename = $this->exists($plugin_key, $version);
+        if ($manifest_filename === null) {
+            return null;
+        }
+
+        $manifest = require $manifest_filename;
+        if (!is_array($manifest)) {
+            return null;
+        }
+
+        $this->manifest_info[$plugin_key][$version] = [
+            'contents' => $manifest,
+            'template_key' => $manifest['template']['key'] ?? null,
+            'removes_uncapsulated_version' => !empty($manifest['removesUnencapsulatedVersion']),
+        ];
+
+        return $manifest;
+    }
+
+    /**
+     * @since ZC v3.0.0
+     */
+    public function exists(string $plugin_key, string $version): ?string
+    {
+        $manifest_filename = DIR_FS_CATALOG . "zc_plugins/$plugin_key/$version/manifest.php";
+        if (isset($this->manifest_info[$plugin_key][$version]) || is_file($manifest_filename)) {
+            return $manifest_filename;
+        }
+        return null;
+    }
+
+    /**
+     * @since ZC v3.0.0
+     */
+    public function isSelectableTemplate(string $plugin_key, string $version): bool
+    {
+        if ($this->get($plugin_key, $version) === null) {
+            return false;
+        }
+        return $this->manifest_info[$plugin_key][$version]['template_key'] !== null;
+    }
+
+    /**
+     * @since ZC v3.0.0
+     */
+    public function removesUnencapsulatedVersion(string $plugin_key, string $version): bool
+    {
+        if ($this->get($plugin_key, $version) === null) {
+            return false;
+        }
+        return $this->manifest_info[$plugin_key][$version]['removes_uncapsulated_version'];
+    }
+
+    /**
+     * @since ZC v3.0.0
+     */
+    public function getSelectableTemplateKey(string $plugin_key, string $version): ?string
+    {
+        if ($this->get($plugin_key, $version) === null) {
+            return null;
+        }
+        return $this->manifest_info[$plugin_key][$version]['template_key'];
+    }
+}

--- a/includes/classes/ResourceLoaders/TemplateResolver.php
+++ b/includes/classes/ResourceLoaders/TemplateResolver.php
@@ -11,6 +11,7 @@ namespace Zencart\ResourceLoaders;
 use Zencart\DbRepositories\PluginControlRepository;
 use Zencart\DbRepositories\PluginControlVersionRepository;
 use Zencart\PluginManager\PluginManager;
+use Zencart\PluginSupport\PluginManifest;
 use Zencart\Templates\TemplateDto;
 
 /**
@@ -274,16 +275,14 @@ class TemplateResolver
             return $templates;
         }
 
+        $pluginManifest = new PluginManifest();
         $installedPlugins = $this->getInstalledPlugins();
         foreach ($installedPlugins as $unique_key => $plugin_info) {
             $version = $plugin_info['version'];
             $versionPath = $this->pluginsRoot . '/' . $unique_key . '/' . $version;
-            $manifestFile = $versionPath . '/manifest.php';
-            if (!is_file($manifestFile)) {
-                continue;
-            }
-            $manifest = require $manifestFile;
-            if (!self::isSelectableTemplateManifest($manifest)) {
+
+            $manifest = $pluginManifest->get($unique_key, $version);
+            if ($manifest === null || !$pluginManifest->isSelectableTemplate($unique_key, $version)) {
                 continue;
             }
 
@@ -311,18 +310,6 @@ class TemplateResolver
         }
 
         return [];
-    }
-
-    /**
-     * @since ZC v3.0.0
-     */
-    private static function isSelectableTemplateManifest(mixed $manifest): bool
-    {
-        if (!is_array($manifest) || empty($manifest['template']) || !is_array($manifest['template'])) {
-            return false;
-        }
-
-        return !empty($manifest['template']['key']);
     }
 
     /**

--- a/includes/classes/ResourceLoaders/TemplateResolver.php
+++ b/includes/classes/ResourceLoaders/TemplateResolver.php
@@ -275,7 +275,7 @@ class TemplateResolver
             return $templates;
         }
 
-        $pluginManifest = new PluginManifest();
+        $pluginManifest = new PluginManifest($this->pluginsRoot);
         $installedPlugins = $this->getInstalledPlugins();
         foreach ($installedPlugins as $unique_key => $plugin_info) {
             $version = $plugin_info['version'];

--- a/includes/classes/TemplateSelect.php
+++ b/includes/classes/TemplateSelect.php
@@ -587,7 +587,7 @@ class TemplateSelect
             "DELETE FROM " . TABLE_TEMPLATE_SELECT . "
               WHERE template_dir = :template_dir:
                 AND template_language != 0";
-        $sql = self::$db->bindVars($sql, ':template_dir:', 'string');
+        $sql = self::$db->bindVars($sql, ':template_dir:', $template_dir, 'string');
         self::$db->Execute($sql);
 
         foreach (self::$dbTemplates as $template_id => $template_info) {

--- a/includes/classes/TemplateSelect.php
+++ b/includes/classes/TemplateSelect.php
@@ -282,7 +282,7 @@ class TemplateSelect
          * includes the requested template as its first element. That's discarded prior to the assignment.
          */
         if (!isset(self::$parentTemplates[$template_dir])) {
-            $inheritance_chain = zen_get_template_inheritance_chain($template_dir, includeTemplateDefault: false);
+            $inheritance_chain = \zen_get_template_inheritance_chain($template_dir, includeTemplateDefault: false);
             array_shift($inheritance_chain);
             self::$parentTemplates[$template_dir] = $inheritance_chain;
         }
@@ -316,7 +316,7 @@ class TemplateSelect
          * includes the requested template as its first element. That's discarded prior to the assignment.
          */
         if (!isset(self::$parentTemplates[$template_dir])) {
-            $inheritance_chain = zen_get_template_inheritance_chain($template_dir, includeTemplateDefault: false);
+            $inheritance_chain = \zen_get_template_inheritance_chain($template_dir, includeTemplateDefault: false);
             array_shift($inheritance_chain);
             self::$parentTemplates[$template_dir] = $inheritance_chain;
         }

--- a/includes/classes/TemplateSelect.php
+++ b/includes/classes/TemplateSelect.php
@@ -32,6 +32,9 @@ use Zencart\PluginSupport\PluginStatus;
  *
  * @since ZC v3.0.0
  */
+if (!defined('IS_ADMIN_FLAG')) {
+    die('Illegal Access');
+}
 class TemplateSelect
 {
     public const int TEMPLATE_BASE_LANGUAGE = -1;
@@ -53,10 +56,10 @@ class TemplateSelect
 
     public function __construct()
     {
-        // -----
-        // If the class 'copy' of the $db object is already set, the class has already
-        // initialized and all its static properties can be reused.
-        //
+        /**
+         * If the class 'copy' of the $db object is already set, the class has already
+         * initialized and all its static properties can be reused.
+         */
         if (isset(self::$db) || !defined('IS_ADMIN_FLAG')) {
             return;
         }
@@ -64,9 +67,9 @@ class TemplateSelect
         global $db;
         self::$db = $db;
 
-        // -----
-        // Start by gathering the current results from the database's `template_select` table.
-        //
+        /**
+         * Start by gathering the current results from the database's `template_select` table.
+         */
         $result = self::$db->Execute(
             "SELECT *
                FROM " . TABLE_TEMPLATE_SELECT
@@ -80,10 +83,10 @@ class TemplateSelect
             }
         }
 
-        // -----
-        // Determine if there's an active template directory (i.e. chosen for
-        // the current language) and, if so, save that for cross-class use.
-        //
+        /**
+         * Determine if there's an active template directory (i.e. chosen for
+         * the current language) and, if so, save that for cross-class use.
+         */
         $active_template_dir = $this->getActiveTemplateDir();
         if ($active_template_dir !== null) {
             TemplateDto::getInstance()->updateTemplate($active_template_dir, ['is_active' => true]);
@@ -105,10 +108,10 @@ class TemplateSelect
      */
     protected function resolveTemplates(): void
     {
-        // -----
-        // Determine which encapsulated plugins are currently installed,
-        // whether enabled or disabled.
-        //
+        /**
+         * Determine which encapsulated plugins are currently installed,
+         * whether enabled or disabled.
+         */
         $installedPluginKeys = [];
         foreach ((new PluginControlRepository(self::$db))->getAll() as $plugin) {
             if (($plugin['status'] ?? PluginStatus::NOT_INSTALLED) !== PluginStatus::NOT_INSTALLED) {
@@ -116,14 +119,14 @@ class TemplateSelect
             }
         }
 
-        // -----
-        // Retrieve the template-related information for all template
-        // directories. This can include encapsulated template packages
-        // that aren't currently installed.
-        //
-        // Then, filter out any records that are associated with template packages
-        // that aren't installed.
-        //
+        /**
+         * Retrieve the template-related information for all template
+         * directories. This can include encapsulated template packages
+         * that aren't currently installed.
+         *
+         * Then, filter out any records that are associated with template packages
+         * that aren't installed.
+         */
         self::$selectableTemplates = array_filter(
             \zen_get_catalog_template_directories(),
             static function (array $template) use ($installedPluginKeys): bool {
@@ -134,11 +137,11 @@ class TemplateSelect
             }
         );
 
-        // -----
-        // Synchronize the database's `template_select` table with the selectable
-        // templates found in the file-system, adding a record with a template_language
-        // of -1 to indicate that this is the 'base' record for the template.
-        //
+        /**
+         * Synchronize the database's `template_select` table with the selectable
+         * templates found in the file-system, adding a record with a template_language
+         * of -1 to indicate that this is the 'base' record for the template.
+         */
         foreach (self::$selectableTemplates as $template_dir => $selected_info) {
             $default_entry_found = false;
             foreach (self::$dbTemplates as $id => $db_info) {
@@ -209,6 +212,21 @@ class TemplateSelect
     /**
      * @since ZC v3.0.0
      */
+    public function isActiveParentTemplate(string $parent_template_dir): bool
+    {
+        foreach (self::$activeTemplates as $lang => $info) {
+            foreach ($this->getParentTemplates($info['template_dir']) as $next_parent_dir) {
+                if ($next_parent_dir === $parent_template_dir) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @since ZC v3.0.0
+     */
     public function getActiveTemplateDir(): ?string
     {
         return $this->getActiveTemplateField('template_dir');
@@ -258,22 +276,22 @@ class TemplateSelect
      */
     public function getInheritedSetting(string $template_dir, string $setting_key, string $default): string
     {
-        // -----
-        // Save the requested template's parents' settings statically, so they don't need to be determined on
-        // every call to this method. zen_get_template_inheritance_chain's returned array (numerically indexed)
-        // includes the requested template as its first element. That's discarded prior to the assignment.
-        //
+        /**
+         * Save the requested template's parents' settings statically, so they don't need to be determined on
+         * every call to this method. zen_get_template_inheritance_chain's returned array (numerically indexed)
+         * includes the requested template as its first element. That's discarded prior to the assignment.
+         */
         if (!isset(self::$parentTemplates[$template_dir])) {
             $inheritance_chain = zen_get_template_inheritance_chain($template_dir, includeTemplateDefault: false);
             array_shift($inheritance_chain);
             self::$parentTemplates[$template_dir] = $inheritance_chain;
         }
 
-        // -----
-        // Loop through the template's parents, looking for the requested setting and returning the
-        // first parent-value found. If no setting exists for the parent, return the supplied default.
-        //
-        foreach (self::$parentTemplates[$template_dir] as $parent_dir) {
+        /**
+         * Loop through the template's parents, looking for the requested setting and returning the
+         * first parent-value found. If no setting exists for the parent, return the supplied default.
+         */
+        foreach ($this->getParentTemplates($template_dir) as $parent_dir) {
             $parent_settings = $this->getTemplateSettings($parent_dir);
             if ($parent_settings === null) {
                 continue;
@@ -283,6 +301,26 @@ class TemplateSelect
             }
         }
         return $default;
+    }
+
+    /**
+     * Returns the array of template parents for the specified template.
+     *
+     * @since ZC v3.0.0
+     */
+    protected function getParentTemplates($template_dir): array
+    {
+        /**
+         * Save the requested template's parents' settings statically, so they don't need to be determined on
+         * every call to this method. zen_get_template_inheritance_chain's returned array (numerically indexed)
+         * includes the requested template as its first element. That's discarded prior to the assignment.
+         */
+        if (!isset(self::$parentTemplates[$template_dir])) {
+            $inheritance_chain = zen_get_template_inheritance_chain($template_dir, includeTemplateDefault: false);
+            array_shift($inheritance_chain);
+            self::$parentTemplates[$template_dir] = $inheritance_chain;
+        }
+        return self::$parentTemplates[$template_dir];
     }
 
     /**
@@ -328,13 +366,13 @@ class TemplateSelect
             $current_settings = [];
         }
 
-        // -----
-        // Remove any settings (based on the $settings_keys supplied) from the template's
-        // current `template_settings` and merge the supplied settings into
-        // that array.
-        //
-        // This handling enables a setting to be removed as a template-specific one.
-        //
+        /**
+         * Remove any settings (based on the $settings_keys supplied) from the template's
+         * current `template_settings` and merge the supplied settings into
+         * that array.
+         *
+         * This handling enables a setting to be removed as a template-specific one.
+         */
         $updated_settings = array_diff_key($current_settings, array_flip($settings_keys));
         $updated_settings = array_merge($updated_settings, $template_settings);
 
@@ -372,7 +410,7 @@ class TemplateSelect
      */
     protected function updateDbTemplateSettings(int $id, ?array $template_settings): int
     {
-        if (!isset(self::$dbTemplates[$id]) || (int)self::$dbTemplates[$id]['template_language'] !== self::TEMPLATE_BASE_LANGUAGE) {
+        if (IS_ADMIN_FLAG !== true || !isset(self::$dbTemplates[$id]) || (int)self::$dbTemplates[$id]['template_language'] !== self::TEMPLATE_BASE_LANGUAGE) {
             return self::SETTINGS_NO_UPDATE;
         }
 
@@ -397,10 +435,10 @@ class TemplateSelect
         $sql = self::$db->bindVars($sql, ':id:', $id, 'integer');
         self::$db->Execute($sql, 1);
 
-        // -----
-        // Update the local cache of database settings (with the json_encoded version of the settings)
-        // and the templateSettings cache (which contains the null|array values).
-        //
+        /**
+         * Update the local cache of database settings (with the json_encoded version of the settings)
+         * and the templateSettings cache (which contains the null|array values).
+         */
         self::$dbTemplates[$id]['template_settings'] = $template_settings;
         self::$templateSettings[self::$dbTemplates[$id]['template_dir']] = $raw_template_settings;
 
@@ -418,7 +456,7 @@ class TemplateSelect
      */
     public function registerNewTemplate(string $template_dir, int $language_id): false|int
     {
-        if ($template_dir === '' || $language_id < 1 || isset(self::$activeTemplates[$language_id])) {
+        if (IS_ADMIN_FLAG !== true || $template_dir === '' || $language_id < 1 || isset(self::$activeTemplates[$language_id])) {
             return false;
         }
 
@@ -430,6 +468,10 @@ class TemplateSelect
      */
     protected function addTemplateToDb(string $template_dir, int $language_id): int
     {
+        if (IS_ADMIN_FLAG !== true) {
+            return -1;
+        }
+
         $sql =
             "INSERT INTO " . TABLE_TEMPLATE_SELECT . "
                 (template_dir, template_language)
@@ -462,7 +504,7 @@ class TemplateSelect
      */
     public function updateTemplateNameForId(int $id, string $template_dir): int
     {
-        if ($template_dir === '' || $id < 0) {
+        if (IS_ADMIN_FLAG !== true || $template_dir === '' || $id < 0) {
             return self::SETTINGS_BAD_INPUTS;
         }
 
@@ -479,13 +521,13 @@ class TemplateSelect
         $sql = self::$db->bindVars($sql, ':id:', $id, 'integer');
         self::$db->Execute($sql, 1);
 
-        // -----
-        // affectedRows() only counts rows whose stored value actually changed,
-        // so a no-op save (submitting the same template_dir that's already set)
-        // would report 0 here even though the row was matched and the desired state is
-        // already in place. Existence against the row was already confirmed above,
-        // so that's not treated as a failure.
-        //
+        /**
+         * affectedRows() only counts rows whose stored value actually changed,
+         * so a no-op save (submitting the same template_dir that's already set)
+         * would report 0 here even though the row was matched and the desired state is
+         * already in place. Existence against the row was already confirmed above,
+         * so that's not treated as a failure.
+         */
         foreach (self::$activeTemplates as $language_id => $template_info) {
             if ($id === (int)$template_info['template_id']) {
                 self::$activeTemplates[$language_id]['template_dir'] = $template_dir;
@@ -505,7 +547,7 @@ class TemplateSelect
      */
     public function deregisterTemplateId(int $id): bool
     {
-        if ($id <= 0) {
+        if (IS_ADMIN_FLAG !== true || $id <= 0) {
             return false;
         }
 
@@ -527,6 +569,41 @@ class TemplateSelect
             }
         }
         return false;
+    }
+
+    /**
+     * Removes the specified template (and its associated settings) from
+     * the database and the class-based arrays.
+     *
+     * @since ZC v3.0.0
+     */
+    public function removeTemplateDir(string $template_dir): bool
+    {
+        if (IS_ADMIN_FLAG !== true || $template_dir === '') {
+            return false;
+        }
+
+        $sql =
+            "DELETE FROM " . TABLE_TEMPLATE_SELECT . "
+              WHERE template_dir = :template_dir:
+                AND template_language != 0";
+        $sql = self::$db->bindVars($sql, ':template_dir:', 'string');
+        self::$db->Execute($sql);
+
+        foreach (self::$dbTemplates as $template_id => $template_info) {
+            if ($template_dir === $template_info['template_dir']) {
+                unset(
+                    self::$activeTemplates[(int)$template_info['template_language']],
+                    self::$dbTemplates[(int)$template_id],
+                    self::$parentTemplates[$template_dir],
+                    self::$templateSettings[$template_dir]
+                );
+                if (isset(self::$selectableTemplates)) {
+                    unset(self::$selectableTemplates[$template_dir]);
+                }
+            }
+        }
+        return true;
     }
 
     /**

--- a/includes/classes/ViewBuilders/PluginManagerController.php
+++ b/includes/classes/ViewBuilders/PluginManagerController.php
@@ -12,8 +12,10 @@ namespace Zencart\ViewBuilders;
 use Zencart\FileSystem\FileSystem;
 use Zencart\PluginManager\PluginManager;
 use Zencart\PluginSupport\InstallerFactory;
+use Zencart\PluginSupport\PluginManifest;
 use Zencart\PluginSupport\PluginStatus;
 use Zencart\ResourceLoaders;
+use Zencart\Templates\TemplateSelect;
 
 /**
  * @since ZC v1.5.8
@@ -22,7 +24,8 @@ class PluginManagerController extends BaseController
 {
     protected PluginManager $pluginManager;
     protected InstallerFactory $installerFactory;
-    protected array $manifests;
+    protected PluginManifest $pluginManifest;
+    protected TemplateSelect $templateSelect;
 
     /**
      * @since ZC v1.5.8
@@ -31,6 +34,8 @@ class PluginManagerController extends BaseController
     {
         $this->pluginManager = $pluginManager;
         $this->installerFactory = $installerFactory;
+
+        $this->pluginManifest = new PluginManifest();
     }
 
     /**
@@ -38,16 +43,7 @@ class PluginManagerController extends BaseController
      */
     protected function getManifest(string $unique_key, string $version): ?array
     {
-        if (isset($this->manifests[$unique_key][$version])) {
-            return $this->manifests[$unique_key][$version];
-        }
-        $manifest_file = DIR_FS_CATALOG . "zc_plugins/$unique_key/$version/manifest.php";
-        if (!file_exists($manifest_file)) {
-            return null;
-        }
-        $manifest = require $manifest_file;
-        $this->manifests[$unique_key][$version] = $manifest;
-        return $manifest;
+        return $this->pluginManifest->get($unique_key, $version);
     }
 
     /**
@@ -55,8 +51,7 @@ class PluginManagerController extends BaseController
      */
     protected function removesUnencapsulatedVersion(string $unique_key, string $version): bool
     {
-        $manifest = $this->getManifest($unique_key, $version);
-        return !empty($manifest['removesUnencapsulatedVersion']);
+        return $this->pluginManifest->removesUnencapsulatedVersion($unique_key, $version);
     }
 
     /**
@@ -64,8 +59,7 @@ class PluginManagerController extends BaseController
      */
     protected function isSelectableTemplate(string $unique_key, string $version): bool
     {
-        $manifest = $this->getManifest($unique_key, $version);
-        return !empty($manifest['template']);
+        return $this->pluginManifest->isSelectableTemplate($unique_key, $version);
     }
 
     /**
@@ -73,8 +67,7 @@ class PluginManagerController extends BaseController
      */
     protected function getSelectableTemplateKey(string $unique_key, string $version): ?string
     {
-        $manifest = $this->getManifest($unique_key, $version);
-        return $manifest['template']['key'] ?? null;
+        return $this->pluginManifest->getSelectableTemplateKey($unique_key, $version);
     }
 
     /**
@@ -131,11 +124,11 @@ class PluginManagerController extends BaseController
         }
 
         if ($status === PluginStatus::ENABLED) {
-            // -----
-            // Template packages have a 'template' array within their manifest and
-            // are enabled/disabled via the "Template Selection" tool, so the 'Disable'
-            // action isn't displayed by the "Plugin Manager".
-            //
+            /**
+             * Template packages have a 'template' array within their manifest and
+             * are enabled/disabled via the "Template Selection" tool, so the 'Disable'
+             * action isn't displayed by the "Plugin Manager".
+             */
             if (!$this->isSelectableTemplate($unique_key, $version)) {
                 $this->setBoxContent(
                     '<a href="' . zen_href_link(
@@ -157,20 +150,11 @@ class PluginManagerController extends BaseController
             if ($this->isSelectableTemplate($unique_key, $version)) {
                 $plugin_template_key = $this->getSelectableTemplateKey($unique_key, $version);
                 if ($plugin_template_key !== null) {
-                    $templateSelect = new \Zencart\Templates\TemplateSelect();
-                    $isAssignedTemplate = false;
-                    foreach ($templateSelect->getAllActiveTemplates() as $selectedTemplate) {
-                        if (($selectedTemplate['template_dir'] ?? null) === $plugin_template_key) {
-                            $isAssignedTemplate = true;
-                            break;
-                        }
-                    }
-
-                    if ($isAssignedTemplate) {
+                    if ($this->setActiveTemplateWarning($plugin_template_key) === true) {
                         $btn_type = 'warning';
-                        $this->setBoxContent(
-                            sprintf(WARNING_TEMPLATE_IS_ACTIVE, zen_href_link(FILENAME_TEMPLATE_SELECT), BOX_TOOLS_TEMPLATE_SELECT)
-                        );
+                    }
+                    if ($this->setParentTemplateWarning($plugin_template_key) === true) {
+                        $btn_type = 'warning';
                     }
                 }
             }
@@ -191,6 +175,40 @@ class PluginManagerController extends BaseController
                 ) . '" class="btn btn-primary" role="button">' . TEXT_CLEANUP . '</a>'
             );
         }
+    }
+
+    /**
+     * @since ZC v3.0.0
+     */
+    protected function setActiveTemplateWarning(string $template): bool
+    {
+        $this->templateSelect ??= new \Zencart\Templates\TemplateSelect();
+        foreach ($this->templateSelect->getAllActiveTemplates() as $selectedTemplate) {
+            if (($selectedTemplate['template_dir'] ?? null) === $template) {
+                $this->setBoxContent(
+                    zen_black_line() .
+                    sprintf(WARNING_TEMPLATE_IS_ACTIVE, zen_href_link(FILENAME_TEMPLATE_SELECT), BOX_TOOLS_TEMPLATE_SELECT)
+                );
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @since ZC v3.0.0
+     */
+    protected function setParentTemplateWarning(string $template): bool
+    {
+        $this->templateSelect ??= new \Zencart\Templates\TemplateSelect();
+        if ($this->templateSelect->isActiveParentTemplate($template) === true) {
+            $this->setBoxContent(
+                zen_black_line() .
+                sprintf(WARNING_TEMPLATE_IS_ACTIVE_PARENT, zen_href_link(FILENAME_TEMPLATE_SELECT), BOX_TOOLS_TEMPLATE_SELECT)
+            );
+            return true;
+        }
+        return false;
     }
 
     /**
@@ -303,6 +321,14 @@ class PluginManagerController extends BaseController
         $additional_content = $installer->processPreUninstall($unique_key, $version);
         foreach ($additional_content as $content) {
             $this->setBoxContent($content);
+        }
+
+        if ($this->isSelectableTemplate($unique_key, $version)) {
+            $plugin_template_key = $this->getSelectableTemplateKey($unique_key, $version);
+            if ($plugin_template_key !== null) {
+                $this->setActiveTemplateWarning($plugin_template_key);
+                $this->setParentTemplateWarning($plugin_template_key);
+            }
         }
 
         $this->setBoxContent(

--- a/includes/classes/ViewBuilders/PluginManagerController.php
+++ b/includes/classes/ViewBuilders/PluginManagerController.php
@@ -186,7 +186,7 @@ class PluginManagerController extends BaseController
         foreach ($this->templateSelect->getAllActiveTemplates() as $selectedTemplate) {
             if (($selectedTemplate['template_dir'] ?? null) === $template) {
                 $this->setBoxContent(
-                    zen_black_line() .
+                    \zen_black_line() .
                     sprintf(WARNING_TEMPLATE_IS_ACTIVE, zen_href_link(FILENAME_TEMPLATE_SELECT), BOX_TOOLS_TEMPLATE_SELECT)
                 );
                 return true;
@@ -203,7 +203,7 @@ class PluginManagerController extends BaseController
         $this->templateSelect ??= new \Zencart\Templates\TemplateSelect();
         if ($this->templateSelect->isActiveParentTemplate($template) === true) {
             $this->setBoxContent(
-                zen_black_line() .
+                \zen_black_line() .
                 sprintf(WARNING_TEMPLATE_IS_ACTIVE_PARENT, zen_href_link(FILENAME_TEMPLATE_SELECT), BOX_TOOLS_TEMPLATE_SELECT)
             );
             return true;

--- a/includes/classes/traits/InteractsWithPlugins.php
+++ b/includes/classes/traits/InteractsWithPlugins.php
@@ -13,6 +13,7 @@ use Zencart\DbRepositories\PluginControlRepository;
 use Zencart\DbRepositories\PluginControlVersionRepository;
 use Zencart\PageLoader\PageLoader;
 use Zencart\PluginManager\PluginManager;
+use Zencart\PluginSupport\PluginManifest;
 
 /**
  * @since ZC v2.1.0
@@ -59,7 +60,7 @@ trait InteractsWithPlugins
         $this->zcPluginContext = $matches[2]; // 'admin' or 'catalog' or 'Installer'
 
         $this->zcPluginPath = str_replace('//', '/', DIR_FS_CATALOG . '/zc_plugins/' . $this->zcPluginDirName . '/' . $this->zcPluginVersionDir . '/');
-        $this->isAZcPlugin = \file_exists($this->zcPluginPath . 'manifest.php');
+        $this->isAZcPlugin = (new PluginManifest()->exists($this->zcPluginDirName, $this->zcPluginVersionDir) !== null);
 
         global $db;
         $plugin_manager = new PluginManager(new PluginControlRepository($db), new PluginControlVersionRepository($db));

--- a/includes/classes/traits/InteractsWithPlugins.php
+++ b/includes/classes/traits/InteractsWithPlugins.php
@@ -60,7 +60,7 @@ trait InteractsWithPlugins
         $this->zcPluginContext = $matches[2]; // 'admin' or 'catalog' or 'Installer'
 
         $this->zcPluginPath = str_replace('//', '/', DIR_FS_CATALOG . '/zc_plugins/' . $this->zcPluginDirName . '/' . $this->zcPluginVersionDir . '/');
-        $this->isAZcPlugin = (new PluginManifest()->exists($this->zcPluginDirName, $this->zcPluginVersionDir) !== null);
+        $this->isAZcPlugin = ((new PluginManifest())->exists($this->zcPluginDirName, $this->zcPluginVersionDir) !== null);
 
         global $db;
         $plugin_manager = new PluginManager(new PluginControlRepository($db), new PluginControlVersionRepository($db));

--- a/not_for_release/testFramework/Unit/testsSundry/PluginManagerControllerTemplateWarningTest.php
+++ b/not_for_release/testFramework/Unit/testsSundry/PluginManagerControllerTemplateWarningTest.php
@@ -17,6 +17,10 @@ namespace Zencart\ViewBuilders {
 }
 
 namespace {
+    function zen_black_line(): string
+    {
+        return '';
+    }
     function zen_get_catalog_template_directories(): array
     {
         return [

--- a/not_for_release/testFramework/Unit/testsSundry/PluginManagerControllerTemplateWarningTest.php
+++ b/not_for_release/testFramework/Unit/testsSundry/PluginManagerControllerTemplateWarningTest.php
@@ -31,6 +31,10 @@ namespace {
             ],
         ];
     }
+    function zen_get_template_inheritance_chain(string $templateKey, bool $includeTemplateDefault = true): array
+    {
+        return [];
+    }
 }
 
 namespace Tests\Unit\testsSundry {

--- a/not_for_release/testFramework/Unit/testsTemplateResolver/TemplateSelectSettingsPersistenceTest.php
+++ b/not_for_release/testFramework/Unit/testsTemplateResolver/TemplateSelectSettingsPersistenceTest.php
@@ -27,6 +27,9 @@ class TemplateSelectSettingsPersistenceTest extends zcUnitTestCase
 
     public function setUp(): void
     {
+        if (!defined('IS_ADMIN_FLAG')) {
+            define('IS_ADMIN_FLAG', true);
+        }
         parent::setUp();
 
         require_once DIR_FS_CATALOG . 'includes/classes/class.base.php';


### PR DESCRIPTION
This PR adds a `PluginManifest` class to consolidate the loading and parsing of a `manifest.php` file.

It also adds an additional cautionary message to the admin's `Modules :: Plugin Manager` when the currently-selected plugin contains a template package that is a **parent** of a currently-active template.